### PR TITLE
Fixed bugs in Avro/Parquet loaders regarding filesystem streams usage

### DIFF
--- a/examples/csv_to_avro.php
+++ b/examples/csv_to_avro.php
@@ -3,15 +3,15 @@
 declare(strict_types=1);
 
 use Aeon\Calendar\Stopwatch;
+use Flow\ETL\DSL\Avro;
 use Flow\ETL\DSL\CSV;
-use Flow\ETL\DSL\Parquet;
 use Flow\ETL\DSL\Transform;
 use Flow\ETL\Flow;
 
 require __DIR__ . '/../vendor/autoload.php';
 
 $csvFileSize = \round(\filesize(__DIR__ . '/output/dataset.csv') / 1024 / 1024);
-print "Converting CSV {$csvFileSize}Mb file into parquet...\n";
+print "Converting CSV {$csvFileSize}Mb file into avro...\n";
 
 $stopwatch = new Stopwatch();
 $stopwatch->start();
@@ -21,12 +21,13 @@ $total = 0;
     ->read(CSV::from(__DIR__ . '/output/dataset.csv', 10_000))
     ->rows(Transform::array_unpack('row'))
     ->drop('row')
-    ->write(Parquet::to(__DIR__ . '/output/dataset_10k.parquet', 10_000))
+    ->rename('last name', 'last_name')
+    ->write(Avro::to(__DIR__ . '/output/dataset.avro'))
     ->run();
 
 $stopwatch->stop();
 
 print "Total elapsed time: {$stopwatch->totalElapsedTime()->inSecondsPrecise()}s\n\n";
 
-$parquetFileSize = \round(\filesize(__DIR__ . '/output/dataset_10k.parquet') / 1024 / 1024);
-print "Output parquet file size {$parquetFileSize}Mb\n";
+$parquetFileSize = \round(\filesize(__DIR__ . '/output/dataset.avro') / 1024 / 1024);
+print "Output avro file size {$parquetFileSize}Mb\n";

--- a/examples/csv_to_parquet_100k.php
+++ b/examples/csv_to_parquet_100k.php
@@ -5,17 +5,10 @@ declare(strict_types=1);
 use Aeon\Calendar\Stopwatch;
 use Flow\ETL\DSL\CSV;
 use Flow\ETL\DSL\Parquet;
-use Flow\ETL\DSL\To;
 use Flow\ETL\DSL\Transform;
 use Flow\ETL\Flow;
-use Flow\ETL\Monitoring\Memory\Consumption;
-use Flow\ETL\Rows;
 
 require __DIR__ . '/../vendor/autoload.php';
-
-if (\file_exists(__DIR__ . '/output/dataset_100k.parquet')) {
-    \unlink(__DIR__ . '/output/dataset_100k.parquet');
-}
 
 $csvFileSize = \round(\filesize(__DIR__ . '/output/dataset.csv') / 1024 / 1024);
 print "Converting CSV {$csvFileSize}Mb file into parquet...\n";
@@ -23,24 +16,16 @@ print "Converting CSV {$csvFileSize}Mb file into parquet...\n";
 $stopwatch = new Stopwatch();
 $stopwatch->start();
 $total = 0;
-$memory = new Consumption();
-$memory->current();
+
 (new Flow())
     ->read(CSV::from(__DIR__ . '/output/dataset.csv', 10_000))
     ->rows(Transform::array_unpack('row'))
     ->drop('row')
-    ->write(To::callback(function (Rows $rows) use (&$total, $memory) : void {
-        $total += $rows->count();
-
-        $memory->current();
-    }))
     ->write(Parquet::to(__DIR__ . '/output/dataset_100k.parquet', 100_000))
     ->run();
 
-$memory->current();
 $stopwatch->stop();
 
-print "Memory consumption, max: {$memory->max()->inMb()}Mb, min: {$memory->min()->inMb()}Mb\n";
 print "Total elapsed time: {$stopwatch->totalElapsedTime()->inSecondsPrecise()}s\n";
 
 $csvFileSize = \round(\filesize(__DIR__ . '/output/dataset_100k.parquet') / 1024 / 1024);

--- a/src/adapter/etl-adapter-avro/src/Flow/ETL/Adapter/Avro/FlixTech/SchemaConverter.php
+++ b/src/adapter/etl-adapter-avro/src/Flow/ETL/Adapter/Avro/FlixTech/SchemaConverter.php
@@ -28,6 +28,12 @@ final class SchemaConverter
         $fields = [];
 
         foreach ($schema->definitions() as $definition) {
+            if (!\AvroName::is_well_formed_name($definition->entry())) {
+                throw new RuntimeException(
+                    'Avro support only entry with names matching following regular expression: "' . \AvroName::NAME_REGEXP . '", entry "' . $definition->entry() . '" does not match it. Consider using DataFrame::rename method before writing to Avro format.'
+                );
+            }
+
             if (\count($definition->types()) === 2 && $definition->isNullable()) {
                 /** @var class-string<Entry> $type */
                 $type = \current(\array_diff($definition->types(), [NullEntry::class]));
@@ -89,7 +95,7 @@ final class SchemaConverter
                     'type' => \AvroSchema::ENUM_SCHEMA,
                     'symbols' => \array_map(
                         fn (\UnitEnum $e) => $e->name,
-                        $definition->metadata()->get(Definition::METADATA_ENUM_CASES)
+                        $definition->metadata()->get(Schema\FlowMetadata::METADATA_ENUM_CASES)
                     ),
                 ],
             ],

--- a/src/adapter/etl-adapter-avro/tests/Flow/ETL/Adapter/Avro/FlixTech/Tests/Integration/AvroTest.php
+++ b/src/adapter/etl-adapter-avro/tests/Flow/ETL/Adapter/Avro/FlixTech/Tests/Integration/AvroTest.php
@@ -113,6 +113,7 @@ final class AvroTest extends TestCase
                     }, \range(1, 100))
                 )
             ))
+            ->parallelize(10)
             ->write(Avro::to($path))
             ->run();
 

--- a/src/adapter/etl-adapter-parquet/tests/Flow/ETL/Adapter/Parquet/Tests/Integration/Codename/ParquetTest.php
+++ b/src/adapter/etl-adapter-parquet/tests/Flow/ETL/Adapter/Parquet/Tests/Integration/Codename/ParquetTest.php
@@ -81,7 +81,7 @@ final class ParquetTest extends TestCase
                     }, \range(1, 100))
                 )
             ))
-            ->write(Parquet::to($path))
+            ->write(Parquet::to($path, 10))
             ->run();
 
         $this->assertFileExists($path);


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>Avro Loader - detecting already existing file</li>
    <li>Avro Loader - error message when converting entries with name not supported by Avro library</li>
    <li>Parquet Loder - detecting already existing files</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Simplified Parquet Loader writing to groups</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

<!-- Please provide a shore description of changes in this section, feel free to use markdown syntax -->