### PR TITLE
Fixed limit behavior when expanding rows during transformations

### DIFF
--- a/src/core/etl/README.md
+++ b/src/core/etl/README.md
@@ -62,7 +62,7 @@ $array = new ArrayMemory();
     ->run();
 ```
 
-### [More Examples](https://github.com/flow-php/etl-examples)
+### [More Examples](https://github.com/flow-php/flow/tree/1.x/examples)
 
 ## DSL - Domain Specific Language
 
@@ -589,7 +589,7 @@ that must be placed before first trigger method to make an effect.
 
 ## Limit
 
-Sometimes you might just want to process only few first rows, maybe for debugging purpose.
+Sometimes you might just want to process only few first rows, maybe for debugging purpose or you don't want to go above certain number of rows.
 
 In this example, Pipeline will take only 5 rows from Extractor passing them through all transformers.
 
@@ -608,6 +608,13 @@ $flow->read($extractor)
     ->limit(5)
     ->run();
 ```
+
+It's important to remember that some transformers might actually change the original number of rows extracted 
+from the source, like for example when you need to expand an array of elements in single row, into new rows.
+
+In that case, Flow will detect the expansion, and it will cut rows accordingly to the total limit however
+it will happen only after expanding transformation. It's done this way because there is no way to predict
+the result of the expansion.
 
 ## Join
 

--- a/src/core/etl/src/Flow/ETL/Pipeline/Limiter.php
+++ b/src/core/etl/src/Flow/ETL/Pipeline/Limiter.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Pipeline;
+
+use Flow\ETL\Exception\InvalidArgumentException;
+use Flow\ETL\Rows;
+
+final class Limiter
+{
+    private Rows $latest;
+
+    private int $total;
+
+    public function __construct(private readonly int|null $limit)
+    {
+        if ($this->limit !== null && $this->limit <= 0) {
+            throw new InvalidArgumentException('Reductor limit can be only greater than zero');
+        }
+
+        $this->total = 0;
+        $this->latest = new Rows();
+    }
+
+    public function latest() : Rows
+    {
+        return $this->latest;
+    }
+
+    public function limit(Rows $rows) : ?Rows
+    {
+        if ($this->limit === null) {
+            return $rows;
+        }
+
+        if ($this->limitReached()) {
+            return null;
+        }
+
+        $this->total += $rows->count();
+        $this->latest = $rows;
+
+        if ($this->total > $this->limit) {
+            $diff = $this->total - $this->limit;
+
+            $this->total = $this->limit;
+            $this->latest = $rows->dropRight($diff);
+
+            return $this->latest;
+        }
+
+        return $rows;
+    }
+
+    public function limitReached() : bool
+    {
+        return $this->total >= $this->limit;
+    }
+
+    public function limitTransformed(Rows $rows) : Rows
+    {
+        if ($this->limit === null) {
+            return $rows;
+        }
+
+        $extra = $rows->count() - $this->latest->count();
+        $this->total += $extra;
+        $this->latest = $rows;
+
+        if ($this->total > $this->limit) {
+            $diff = $this->total - $this->limit;
+
+            $this->total = $this->limit;
+            $this->latest = $rows->dropRight($diff);
+
+            return $this->latest;
+        }
+
+        return $rows;
+    }
+}

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/DataFrameTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/DataFrameTest.php
@@ -1208,7 +1208,8 @@ ASCIITABLE,
                         $this->assertSame(3, $rows->count());
                     }
                 ) implements
-                Closure, Loader
+                    Closure,
+                Loader
                 {
 
                     private $load;

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/DataFrameTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/DataFrameTest.php
@@ -8,6 +8,7 @@ use Flow\ETL\DataFrame;
 use Flow\ETL\DataFrameFactory;
 use Flow\ETL\DSL\Entry;
 use Flow\ETL\DSL\Partitions;
+use Flow\ETL\DSL\To;
 use Flow\ETL\DSL\Transform;
 use Flow\ETL\ErrorHandler\IgnoreError;
 use Flow\ETL\Exception\InvalidArgumentException;
@@ -1166,6 +1167,84 @@ ASCIITABLE,
 
         (new Flow())->process(new Rows())
             ->limit(-1);
+    }
+
+    public function test_limit_when_transformation_is_expanding_rows_extracted_from_extractor() : void
+    {
+        $rows = (new Flow())->extract(
+            new class implements Extractor {
+                /**
+                 * @param FlowContext $context
+                 *
+                 * @return \Generator<int, Rows, mixed, void>
+                 */
+                public function extract(FlowContext $context) : \Generator
+                {
+                    for ($i = 0; $i < 1000; $i++) {
+                        yield new Rows(
+                            Row::create(new ArrayEntry('ids', [
+                                ['id' => $i + 1, 'more_ids' => [['more_id' => $i + 4], ['more_id' => $i + 7]]],
+                                ['id' => $i + 2, 'more_ids' => [['more_id' => $i + 5], ['more_id' => $i + 8]]],
+                                ['id' => $i + 3, 'more_ids' => [['more_id' => $i + 6], ['more_id' => $i + 9]]],
+                            ])),
+                        );
+                    }
+                }
+            }
+        )
+            ->rows(Transform::array_expand('ids'))
+            ->rows(Transform::array_unpack('element'))
+            ->drop('element')
+            ->rows(Transform::array_expand('more_ids'))
+            ->load(To::callback(function (Rows $rows) : void {
+                $this->assertSame(3, $rows->count());
+            }))
+            ->load(
+                new class(
+                    function (Rows $rows) : void {
+                        $this->assertSame(3, $rows->count());
+                    },
+                    function (Rows $rows) : void {
+                        $this->assertSame(3, $rows->count());
+                    }
+                ) implements
+                Closure, Loader
+                {
+
+                    private $load;
+
+                    private $closure;
+
+                    public function __construct(callable $load, callable $closure)
+                    {
+                        $this->load = $load;
+                        $this->closure = $closure;
+                    }
+
+                    public function closure(Rows $rows, FlowContext $context) : void
+                    {
+                        ($this->closure)($rows);
+                    }
+
+                    public function load(Rows $rows, FlowContext $context) : void
+                    {
+                        ($this->load)($rows);
+                    }
+
+                    public function __serialize() : array
+                    {
+                        return [];
+                    }
+
+                    public function __unserialize(array $data) : void
+                    {
+                    }
+                }
+            )
+            ->limit(3)
+            ->fetch();
+
+        $this->assertCount(3, $rows);
     }
 
     public function test_overriding_group_by() : void

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Pipeline/LimiterTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Pipeline/LimiterTest.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Tests\Unit\Pipeline;
+
+use Flow\ETL\DSL\Entry;
+use Flow\ETL\Exception\InvalidArgumentException;
+use Flow\ETL\Pipeline\Limiter;
+use Flow\ETL\Row;
+use Flow\ETL\Rows;
+use PHPUnit\Framework\TestCase;
+
+final class LimiterTest extends TestCase
+{
+    public function test_expanding_above_limit() : void
+    {
+        $limiter = new Limiter(5);
+
+        $limiter->limit(new Rows(
+            Row::create(Entry::integer('id', 1)),
+            Row::create(Entry::integer('id', 2)),
+            Row::create(Entry::integer('id', 3))
+        ));
+
+        $this->assertFalse($limiter->limitReached());
+
+        $limited = $limiter->limitTransformed(new Rows(
+            Row::create(Entry::integer('id', 1)),
+            Row::create(Entry::integer('id', 1)),
+            Row::create(Entry::integer('id', 2)),
+            Row::create(Entry::integer('id', 2)),
+            Row::create(Entry::integer('id', 3)),
+            Row::create(Entry::integer('id', 3))
+        ));
+
+        $this->assertEquals(
+            $latest = new Rows(
+                Row::create(Entry::integer('id', 1)),
+                Row::create(Entry::integer('id', 1)),
+                Row::create(Entry::integer('id', 2)),
+                Row::create(Entry::integer('id', 2)),
+                Row::create(Entry::integer('id', 3)),
+            ),
+            $limited
+        );
+        $this->assertEquals(
+            $latest,
+            $limiter->latest()
+        );
+        $this->assertTrue($limiter->limitReached());
+        $this->assertNull($limiter->limit(new Rows(
+            Row::create(Entry::integer('id', 10)),
+            Row::create(Entry::integer('id', 11)),
+        )));
+    }
+
+    public function test_limit() : void
+    {
+        $limiter = new Limiter(5);
+
+        $limiter->limit(new Rows(
+            Row::create(Entry::integer('id', 1)),
+            Row::create(Entry::integer('id', 2)),
+            Row::create(Entry::integer('id', 3))
+        ));
+
+        $this->assertFalse($limiter->limitReached());
+
+        $limited = $limiter->limit(new Rows(
+            Row::create(Entry::integer('id', 4)),
+            Row::create(Entry::integer('id', 5)),
+            Row::create(Entry::integer('id', 6))
+        ));
+
+        $this->assertEquals(
+            $latest = new Rows(
+                Row::create(Entry::integer('id', 4)),
+                Row::create(Entry::integer('id', 5)),
+            ),
+            $limited
+        );
+        $this->assertEquals(
+            $latest,
+            $limiter->latest()
+        );
+        $this->assertTrue($limiter->limitReached());
+
+        $this->assertNull($limiter->limit(new Rows(
+            Row::create(Entry::integer('id', 10)),
+            Row::create(Entry::integer('id', 11)),
+        )));
+    }
+
+    public function test_limit_below_zero() : void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new Limiter(-1);
+    }
+
+    public function test_limit_zero() : void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new Limiter(0);
+    }
+
+    public function test_passing_through_anything_when_limit_is_null() : void
+    {
+        $limiter = new Limiter(null);
+
+        $this->assertSame(
+            $rows = new Rows(
+                Row::create(Entry::integer('id', 1)),
+                Row::create(Entry::integer('id', 2)),
+                Row::create(Entry::integer('id', 3))
+            ),
+            $limiter->limit($rows)
+        );
+
+        $this->assertSame(
+            $rows = new Rows(
+                Row::create(Entry::integer('id', 1)),
+                Row::create(Entry::integer('id', 2)),
+                Row::create(Entry::integer('id', 3))
+            ),
+            $limiter->limitTransformed($rows)
+        );
+    }
+
+    public function test_reducing_below_limit() : void
+    {
+        $limiter = new Limiter(5);
+
+        $limiter->limit(new Rows(
+            Row::create(Entry::integer('id', 1)),
+            Row::create(Entry::integer('id', 2)),
+            Row::create(Entry::integer('id', 3))
+        ));
+
+        $this->assertFalse($limiter->limitReached());
+
+        $this->assertSame(
+            $rows = new Rows(
+                Row::create(Entry::integer('id', 1)),
+                Row::create(Entry::integer('id', 2)),
+            ),
+            $limiter->limitTransformed($rows)
+        );
+    }
+}


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>limit behavior when expanding rows during transformations</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

<!-- Please provide a shore description of changes in this section, feel free to use markdown syntax -->