### PR TITLE
Moved ErrorHandler to FlowContext

### DIFF
--- a/src/core/etl/src/Flow/ETL/Config.php
+++ b/src/core/etl/src/Flow/ETL/Config.php
@@ -20,8 +20,7 @@ final class Config
         private readonly Cache $cache,
         private readonly ExternalSort $externalSort,
         private readonly Serializer $serializer,
-        private readonly Filesystem $filesystem,
-        private ErrorHandler $errorHandler
+        private readonly Filesystem $filesystem
     ) {
     }
 
@@ -45,11 +44,6 @@ final class Config
         $this->limit = null;
 
         return $this;
-    }
-
-    public function errorHandler() : ErrorHandler
-    {
-        return $this->errorHandler;
     }
 
     public function externalSort() : ExternalSort
@@ -80,13 +74,6 @@ final class Config
     public function serializer() : Serializer
     {
         return $this->serializer;
-    }
-
-    public function setErrorHandler(ErrorHandler $errorHandler) : self
-    {
-        $this->errorHandler = $errorHandler;
-
-        return $this;
     }
 
     public function setLimit(int $limit) : self

--- a/src/core/etl/src/Flow/ETL/ConfigBuilder.php
+++ b/src/core/etl/src/Flow/ETL/ConfigBuilder.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Flow\ETL;
 
 use Flow\ETL\Cache\LocalFilesystemCache;
-use Flow\ETL\ErrorHandler\ThrowError;
 use Flow\ETL\ExternalSort\MemorySort;
 use Flow\ETL\Filesystem\FlysystemFS;
 use Flow\ETL\Monitoring\Memory\Unit;
@@ -15,8 +14,6 @@ use Flow\Serializer\Serializer;
 final class ConfigBuilder
 {
     private ?Cache $cache;
-
-    private ?ErrorHandler $errorHandler;
 
     private ?ExternalSort $externalSort;
 
@@ -32,7 +29,6 @@ final class ConfigBuilder
         $this->cache = null;
         $this->externalSort = null;
         $this->serializer = null;
-        $this->errorHandler = null;
         $this->filesystem = null;
     }
 
@@ -54,7 +50,6 @@ final class ConfigBuilder
             $this->cache,
             \is_string(\getenv(Config::EXTERNAL_SORT_MAX_MEMORY_ENV)) ? Unit::fromString(\getenv(Config::EXTERNAL_SORT_MAX_MEMORY_ENV)) : Unit::fromMb(200)
         );
-        $this->errorHandler ??= new ThrowError();
         $this->filesystem ??= new FlysystemFS();
 
         return new Config(
@@ -62,8 +57,7 @@ final class ConfigBuilder
             $this->cache,
             $this->externalSort,
             $this->serializer,
-            $this->filesystem,
-            $this->errorHandler
+            $this->filesystem
         );
     }
 

--- a/src/core/etl/src/Flow/ETL/DataFrame.php
+++ b/src/core/etl/src/Flow/ETL/DataFrame.php
@@ -260,7 +260,7 @@ final class DataFrame
 
     public function onError(ErrorHandler $handler) : self
     {
-        $this->context->config->setErrorHandler($handler);
+        $this->context->setErrorHandler($handler);
 
         return $this;
     }

--- a/src/core/etl/src/Flow/ETL/FlowContext.php
+++ b/src/core/etl/src/Flow/ETL/FlowContext.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Flow\ETL;
 
+use Flow\ETL\ErrorHandler\ThrowError;
 use Flow\ETL\Filesystem\SaveMode;
 use Flow\ETL\Partition\NoopFilter;
 use Flow\ETL\Partition\PartitionFilter;
@@ -11,6 +12,8 @@ use Flow\Serializer\Serializer;
 
 final class FlowContext
 {
+    private ErrorHandler $errorHandler;
+
     private SaveMode $mode = SaveMode::ExceptionIfExists;
 
     private PartitionFilter $partitionFilter;
@@ -25,12 +28,18 @@ final class FlowContext
     public function __construct(public readonly Config $config)
     {
         $this->partitionFilter = new NoopFilter();
+        $this->errorHandler = new ThrowError();
         $this->partitions = [];
     }
 
     public function cache() : Cache
     {
         return $this->config->cache();
+    }
+
+    public function errorHandler() : ErrorHandler
+    {
+        return $this->errorHandler;
     }
 
     public function filterPartitions(PartitionFilter $filter) : self
@@ -73,6 +82,13 @@ final class FlowContext
     public function serializer() : Serializer
     {
         return $this->config->serializer();
+    }
+
+    public function setErrorHandler(ErrorHandler $handler) : self
+    {
+        $this->errorHandler = $handler;
+
+        return $this;
     }
 
     public function setMode(SaveMode $mode) : self

--- a/src/core/etl/src/Flow/ETL/Pipeline/SynchronousPipeline.php
+++ b/src/core/etl/src/Flow/ETL/Pipeline/SynchronousPipeline.php
@@ -74,11 +74,11 @@ final class SynchronousPipeline implements Pipeline
                         }
                     }
                 } catch (\Throwable $exception) {
-                    if ($context->config->errorHandler()->throw($exception, $rows)) {
+                    if ($context->errorHandler()->throw($exception, $rows)) {
                         throw $exception;
                     }
 
-                    if ($context->config->errorHandler()->skipRows($exception, $rows)) {
+                    if ($context->errorHandler()->skipRows($exception, $rows)) {
                         break;
                     }
                 }


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Moved ErrorHandler to FlowContext</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

FlowContext is supposed to live with a single DataFrame when Config is something a bit more global (multiple DataFrames can share the same config). Because of that ErrorHandler which depends purely on specific DataFrame fits better into FlowContext than Config. 