### PR TITLE
CSV - Double the number of possible characters in one line

### DIFF
--- a/src/adapter/etl-adapter-csv/src/Flow/ETL/Adapter/CSV/CSVExtractor.php
+++ b/src/adapter/etl-adapter-csv/src/Flow/ETL/Adapter/CSV/CSVExtractor.php
@@ -43,11 +43,11 @@ final class CSVExtractor implements Extractor
 
             if ($this->withHeader && \count($headers) === 0) {
                 /** @var array<string> $headers */
-                $headers = \fgetcsv($stream->resource(), 1000, $this->separator, $this->enclosure, $this->escape);
+                $headers = \fgetcsv($stream->resource(), 2000, $this->separator, $this->enclosure, $this->escape);
             }
 
             /** @var array<mixed> $rowData */
-            $rowData = \fgetcsv($stream->resource(), 1000, $this->separator, $this->enclosure, $this->escape);
+            $rowData = \fgetcsv($stream->resource(), 2000, $this->separator, $this->enclosure, $this->escape);
 
             if (!\count($headers)) {
                 $headers = \array_map(fn (int $e) : string => 'e' . \str_pad((string) $e, 2, '0', STR_PAD_LEFT), \range(0, \count($rowData) - 1));
@@ -88,7 +88,7 @@ final class CSVExtractor implements Extractor
                     $rows = [];
                 }
 
-                $rowData = \fgetcsv($stream->resource(), 1000, $this->separator, $this->enclosure, $this->escape);
+                $rowData = \fgetcsv($stream->resource(), 2000, $this->separator, $this->enclosure, $this->escape);
             }
 
             if (\count($rows)) {


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Double the number of possible characters in one line</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

Big CSV export files can have way more than 1000 characters, especially since we need to count also all separators and escaping characters.