### PR TITLE
Removed psalm-immutable annotation from transformers and extractors

### DIFF
--- a/src/adapter/etl-adapter-avro/src/Flow/ETL/Adapter/Avro/FlixTech/AvroExtractor.php
+++ b/src/adapter/etl-adapter-avro/src/Flow/ETL/Adapter/Avro/FlixTech/AvroExtractor.php
@@ -11,9 +11,6 @@ use Flow\ETL\FlowContext;
 use Flow\ETL\Row;
 use Flow\ETL\Rows;
 
-/**
- * @psalm-immutable
- */
 final class AvroExtractor implements Extractor
 {
     /**

--- a/src/adapter/etl-adapter-csv/src/Flow/ETL/Adapter/CSV/CSVExtractor.php
+++ b/src/adapter/etl-adapter-csv/src/Flow/ETL/Adapter/CSV/CSVExtractor.php
@@ -11,9 +11,6 @@ use Flow\ETL\FlowContext;
 use Flow\ETL\Row;
 use Flow\ETL\Rows;
 
-/**
- * @psalm-immutable
- */
 final class CSVExtractor implements Extractor
 {
     /**

--- a/src/adapter/etl-adapter-doctrine/src/Flow/ETL/Adapter/Doctrine/DbalLimitOffsetExtractor.php
+++ b/src/adapter/etl-adapter-doctrine/src/Flow/ETL/Adapter/Doctrine/DbalLimitOffsetExtractor.php
@@ -11,9 +11,6 @@ use Flow\ETL\FlowContext;
 use Flow\ETL\Row;
 use Flow\ETL\Rows;
 
-/**
- * @psalm-immutable
- */
 final class DbalLimitOffsetExtractor implements Extractor
 {
     /**
@@ -32,9 +29,6 @@ final class DbalLimitOffsetExtractor implements Extractor
         }
     }
 
-    /**
-     * @psalm-suppress ImpureMethodCall
-     */
     public function extract(FlowContext $context) : \Generator
     {
         if (isset($this->maximum)) {

--- a/src/adapter/etl-adapter-doctrine/src/Flow/ETL/Adapter/Doctrine/DbalQueryExtractor.php
+++ b/src/adapter/etl-adapter-doctrine/src/Flow/ETL/Adapter/Doctrine/DbalQueryExtractor.php
@@ -11,9 +11,6 @@ use Flow\ETL\FlowContext;
 use Flow\ETL\Row;
 use Flow\ETL\Rows;
 
-/**
- * @psalm-immutable
- */
 final class DbalQueryExtractor implements Extractor
 {
     /**

--- a/src/adapter/etl-adapter-http/src/Flow/ETL/Adapter/Http/PsrHttpClientDynamicExtractor.php
+++ b/src/adapter/etl-adapter-http/src/Flow/ETL/Adapter/Http/PsrHttpClientDynamicExtractor.php
@@ -13,9 +13,6 @@ use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
-/**
- * @psalm-immutable
- */
 final class PsrHttpClientDynamicExtractor implements Extractor
 {
     /**

--- a/src/adapter/etl-adapter-http/src/Flow/ETL/Adapter/Http/PsrHttpClientStaticExtractor.php
+++ b/src/adapter/etl-adapter-http/src/Flow/ETL/Adapter/Http/PsrHttpClientStaticExtractor.php
@@ -12,30 +12,22 @@ use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
-/**
- * @psalm-immutable
- */
 final class PsrHttpClientStaticExtractor implements Extractor
 {
     /**
-     * @psalm-var pure-callable(RequestInterface, ResponseInterface) : void|null
-     *
      * @var null|callable(RequestInterface, ResponseInterface) : void
      */
     private $postRequest;
 
     /**
-     * @psalm-var pure-callable(RequestInterface) : void|null
-     *
      * @var null|callable(RequestInterface) : void
      */
     private $preRequest;
 
     /**
      * @param iterable<RequestInterface> $requests
-     *
-     * @psalm-param pure-callable(RequestInterface) : void|null $preRequest
-     * @psalm-param pure-callable(RequestInterface, ResponseInterface) : void|null $postRequest
+     * @param null|callable(RequestInterface) : void $preRequest
+     * @param null|callable(RequestInterface, ResponseInterface) : void $postRequest
      */
     public function __construct(private readonly ClientInterface $client, private readonly iterable $requests, ?callable $preRequest = null, ?callable $postRequest = null)
     {
@@ -53,7 +45,6 @@ final class PsrHttpClientStaticExtractor implements Extractor
                 ($this->preRequest)($request);
             }
 
-            /** @psalm-suppress ImpureMethodCall */
             $response = $this->client->sendRequest($request);
 
             if ($this->postRequest) {

--- a/src/adapter/etl-adapter-json/src/Flow/ETL/Adapter/JSON/JSONMachine/JsonExtractor.php
+++ b/src/adapter/etl-adapter-json/src/Flow/ETL/Adapter/JSON/JSONMachine/JsonExtractor.php
@@ -12,9 +12,6 @@ use Flow\ETL\Row;
 use Flow\ETL\Rows;
 use JsonMachine\Items;
 
-/**
- * @psalm-immutable
- */
 final class JsonExtractor implements Extractor
 {
     public function __construct(
@@ -24,17 +21,12 @@ final class JsonExtractor implements Extractor
     ) {
     }
 
-    /**
-     * @psalm-suppress ImpureMethodCall
-     */
     public function extract(FlowContext $context) : \Generator
     {
         $rows = new Rows();
 
         foreach ($context->streams()->fs()->scan($this->path, $context->partitionFilter()) as $filePath) {
             /**
-             * @psalm-suppress ImpureMethodCall
-             *
              * @var array|object $row
              */
             foreach (Items::fromStream($context->streams()->fs()->open($filePath, Mode::READ)->resource())->getIterator() as $row) {

--- a/src/adapter/etl-adapter-parquet/src/Flow/ETL/Adapter/Parquet/Codename/ParquetExtractor.php
+++ b/src/adapter/etl-adapter-parquet/src/Flow/ETL/Adapter/Parquet/Codename/ParquetExtractor.php
@@ -12,9 +12,6 @@ use Flow\ETL\FlowContext;
 use Flow\ETL\Row;
 use Flow\ETL\Rows;
 
-/**
- * @psalm-suppress MissingImmutableAnnotation
- */
 final class ParquetExtractor implements Extractor
 {
     /**

--- a/src/adapter/etl-adapter-text/src/Flow/ETL/Adapter/Text/TextExtractor.php
+++ b/src/adapter/etl-adapter-text/src/Flow/ETL/Adapter/Text/TextExtractor.php
@@ -11,9 +11,6 @@ use Flow\ETL\FlowContext;
 use Flow\ETL\Row;
 use Flow\ETL\Rows;
 
-/**
- * @psalm-immutable
- */
 final class TextExtractor implements Extractor
 {
     public function __construct(

--- a/src/adapter/etl-adapter-xml/src/Flow/ETL/Adapter/XML/XMLReaderExtractor.php
+++ b/src/adapter/etl-adapter-xml/src/Flow/ETL/Adapter/XML/XMLReaderExtractor.php
@@ -11,9 +11,6 @@ use Flow\ETL\FlowContext;
 use Flow\ETL\Row;
 use Flow\ETL\Rows;
 
-/**
- * @psalm-immutable
- */
 final class XMLReaderExtractor implements Extractor
 {
     /**
@@ -39,9 +36,6 @@ final class XMLReaderExtractor implements Extractor
     ) {
     }
 
-    /**
-     * @psalm-suppress ImpureMethodCall
-     */
     public function extract(FlowContext $context) : \Generator
     {
         foreach ($context->streams()->fs()->scan($this->path, $context->partitionFilter()) as $filePath) {

--- a/src/core/etl/src/Flow/ETL/Extractor.php
+++ b/src/core/etl/src/Flow/ETL/Extractor.php
@@ -4,9 +4,6 @@ declare(strict_types=1);
 
 namespace Flow\ETL;
 
-/**
- * @psalm-immutable
- */
 interface Extractor
 {
     /**

--- a/src/core/etl/src/Flow/ETL/Extractor/BufferExtractor.php
+++ b/src/core/etl/src/Flow/ETL/Extractor/BufferExtractor.php
@@ -8,9 +8,6 @@ use Flow\ETL\Extractor;
 use Flow\ETL\FlowContext;
 use Flow\ETL\Rows;
 
-/**
- * @psalm-immutable
- */
 final class BufferExtractor implements Extractor, OverridingExtractor
 {
     public function __construct(

--- a/src/core/etl/src/Flow/ETL/Extractor/CacheExtractor.php
+++ b/src/core/etl/src/Flow/ETL/Extractor/CacheExtractor.php
@@ -9,9 +9,6 @@ use Flow\ETL\Extractor;
 use Flow\ETL\FlowContext;
 use Flow\ETL\Rows;
 
-/**
- * @psalm-immutable
- */
 final class CacheExtractor implements Extractor
 {
     public function __construct(

--- a/src/core/etl/src/Flow/ETL/Extractor/ChainExtractor.php
+++ b/src/core/etl/src/Flow/ETL/Extractor/ChainExtractor.php
@@ -7,9 +7,6 @@ namespace Flow\ETL\Extractor;
 use Flow\ETL\Extractor;
 use Flow\ETL\FlowContext;
 
-/**
- * @psalm-immutable
- */
 final class ChainExtractor implements Extractor, OverridingExtractor
 {
     /**

--- a/src/core/etl/src/Flow/ETL/Extractor/ChunkExtractor.php
+++ b/src/core/etl/src/Flow/ETL/Extractor/ChunkExtractor.php
@@ -7,9 +7,6 @@ namespace Flow\ETL\Extractor;
 use Flow\ETL\Extractor;
 use Flow\ETL\FlowContext;
 
-/**
- * @psalm-immutable
- */
 final class ChunkExtractor implements Extractor, OverridingExtractor
 {
     public function __construct(

--- a/src/core/etl/src/Flow/ETL/Extractor/MemoryExtractor.php
+++ b/src/core/etl/src/Flow/ETL/Extractor/MemoryExtractor.php
@@ -10,9 +10,6 @@ use Flow\ETL\Memory\Memory;
 use Flow\ETL\Row;
 use Flow\ETL\Rows;
 
-/**
- * @psalm-immutable
- */
 final class MemoryExtractor implements Extractor
 {
     private const CHUNK_SIZE = 100;

--- a/src/core/etl/src/Flow/ETL/Extractor/PipelineExtractor.php
+++ b/src/core/etl/src/Flow/ETL/Extractor/PipelineExtractor.php
@@ -9,9 +9,6 @@ use Flow\ETL\FlowContext;
 use Flow\ETL\Pipeline;
 use Flow\ETL\Rows;
 
-/**
- * @psalm-immutable
- */
 final class PipelineExtractor implements Extractor
 {
     public function __construct(

--- a/src/core/etl/src/Flow/ETL/Extractor/ProcessExtractor.php
+++ b/src/core/etl/src/Flow/ETL/Extractor/ProcessExtractor.php
@@ -10,8 +10,6 @@ use Flow\ETL\Rows;
 
 /**
  * @internal
- *
- * @psalm-immutable
  */
 final class ProcessExtractor implements Extractor
 {

--- a/src/core/etl/src/Flow/ETL/Transformer.php
+++ b/src/core/etl/src/Flow/ETL/Transformer.php
@@ -10,8 +10,6 @@ use Flow\Serializer\Serializable;
  * @template T
  *
  * @extends Serializable<T>
- *
- * @psalm-immutable
  */
 interface Transformer extends Serializable
 {

--- a/src/core/etl/src/Flow/ETL/Transformer/ArrayCollectionGetTransformer.php
+++ b/src/core/etl/src/Flow/ETL/Transformer/ArrayCollectionGetTransformer.php
@@ -14,8 +14,6 @@ use Flow\ETL\Transformer;
 
 /**
  * @implements Transformer<array{keys: array<string>, array_entry_name: string, new_entry_name: string, index: string}>
- *
- * @psalm-immutable
  */
 final class ArrayCollectionGetTransformer implements Transformer
 {

--- a/src/core/etl/src/Flow/ETL/Transformer/ArrayCollectionMergeTransformer.php
+++ b/src/core/etl/src/Flow/ETL/Transformer/ArrayCollectionMergeTransformer.php
@@ -12,8 +12,6 @@ use Flow\ETL\Transformer;
 
 /**
  * @implements Transformer<array{array_entry_name: string, new_entry_name: string}>
- *
- * @psalm-immutable
  */
 final class ArrayCollectionMergeTransformer implements Transformer
 {

--- a/src/core/etl/src/Flow/ETL/Transformer/ArrayDotGetTransformer.php
+++ b/src/core/etl/src/Flow/ETL/Transformer/ArrayDotGetTransformer.php
@@ -15,8 +15,6 @@ use Flow\ETL\Transformer;
 
 /**
  * @implements Transformer<array{array_entry_name: string, path: string, new_entry_name: string, entry_factory: EntryFactory}>
- *
- * @psalm-immutable
  */
 final class ArrayDotGetTransformer implements Transformer
 {

--- a/src/core/etl/src/Flow/ETL/Transformer/ArrayDotRenameTransformer.php
+++ b/src/core/etl/src/Flow/ETL/Transformer/ArrayDotRenameTransformer.php
@@ -14,8 +14,6 @@ use Flow\ETL\Transformer\Rename\ArrayKeyRename;
 
 /**
  * @implements Transformer<array{array_key_renames: array<ArrayKeyRename>}>
- *
- * @psalm-immutable
  */
 final class ArrayDotRenameTransformer implements Transformer
 {

--- a/src/core/etl/src/Flow/ETL/Transformer/ArrayExpandTransformer.php
+++ b/src/core/etl/src/Flow/ETL/Transformer/ArrayExpandTransformer.php
@@ -15,8 +15,6 @@ use Flow\ETL\Transformer;
 
 /**
  * @implements Transformer<array{array_entry_name: string, expand_entry_name: string, entry_factory: EntryFactory}>
- *
- * @psalm-immutable
  */
 final class ArrayExpandTransformer implements Transformer
 {

--- a/src/core/etl/src/Flow/ETL/Transformer/ArrayKeysStyleConverterTransformer.php
+++ b/src/core/etl/src/Flow/ETL/Transformer/ArrayKeysStyleConverterTransformer.php
@@ -18,8 +18,6 @@ use Jawira\CaseConverter\Convert;
 
 /**
  * @implements Transformer<array{array_entry_name: string, style: string, entry_factory: EntryFactory}>
- *
- * @psalm-immutable
  */
 final class ArrayKeysStyleConverterTransformer implements Transformer
 {

--- a/src/core/etl/src/Flow/ETL/Transformer/ArrayMergeTransformer.php
+++ b/src/core/etl/src/Flow/ETL/Transformer/ArrayMergeTransformer.php
@@ -12,8 +12,6 @@ use Flow\ETL\Transformer;
 
 /**
  * @implements Transformer<array{array_entries: array<string>, new_entry_name: string}>
- *
- * @psalm-immutable
  */
 final class ArrayMergeTransformer implements Transformer
 {

--- a/src/core/etl/src/Flow/ETL/Transformer/ArrayReverseTransformer.php
+++ b/src/core/etl/src/Flow/ETL/Transformer/ArrayReverseTransformer.php
@@ -13,8 +13,6 @@ use Flow\ETL\Transformer;
 
 /**
  * @implements Transformer<array{array_entry_name: string}>
- *
- * @psalm-immutable
  */
 final class ArrayReverseTransformer implements Transformer
 {

--- a/src/core/etl/src/Flow/ETL/Transformer/ArraySortTransformer.php
+++ b/src/core/etl/src/Flow/ETL/Transformer/ArraySortTransformer.php
@@ -12,8 +12,6 @@ use Flow\ETL\Transformer;
 
 /**
  * @implements Transformer<array{array_entry_name: string, sorting_flag: int}>
- *
- * @psalm-immutable
  */
 final class ArraySortTransformer implements Transformer
 {

--- a/src/core/etl/src/Flow/ETL/Transformer/ArrayUnpackTransformer.php
+++ b/src/core/etl/src/Flow/ETL/Transformer/ArrayUnpackTransformer.php
@@ -14,8 +14,6 @@ use Flow\ETL\Transformer;
 
 /**
  * @implements Transformer<array{array_entry_name: string, skip_entry_names: array<string>, entry_factory: EntryFactory, entry_prefix: null|string}>
- *
- * @psalm-immutable
  */
 final class ArrayUnpackTransformer implements Transformer
 {

--- a/src/core/etl/src/Flow/ETL/Transformer/CallUserFunctionTransformer.php
+++ b/src/core/etl/src/Flow/ETL/Transformer/CallUserFunctionTransformer.php
@@ -22,8 +22,6 @@ use Laravel\SerializableClosure\SerializableClosure;
  *     value_argument_name: ?string,
  *     entry_factory: EntryFactory
  *  }>
- *
- * @psalm-immutable
  */
 final class CallUserFunctionTransformer implements Transformer
 {

--- a/src/core/etl/src/Flow/ETL/Transformer/CallbackEntryTransformer.php
+++ b/src/core/etl/src/Flow/ETL/Transformer/CallbackEntryTransformer.php
@@ -15,8 +15,6 @@ use Laravel\SerializableClosure\SerializableClosure;
 
 /**
  * @implements Transformer<array{callables: array<SerializableClosure>}>
- *
- * @psalm-immutable
  */
 final class CallbackEntryTransformer implements Transformer
 {

--- a/src/core/etl/src/Flow/ETL/Transformer/CallbackRowTransformer.php
+++ b/src/core/etl/src/Flow/ETL/Transformer/CallbackRowTransformer.php
@@ -14,8 +14,6 @@ use Laravel\SerializableClosure\SerializableClosure;
 
 /**
  * @implements Transformer<array{callable: SerializableClosure}>
- *
- * @psalm-immutable
  */
 final class CallbackRowTransformer implements Transformer
 {

--- a/src/core/etl/src/Flow/ETL/Transformer/CastTransformer.php
+++ b/src/core/etl/src/Flow/ETL/Transformer/CastTransformer.php
@@ -12,8 +12,6 @@ use Flow\ETL\Transformer;
 
 /**
  * @implements Transformer<array{row_casts: array<RowConverter>}>
- *
- * @psalm-immutable
  */
 final class CastTransformer implements Transformer
 {

--- a/src/core/etl/src/Flow/ETL/Transformer/ChainTransformer.php
+++ b/src/core/etl/src/Flow/ETL/Transformer/ChainTransformer.php
@@ -10,8 +10,6 @@ use Flow\ETL\Transformer;
 
 /**
  * @implements Transformer<array{transformers: array<Transformer>}>
- *
- * @psalm-immutable
  */
 final class ChainTransformer implements Transformer
 {

--- a/src/core/etl/src/Flow/ETL/Transformer/CloneEntryTransformer.php
+++ b/src/core/etl/src/Flow/ETL/Transformer/CloneEntryTransformer.php
@@ -11,8 +11,6 @@ use Flow\ETL\Transformer;
 
 /**
  * @implements Transformer<array{from: string, to: string}>
- *
- * @psalm-immutable
  */
 final class CloneEntryTransformer implements Transformer
 {

--- a/src/core/etl/src/Flow/ETL/Transformer/ConditionalTransformer.php
+++ b/src/core/etl/src/Flow/ETL/Transformer/ConditionalTransformer.php
@@ -11,8 +11,6 @@ use Flow\ETL\Transformer;
 
 /**
  * @implements Transformer<array{condition: Condition\RowCondition, transformer: Transformer}>
- *
- * @psalm-immutable
  */
 final class ConditionalTransformer implements Transformer
 {

--- a/src/core/etl/src/Flow/ETL/Transformer/DynamicEntryTransformer.php
+++ b/src/core/etl/src/Flow/ETL/Transformer/DynamicEntryTransformer.php
@@ -14,8 +14,6 @@ use Laravel\SerializableClosure\SerializableClosure;
 
 /**
  * @implements Transformer<array{generator: SerializableClosure}>
- *
- * @psalm-immutable
  */
 final class DynamicEntryTransformer implements Transformer
 {

--- a/src/core/etl/src/Flow/ETL/Transformer/EntryNameStyleConverterTransformer.php
+++ b/src/core/etl/src/Flow/ETL/Transformer/EntryNameStyleConverterTransformer.php
@@ -16,8 +16,6 @@ use Jawira\CaseConverter\Convert;
 
 /**
  * @implements Transformer<array{style: string}>
- *
- * @psalm-immutable
  */
 final class EntryNameStyleConverterTransformer implements Transformer
 {

--- a/src/core/etl/src/Flow/ETL/Transformer/FilterRowsTransformer.php
+++ b/src/core/etl/src/Flow/ETL/Transformer/FilterRowsTransformer.php
@@ -12,8 +12,6 @@ use Flow\ETL\Transformer\Filter\Filter;
 
 /**
  * @implements Transformer<array{filters: array<Filter>}>
- *
- * @psalm-immutable
  */
 final class FilterRowsTransformer implements Transformer
 {

--- a/src/core/etl/src/Flow/ETL/Transformer/GroupToArrayTransformer.php
+++ b/src/core/etl/src/Flow/ETL/Transformer/GroupToArrayTransformer.php
@@ -12,8 +12,6 @@ use Flow\ETL\Transformer;
 
 /**
  * @implements Transformer<array{group_by_entry: string, new_entry_name: string}>
- *
- * @psalm-immutable
  */
 final class GroupToArrayTransformer implements Transformer
 {

--- a/src/core/etl/src/Flow/ETL/Transformer/HashTransformer.php
+++ b/src/core/etl/src/Flow/ETL/Transformer/HashTransformer.php
@@ -13,8 +13,6 @@ use Flow\ETL\Transformer;
 
 /**
  * @implements Transformer<array{algorithm: string, entries: array<string>, new_entry_name: string}>
- *
- * @psalm-immutable
  */
 final class HashTransformer implements Transformer
 {

--- a/src/core/etl/src/Flow/ETL/Transformer/JoinEachRowsTransformer.php
+++ b/src/core/etl/src/Flow/ETL/Transformer/JoinEachRowsTransformer.php
@@ -13,8 +13,6 @@ use Flow\ETL\Transformer;
 
 /**
  * @implements Transformer<array{factory: DataFrameFactory, condition: Expression, type: Join}>
- *
- * @psalm-immutable
  */
 final class JoinEachRowsTransformer implements Transformer
 {
@@ -25,33 +23,21 @@ final class JoinEachRowsTransformer implements Transformer
     ) {
     }
 
-    /**
-     * @psalm-pure
-     */
     public static function inner(DataFrameFactory $right, Expression $condition) : self
     {
         return new self($right, $condition, Join::inner);
     }
 
-    /**
-     * @psalm-pure
-     */
     public static function left(DataFrameFactory $right, Expression $condition) : self
     {
         return new self($right, $condition, Join::left);
     }
 
-    /**
-     * @psalm-pure
-     */
     public static function leftAnti(DataFrameFactory $right, Expression $condition) : self
     {
         return new self($right, $condition, Join::left_anti);
     }
 
-    /**
-     * @psalm-pure
-     */
     public static function right(DataFrameFactory $right, Expression $condition) : self
     {
         return new self($right, $condition, Join::right);
@@ -75,8 +61,6 @@ final class JoinEachRowsTransformer implements Transformer
 
     /**
      * @param FlowContext $context
-     *
-     * @psalm-suppress ImpureMethodCall
      *
      * @throws \Flow\ETL\Exception\InvalidArgumentException
      */

--- a/src/core/etl/src/Flow/ETL/Transformer/JoinRowsTransformer.php
+++ b/src/core/etl/src/Flow/ETL/Transformer/JoinRowsTransformer.php
@@ -14,8 +14,6 @@ use Flow\ETL\Transformer;
 
 /**
  * @implements Transformer<array{data_frame: ?DataFrame, condition: Expression, type: Join, rows: ?Rows}>
- *
- * @psalm-immutable
  */
 final class JoinRowsTransformer implements Transformer
 {
@@ -28,33 +26,21 @@ final class JoinRowsTransformer implements Transformer
     ) {
     }
 
-    /**
-     * @psalm-pure
-     */
     public static function inner(DataFrame $right, Expression $condition) : self
     {
         return new self($right, $condition, Join::inner);
     }
 
-    /**
-     * @psalm-pure
-     */
     public static function left(DataFrame $right, Expression $condition) : self
     {
         return new self($right, $condition, Join::left);
     }
 
-    /**
-     * @psalm-pure
-     */
     public static function leftAnti(DataFrame $right, Expression $condition) : self
     {
         return new self($right, $condition, Join::left_anti);
     }
 
-    /**
-     * @psalm-pure
-     */
     public static function right(DataFrame $right, Expression $condition) : self
     {
         return new self($right, $condition, Join::right);
@@ -74,7 +60,6 @@ final class JoinRowsTransformer implements Transformer
     {
         /** @var Rows $rows */
         $rows = $data['rows'];
-        /** @psalm-suppress ImpureMethodCall */
         $this->dataFrame = (new Flow())->process($rows);
         $this->condition = $data['condition'];
         $this->type = $data['type'];
@@ -95,7 +80,6 @@ final class JoinRowsTransformer implements Transformer
      * @psalm-suppress InvalidNullableReturnType
      * @psalm-suppress NullableReturnStatement
      * @psalm-suppress InaccessibleProperty
-     * @psalm-suppress ImpureMethodCall
      */
     private function rows() : Rows
     {

--- a/src/core/etl/src/Flow/ETL/Transformer/KeepEntriesTransformer.php
+++ b/src/core/etl/src/Flow/ETL/Transformer/KeepEntriesTransformer.php
@@ -13,8 +13,6 @@ use Flow\ETL\Transformer;
 
 /**
  * @implements Transformer<array{names: array<string>}>
- *
- * @psalm-immutable
  */
 final class KeepEntriesTransformer implements Transformer
 {

--- a/src/core/etl/src/Flow/ETL/Transformer/MathOperationTransformer.php
+++ b/src/core/etl/src/Flow/ETL/Transformer/MathOperationTransformer.php
@@ -13,8 +13,6 @@ use Flow\ETL\Transformer\Math\Operation;
 
 /**
  * @implements Transformer<array{left_entry: string, right_entry: string, operation: Operation|string, new_entry_name: string}>
- *
- * @psalm-immutable
  */
 final class MathOperationTransformer implements Transformer
 {

--- a/src/core/etl/src/Flow/ETL/Transformer/MathValueOperationTransformer.php
+++ b/src/core/etl/src/Flow/ETL/Transformer/MathValueOperationTransformer.php
@@ -13,8 +13,6 @@ use Flow\ETL\Transformer\Math\Operation;
 
 /**
  * @implements Transformer<array{left_entry: string, right_value: int|float, operation: Operation|string, new_entry_name: string}>
- *
- * @psalm-immutable
  */
 final class MathValueOperationTransformer implements Transformer
 {

--- a/src/core/etl/src/Flow/ETL/Transformer/NullStringIntoNullEntryTransformer.php
+++ b/src/core/etl/src/Flow/ETL/Transformer/NullStringIntoNullEntryTransformer.php
@@ -11,8 +11,6 @@ use Flow\ETL\Transformer;
 
 /**
  * @implements Transformer<array{entry_names: array<string>}>
- *
- * @psalm-immutable
  */
 final class NullStringIntoNullEntryTransformer implements Transformer
 {

--- a/src/core/etl/src/Flow/ETL/Transformer/ObjectMethodTransformer.php
+++ b/src/core/etl/src/Flow/ETL/Transformer/ObjectMethodTransformer.php
@@ -14,8 +14,6 @@ use Flow\ETL\Transformer;
 
 /**
  * @implements Transformer<array{object_entry_name: string, method: string, new_entry_name: string, parameters: array<mixed>, entry_factory: EntryFactory}>
- *
- * @psalm-immutable
  */
 final class ObjectMethodTransformer implements Transformer
 {

--- a/src/core/etl/src/Flow/ETL/Transformer/ObjectToArrayTransformer.php
+++ b/src/core/etl/src/Flow/ETL/Transformer/ObjectToArrayTransformer.php
@@ -13,8 +13,6 @@ use Laminas\Hydrator\HydratorInterface;
 
 /**
  * @implements Transformer<array{object_entry_name: string, hydrator: HydratorInterface}>
- *
- * @psalm-immutable
  */
 final class ObjectToArrayTransformer implements Transformer
 {

--- a/src/core/etl/src/Flow/ETL/Transformer/RemoveEntriesTransformer.php
+++ b/src/core/etl/src/Flow/ETL/Transformer/RemoveEntriesTransformer.php
@@ -11,8 +11,6 @@ use Flow\ETL\Transformer;
 
 /**
  * @implements Transformer<array{names: array<string>}>
- *
- * @psalm-immutable
  */
 final class RemoveEntriesTransformer implements Transformer
 {

--- a/src/core/etl/src/Flow/ETL/Transformer/RenameEntriesTransformer.php
+++ b/src/core/etl/src/Flow/ETL/Transformer/RenameEntriesTransformer.php
@@ -11,8 +11,6 @@ use Flow\ETL\Transformer;
 
 /**
  * @implements Transformer<array{entry_renames: array<Transformer\Rename\EntryRename>}>
- *
- * @psalm-immutable
  */
 final class RenameEntriesTransformer implements Transformer
 {

--- a/src/core/etl/src/Flow/ETL/Transformer/StaticEntryTransformer.php
+++ b/src/core/etl/src/Flow/ETL/Transformer/StaticEntryTransformer.php
@@ -12,8 +12,6 @@ use Flow\ETL\Transformer;
 
 /**
  * @implements Transformer<array{entry: Entry}>
- *
- * @psalm-immutable
  */
 final class StaticEntryTransformer implements Transformer
 {

--- a/src/core/etl/src/Flow/ETL/Transformer/StringConcatTransformer.php
+++ b/src/core/etl/src/Flow/ETL/Transformer/StringConcatTransformer.php
@@ -11,8 +11,6 @@ use Flow\ETL\Transformer;
 
 /**
  * @implements Transformer<array{string_entry_names: array<string>, glue: string, new_entry_name: string}>
- *
- * @psalm-immutable
  */
 final class StringConcatTransformer implements Transformer
 {

--- a/src/core/etl/src/Flow/ETL/Transformer/StringEntryValueCaseConverterTransformer.php
+++ b/src/core/etl/src/Flow/ETL/Transformer/StringEntryValueCaseConverterTransformer.php
@@ -11,8 +11,6 @@ use Flow\ETL\Transformer;
 
 /**
  * @implements Transformer<array{case: string, entry_names: array<string>}>
- *
- * @psalm-immutable
  */
 final class StringEntryValueCaseConverterTransformer implements Transformer
 {

--- a/src/core/etl/src/Flow/ETL/Transformer/StringFormatTransformer.php
+++ b/src/core/etl/src/Flow/ETL/Transformer/StringFormatTransformer.php
@@ -11,8 +11,6 @@ use Flow\ETL\Transformer;
 
 /**
  * @implements Transformer<array{entry_name:string,format:string}>
- *
- * @psalm-immutable
  */
 final class StringFormatTransformer implements Transformer
 {

--- a/src/core/etl/tests/Flow/ETL/Tests/Double/AddStampToStringEntryTransformer.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Double/AddStampToStringEntryTransformer.php
@@ -10,9 +10,6 @@ use Flow\ETL\Row\Entry\StringEntry;
 use Flow\ETL\Rows;
 use Flow\ETL\Transformer;
 
-/**
- * @psalm-immutable
- */
 final class AddStampToStringEntryTransformer implements Transformer
 {
     public function __construct(private string $entryName, private string $stamp, private string $divider)


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <li>psalm-immutable annotation from transformers and extractors</li>
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

Transformers and Extractors are not truly immutable, at least not from psalm point of view