### PR TITLE
Add ability to use querybuilder inside DbalLimitOffsetExtractor

### DIFF
--- a/examples/topics/db/db_to_db_sync.php
+++ b/examples/topics/db/db_to_db_sync.php
@@ -26,7 +26,7 @@ print "Loading {$rows} rows into postgresql...\n";
         Dbal::from_limit_offset(
             $sourceDbConnection,
             'source_dataset_table',
-            new OrderBy('id', Order::DESC)
+           ['id' => Order::DESC]
         )
     )
     ->rows(Transform::array_unpack('row'))


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <li>Support for querying over joined tabled with limit/offset</li> 
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>LimitOffsetExtractor contract</li> 
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

I had to query with join and iterate over chunks - modyfying DbalLimitOffsetExtractor was easiest way, I think it could be useful for everyone, and current part of lib life still allows to change contracts.