### PR TITLE
Allow extractors to put input options into extracted results

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -24,6 +24,8 @@ adapter-doctrine:
   - any: ["src/adapter/etl-adapter-doctrine/**/*"]
 adapter-elasticsearch:
   - any: ["src/adapter/etl-adapter-elasticsearch/**/*"]
+adapter-google-sheet:
+  - any: ["src/adapter/etl-adapter-google-sheet/**/*"]
 adapter-http:
   - any: ["src/adapter/etl-adapter-http/**/*"]
 adapter-json:

--- a/composer.lock
+++ b/composer.lock
@@ -4237,16 +4237,16 @@
         },
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.257.6",
+            "version": "3.257.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "de8666f4dc87b6c4eeef1388c8aea09722549d92"
+                "reference": "97c41c42690e4fd7846915eae520e508d71c0baf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/de8666f4dc87b6c4eeef1388c8aea09722549d92",
-                "reference": "de8666f4dc87b6c4eeef1388c8aea09722549d92",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/97c41c42690e4fd7846915eae520e508d71c0baf",
+                "reference": "97c41c42690e4fd7846915eae520e508d71c0baf",
                 "shasum": ""
             },
             "require": {
@@ -4325,9 +4325,9 @@
             "support": {
                 "forum": "https://forums.aws.amazon.com/forum.jspa?forumID=80",
                 "issues": "https://github.com/aws/aws-sdk-php/issues",
-                "source": "https://github.com/aws/aws-sdk-php/tree/3.257.6"
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.257.9"
             },
-            "time": "2023-01-23T19:28:48+00:00"
+            "time": "2023-01-26T19:21:26+00:00"
         },
         {
             "name": "clue/stream-filter",
@@ -5633,16 +5633,16 @@
         },
         {
             "name": "symfony/options-resolver",
-            "version": "v6.2.0",
+            "version": "v6.2.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/options-resolver.git",
-                "reference": "d28f02acde71ff75e957082cd36e973df395f626"
+                "reference": "e8324d44f5af99ec2ccec849934a242f64458f86"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/d28f02acde71ff75e957082cd36e973df395f626",
-                "reference": "d28f02acde71ff75e957082cd36e973df395f626",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/e8324d44f5af99ec2ccec849934a242f64458f86",
+                "reference": "e8324d44f5af99ec2ccec849934a242f64458f86",
                 "shasum": ""
             },
             "require": {
@@ -5680,7 +5680,7 @@
                 "options"
             ],
             "support": {
-                "source": "https://github.com/symfony/options-resolver/tree/v6.2.0"
+                "source": "https://github.com/symfony/options-resolver/tree/v6.2.5"
             },
             "funding": [
                 {
@@ -5696,7 +5696,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-11-02T09:08:04+00:00"
+            "time": "2023-01-01T08:38:09+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",

--- a/src/adapter/etl-adapter-avro/src/Flow/ETL/Adapter/Avro/FlixTech/AvroExtractor.php
+++ b/src/adapter/etl-adapter-avro/src/Flow/ETL/Adapter/Avro/FlixTech/AvroExtractor.php
@@ -49,7 +49,14 @@ final class AvroExtractor implements Extractor
             $valueConverter = new ValueConverter(\json_decode($reader->metadata['avro.schema'], true));
 
             foreach ($reader->data() as $rowData) {
-                $rows[] = Row::create(new Row\Entry\ArrayEntry($this->rowEntryName, $valueConverter->convert($rowData)));
+                if ($context->config->shouldPutInputIntoRows()) {
+                    $rows[] = Row::create(
+                        new Row\Entry\ArrayEntry($this->rowEntryName, $valueConverter->convert($rowData)),
+                        new Row\Entry\StringEntry('input_file_uri', $filePath->uri())
+                    );
+                } else {
+                    $rows[] = Row::create(new Row\Entry\ArrayEntry($this->rowEntryName, $valueConverter->convert($rowData)));
+                }
 
                 if (\count($rows) >= $this->rowsInBach) {
                     yield new Rows(...$rows);

--- a/src/adapter/etl-adapter-avro/tests/Flow/ETL/Adapter/Avro/FlixTech/Tests/Integration/AvroTest.php
+++ b/src/adapter/etl-adapter-avro/tests/Flow/ETL/Adapter/Avro/FlixTech/Tests/Integration/AvroTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Adapter\Avro\FlixTech\Tests\Integration;
 
+use Flow\ETL\Config;
 use Flow\ETL\DSL\Avro;
 use Flow\ETL\DSL\Entry;
 use Flow\ETL\DSL\From;
@@ -128,10 +129,11 @@ final class AvroTest extends TestCase
 
         $this->assertEquals(
             $rows,
-            (new Flow())
+            Flow::setUp(Config::builder()->putInputIntoRows()->build())
                 ->read(Avro::from($path))
                 ->transform(Transform::array_unpack('row'))
                 ->drop('row')
+                ->drop('input_file_uri')
                 ->fetch()
         );
 

--- a/src/adapter/etl-adapter-csv/src/Flow/ETL/Adapter/CSV/CSVExtractor.php
+++ b/src/adapter/etl-adapter-csv/src/Flow/ETL/Adapter/CSV/CSVExtractor.php
@@ -86,7 +86,14 @@ final class CSVExtractor implements Extractor
                     continue;
                 }
 
-                $rows[] = Row::create(new Row\Entry\ArrayEntry($this->rowEntryName, \array_combine($headers, $rowData)));
+                if ($context->config->shouldPutInputIntoRows()) {
+                    $rows[] = Row::create(
+                        new Row\Entry\ArrayEntry($this->rowEntryName, \array_combine($headers, $rowData)),
+                        new Row\Entry\StringEntry('input_file_uri', $stream->path()->uri())
+                    );
+                } else {
+                    $rows[] = Row::create(new Row\Entry\ArrayEntry($this->rowEntryName, \array_combine($headers, $rowData)));
+                }
 
                 if (\count($rows) >= $this->rowsInBatch) {
                     yield new Rows(...$rows);

--- a/src/adapter/etl-adapter-csv/src/Flow/ETL/DSL/CSV.php
+++ b/src/adapter/etl-adapter-csv/src/Flow/ETL/DSL/CSV.php
@@ -21,9 +21,9 @@ class CSV
      * @param string $delimiter
      * @param string $enclosure
      * @param string $escape
-     * @param int<0, max> $charactersReadInLine
+     * @param int<0, max> $characters_read_in_line
      *
-     * @throws \Flow\ETL\Exception\InvalidArgumentException
+     *@throws \Flow\ETL\Exception\InvalidArgumentException
      *
      * @return Extractor
      */
@@ -36,7 +36,7 @@ class CSV
         string $delimiter = ',',
         string $enclosure = '"',
         string $escape = '\\',
-        int $charactersReadInLine = 1000
+        int $characters_read_in_line = 1000
     ) : Extractor {
         if (\is_array($uri)) {
             $extractors = [];
@@ -51,7 +51,7 @@ class CSV
                     $delimiter,
                     $enclosure,
                     $escape,
-                    $charactersReadInLine
+                    $characters_read_in_line
                 );
             }
 
@@ -67,7 +67,7 @@ class CSV
             $delimiter,
             $enclosure,
             $escape,
-            $charactersReadInLine
+            $characters_read_in_line
         );
     }
 

--- a/src/adapter/etl-adapter-csv/tests/Flow/ETL/Adapter/CSV/Tests/Integration/CSVExtractorTest.php
+++ b/src/adapter/etl-adapter-csv/tests/Flow/ETL/Adapter/CSV/Tests/Integration/CSVExtractorTest.php
@@ -19,8 +19,8 @@ final class CSVExtractorTest extends TestCase
     public function test_extracting_csv_empty_columns_as_empty_strings() : void
     {
         $extractor = CSV::from(
-            __DIR__ . '/../Fixtures/file_with_empty_columns.csv',
-            empty_to_null: false
+            $path = Path::realpath(__DIR__ . '/../Fixtures/file_with_empty_columns.csv'),
+            empty_to_null: false,
         );
 
         $this->assertSame(
@@ -31,6 +31,7 @@ final class CSVExtractorTest extends TestCase
                         'name' => '',
                         'active' => 'false',
                     ],
+                    'input_file_uri' => $path->uri(),
                 ],
                 [
                     'row' => [
@@ -38,9 +39,10 @@ final class CSVExtractorTest extends TestCase
                         'name' => 'Norbert',
                         'active' => '',
                     ],
+                    'input_file_uri' => $path->uri(),
                 ],
             ],
-            \iterator_to_array($extractor->extract(new FlowContext(Config::default())))[0]->toArray()
+            \iterator_to_array($extractor->extract(new FlowContext(Config::builder()->putInputIntoRows()->build())))[0]->toArray()
         );
     }
 
@@ -227,7 +229,7 @@ final class CSVExtractorTest extends TestCase
         $this->assertCount(
             1,
             (new Flow())
-                ->read(CSV::from(__DIR__ . '/../Fixtures/more_than_1000_characters_per_line.csv', charactersReadInLine: 2000))
+                ->read(CSV::from(__DIR__ . '/../Fixtures/more_than_1000_characters_per_line.csv', characters_read_in_line: 2000))
                 ->rows(Transform::array_unpack('row'))
                 ->drop('row')
                 ->fetch()

--- a/src/adapter/etl-adapter-doctrine/src/Flow/ETL/Adapter/Doctrine/DbalQueryExtractor.php
+++ b/src/adapter/etl-adapter-doctrine/src/Flow/ETL/Adapter/Doctrine/DbalQueryExtractor.php
@@ -6,6 +6,7 @@ namespace Flow\ETL\Adapter\Doctrine;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Types\Type;
+use Flow\ETL\DSL\Entry;
 use Flow\ETL\Extractor;
 use Flow\ETL\FlowContext;
 use Flow\ETL\Row;
@@ -48,7 +49,7 @@ final class DbalQueryExtractor implements Extractor
 
             /** @psalm-suppress ImpureMethodCall */
             foreach ($this->connection->fetchAllAssociative($this->query, $parameters, $this->types) as $row) {
-                $rows[] = Row::create(new Row\Entry\ArrayEntry($this->rowEntryName, $row));
+                $rows[] = Row::create(Entry::array($this->rowEntryName, $row));
             }
 
             yield new Rows(...$rows);

--- a/src/adapter/etl-adapter-google-sheet/tests/Flow/ETL/Adapter/GoogleSheet/Tests/Unit/GoogleSheetExtractorTest.php
+++ b/src/adapter/etl-adapter-google-sheet/tests/Flow/ETL/Adapter/GoogleSheet/Tests/Unit/GoogleSheetExtractorTest.php
@@ -46,7 +46,7 @@ final class GoogleSheetExtractorTest extends TestCase
             ->willReturnOnConsecutiveCalls($firstValueRangeMock, $secondValueRangeMock);
 
         /** @var array<Rows> $rowsArray */
-        $rowsArray = \iterator_to_array($extractor->extract(new FlowContext((new ConfigBuilder())->build())));
+        $rowsArray = \iterator_to_array($extractor->extract(new FlowContext((new ConfigBuilder())->putInputIntoRows()->build())));
         $this->assertCount(2, $rowsArray);
         $this->assertSame(1, $rowsArray[0]->count());
         $this->assertEquals(Row::create($sheetNameEntry, $spreadSheetIdEntry, new ArrayEntry('row', ['header'=>'row1'])), $rowsArray[0]->first());

--- a/src/adapter/etl-adapter-json/src/Flow/ETL/Adapter/JSON/JSONMachine/JsonExtractor.php
+++ b/src/adapter/etl-adapter-json/src/Flow/ETL/Adapter/JSON/JSONMachine/JsonExtractor.php
@@ -31,7 +31,14 @@ final class JsonExtractor implements Extractor
              * @var array|object $row
              */
             foreach (Items::fromStream($context->streams()->fs()->open($filePath, Mode::READ)->resource(), $this->readerOptions())->getIterator() as $row) {
-                $rows = $rows->add(Row::create(new Row\Entry\ArrayEntry($this->rowEntryName, (array) $row)));
+                if ($context->config->shouldPutInputIntoRows()) {
+                    $rows = $rows->add(Row::create(
+                        new Row\Entry\ArrayEntry($this->rowEntryName, (array) $row),
+                        new Row\Entry\StringEntry('input_file_uri', $filePath->uri())
+                    ));
+                } else {
+                    $rows = $rows->add(Row::create(new Row\Entry\ArrayEntry($this->rowEntryName, (array) $row)));
+                }
 
                 if ($rows->count() >= $this->rowsInBatch) {
                     yield $rows;

--- a/src/adapter/etl-adapter-json/src/Flow/ETL/DSL/Json.php
+++ b/src/adapter/etl-adapter-json/src/Flow/ETL/DSL/Json.php
@@ -20,8 +20,12 @@ class Json
      *
      * @return Extractor
      */
-    public static function from(string|Path|array $path, int $rows_in_batch = 1000, string $row_entry_name = 'row', string $pointer = null) : Extractor
-    {
+    public static function from(
+        string|Path|array $path,
+        int $rows_in_batch = 1000,
+        string $row_entry_name = 'row',
+        string $pointer = null
+    ) : Extractor {
         if (\is_array($path)) {
             $extractors = [];
 

--- a/src/adapter/etl-adapter-text/src/Flow/ETL/Adapter/Text/TextExtractor.php
+++ b/src/adapter/etl-adapter-text/src/Flow/ETL/Adapter/Text/TextExtractor.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Adapter\Text;
 
+use Flow\ETL\DSL\Entry;
 use Flow\ETL\Extractor;
 use Flow\ETL\Filesystem\Path;
 use Flow\ETL\Filesystem\Stream\Mode;
@@ -39,7 +40,14 @@ final class TextExtractor implements Extractor
             }
 
             while ($rowData !== false) {
-                $rows[] = Row::create(new Row\Entry\StringEntry($this->rowEntryName, \rtrim($rowData)));
+                if ($context->config->shouldPutInputIntoRows()) {
+                    $rows[] = Row::create(
+                        Entry::string($this->rowEntryName, \rtrim($rowData)),
+                        Entry::string('input_file_uri', $filePath->uri())
+                    );
+                } else {
+                    $rows[] = Row::create(Entry::string($this->rowEntryName, \rtrim($rowData)));
+                }
 
                 if (\count($rows) >= $this->rowsInBatch) {
                     yield new Rows(...$rows);

--- a/src/adapter/etl-adapter-xml/src/Flow/ETL/Adapter/XML/XMLReaderExtractor.php
+++ b/src/adapter/etl-adapter-xml/src/Flow/ETL/Adapter/XML/XMLReaderExtractor.php
@@ -69,7 +69,14 @@ final class XMLReaderExtractor implements Extractor
                         /** @psalm-suppress ArgumentTypeCoercion */
                         $node->loadXML($xmlReader->readOuterXml());
 
-                        $rows[] = Row::create(Entry::array($this->rowEntryName, $this->convertDOMDocument($node)));
+                        if ($context->config->shouldPutInputIntoRows()) {
+                            $rows[] = Row::create(
+                                Entry::array($this->rowEntryName, $this->convertDOMDocument($node)),
+                                Entry::string('input_file_uri', $filePath->uri())
+                            );
+                        } else {
+                            $rows[] = Row::create(Entry::array($this->rowEntryName, $this->convertDOMDocument($node)));
+                        }
 
                         if (\count($rows) >= $this->rowsInBatch) {
                             yield new Rows(...$rows);

--- a/src/core/etl/src/Flow/ETL/Config.php
+++ b/src/core/etl/src/Flow/ETL/Config.php
@@ -27,7 +27,8 @@ final class Config
         private readonly ExternalSort $externalSort,
         private readonly Serializer $serializer,
         private readonly FilesystemStreams $filesystemStreams,
-        private readonly Processors $processors
+        private readonly Processors $processors,
+        private readonly bool $putInputIntoRows
     ) {
     }
 
@@ -97,5 +98,10 @@ final class Config
         $this->limit = $limit;
 
         return $this;
+    }
+
+    public function shouldPutInputIntoRows() : bool
+    {
+        return $this->putInputIntoRows;
     }
 }

--- a/src/core/etl/src/Flow/ETL/ConfigBuilder.php
+++ b/src/core/etl/src/Flow/ETL/ConfigBuilder.php
@@ -24,6 +24,8 @@ final class ConfigBuilder
 
     private ?string $id;
 
+    private bool $putInputIntoRows;
+
     private ?Serializer $serializer;
 
     public function __construct()
@@ -33,6 +35,7 @@ final class ConfigBuilder
         $this->externalSort = null;
         $this->serializer = null;
         $this->filesystem = null;
+        $this->putInputIntoRows = false;
     }
 
     /**
@@ -63,13 +66,21 @@ final class ConfigBuilder
             new FilesystemStreams($this->filesystem),
             new Processors(
                 new FilesystemProcessor()
-            )
+            ),
+            $this->putInputIntoRows
         );
     }
 
     public function cache(Cache $cache) : self
     {
         $this->cache = $cache;
+
+        return $this;
+    }
+
+    public function dontPutInputIntoRows() : self
+    {
+        $this->putInputIntoRows = false;
 
         return $this;
     }
@@ -91,6 +102,17 @@ final class ConfigBuilder
     public function id(string $id) : self
     {
         $this->id = $id;
+
+        return $this;
+    }
+
+    /**
+     * When set, each extractor will try to put additional rows with input parameters, like for example uri to the source file from which
+     * data is extracted.
+     */
+    public function putInputIntoRows() : self
+    {
+        $this->putInputIntoRows = true;
 
         return $this;
     }


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <li>config option that can be later used by extractor to decide if input options should be added to extracted rows</li>
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

This feature is really useful when reading files with `*` glob pattern, when file paths comes with some important data it can be later easily extracted from it using different transformations. 