### PR TITLE
Update PHPStan to `^1.10` & cleanup reported code issues

### DIFF
--- a/src/core/etl/src/Flow/ETL/Row/Factory/NativeEntryFactory.php
+++ b/src/core/etl/src/Flow/ETL/Row/Factory/NativeEntryFactory.php
@@ -226,7 +226,6 @@ final class NativeEntryFactory implements EntryFactory
                             return new Entry\ListEntry(
                                 $definition->entry(),
                                 $listType,
-                                /** @phpstan-ignore-next-line */
                                 \array_map(static fn (string $datetime) : \DateTimeImmutable => new \DateTimeImmutable($datetime), $value)
                             );
                         }

--- a/src/core/etl/src/Flow/ETL/Transformer/MathOperationTransformer.php
+++ b/src/core/etl/src/Flow/ETL/Transformer/MathOperationTransformer.php
@@ -108,7 +108,6 @@ final class MathOperationTransformer implements Transformer
                 Operation::divide => $left->value() / $right->value(),
                 Operation::modulo => $left->value() % $right->value(),
                 Operation::power => $left->value() ** $right->value(),
-                default => throw new RuntimeException('Unknown operation'),
             };
 
             if (\is_float($value)) {

--- a/src/core/etl/src/Flow/ETL/Transformer/MathValueOperationTransformer.php
+++ b/src/core/etl/src/Flow/ETL/Transformer/MathValueOperationTransformer.php
@@ -99,7 +99,6 @@ final class MathValueOperationTransformer implements Transformer
                 Operation::divide => $left->value() / $this->rightValue,
                 Operation::modulo => $left->value() % $this->rightValue,
                 Operation::power => $left->value() ** $this->rightValue,
-                default => throw new RuntimeException('Unknown operation'),
             };
 
             if (\is_float($value)) {

--- a/tools/phpstan/composer.json
+++ b/tools/phpstan/composer.json
@@ -2,7 +2,7 @@
   "name": "flow-php/etl-tools",
   "description": "Flow PHP ETL - Tools",
   "require-dev": {
-    "phpstan/phpstan": "^1.0.0"
+    "phpstan/phpstan": "^1.10"
   },
   "config": {
     "allow-plugins": false

--- a/tools/phpstan/composer.lock
+++ b/tools/phpstan/composer.lock
@@ -4,21 +4,21 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a73998da9af117d905d43c13690dd4c2",
+    "content-hash": "cbeaaf46627091a7967f5d54550c8a54",
     "packages": [],
     "packages-dev": [
         {
             "name": "phpstan/phpstan",
-            "version": "1.9.18",
+            "version": "1.10.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "f2d5cf71be91172a57c649770b73c20ebcffb0bf"
+                "reference": "a2ffec7db373d8da4973d1d62add872db5cd22dd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/f2d5cf71be91172a57c649770b73c20ebcffb0bf",
-                "reference": "f2d5cf71be91172a57c649770b73c20ebcffb0bf",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/a2ffec7db373d8da4973d1d62add872db5cd22dd",
+                "reference": "a2ffec7db373d8da4973d1d62add872db5cd22dd",
                 "shasum": ""
             },
             "require": {
@@ -48,7 +48,7 @@
             ],
             "support": {
                 "issues": "https://github.com/phpstan/phpstan/issues",
-                "source": "https://github.com/phpstan/phpstan/tree/1.9.18"
+                "source": "https://github.com/phpstan/phpstan/tree/1.10.2"
             },
             "funding": [
                 {
@@ -64,7 +64,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-02-17T15:01:27+00:00"
+            "time": "2023-02-23T14:36:46+00:00"
         }
     ],
     "aliases": [],


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Update PHPStan to `^1.10`</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <li>Removed not reachable throw in a `match()` in `MathOperationTransformer` & `MathValueOperationTransformer`
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

Throwing exception on `match()` in `MathOperationTransformer` & `MathValueOperationTransformer` is not needed as the value used in the comparison is always validated by the `Operation` enum which already handles invalid values.

This PR replaces: https://github.com/flow-php/flow/pull/330
