### PR TITLE
Remove support for not maintained Doctrine DBAL versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "amphp/process": "^2",
         "amphp/socket": "^2",
         "codename/parquet": "~0.6.2 || ~0.7.0",
-        "doctrine/dbal": "^2.12 || ^3.1.4",
+        "doctrine/dbal": "^3.6",
         "elasticsearch/elasticsearch": "^7.6|^8.0",
         "flix-tech/avro-php": "~4.2.0 || ~4.3.0",
         "google/apiclient": "^2.13",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0b2b694559c3c7346fc6082fc23c296d",
+    "content-hash": "b7cc6ce5c4d6834f3060ff17ae846ec2",
     "packages": [
         {
             "name": "amphp/amp",

--- a/src/lib/doctrine-dbal-bulk/composer.json
+++ b/src/lib/doctrine-dbal-bulk/composer.json
@@ -6,7 +6,7 @@
     "keywords": ["doctrine", "dbal", "bulk", "insert", "upsert"],
     "require": {
         "php": "~8.1 || ~8.2",
-        "doctrine/dbal": "^2.12 || ^3.1.4"
+        "doctrine/dbal": "^3.6"
     },
     "autoload": {
         "psr-4": {

--- a/src/lib/doctrine-dbal-bulk/src/Flow/Doctrine/Bulk/DbalPlatform.php
+++ b/src/lib/doctrine-dbal-bulk/src/Flow/Doctrine/Bulk/DbalPlatform.php
@@ -37,27 +37,11 @@ final class DbalPlatform
 
     private function isMysql() : bool
     {
-        // DBAL version >= 3.2
-        if (\class_exists(MySQLPlatform::class)) {
-            return $this->platform instanceof MySQLPlatform;
-        }
-
-        /**
-         * @psalm-suppress DeprecatedMethod
-         */
-        return $this->platform->getName() === 'mysql';
+        return $this->platform instanceof MySQLPlatform;
     }
 
     private function isPostgreSQL() : bool
     {
-        // DBAL version >= 3.2
-        if (\class_exists(PostgreSQLPlatform::class)) {
-            return $this->platform instanceof PostgreSQLPlatform;
-        }
-
-        /**
-         * @psalm-suppress DeprecatedMethod
-         */
-        return $this->platform->getName() === 'postgresql';
+        return $this->platform instanceof PostgreSQLPlatform;
     }
 }

--- a/src/lib/doctrine-dbal-bulk/tests/Flow/Doctrine/Bulk/Tests/Integration/MySqlBulkInsertTest.php
+++ b/src/lib/doctrine-dbal-bulk/tests/Flow/Doctrine/Bulk/Tests/Integration/MySqlBulkInsertTest.php
@@ -14,47 +14,6 @@ use Flow\Doctrine\Bulk\Tests\MysqlIntegrationTestCase;
 
 final class MySqlBulkInsertTest extends MysqlIntegrationTestCase
 {
-    public function test_inserts_deprecated_json_array_row() : void
-    {
-        if (!\defined('Doctrine\DBAL\Types\Types::JSON_ARRAY')) {
-            $this->markTestSkipped('DBAL version >= 3.0');
-        }
-
-        $this->mysqlDatabaseContext->createTable(
-            (new Table(
-                $table = 'flow_doctrine_bulk_test',
-                [
-                    new Column('id', Type::getType(Types::STRING), ['notnull' => true]),
-                    new Column('age', Type::getType(Types::INTEGER), ['notnull' => true]),
-                    new Column('tags', Type::getType(Types::JSON), ['notnull' => true, 'platformOptions' => ['jsonb' => true]]),
-                ],
-            ))
-                ->setPrimaryKey(['id'])
-        );
-
-        Bulk::create()->insert(
-            $this->mysqlDatabaseContext->connection(),
-            $table,
-            new BulkData([
-                ['id' => $id1 = \uniqid(), 'age' => 20, 'tags' => \json_encode(['a', 'b', 'c'])],
-                ['id' => $id2 = \uniqid(), 'age' => 30, 'tags' => \json_encode(['a', 'b', 'c'])],
-                ['id' => $id3 = \uniqid(), 'age' => 40, 'tags' => \json_encode(['a', 'b', 'c'])],
-            ])
-        );
-
-        $this->assertEquals(3, $this->mysqlDatabaseContext->tableCount($table));
-        $this->assertEquals(1, $this->mysqlDatabaseContext->numberOfExecutedInsertQueries());
-
-        $this->assertSame(
-            [
-                ['id' => $id1, 'age' => 20, 'tags' => '["a", "b", "c"]'],
-                ['id' => $id2, 'age' => 30, 'tags' => '["a", "b", "c"]'],
-                ['id' => $id3, 'age' => 40, 'tags' => '["a", "b", "c"]'],
-            ],
-            $this->mysqlDatabaseContext->connection()->executeQuery("SELECT * FROM {$table} ORDER BY age ASC")->fetchAllAssociative()
-        );
-    }
-
     public function test_inserts_multiple_rows_at_once() : void
     {
         $this->mysqlDatabaseContext->createTable(

--- a/src/lib/doctrine-dbal-bulk/tests/Flow/Doctrine/Bulk/Tests/Integration/PostgreSqlBulkInsertTest.php
+++ b/src/lib/doctrine-dbal-bulk/tests/Flow/Doctrine/Bulk/Tests/Integration/PostgreSqlBulkInsertTest.php
@@ -14,47 +14,6 @@ use Flow\Doctrine\Bulk\Tests\IntegrationTestCase;
 
 final class PostgreSqlBulkInsertTest extends IntegrationTestCase
 {
-    public function test_inserts_deprecated_json_array_row() : void
-    {
-        if (!\defined('Doctrine\DBAL\Types\Types::JSON_ARRAY')) {
-            $this->markTestSkipped('DBAL version >= 3.0');
-        }
-
-        $this->pgsqlDatabaseContext->createTable(
-            (new Table(
-                $table = 'flow_doctrine_bulk_test',
-                [
-                    new Column('id', Type::getType(Types::STRING), ['notnull' => true]),
-                    new Column('age', Type::getType(Types::INTEGER), ['notnull' => true]),
-                    new Column('tags', Type::getType(Types::JSON), ['notnull' => true, 'platformOptions' => ['jsonb' => true]]),
-                ],
-            ))
-                ->setPrimaryKey(['id'])
-        );
-
-        Bulk::create()->insert(
-            $this->pgsqlDatabaseContext->connection(),
-            $table,
-            new BulkData([
-                ['id' => $id1 = \uniqid(), 'age' => 20, 'tags' => \json_encode(['a', 'b', 'c'])],
-                ['id' => $id2 = \uniqid(), 'age' => 30, 'tags' => \json_encode(['a', 'b', 'c'])],
-                ['id' => $id3 = \uniqid(), 'age' => 40, 'tags' => \json_encode(['a', 'b', 'c'])],
-            ])
-        );
-
-        $this->assertEquals(3, $this->pgsqlDatabaseContext->tableCount($table));
-        $this->assertEquals(1, $this->pgsqlDatabaseContext->numberOfExecutedInsertQueries());
-
-        $this->assertSame(
-            [
-                ['id' => $id1, 'age' => 20, 'tags' => '["a", "b", "c"]'],
-                ['id' => $id2, 'age' => 30, 'tags' => '["a", "b", "c"]'],
-                ['id' => $id3, 'age' => 40, 'tags' => '["a", "b", "c"]'],
-            ],
-            $this->pgsqlDatabaseContext->connection()->executeQuery("SELECT * FROM {$table} ORDER BY age ASC")->fetchAllAssociative()
-        );
-    }
-
     public function test_inserts_multiple_rows_at_once() : void
     {
         $this->pgsqlDatabaseContext->createTable(

--- a/src/lib/doctrine-dbal-bulk/tests/Flow/Doctrine/Bulk/Tests/Unit/DbalPlatformTest.php
+++ b/src/lib/doctrine-dbal-bulk/tests/Flow/Doctrine/Bulk/Tests/Unit/DbalPlatformTest.php
@@ -3,7 +3,6 @@
 namespace Flow\Doctrine\Bulk\Tests\Unit;
 
 use Doctrine\DBAL\Platforms\MySQL80Platform;
-use Doctrine\DBAL\Platforms\PostgreSQL94Platform;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Flow\Doctrine\Bulk\DbalPlatform;
@@ -21,7 +20,7 @@ final class DbalPlatformTest extends TestCase
         $this->assertInstanceOf(MySQLDialect::class, $platform->dialect());
     }
 
-    public function test_is_no_postgres_sql() : void
+    public function test_is_no_sqlite_sql() : void
     {
         $platform = new DbalPlatform(new SqlitePlatform());
 
@@ -31,22 +30,9 @@ final class DbalPlatformTest extends TestCase
         $platform->dialect();
     }
 
-    public function test_is_postgres_sql_for_dbal_3_2() : void
+    public function test_is_postgres_sql() : void
     {
-        $this->markTestSkipped('For some reason this test is failing at Github Actions - composer u --prefer-lowest');
-
         $platform = new DbalPlatform(new PostgreSQLPlatform());
-
-        $this->assertInstanceOf(PostgreSQLDialect::class, $platform->dialect());
-    }
-
-    public function test_is_postgres_sql_for_dbal_less_than_3_2() : void
-    {
-        if (\class_exists(PostgreSQLPlatform::class)) {
-            $this->markTestSkipped('DBAL version >= 3.2');
-        }
-
-        $platform = new DbalPlatform(new PostgreSQL94Platform());
 
         $this->assertInstanceOf(PostgreSQLDialect::class, $platform->dialect());
     }


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <li>Remove support for not maintained Doctrine DBAL versions</li>
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

According to [official Doctrine documentation](https://www.doctrine-project.org/projects/dbal.html), the latest supported version of DBAL is `^3.6`.
