### PR TITLE
Fixed issue with accessing empty arrays using array_get with nullsafe operator

### DIFF
--- a/src/lib/array-dot/src/Flow/ArrayDot/array_dot.php
+++ b/src/lib/array-dot/src/Flow/ArrayDot/array_dot.php
@@ -120,6 +120,10 @@ function array_dot_set(array $array, string $path, $value) : array
 function array_dot_get(array $array, string $path) : mixed
 {
     if (\count($array) === 0) {
+        if (\str_starts_with($path, '?')) {
+            return null;
+        }
+
         throw new InvalidPathException(
             \sprintf(
                 'Path "%s" does not exists in array "%s".',

--- a/src/lib/array-dot/tests/Flow/ArrayDot/Tests/Unit/ArrayDotGetTest.php
+++ b/src/lib/array-dot/tests/Flow/ArrayDot/Tests/Unit/ArrayDotGetTest.php
@@ -397,6 +397,29 @@ final class ArrayDotGetTest extends TestCase
         );
     }
 
+    public function test_accessing_not_nested_nullsafe() : void
+    {
+        $this->assertNull(
+            array_dot_get(
+                [
+                    '@name' => 'Test',
+                ],
+                '?@id'
+            )
+        );
+    }
+
+    public function test_accessing_not_nested_nullsafe_on_empty_array() : void
+    {
+        $this->assertNull(
+            array_dot_get(
+                [
+                ],
+                '?@id'
+            )
+        );
+    }
+
     public function test_all_multi_key_get() : void
     {
         $this->assertSame(


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>accessing empty arrays using array_get with nullsafe operator</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

<!-- Please provide a short description of changes in this section, feel free to use markdown syntax -->
