### PR TITLE
Replace hashing algorithm with more efficient one

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
     "require": {
         "php": "~8.1 || ~8.2",
         "ext-dom": "*",
+        "ext-hash": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
         "ext-xmlreader": "*",

--- a/src/adapter/etl-adapter-elasticsearch/composer.json
+++ b/src/adapter/etl-adapter-elasticsearch/composer.json
@@ -12,6 +12,7 @@
     ],
     "require": {
         "php": "~8.1 || ~8.2",
+        "ext-hash": "*",
         "ext-json": "*",
         "elasticsearch/elasticsearch": "^7.6|^8.0",
         "flow-php/etl": "^0.2 || 1.x-dev"

--- a/src/adapter/etl-adapter-elasticsearch/src/Flow/ETL/Adapter/Elasticsearch/EntryIdFactory/HashIdFactory.php
+++ b/src/adapter/etl-adapter-elasticsearch/src/Flow/ETL/Adapter/Elasticsearch/EntryIdFactory/HashIdFactory.php
@@ -10,10 +10,8 @@ use Flow\ETL\Row\Entry;
 
 /**
  * @implements IdFactory<array{entry_names: array<string>}>
- *
- * @deprecated Use HashIdFactory instead {@see HashIdFactory}
  */
-final class Sha1IdFactory implements IdFactory
+final class HashIdFactory implements IdFactory
 {
     /**
      * @var string[]
@@ -41,7 +39,8 @@ final class Sha1IdFactory implements IdFactory
     {
         return new Row\Entry\StringEntry(
             'id',
-            \sha1(
+            \hash(
+                'xxh128',
                 /** @phpstan-ignore-next-line */
                 \implode(':', \array_map(fn (string $name) : string => (string) $row->valueOf($name), $this->entryNames))
             )

--- a/src/adapter/etl-adapter-elasticsearch/tests/Flow/ETL/Adapter/Elasticsearch/Tests/Integration/ElasticsearchPHP/ElasticsearchLoaderTest.php
+++ b/src/adapter/etl-adapter-elasticsearch/tests/Flow/ETL/Adapter/Elasticsearch/Tests/Integration/ElasticsearchPHP/ElasticsearchLoaderTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Flow\ETL\Adapter\Elasticsearch\Tests\Integration\ElasticsearchPHP;
 
 use Flow\ETL\Adapter\Elasticsearch\EntryIdFactory\EntryIdFactory;
-use Flow\ETL\Adapter\Elasticsearch\EntryIdFactory\Sha1IdFactory;
+use Flow\ETL\Adapter\Elasticsearch\EntryIdFactory\HashIdFactory;
 use Flow\ETL\Adapter\Elasticsearch\Tests\Integration\TestCase;
 use Flow\ETL\Config;
 use Flow\ETL\DSL\Elasticsearch;
@@ -13,7 +13,6 @@ use Flow\ETL\FlowContext;
 use Flow\ETL\Row;
 use Flow\ETL\Rows;
 use Flow\Serializer\CompressingSerializer;
-use Flow\Serializer\NativePHPSerializer;
 
 final class ElasticsearchLoaderTest extends TestCase
 {
@@ -97,7 +96,7 @@ final class ElasticsearchLoaderTest extends TestCase
 
     public function test_integration_with_json_entry() : void
     {
-        $loader = Elasticsearch::bulk_index($this->elasticsearchContext->clientConfig(), 2, self::INDEX_NAME, new Sha1IdFactory('id'), ['refresh' => true]);
+        $loader = Elasticsearch::bulk_index($this->elasticsearchContext->clientConfig(), 2, self::INDEX_NAME, new HashIdFactory('id'), ['refresh' => true]);
 
         $loader->load(new Rows(
             Row::create(
@@ -126,7 +125,7 @@ final class ElasticsearchLoaderTest extends TestCase
 
     public function test_integration_with_partial_update_id_factory() : void
     {
-        $insertLoader = Elasticsearch::bulk_index($this->elasticsearchContext->clientConfig(), 2, self::INDEX_NAME, new Sha1IdFactory('id'), ['refresh' => true]);
+        $insertLoader = Elasticsearch::bulk_index($this->elasticsearchContext->clientConfig(), 2, self::INDEX_NAME, new HashIdFactory('id'), ['refresh' => true]);
 
         $insertLoader->load(new Rows(
             Row::create(
@@ -137,7 +136,7 @@ final class ElasticsearchLoaderTest extends TestCase
             ),
         ), new FlowContext(Config::default()));
 
-        $updateLoader = Elasticsearch::bulk_update($this->elasticsearchContext->clientConfig(), 2, self::INDEX_NAME, new Sha1IdFactory('id'), ['refresh' => true]);
+        $updateLoader = Elasticsearch::bulk_update($this->elasticsearchContext->clientConfig(), 2, self::INDEX_NAME, new HashIdFactory('id'), ['refresh' => true]);
 
         $updateLoader->load(new Rows(
             Row::create(
@@ -180,10 +179,10 @@ final class ElasticsearchLoaderTest extends TestCase
 
     public function test_integration_with_serialization() : void
     {
-        $serializer = new CompressingSerializer(new NativePHPSerializer());
+        $serializer = new CompressingSerializer();
 
         $loaderSerialized = $serializer->serialize(
-            Elasticsearch::bulk_index($this->elasticsearchContext->clientConfig(), 2, self::INDEX_NAME, new Sha1IdFactory('id'), ['refresh' => true])
+            Elasticsearch::bulk_index($this->elasticsearchContext->clientConfig(), 2, self::INDEX_NAME, new HashIdFactory('id'), ['refresh' => true])
         );
 
         $serializer->unserialize($loaderSerialized)->load(new Rows(
@@ -213,7 +212,7 @@ final class ElasticsearchLoaderTest extends TestCase
 
     public function test_integration_with_sha1_id_factory() : void
     {
-        $loader = Elasticsearch::bulk_index($this->elasticsearchContext->clientConfig(), 2, self::INDEX_NAME, new Sha1IdFactory('id'), ['refresh' => true]);
+        $loader = Elasticsearch::bulk_index($this->elasticsearchContext->clientConfig(), 2, self::INDEX_NAME, new HashIdFactory('id'), ['refresh' => true]);
 
         $loader->load(new Rows(
             Row::create(

--- a/src/core/etl/src/Flow/ETL/Transformer/DropDuplicatesTransformer.php
+++ b/src/core/etl/src/Flow/ETL/Transformer/DropDuplicatesTransformer.php
@@ -43,8 +43,6 @@ final class DropDuplicatesTransformer implements Transformer
     }
 
     /**
-     * @param array $data
-     *
      * @throws RuntimeException
      */
     public function __unserialize(array $data) : void
@@ -69,7 +67,7 @@ final class DropDuplicatesTransformer implements Transformer
                 }
             }
 
-            $hash = \md5(\serialize($values));
+            $hash = \hash('xxh128', \serialize($values));
 
             if (!$this->deduplication->exists($hash)) {
                 $newRows[] = $row;


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <li>Added `HashIdFactory` into Elastic adapter</li>
    <li>Added `ext-hash` PHP extension as required for Flow</li>
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Replaced usage of `md5()` with `xxh128` hash algorithm</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <li>Deprecated `Sha1IdFactory` in favor of `HashIdFactory`</li>
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

According to: https://php.watch/articles/php-hash-benchmark, `xxh128` algorithm is way more efficient compared to `md5` or `sha1` ones.
