### PR TITLE
Added extra padding to ascii table headers/body

### DIFF
--- a/src/core/etl/src/Flow/ETL/Formatter/ASCII/ASCIIBody.php
+++ b/src/core/etl/src/Flow/ETL/Formatter/ASCII/ASCIIBody.php
@@ -30,7 +30,7 @@ final class ASCIIBody
 
                 $length = \max($header->length($truncate), $this->body->maximumLength($name, $truncate));
 
-                $buffer .= ASCIIValue::mb_str_pad($value->print($truncate), $length, ' ', STR_PAD_LEFT) . '|';
+                $buffer .= ' ' . ASCIIValue::mb_str_pad($value->print($truncate), $length, ' ', STR_PAD_LEFT) . ' |';
             }
 
             $buffer .= PHP_EOL;
@@ -43,7 +43,7 @@ final class ASCIIBody
 
             $length = \max($headerName->length($truncate), $this->body->maximumLength($name, $truncate));
 
-            $buffer .= \str_repeat('-', $length) . '+';
+            $buffer .= '-' . \str_repeat('-', $length) . '-+';
         }
 
         return $buffer;

--- a/src/core/etl/src/Flow/ETL/Formatter/ASCII/ASCIIHeaders.php
+++ b/src/core/etl/src/Flow/ETL/Formatter/ASCII/ASCIIHeaders.php
@@ -19,7 +19,7 @@ final class ASCIIHeaders
 
             $length = \max($headerName->length($truncate), $this->body->maximumLength($name, $truncate));
 
-            $buffer .= \str_repeat('-', $length) . '+';
+            $buffer .= '-' . \str_repeat('-', $length) . '-+';
         }
 
         $topLine = $buffer;
@@ -32,7 +32,7 @@ final class ASCIIHeaders
 
             $length = \max($headerName->length($truncate), $this->body->maximumLength($name, $truncate));
 
-            $buffer .= ASCIIValue::mb_str_pad($headerName->print($truncate), $length, ' ', STR_PAD_LEFT) . '|';
+            $buffer .= ' ' . ASCIIValue::mb_str_pad($headerName->print($truncate), $length, ' ', STR_PAD_LEFT) . ' |';
         }
 
         $buffer .= PHP_EOL;

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/DataFrameTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/DataFrameTest.php
@@ -333,15 +333,15 @@ final class DataFrameTest extends TestCase
 
         $this->assertSame(
             <<<'ASCIITABLE'
-+----+------+---+-------+--------------------+-----+--------------------+--------------------+--------------------+--------------------+-----+
-|  id| price|100|deleted|          created-at|phase|               array|               items|                tags|              object| enum|
-+----+------+---+-------+--------------------+-----+--------------------+--------------------+--------------------+--------------------+-----+
-|1234|123.45|100|  false|2020-07-13T15:00:00+| null|[{"id":1,"status":"N|{"item-id":"1","name|[{"item-id":"1","nam|ArrayIterator Object|three|
-|1234|123.45|100|  false|2020-07-13T15:00:00+| null|[{"id":1,"status":"N|{"item-id":"1","name|[{"item-id":"1","nam|ArrayIterator Object|three|
-|1234|123.45|100|  false|2020-07-13T15:00:00+| null|[{"id":1,"status":"N|{"item-id":"1","name|[{"item-id":"1","nam|ArrayIterator Object|three|
-|1234|123.45|100|  false|2020-07-13T15:00:00+| null|[{"id":1,"status":"N|{"item-id":"1","name|[{"item-id":"1","nam|ArrayIterator Object|three|
-|1234|123.45|100|  false|2020-07-13T15:00:00+| null|[{"id":1,"status":"N|{"item-id":"1","name|[{"item-id":"1","nam|ArrayIterator Object|three|
-+----+------+---+-------+--------------------+-----+--------------------+--------------------+--------------------+--------------------+-----+
++------+--------+-----+---------+----------------------+-------+----------------------+----------------------+----------------------+----------------------+-------+
+|   id |  price | 100 | deleted |           created-at | phase |                array |                items |                 tags |               object |  enum |
++------+--------+-----+---------+----------------------+-------+----------------------+----------------------+----------------------+----------------------+-------+
+| 1234 | 123.45 | 100 |   false | 2020-07-13T15:00:00+ |  null | [{"id":1,"status":"N | {"item-id":"1","name | [{"item-id":"1","nam | ArrayIterator Object | three |
+| 1234 | 123.45 | 100 |   false | 2020-07-13T15:00:00+ |  null | [{"id":1,"status":"N | {"item-id":"1","name | [{"item-id":"1","nam | ArrayIterator Object | three |
+| 1234 | 123.45 | 100 |   false | 2020-07-13T15:00:00+ |  null | [{"id":1,"status":"N | {"item-id":"1","name | [{"item-id":"1","nam | ArrayIterator Object | three |
+| 1234 | 123.45 | 100 |   false | 2020-07-13T15:00:00+ |  null | [{"id":1,"status":"N | {"item-id":"1","name | [{"item-id":"1","nam | ArrayIterator Object | three |
+| 1234 | 123.45 | 100 |   false | 2020-07-13T15:00:00+ |  null | [{"id":1,"status":"N | {"item-id":"1","name | [{"item-id":"1","nam | ArrayIterator Object | three |
++------+--------+-----+---------+----------------------+-------+----------------------+----------------------+----------------------+----------------------+-------+
 5 rows
 
 ASCIITABLE,
@@ -350,16 +350,16 @@ ASCIITABLE,
 
         $this->assertSame(
             <<<'ASCIITABLE'
-+----+------+---+-------+-------------------------+-----+-----------------------------------------------------+----------------------------+------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------+-----+
-|  id| price|100|deleted|               created-at|phase|                                                array|                       items|                                                                                      tags|                                                                                        object| enum|
-+----+------+---+-------+-------------------------+-----+-----------------------------------------------------+----------------------------+------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------+-----+
-|1234|123.45|100|  false|2020-07-13T15:00:00+00:00| null|[{"id":1,"status":"NEW"},{"id":2,"status":"PENDING"}]|{"item-id":"1","name":"one"}|[{"item-id":"1","name":"one"},{"item-id":"2","name":"two"},{"item-id":"3","name":"three"}]|ArrayIterator Object( [storage:ArrayIterator:private] => Array ( [0] => 1 [1] => 2 [2] => 3 ))|three|
-|1234|123.45|100|  false|2020-07-13T15:00:00+00:00| null|[{"id":1,"status":"NEW"},{"id":2,"status":"PENDING"}]|{"item-id":"1","name":"one"}|[{"item-id":"1","name":"one"},{"item-id":"2","name":"two"},{"item-id":"3","name":"three"}]|ArrayIterator Object( [storage:ArrayIterator:private] => Array ( [0] => 1 [1] => 2 [2] => 3 ))|three|
-|1234|123.45|100|  false|2020-07-13T15:00:00+00:00| null|[{"id":1,"status":"NEW"},{"id":2,"status":"PENDING"}]|{"item-id":"1","name":"one"}|[{"item-id":"1","name":"one"},{"item-id":"2","name":"two"},{"item-id":"3","name":"three"}]|ArrayIterator Object( [storage:ArrayIterator:private] => Array ( [0] => 1 [1] => 2 [2] => 3 ))|three|
-|1234|123.45|100|  false|2020-07-13T15:00:00+00:00| null|[{"id":1,"status":"NEW"},{"id":2,"status":"PENDING"}]|{"item-id":"1","name":"one"}|[{"item-id":"1","name":"one"},{"item-id":"2","name":"two"},{"item-id":"3","name":"three"}]|ArrayIterator Object( [storage:ArrayIterator:private] => Array ( [0] => 1 [1] => 2 [2] => 3 ))|three|
-|1234|123.45|100|  false|2020-07-13T15:00:00+00:00| null|[{"id":1,"status":"NEW"},{"id":2,"status":"PENDING"}]|{"item-id":"1","name":"one"}|[{"item-id":"1","name":"one"},{"item-id":"2","name":"two"},{"item-id":"3","name":"three"}]|ArrayIterator Object( [storage:ArrayIterator:private] => Array ( [0] => 1 [1] => 2 [2] => 3 ))|three|
-|1234|123.45|100|  false|2020-07-13T15:00:00+00:00| null|[{"id":1,"status":"NEW"},{"id":2,"status":"PENDING"}]|{"item-id":"1","name":"one"}|[{"item-id":"1","name":"one"},{"item-id":"2","name":"two"},{"item-id":"3","name":"three"}]|ArrayIterator Object( [storage:ArrayIterator:private] => Array ( [0] => 1 [1] => 2 [2] => 3 ))|three|
-+----+------+---+-------+-------------------------+-----+-----------------------------------------------------+----------------------------+------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------+-----+
++------+--------+-----+---------+---------------------------+-------+-------------------------------------------------------+------------------------------+--------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------+-------+
+|   id |  price | 100 | deleted |                created-at | phase |                                                 array |                        items |                                                                                       tags |                                                                                         object |  enum |
++------+--------+-----+---------+---------------------------+-------+-------------------------------------------------------+------------------------------+--------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------+-------+
+| 1234 | 123.45 | 100 |   false | 2020-07-13T15:00:00+00:00 |  null | [{"id":1,"status":"NEW"},{"id":2,"status":"PENDING"}] | {"item-id":"1","name":"one"} | [{"item-id":"1","name":"one"},{"item-id":"2","name":"two"},{"item-id":"3","name":"three"}] | ArrayIterator Object( [storage:ArrayIterator:private] => Array ( [0] => 1 [1] => 2 [2] => 3 )) | three |
+| 1234 | 123.45 | 100 |   false | 2020-07-13T15:00:00+00:00 |  null | [{"id":1,"status":"NEW"},{"id":2,"status":"PENDING"}] | {"item-id":"1","name":"one"} | [{"item-id":"1","name":"one"},{"item-id":"2","name":"two"},{"item-id":"3","name":"three"}] | ArrayIterator Object( [storage:ArrayIterator:private] => Array ( [0] => 1 [1] => 2 [2] => 3 )) | three |
+| 1234 | 123.45 | 100 |   false | 2020-07-13T15:00:00+00:00 |  null | [{"id":1,"status":"NEW"},{"id":2,"status":"PENDING"}] | {"item-id":"1","name":"one"} | [{"item-id":"1","name":"one"},{"item-id":"2","name":"two"},{"item-id":"3","name":"three"}] | ArrayIterator Object( [storage:ArrayIterator:private] => Array ( [0] => 1 [1] => 2 [2] => 3 )) | three |
+| 1234 | 123.45 | 100 |   false | 2020-07-13T15:00:00+00:00 |  null | [{"id":1,"status":"NEW"},{"id":2,"status":"PENDING"}] | {"item-id":"1","name":"one"} | [{"item-id":"1","name":"one"},{"item-id":"2","name":"two"},{"item-id":"3","name":"three"}] | ArrayIterator Object( [storage:ArrayIterator:private] => Array ( [0] => 1 [1] => 2 [2] => 3 )) | three |
+| 1234 | 123.45 | 100 |   false | 2020-07-13T15:00:00+00:00 |  null | [{"id":1,"status":"NEW"},{"id":2,"status":"PENDING"}] | {"item-id":"1","name":"one"} | [{"item-id":"1","name":"one"},{"item-id":"2","name":"two"},{"item-id":"3","name":"three"}] | ArrayIterator Object( [storage:ArrayIterator:private] => Array ( [0] => 1 [1] => 2 [2] => 3 )) | three |
+| 1234 | 123.45 | 100 |   false | 2020-07-13T15:00:00+00:00 |  null | [{"id":1,"status":"NEW"},{"id":2,"status":"PENDING"}] | {"item-id":"1","name":"one"} | [{"item-id":"1","name":"one"},{"item-id":"2","name":"two"},{"item-id":"3","name":"three"}] | ArrayIterator Object( [storage:ArrayIterator:private] => Array ( [0] => 1 [1] => 2 [2] => 3 )) | three |
++------+--------+-----+---------+---------------------------+-------+-------------------------------------------------------+------------------------------+--------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------+-------+
 6 rows
 
 ASCIITABLE,
@@ -397,15 +397,15 @@ ASCIITABLE,
 
         $this->assertStringContainsString(
             <<<'ASCIITABLE'
-+--------------------+
-|this is very long en|
-+--------------------+
-|[{"id":1,"status":"N|
-|[{"id":1,"status":"N|
-|[{"id":1,"status":"N|
-|[{"id":1,"status":"N|
-|[{"id":1,"status":"N|
-+--------------------+
++----------------------+
+| this is very long en |
++----------------------+
+| [{"id":1,"status":"N |
+| [{"id":1,"status":"N |
+| [{"id":1,"status":"N |
+| [{"id":1,"status":"N |
+| [{"id":1,"status":"N |
++----------------------+
 5 rows
 ASCIITABLE,
             $etl->display(5)
@@ -413,15 +413,15 @@ ASCIITABLE,
 
         $this->assertStringContainsString(
             <<<'ASCIITABLE'
-+-------------------------------------------------------------+
-|this is very long entry name that should be longer than items|
-+-------------------------------------------------------------+
-|        [{"id":1,"status":"NEW"},{"id":2,"status":"PENDING"}]|
-|        [{"id":1,"status":"NEW"},{"id":2,"status":"PENDING"}]|
-|        [{"id":1,"status":"NEW"},{"id":2,"status":"PENDING"}]|
-|        [{"id":1,"status":"NEW"},{"id":2,"status":"PENDING"}]|
-|        [{"id":1,"status":"NEW"},{"id":2,"status":"PENDING"}]|
-+-------------------------------------------------------------+
++---------------------------------------------------------------+
+| this is very long entry name that should be longer than items |
++---------------------------------------------------------------+
+|         [{"id":1,"status":"NEW"},{"id":2,"status":"PENDING"}] |
+|         [{"id":1,"status":"NEW"},{"id":2,"status":"PENDING"}] |
+|         [{"id":1,"status":"NEW"},{"id":2,"status":"PENDING"}] |
+|         [{"id":1,"status":"NEW"},{"id":2,"status":"PENDING"}] |
+|         [{"id":1,"status":"NEW"},{"id":2,"status":"PENDING"}] |
++---------------------------------------------------------------+
 5 rows
 ASCIITABLE,
             $etl->display(5, 0)
@@ -1450,20 +1450,20 @@ ASCIITABLE,
 
         $this->assertStringContainsString(
             <<<'ASCII'
-+--+-------+---+
-|id|country|age|
-+--+-------+---+
-| 1|     PL| 20|
-| 2|     PL| 20|
-| 3|     PL| 25|
-+--+-------+---+
++----+---------+-----+
+| id | country | age |
++----+---------+-----+
+|  1 |      PL |  20 |
+|  2 |      PL |  20 |
+|  3 |      PL |  25 |
++----+---------+-----+
 3 rows
-+--+-------+---+------+
-|id|country|age|salary|
-+--+-------+---+------+
-| 1|     PL| 20|  5000|
-| 1|     PL| 20|  null|
-+--+-------+---+------+
++----+---------+-----+--------+
+| id | country | age | salary |
++----+---------+-----+--------+
+|  1 |      PL |  20 |   5000 |
+|  1 |      PL |  20 |   null |
++----+---------+-----+--------+
 2 rows
 ASCII,
             $output

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Formatter/ASCII/ASCIIBodyTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Formatter/ASCII/ASCIIBodyTest.php
@@ -28,9 +28,9 @@ final class ASCIIBodyTest extends TestCase
 
         $this->assertStringContainsString(
             <<<'TABLE'
-| 1|  1.4|
-| 2|  3.4|
-+--+-----+
+|  1 |   1.4 |
+|  2 |   3.4 |
++----+-------+
 TABLE,
             $headers->print(false)
         );

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Formatter/ASCII/ASCIIHeadersTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Formatter/ASCII/ASCIIHeadersTest.php
@@ -28,9 +28,9 @@ final class ASCIIHeadersTest extends TestCase
 
         $this->assertStringContainsString(
             <<<'TABLE'
-+--+-----+
-|id|value|
-+--+-----+
++----+-------+
+| id | value |
++----+-------+
 TABLE,
             $headers->print(false)
         );

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Formatter/ASCIITableTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Formatter/ASCIITableTest.php
@@ -26,17 +26,17 @@ final class ASCIITableTest extends TestCase
 
         $this->assertStringContainsString(
             <<<'TABLE'
-+-----------------------------------------------------------------------------------+
-|                                                                                row|
-+-----------------------------------------------------------------------------------+
-|                              [498][534]/Wiele z tego,|/co niegdyś było, przepadło.|
-|                 [540][572]/A nie żyje już nikt z tych,|/którzy by o tym pamiętali.|
-|                                                        [572][647]WŁADCA PIERŚCIENI|
-|                     [701][741]/Wszystko zaczęło się|/od wykucia Pierścieni Władzy.|
-|                                              [742][762]/Trzy zostały dane elfom...|
-|[763][805]/nieśmiertelnym, najmędrszym|/i najbliższym magii spośród wszystkich ras.|
-|                      [816][853]/Siedem - władcom krasnoludów,|/wspaniałym górnikom|
-+-----------------------------------------------------------------------------------+
++-------------------------------------------------------------------------------------+
+|                                                                                 row |
++-------------------------------------------------------------------------------------+
+|                               [498][534]/Wiele z tego,|/co niegdyś było, przepadło. |
+|                  [540][572]/A nie żyje już nikt z tych,|/którzy by o tym pamiętali. |
+|                                                         [572][647]WŁADCA PIERŚCIENI |
+|                      [701][741]/Wszystko zaczęło się|/od wykucia Pierścieni Władzy. |
+|                                               [742][762]/Trzy zostały dane elfom... |
+| [763][805]/nieśmiertelnym, najmędrszym|/i najbliższym magii spośród wszystkich ras. |
+|                       [816][853]/Siedem - władcom krasnoludów,|/wspaniałym górnikom |
++-------------------------------------------------------------------------------------+
 TABLE,
             (new ASCIITable($rows))->print(false)
         );
@@ -56,17 +56,17 @@ TABLE,
 
         $this->assertStringContainsString(
             <<<'TABLE'
-+--------------------+
-|                 row|
-+--------------------+
-|[498][534]/Wiele z t|
-| [540][572]/A nie ży|
-| [572][647]WŁADCA PI|
-|[701][741]/Wszystko |
-|[742][762]/Trzy zost|
-| [763][805]/nieśmier|
-|[816][853]/Siedem - |
-+--------------------+
++----------------------+
+|                  row |
++----------------------+
+| [498][534]/Wiele z t |
+|  [540][572]/A nie ży |
+|  [572][647]WŁADCA PI |
+| [701][741]/Wszystko  |
+| [742][762]/Trzy zost |
+|  [763][805]/nieśmier |
+| [816][853]/Siedem -  |
++----------------------+
 TABLE,
             (new ASCIITable($rows))->print(true)
         );
@@ -86,17 +86,17 @@ TABLE,
 
         $this->assertStringContainsString(
             <<<'TABLE'
-+-----------------------------------------------------------------------------------+-------------------------------------------------------------+
-|                                                                                row|                                                         test|
-+-----------------------------------------------------------------------------------+-------------------------------------------------------------+
-|                              [498][534]/Wiele z tego,|/co niegdyś było, przepadło.|                                                             |
-|                 [540][572]/A nie żyje już nikt z tych,|/którzy by o tym pamiętali.|                                                             |
-|                                                        [572][647]WŁADCA PIERŚCIENI|                                                             |
-|                     [701][741]/Wszystko zaczęło się|/od wykucia Pierścieni Władzy.|                                                             |
-|                                              [742][762]/Trzy zostały dane elfom...|                                                             |
-|[763][805]/nieśmiertelnym, najmędrszym|/i najbliższym magii spośród wszystkich ras.|                                                             |
-|                                                                                   |[816][853]/Siedem - władcom krasnoludów,|/wspaniałym górnikom|
-+-----------------------------------------------------------------------------------+-------------------------------------------------------------+
++-------------------------------------------------------------------------------------+---------------------------------------------------------------+
+|                                                                                 row |                                                          test |
++-------------------------------------------------------------------------------------+---------------------------------------------------------------+
+|                               [498][534]/Wiele z tego,|/co niegdyś było, przepadło. |                                                               |
+|                  [540][572]/A nie żyje już nikt z tych,|/którzy by o tym pamiętali. |                                                               |
+|                                                         [572][647]WŁADCA PIERŚCIENI |                                                               |
+|                      [701][741]/Wszystko zaczęło się|/od wykucia Pierścieni Władzy. |                                                               |
+|                                               [742][762]/Trzy zostały dane elfom... |                                                               |
+| [763][805]/nieśmiertelnym, najmędrszym|/i najbliższym magii spośród wszystkich ras. |                                                               |
+|                                                                                     | [816][853]/Siedem - władcom krasnoludów,|/wspaniałym górnikom |
++-------------------------------------------------------------------------------------+---------------------------------------------------------------+
 TABLE,
             (new ASCIITable($rows))->print(false)
         );
@@ -110,12 +110,12 @@ TABLE,
 
         $this->assertStringContainsString(
             <<<'TABLE'
-+--+----+
-|id|name|
-+--+----+
-| 1|  EN|
-| 2|  PL|
-+--+----+
++----+------+
+| id | name |
++----+------+
+|  1 |   EN |
+|  2 |   PL |
++----+------+
 TABLE,
             (new ASCIITable(new Rows(
                 Row::create(Entry::integer('id', 1), Entry::string('name', 'EN')),

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Loader/StreamLoaderTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Loader/StreamLoaderTest.php
@@ -53,13 +53,13 @@ final class StreamLoaderTest extends TestCase
 
         $this->assertSame(
             <<<'ASCII'
-+--+----+
-|id|name|
-+--+----+
-| 1|id_1|
-| 2|id_2|
-| 3|id_3|
-+--+----+
++----+------+
+| id | name |
++----+------+
+|  1 | id_1 |
+|  2 | id_2 |
+|  3 | id_3 |
++----+------+
 3 rows
 
 schema
@@ -90,13 +90,13 @@ ASCII,
 
         $this->assertStringContainsString(
             <<<'TABLE'
-+--+----+
-|id|name|
-+--+----+
-| 1|id_1|
-| 2|id_2|
-| 3|id_3|
-+--+----+
++----+------+
+| id | name |
++----+------+
+|  1 | id_1 |
+|  2 | id_2 |
+|  3 | id_3 |
++----+------+
 3 rows
 TABLE,
             $output


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <li>extra padding to ascii table headers/body</li>
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

This padding will make it easier to copy specific headers/values from the output. 

<!-- Please provide a short description of changes in this section, feel free to use markdown syntax -->
