### PR TITLE
Adjust string value extraction in ASCIIValue

### DIFF
--- a/src/core/etl/src/Flow/ETL/Formatter/ASCII/ASCIIValue.php
+++ b/src/core/etl/src/Flow/ETL/Formatter/ASCII/ASCIIValue.php
@@ -107,7 +107,6 @@ final class ASCIIValue
                 $this->stringValue = match (\gettype($val)) {
                     'string' => $val,
                     'boolean' => ($val) ? 'true' : 'false',
-                    /** @phpstan-ignore-next-line */
                     'double', 'integer' => (string) $val,
                     'array' => \json_encode($val, JSON_THROW_ON_ERROR),
                     default => '',

--- a/src/core/etl/src/Flow/ETL/Formatter/ASCII/ASCIIValue.php
+++ b/src/core/etl/src/Flow/ETL/Formatter/ASCII/ASCIIValue.php
@@ -108,7 +108,7 @@ final class ASCIIValue
                     'string' => $val,
                     'boolean' => ($val) ? 'true' : 'false',
                     /** @phpstan-ignore-next-line */
-                    'float', 'double', 'integer' => (string) $val,
+                    'double', 'integer' => (string) $val,
                     'array' => \json_encode($val, JSON_THROW_ON_ERROR),
                     default => '',
                 };


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Adjust string value extraction in ASCIIValue to match PHP docs</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

According to [PHP docs about `gettype()`](https://www.php.net/manual/en/function.gettype.php#refsect1-function.gettype-returnvalues), it will never return a `false` value, but it will be `double` instead.
