### PR TITLE
Modify `StrReplace` expression to work with arrays

### DIFF
--- a/src/core/etl/src/Flow/ETL/Row/Reference/EntryExpression.php
+++ b/src/core/etl/src/Flow/ETL/Row/Reference/EntryExpression.php
@@ -257,7 +257,11 @@ trait EntryExpression
         return new Expressions(new StartsWith($this, $needle));
     }
 
-    public function strReplace(string $search, string $replace) : Expression
+    /**
+     * @param string|string[] $search
+     * @param string|string[] $replace
+     */
+    public function strReplace(string|array $search, string|array $replace) : Expression
     {
         return new Expressions(new Expression\StrReplace($this, $search, $replace));
     }

--- a/src/core/etl/src/Flow/ETL/Row/Reference/Expression/StrReplace.php
+++ b/src/core/etl/src/Flow/ETL/Row/Reference/Expression/StrReplace.php
@@ -9,10 +9,14 @@ use Flow\ETL\Row\Reference\Expression;
 
 final class StrReplace implements Expression
 {
+    /**
+     * @param string|string[] $search
+     * @param string|string[] $replace
+     */
     public function __construct(
         private readonly Expression $ref,
-        private readonly string $search,
-        private readonly string $replace
+        private readonly string|array $search,
+        private readonly string|array $replace
     ) {
     }
 

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Reference/Expression/StrReplaceTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Reference/Expression/StrReplaceTest.php
@@ -25,4 +25,12 @@ final class StrReplaceTest extends TestCase
             ref('value')->strReplace('test', '1')->eval(Row::create(Entry::str('value', 'test'))),
         );
     }
+
+    public function test_str_replace_on_valid_string_with_array_of_replacements() : void
+    {
+        $this->assertSame(
+            'test was successful',
+            ref('value')->strReplace(['is', 'broken'], ['was', 'successful'])->eval(Row::create(Entry::str('value', 'test is broken'))),
+        );
+    }
 }


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Modify `StrReplace` expression to work with arrays</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

PHP implementation of `str_replace` works both, with single strings, and arrays of pairs.
