### PR TITLE
Add more cache for static analyse on GH actions

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -215,6 +215,17 @@ jobs:
           restore-keys: |
             php-${{ matrix.php-version }}-locked-composer-
 
+      - name: "Create cache directory"
+        run: "mkdir -p var/infection/cache"
+
+      - name: "Cache infection results"
+        uses: "actions/cache@v3"
+        with:
+          path: "var/infection/cache"
+          key: "php-${{ matrix.php-version }}-cache-infection-${{ github.run_id }}"
+          restore-keys: |
+            php-${{ matrix.php-version }}-cache-infection-
+
       - name: "Install locked dependencies"
         run: "composer install --no-interaction --no-progress --no-suggest"
 

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -34,22 +34,51 @@ jobs:
           php-version: "${{ matrix.php-version }}"
           ini-values: memory_limit=-1
 
+      - name: "Create cache directories"
+        run: |
+          mkdir -p var/cs-fixer
+          mkdir -p var/phpstan/cache
+          mkdir -p var/psalm/cache
+
       - name: "Get Composer Cache Directory"
         id: composer-cache
         run: |
           echo "::set-output name=dir::$(composer config cache-files-dir)"
 
       - name: "Cache Composer dependencies"
-        uses: "actions/cache@v2"
+        uses: "actions/cache@v3"
         with:
-          path: |
-            ${{ steps.composer-cache.outputs.dir }}
+          path: "${{ steps.composer-cache.outputs.dir }}"
           key: "php-${{ matrix.php-version }}-locked-composer-${{ hashFiles('**/composer.lock') }}"
           restore-keys: |
             php-${{ matrix.php-version }}-locked-composer-
 
       - name: "Install locked dependencies"
         run: "composer install --no-interaction --no-progress"
+
+      - name: "Cache cs-fixer results"
+        uses: "actions/cache@v3"
+        with:
+          path: "var/cs-fixer"
+          key: "php-${{ matrix.php-version }}-cache-cs-fixer-${{ github.run_id }}"
+          restore-keys: |
+            php-${{ matrix.php-version }}-cache-cs-fixer-
+
+      - name: "Cache phpstan results"
+        uses: "actions/cache@v3"
+        with:
+          path: "var/phpstan/cache"
+          key: "php-${{ matrix.php-version }}-cache-phpstan-${{ github.run_id }}"
+          restore-keys: |
+            php-${{ matrix.php-version }}-cache-phpstan-
+
+      - name: "Cache psalm results"
+        uses: "actions/cache@v3"
+        with:
+          path: "var/psalm/cache"
+          key: "php-${{ matrix.php-version }}-cache-psalm-${{ github.run_id }}"
+          restore-keys: |
+            php-${{ matrix.php-version }}-cache-psalm-
 
       - name: "Static Analyze"
         run: "composer static:analyze"
@@ -121,10 +150,9 @@ jobs:
           echo "::set-output name=dir::$(composer config cache-files-dir)"
 
       - name: "Cache Composer dependencies"
-        uses: "actions/cache@v2"
+        uses: "actions/cache@v3"
         with:
-          path: |
-            ${{ steps.composer-cache.outputs.dir }}
+          path: "${{ steps.composer-cache.outputs.dir }}"
           key: "php-${{ matrix.php-version }}-${{ matrix.dependencies }}-composer-${{ hashFiles('**/composer.lock') }}"
           restore-keys: |
             php-${{ matrix.php-version }}-${{ matrix.dependencies }}-composer-
@@ -180,10 +208,9 @@ jobs:
           echo "::set-output name=dir::$(composer config cache-files-dir)"
 
       - name: "Cache Composer dependencies"
-        uses: "actions/cache@v2"
+        uses: "actions/cache@v3"
         with:
-          path: |
-            ${{ steps.composer-cache.outputs.dir }}
+          path: "${{ steps.composer-cache.outputs.dir }}"
           key: "php-${{ matrix.php-version }}-locked-composer-${{ hashFiles('**/composer.lock') }}"
           restore-keys: |
             php-${{ matrix.php-version }}-locked-composer-

--- a/infection.json
+++ b/infection.json
@@ -78,6 +78,7 @@
   "phpUnit": {
     "customPath": "tools/phpunit/vendor/bin/phpunit"
   },
+  "tmpDir": "var/infection/cache",
   "testFrameworkOptions": "--testsuite=unit",
   "minMsi": 50,
   "minCoveredMsi": 50

--- a/src/core/etl/src/Flow/ETL/Monitoring/Memory/Consumption.php
+++ b/src/core/etl/src/Flow/ETL/Monitoring/Memory/Consumption.php
@@ -44,9 +44,6 @@ final class Consumption
         return $this->initial;
     }
 
-    /**
-     * @return Unit
-     */
     public function max() : Unit
     {
         return $this->max;
@@ -57,9 +54,6 @@ final class Consumption
         return $this->max()->diff($this->initial());
     }
 
-    /**
-     * @return Unit
-     */
     public function min() : Unit
     {
         return $this->min;


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <li>Add more cache for static analysis on GH actions</li>
    <li>Add more cache for inflection on GH actions</li>
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

All those new caches save ~1 min on CI.
