### PR TITLE
Allow to use Symfony UID for UUID generation

### DIFF
--- a/src/core/etl/src/Flow/ETL/DSL/Entry.php
+++ b/src/core/etl/src/Flow/ETL/DSL/Entry.php
@@ -7,6 +7,7 @@ namespace Flow\ETL\DSL;
 use Flow\ETL\Exception\InvalidArgumentException;
 use Flow\ETL\Row\Entries;
 use Flow\ETL\Row\Entry as RowEntry;
+use Flow\ETL\Row\Entry\Type\Uuid;
 use Flow\ETL\Row\Entry\TypedCollection\ScalarType;
 
 /**
@@ -291,6 +292,14 @@ class Entry
     }
 
     /**
+     * @return RowEntry\UuidEntry
+     */
+    final public static function uuid(string $name, string $value) : RowEntry
+    {
+        return new RowEntry\UuidEntry($name, Uuid::fromString($value));
+    }
+
+    /**
      * @return RowEntry\XMLEntry
      */
     final public static function xml(string $name, \DOMDocument|string $data) : RowEntry
@@ -298,6 +307,9 @@ class Entry
         return new RowEntry\XMLEntry($name, $data);
     }
 
+    /**
+     * @return RowEntry\XMLNodeEntry
+     */
     final public static function xml_node(string $name, \DOMNode $data) : RowEntry
     {
         return new RowEntry\XMLNodeEntry($name, $data);

--- a/src/core/etl/src/Flow/ETL/Row/Entry/Type/Uuid.php
+++ b/src/core/etl/src/Flow/ETL/Row/Entry/Type/Uuid.php
@@ -1,0 +1,56 @@
+<?php declare(strict_types=1);
+
+namespace Flow\ETL\Row\Entry\Type;
+
+use Flow\ETL\Exception\InvalidArgumentException;
+use Flow\ETL\Exception\RuntimeException;
+
+final class Uuid
+{
+    /**
+     * This regexp is a port of the Uuid library,
+     * which is copyright Ben Ramsey, @see https://github.com/ramsey/uuid.
+     */
+    public const UUID_REGEXP = '/\A[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\z/ms';
+
+    private readonly string $value;
+
+    /**
+     * @throws InvalidArgumentException|RuntimeException
+     */
+    public function __construct(string|\Ramsey\Uuid\UuidInterface|\Symfony\Component\Uid\Uuid $value)
+    {
+        if (\is_string($value)) {
+            try {
+                if (\class_exists(\Ramsey\Uuid\UuidInterface::class)) {
+                    $this->value = (string) \Ramsey\Uuid\Uuid::fromString($value);
+                } elseif (\class_exists(\Symfony\Component\Uid\Uuid::class)) {
+                    $this->value = \Symfony\Component\Uid\Uuid::fromString($value)->toRfc4122();
+                } else {
+                    throw new RuntimeException("\Ramsey\Uuid\Uuid nor \Symfony\Component\Uid\Uuid class not found, please add 'ramsey/uuid' or 'symfony/uid' as a dependency to the project first.");
+                }
+            } catch (\InvalidArgumentException $e) {
+                throw new InvalidArgumentException("Invalid UUID: '{$value}'", 0, $e);
+            }
+        } elseif ($value instanceof \Ramsey\Uuid\UuidInterface) {
+            $this->value = $value->toString();
+        } else {
+            $this->value = $value->toRfc4122();
+        }
+    }
+
+    public static function fromString(string $value) : self
+    {
+        return new self($value);
+    }
+
+    public function isEqual(self $type) : bool
+    {
+        return $this->toString() === $type->toString();
+    }
+
+    public function toString() : string
+    {
+        return $this->value;
+    }
+}

--- a/src/core/etl/src/Flow/ETL/Row/Entry/UuidEntry.php
+++ b/src/core/etl/src/Flow/ETL/Row/Entry/UuidEntry.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Row\Entry;
+
+use Flow\ETL\Exception\InvalidArgumentException;
+use Flow\ETL\Row\Entry;
+use Flow\ETL\Row\Reference;
+use Flow\ETL\Row\Schema\Definition;
+
+/**
+ * @implements Entry<Entry\Type\Uuid, array{name: string, value: string}>
+ */
+final class UuidEntry implements \Stringable, Entry
+{
+    use EntryRef;
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    public function __construct(private readonly string $name, private readonly Entry\Type\Uuid $value)
+    {
+        if ('' === $name) {
+            throw InvalidArgumentException::because('Entry name cannot be empty');
+        }
+    }
+
+    public static function from(string $name, string $value) : self
+    {
+        return new self($name, Entry\Type\Uuid::fromString($value));
+    }
+
+    public function __serialize() : array
+    {
+        return ['name' => $this->name, 'value' => $this->value->toString()];
+    }
+
+    public function __toString() : string
+    {
+        return $this->toString();
+    }
+
+    public function __unserialize(array $data) : void
+    {
+        $this->name = $data['name'];
+        $this->value = new Entry\Type\Uuid($data['value']);
+    }
+
+    public function definition() : Definition
+    {
+        return Definition::uuid($this->name);
+    }
+
+    public function is(string|Reference $name) : bool
+    {
+        if ($name instanceof Reference) {
+            return $this->name === $name->name();
+        }
+
+        return $this->name === $name;
+    }
+
+    public function isEqual(Entry $entry) : bool
+    {
+        return $this->is($entry->name()) && $entry instanceof self && $this->value()->isEqual($entry->value());
+    }
+
+    public function map(callable $mapper) : Entry
+    {
+        return new self($this->name, $mapper($this->value));
+    }
+
+    public function name() : string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    public function rename(string $name) : Entry
+    {
+        return new self($name, $this->value);
+    }
+
+    public function toString() : string
+    {
+        return $this->value->toString();
+    }
+
+    public function value() : Entry\Type\Uuid
+    {
+        return $this->value;
+    }
+}

--- a/src/core/etl/src/Flow/ETL/Row/Schema/Definition.php
+++ b/src/core/etl/src/Flow/ETL/Row/Schema/Definition.php
@@ -20,6 +20,7 @@ use Flow\ETL\Row\Entry\ObjectEntry;
 use Flow\ETL\Row\Entry\StringEntry;
 use Flow\ETL\Row\Entry\StructureEntry;
 use Flow\ETL\Row\Entry\TypedCollection\Type;
+use Flow\ETL\Row\Entry\UuidEntry;
 use Flow\ETL\Row\Entry\XMLEntry;
 use Flow\ETL\Row\EntryReference;
 use Flow\ETL\Row\Schema\Constraint\Any;
@@ -161,6 +162,11 @@ final class Definition implements Serializable
         }
 
         return new self($entry, $types, $constraint, $metadata);
+    }
+
+    public static function uuid(string|EntryReference $entry, ?Constraint $constraint = null, ?Metadata $metadata = null) : self
+    {
+        return new self($entry, [UuidEntry::class], $constraint, $metadata);
     }
 
     public static function xml(string|EntryReference $entry, bool $nullable = false, ?Constraint $constraint = null, ?Metadata $metadata = null) : self

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Entry/UuidEntryTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Entry/UuidEntryTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Tests\Unit\Row\Entry;
+
+use Flow\ETL\Row\Entry\Type\Uuid;
+use Flow\ETL\Row\Entry\UuidEntry;
+use PHPUnit\Framework\TestCase;
+
+final class UuidEntryTest extends TestCase
+{
+    public static function is_equal_data_provider() : \Generator
+    {
+        yield 'equal names and values' => [
+            true,
+            new UuidEntry('name', Uuid::fromString('00000000-0000-0000-0000-000000000000')),
+            new UuidEntry('name', Uuid::fromString('00000000-0000-0000-0000-000000000000')),
+        ];
+        yield 'different names and values' => [
+            false,
+            new UuidEntry('name', Uuid::fromString('00000000-0000-0000-0000-000000000000')),
+            new UuidEntry('different_name', Uuid::fromString('11111111-1111-1111-1111-111111111111')),
+        ];
+        yield 'equal names and different values' => [
+            false,
+            new UuidEntry('name', Uuid::fromString('00000000-0000-0000-0000-000000000000')),
+            new UuidEntry('name', Uuid::fromString('11111111-1111-1111-1111-111111111111')),
+        ];
+        yield 'different names characters and equal values' => [
+            false,
+            new UuidEntry('NAME', Uuid::fromString('00000000-0000-0000-0000-000000000000')),
+            new UuidEntry('name', Uuid::fromString('00000000-0000-0000-0000-000000000000')),
+        ];
+    }
+
+    public static function valid_string_entries() : \Generator
+    {
+        yield ['00000000-0000-0000-0000-000000000000'];
+        yield ['11111111-1111-1111-1111-111111111111'];
+        yield ['fa2e03e9-707f-4ebc-a40d-4c3c846fef75'];
+        yield ['9a419c18-fc21-4481-9dea-5e9cf057d137'];
+    }
+
+    protected function setUp() : void
+    {
+        if (!\class_exists(\Ramsey\Uuid\Uuid::class) && !\class_exists(\Symfony\Component\Uid\Uuid::class)) {
+            $this->markTestSkipped("Package 'ramsey/uuid' or 'symfony/uid' is required for this test.");
+        }
+    }
+
+    /**
+     * @dataProvider valid_string_entries
+     */
+    public function test_creates_uuid_entry_from_string(string $value) : void
+    {
+        $entry = UuidEntry::from('entry-name', $value);
+
+        $this->assertEquals($value, $entry->value()->toString());
+    }
+
+    /**
+     * @dataProvider is_equal_data_provider
+     */
+    public function test_is_equal(bool $equals, UuidEntry $entry, UuidEntry $nextEntry) : void
+    {
+        $this->assertSame($equals, $entry->isEqual($nextEntry));
+    }
+
+    public function test_map() : void
+    {
+        $entry = new UuidEntry('entry-name', Uuid::fromString('00000000-0000-0000-0000-000000000000'));
+
+        $this->assertEquals(
+            $entry,
+            $entry->map(fn ($value) => $value)
+        );
+    }
+
+    public function test_prevents_from_creating_entry_from_random_value() : void
+    {
+        $this->expectExceptionMessage("Invalid UUID: 'random-value'");
+
+        UuidEntry::from('entry-name', 'random-value');
+    }
+
+    public function test_prevents_from_creating_entry_with_empty_entry_name() : void
+    {
+        $this->expectExceptionMessage('Entry name cannot be empty');
+
+        new UuidEntry('', Uuid::fromString('00000000-0000-0000-0000-000000000000'));
+    }
+
+    public function test_renames_entry() : void
+    {
+        $entry = new UuidEntry('entry-name', $uuid = Uuid::fromString('00000000-0000-0000-0000-000000000000'));
+        /** @var UuidEntry $newEntry */
+        $newEntry = $entry->rename('new-entry-name');
+
+        $this->assertEquals('new-entry-name', $newEntry->name());
+        $this->assertEquals($uuid->toString(), $newEntry->value()->toString());
+    }
+}

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Factory/NativeEntryFactoryTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Factory/NativeEntryFactoryTest.php
@@ -269,6 +269,34 @@ final class NativeEntryFactoryTest extends TestCase
         );
     }
 
+    public function test_uuid_from_ramsey_uuid_library() : void
+    {
+        if (!\class_exists(\Ramsey\Uuid\Uuid::class)) {
+            $this->markTestSkipped("Package 'ramsey/uuid' is required for this test.");
+        }
+
+        $this->assertEquals(
+            Entry::uuid('e', $uuid = \Ramsey\Uuid\Uuid::uuid4()->toString()),
+            (new NativeEntryFactory())->create('e', $uuid)
+        );
+    }
+
+    public function test_uuid_from_string() : void
+    {
+        $this->assertEquals(
+            Entry::uuid('e', $uuid = '00000000-0000-0000-0000-000000000000'),
+            (new NativeEntryFactory())->create('e', $uuid)
+        );
+    }
+
+    public function test_uuid_string_with_uuid_definition_provided() : void
+    {
+        $this->assertEquals(
+            Entry::uuid('e', $uuid = '00000000-0000-0000-0000-000000000000'),
+            (new NativeEntryFactory(new Schema(Schema\Definition::uuid('e'))))->create('e', $uuid)
+        );
+    }
+
     public function test_xml_from_dom_document() : void
     {
         $doc = new \DOMDocument();

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Reference/Expression/UuidTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Reference/Expression/UuidTest.php
@@ -9,15 +9,25 @@ use function Flow\ETL\DSL\uuid_v4;
 use function Flow\ETL\DSL\uuid_v7;
 use Flow\ETL\Row;
 use PHPUnit\Framework\TestCase;
-use Ramsey\Uuid\Uuid;
 
 final class UuidTest extends TestCase
 {
+    protected function setUp() : void
+    {
+        if (!\class_exists(\Ramsey\Uuid\Uuid::class) && !\class_exists(\Symfony\Component\Uid\Uuid::class)) {
+            $this->markTestSkipped("Package 'ramsey/uuid' or 'symfony/uid' is required for this test.");
+        }
+    }
+
     public function test_uuid4() : void
     {
+        if (!\class_exists(\Ramsey\Uuid\Uuid::class)) {
+            $this->markTestSkipped("Package 'ramsey/uuid' is required for this test.");
+        }
+
         $expression = uuid_v4();
         $this->assertTrue(
-            Uuid::isValid(
+            \Ramsey\Uuid\Uuid::isValid(
                 $expression->eval(Row::create())->toString()
             )
         );
@@ -39,8 +49,12 @@ final class UuidTest extends TestCase
 
     public function test_uuid7() : void
     {
+        if (!\class_exists(\Ramsey\Uuid\Uuid::class)) {
+            $this->markTestSkipped("Package 'ramsey/uuid' is required for this test.");
+        }
+
         $this->assertTrue(
-            Uuid::isValid(
+            \Ramsey\Uuid\Uuid::isValid(
                 uuid_v7(lit(new \DateTimeImmutable('2020-01-01 00:00:00', new \DateTimeZone('UTC'))))->eval(Row::create())->toString()
             )
         );


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Allow to use Symfony UID for UUID generation</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

The reason behind this is that now you can have either Ramsey or Symfony library, the `uuid()` will work with both.
