### PR TITLE
Remove unnecessary template overwrite in ChartJS adapter

### DIFF
--- a/src/adapter/etl-adapter-chartjs/src/Flow/ETL/DSL/ChartJS.php
+++ b/src/adapter/etl-adapter-chartjs/src/Flow/ETL/DSL/ChartJS.php
@@ -14,43 +14,32 @@ use Flow\ETL\Row\EntryReference;
 class ChartJS
 {
     /**
-     * @param EntryReference $label
      * @param array<EntryReference> $datasets
      *
      * @throws InvalidArgumentException
-     *
-     * @return Chart
      */
     final public static function bar(EntryReference $label, array $datasets) : Chart
     {
         return new Chart\BarChart($label, $datasets);
     }
 
-    /**
-     * @param Chart $type
-     *
-     * @return Loader
-     */
-    final public static function chart(Chart $type, Path|string $output = null, Path|string $template = __DIR__ . '/../Adapter/ChartJS/Resources/template/full_page.html') : Loader
+    final public static function chart(Chart $type, Path|string $output = null, Path|string $template = null) : Loader
     {
         if (\is_string($output)) {
             $output = Path::realpath($output);
         }
 
-        if (\is_string($template)) {
-            $template = Path::realpath($template);
+        if (null === $template || \is_string($template)) {
+            $template = Path::realpath($template ?: __DIR__ . '/../Adapter/ChartJS/Resources/template/full_page.html');
         }
 
         return new ChartJSLoader($type, $output, $template);
     }
 
     /**
-     * @param EntryReference $label
      * @param array<EntryReference> $datasets
      *
      * @throws InvalidArgumentException
-     *
-     * @return Chart
      */
     final public static function line(EntryReference $label, array $datasets) : Chart
     {
@@ -61,8 +50,6 @@ class ChartJS
      * @param array<EntryReference> $datasets
      *
      * @throws InvalidArgumentException
-     *
-     * @return Chart
      */
     final public static function pie(array $datasets) : Chart
     {

--- a/src/adapter/etl-adapter-chartjs/src/Flow/ETL/DSL/ChartJS.php
+++ b/src/adapter/etl-adapter-chartjs/src/Flow/ETL/DSL/ChartJS.php
@@ -29,8 +29,12 @@ class ChartJS
             $output = Path::realpath($output);
         }
 
-        if (null === $template || \is_string($template)) {
-            $template = Path::realpath($template ?: __DIR__ . '/../Adapter/ChartJS/Resources/template/full_page.html');
+        if (null === $template) {
+            return new ChartJSLoader($type, $output);
+        }
+
+        if (\is_string($template)) {
+            $template = Path::realpath($template);
         }
 
         return new ChartJSLoader($type, $output, $template);


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Remove unnecessary template overwrite in ChartJS adapter</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

The default template is already defined one level lower in the `ChartJSLoader` class.
