### PR TITLE
Add Google services cleanup tasks to composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -165,6 +165,7 @@
         "cs:php:fix": [
             "tools/cs-fixer/vendor/bin/php-cs-fixer fix"
         ],
+        "pre-autoload-dump": "Google\\Task\\Composer::cleanup",
         "post-install-cmd": [
             "@tools:install"
         ],
@@ -179,6 +180,11 @@
             "composer install --working-dir=./tools/psalm",
             "composer install --working-dir=./tools/phpunit",
             "composer install --working-dir=./tools/rector"
+        ]
+    },
+    "extra": {
+        "google/apiclient-services": [
+            "Sheets"
         ]
     },
     "minimum-stability": "dev",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6960b19ed2bc26b224096c8c06c5ca1b",
+    "content-hash": "5f3f561815ec81fac94fe0186157139e",
     "packages": [
         {
             "name": "amphp/amp",

--- a/src/adapter/etl-adapter-google-sheet/composer.json
+++ b/src/adapter/etl-adapter-google-sheet/composer.json
@@ -48,11 +48,17 @@
         ],
         "cs:php:fix": "tools/vendor/bin/php-cs-fixer fix",
         "tools:install": "composer install --working-dir=./tools",
+        "pre-autoload-dump": "Google\\Task\\Composer::cleanup",
         "post-install-cmd": [
             "@tools:install"
         ],
         "post-update-cmd": [
             "@tools:install"
+        ]
+    },
+    "extra": {
+        "google/apiclient-services": [
+            "Sheets"
         ]
     },
     "minimum-stability": "dev",


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Add Google services cleanup tasks to composer</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

In order to reduce vendor size, we should use a cleanup service provided by Google that leaves only services used by the adapter.
