### PR TITLE
Allow to run `runtime.php` outside of phar

### DIFF
--- a/build/runtime.php
+++ b/build/runtime.php
@@ -2,7 +2,11 @@
 
 declare(strict_types=1);
 
-require 'phar://flow-php.phar/vendor/autoload.php';
+if ('' !== \Phar::running(false)) {
+    require 'phar://flow-php.phar/vendor/autoload.php';
+} else {
+    require __DIR__ . '/../vendor/autoload.php';
+}
 
 use Flow\ETL\PipelineFactory;
 use Symfony\Component\Console\Command\Command;


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Allow to run `runtime.php` outside of phar</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

```shell
stloyd@MacBook-Pro-2 flow % php build/runtime.php

                                                 
  Not enough arguments (missing: "input-file").  
                                                 

build/runtime.php <input-file>

```
