### PR TITLE
Prevent fatal error when passing empty string to `\DOMDocument`

### DIFF
--- a/src/core/etl/src/Flow/ETL/Row/Factory/NativeEntryFactory.php
+++ b/src/core/etl/src/Flow/ETL/Row/Factory/NativeEntryFactory.php
@@ -298,6 +298,10 @@ final class NativeEntryFactory implements EntryFactory
 
     private function isJson(string $string) : bool
     {
+        if ('' === $string) {
+            return false;
+        }
+
         try {
             return \is_array(\json_decode($string, true, self::JSON_DEPTH, JSON_THROW_ON_ERROR));
         } catch (\Exception) {
@@ -307,6 +311,10 @@ final class NativeEntryFactory implements EntryFactory
 
     private function isUuid(string $string) : bool
     {
+        if ('' === $string) {
+            return false;
+        }
+
         return 0 !== \preg_match(Entry\Type\Uuid::UUID_REGEXP, $string);
     }
 

--- a/src/core/etl/src/Flow/ETL/Row/Factory/NativeEntryFactory.php
+++ b/src/core/etl/src/Flow/ETL/Row/Factory/NativeEntryFactory.php
@@ -312,6 +312,10 @@ final class NativeEntryFactory implements EntryFactory
 
     private function isXML(string $string) : bool
     {
+        if ('' === $string) {
+            return false;
+        }
+
         try {
             \libxml_use_internal_errors(true);
 

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Factory/NativeEntryFactoryTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Factory/NativeEntryFactoryTest.php
@@ -117,6 +117,14 @@ final class NativeEntryFactoryTest extends TestCase
         );
     }
 
+    public function test_from_empty_string() : void
+    {
+        $this->assertEquals(
+            Entry::string('e', ''),
+            (new NativeEntryFactory())->create('e', '')
+        );
+    }
+
     public function test_int() : void
     {
         $this->assertEquals(


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>Prevent fatal error when passing empty string to `\DOMDocument`</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

Error:
```
Fatal error: Uncaught ValueError: DOMDocument::loadXML(): Argument #1 ($source) must not be empty in /home/user/scripts/code.php:4
Stack trace:
#0 /home/user/scripts/code.php(4): DOMDocument->loadXML('')
#1 {main}
  thrown in /home/user/scripts/code.php on line 4
```
