### PR TITLE
Fixed `Cast` expression to handle `null` as first

### DIFF
--- a/src/core/etl/src/Flow/ETL/Row/Reference/Expression/Cast.php
+++ b/src/core/etl/src/Flow/ETL/Row/Reference/Expression/Cast.php
@@ -25,6 +25,10 @@ final class Cast implements Expression
         /** @psalm-suppress MixedAssignment */
         $value = $this->ref->eval($row);
 
+        if (null === $value) {
+            return null;
+        }
+
         return match (\mb_strtolower($this->type)) {
             'datetime' => match (\gettype($value)) {
                 'string' => new \DateTimeImmutable($value),

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Reference/Expression/CastTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Reference/Expression/CastTest.php
@@ -19,6 +19,7 @@ final class CastTest extends TestCase
         $xml->loadXML($xmlString = '<root><foo baz="buz">bar</foo></root>');
 
         return [
+            'invalid' => [null, 'int', null],
             'int' => ['1', 'int', 1],
             'integer' => ['1', 'integer', 1],
             'float' => ['1', 'float', 1.0],
@@ -42,14 +43,16 @@ final class CastTest extends TestCase
      */
     public function test_cast(mixed $from, string $to, mixed $expected) : void
     {
-        $this->assertEquals(
-            $expected,
-            ref('value')->cast($to)->eval(Row::create((new NativeEntryFactory())->create('value', $from)))
-        );
-        $this->assertEquals(
-            $expected,
-            cast(ref('value'), $to)->eval(Row::create((new NativeEntryFactory())->create('value', $from)))
-        );
+        $resultRefCast = ref('value')->cast($to)->eval(Row::create((new NativeEntryFactory())->create('value', $from)));
+        $resultCastRef = cast(ref('value'), $to)->eval(Row::create((new NativeEntryFactory())->create('value', $from)));
+
+        if (\is_object($expected)) {
+            $this->assertEquals($expected, $resultRefCast);
+            $this->assertEquals($expected, $resultCastRef);
+        } else {
+            $this->assertSame($expected, $resultRefCast);
+            $this->assertSame($expected, $resultCastRef);
+        }
     }
 
     public function test_casting_integer_to_xml() : void


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>Fixed `Cast` expression to handle `null` as first</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

Right now invalid cast i.e. `null` to `integer` would generate `0`, not `null`.
