### PR TITLE
Use default value for `json_decode()` in `NativeEntryFactory`

### DIFF
--- a/src/core/etl/src/Flow/ETL/Row/Factory/NativeEntryFactory.php
+++ b/src/core/etl/src/Flow/ETL/Row/Factory/NativeEntryFactory.php
@@ -17,8 +17,6 @@ use Flow\ETL\Row\Schema;
  */
 final class NativeEntryFactory implements EntryFactory
 {
-    private const JSON_DEPTH = 512;
-
     public function __construct(private readonly ?Schema $schema = null)
     {
     }
@@ -303,7 +301,7 @@ final class NativeEntryFactory implements EntryFactory
         }
 
         try {
-            return \is_array(\json_decode($string, true, self::JSON_DEPTH, JSON_THROW_ON_ERROR));
+            return \is_array(\json_decode($string, true, flags: \JSON_THROW_ON_ERROR));
         } catch (\Exception) {
             return false;
         }


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Use default value for `json_decode()` in `NativeEntryFactory`</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

There is no point in holding the same value as is the default in PHP as private `const`.
