### PR TITLE
Rework `Trim` expression to use enum instead of constants

### DIFF
--- a/src/core/etl/src/Flow/ETL/Row/Reference/EntryExpression.php
+++ b/src/core/etl/src/Flow/ETL/Row/Reference/EntryExpression.php
@@ -372,10 +372,7 @@ trait EntryExpression
         return new Expressions(new Expression\ToDateTime($this, $format, $timeZone));
     }
 
-    /**
-     * @param int<0, 2> $type
-     */
-    public function trim(int $type = Trim::BOTH, string $characters = " \t\n\r\0\x0B") : Expression|EntryReference
+    public function trim(Trim\Type $type = Trim\Type::BOTH, string $characters = " \t\n\r\0\x0B") : Expression|EntryReference
     {
         return new Expressions(new Expression\Trim($this, $type, $characters));
     }

--- a/src/core/etl/src/Flow/ETL/Row/Reference/Expression/Trim/Type.php
+++ b/src/core/etl/src/Flow/ETL/Row/Reference/Expression/Trim/Type.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types=1);
+
+namespace Flow\ETL\Row\Reference\Expression\Trim;
+
+enum Type : string
+{
+    case BOTH = 'trim';
+
+    case LEFT = 'ltrim';
+
+    case RIGHT = 'rtrim';
+}

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Reference/Expression/TrimTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Reference/Expression/TrimTest.php
@@ -7,7 +7,7 @@ namespace Flow\ETL\Tests\Unit\Row\Reference\Expression;
 use function Flow\ETL\DSL\ref;
 use Flow\ETL\DSL\Entry;
 use Flow\ETL\Row;
-use Flow\ETL\Row\Reference\Expression\Trim;
+use Flow\ETL\Row\Reference\Expression\Trim\Type;
 use PHPUnit\Framework\TestCase;
 
 final class TrimTest extends TestCase
@@ -31,7 +31,7 @@ final class TrimTest extends TestCase
     {
         $this->assertSame(
             'value   ',
-            ref('string')->trim(Trim::LEFT)->eval(Row::create(Entry::str('string', '   value   ')))
+            ref('string')->trim(Type::LEFT)->eval(Row::create(Entry::str('string', '   value   ')))
         );
     }
 
@@ -39,7 +39,7 @@ final class TrimTest extends TestCase
     {
         $this->assertSame(
             '   value',
-            ref('string')->trim(Trim::RIGHT)->eval(Row::create(Entry::str('string', '   value   ')))
+            ref('string')->trim(Type::RIGHT)->eval(Row::create(Entry::str('string', '   value   ')))
         );
     }
 }


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Rework `Trim` expression to use enum instead of constants</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

<!-- Please provide a short description of changes in this section, feel free to use markdown syntax -->
