### PR TITLE
Allow enum as style param in `ArrayKeysStyleConvert` expression

### DIFF
--- a/src/core/etl/src/Flow/ETL/DSL/functions.php
+++ b/src/core/etl/src/Flow/ETL/DSL/functions.php
@@ -91,9 +91,9 @@ function array_key_rename(Expression $ref, string $path, string $newName) : Expr
     return new Expression\ArrayKeyRename($ref, $path, $newName);
 }
 
-function array_keys_style_convert(Expression $ref, string $style) : Expression
+function array_keys_style_convert(Expression $ref, StringStyles|string $style = StringStyles::SNAKE) : Expression
 {
-    return new Expression\ArrayKeysStyleConvert($ref, StringStyles::fromString($style));
+    return new Expression\ArrayKeysStyleConvert($ref, $style instanceof StringStyles ? $style : StringStyles::fromString($style));
 }
 
 function array_sort(Expression $expression, string $function = null, int $flags = null, bool $recursive = true) : Expression


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Allow enum as style param in `ArrayKeysStyleConvert` expression</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

<!-- Please provide a short description of changes in this section, feel free to use markdown syntax -->
