### PR TITLE
Add options to `array_expand` expression

### DIFF
--- a/src/core/etl/src/Flow/ETL/DSL/functions.php
+++ b/src/core/etl/src/Flow/ETL/DSL/functions.php
@@ -8,6 +8,7 @@ use Flow\ETL\Exception\InvalidArgumentException;
 use Flow\ETL\Row\EntryReference;
 use Flow\ETL\Row\Reference;
 use Flow\ETL\Row\Reference\Expression;
+use Flow\ETL\Row\Reference\Expression\ArrayExpand\ArrayExpand;
 use Flow\ETL\Row\Reference\Expression\ArraySort\Sort;
 use Flow\ETL\Row\Reference\Expression\Literal;
 use Flow\ETL\Row\Reference\Expression\StyleConverter\StringStyles;
@@ -198,9 +199,9 @@ function array_unpack(Expression $expression, array $skip_keys = [], ?string $en
  *   | 1|       3|
  *   +--+--------+
  */
-function array_expand(Expression $expression) : Expression
+function array_expand(Expression $expression, ArrayExpand $expand = ArrayExpand::VALUES) : Expression
 {
-    return new Expression\ArrayExpand($expression);
+    return new Expression\ArrayExpand($expression, $expand);
 }
 
 function size(Expression $expression) : Expression

--- a/src/core/etl/src/Flow/ETL/Row/Reference/EntryExpression.php
+++ b/src/core/etl/src/Flow/ETL/Row/Reference/EntryExpression.php
@@ -8,6 +8,7 @@ use function Flow\ETL\DSL\lit;
 use Flow\ETL\Exception\InvalidArgumentException;
 use Flow\ETL\Row\Entry;
 use Flow\ETL\Row\EntryReference;
+use Flow\ETL\Row\Reference\Expression\ArrayExpand\ArrayExpand;
 use Flow\ETL\Row\Reference\Expression\ArraySort\Sort;
 use Flow\ETL\Row\Reference\Expression\Cast;
 use Flow\ETL\Row\Reference\Expression\Contains;
@@ -149,9 +150,9 @@ trait EntryExpression
      *   | 1|       3|
      *   +--+--------+
      */
-    public function expand(string $expandEntryName = 'element') : Expression|EntryReference
+    public function expand(string $expandEntryName = 'element', ArrayExpand $expand = ArrayExpand::VALUES) : Expression|EntryReference
     {
-        return new Expressions(new Expression\ArrayExpand($this));
+        return new Expressions(new Expression\ArrayExpand($this, $expand));
     }
 
     public function greaterThan(Expression $ref) : Expression|EntryReference

--- a/src/core/etl/src/Flow/ETL/Row/Reference/Expression/ArrayExpand.php
+++ b/src/core/etl/src/Flow/ETL/Row/Reference/Expression/ArrayExpand.php
@@ -11,7 +11,7 @@ use Flow\ETL\Row\Reference\Expression;
 
 final class ArrayExpand implements ExpandResults, Expression
 {
-    public function __construct(private readonly Expression $ref)
+    public function __construct(private readonly Expression $ref, private readonly ArrayExpand\ArrayExpand $expand)
     {
     }
 
@@ -21,6 +21,14 @@ final class ArrayExpand implements ExpandResults, Expression
 
         if (!\is_array($array)) {
             throw new RuntimeException(\get_class($this->ref) . ' is not an array, got: ' . \gettype($array));
+        }
+
+        if ($this->expand === ArrayExpand\ArrayExpand::KEYS) {
+            return \array_keys($array);
+        }
+
+        if ($this->expand === ArrayExpand\ArrayExpand::BOTH) {
+            return \array_map(fn ($key, $value) => [$key => $value], \array_keys($array), $array);
         }
 
         return $array;

--- a/src/core/etl/src/Flow/ETL/Row/Reference/Expression/ArrayExpand/ArrayExpand.php
+++ b/src/core/etl/src/Flow/ETL/Row/Reference/Expression/ArrayExpand/ArrayExpand.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types=1);
+
+namespace Flow\ETL\Row\Reference\Expression\ArrayExpand;
+
+enum ArrayExpand : string
+{
+    case BOTH = 'both';
+
+    case KEYS = 'keys';
+
+    case VALUES = 'values';
+}

--- a/src/core/etl/tests/Flow/ETL/Tests/Integration/Row/Reference/Expression/ArrayExpandTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Integration/Row/Reference/Expression/ArrayExpandTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Tests\Integration\Row\Reference\Expression;
+
+use function Flow\ETL\DSL\array_expand;
+use function Flow\ETL\DSL\ref;
+use Flow\ETL\DSL\From;
+use Flow\ETL\DSL\To;
+use Flow\ETL\Flow;
+use Flow\ETL\Memory\ArrayMemory;
+use Flow\ETL\Row\Reference\Expression\ArrayExpand\ArrayExpand;
+use PHPUnit\Framework\TestCase;
+
+final class ArrayExpandTest extends TestCase
+{
+    public function test_expand_both() : void
+    {
+        (new Flow())
+            ->read(
+                From::array(
+                    [
+                        ['id' => 1, 'array' => ['a' => 1, 'b' => 2, 'c' => 3]],
+                    ]
+                )
+            )
+            ->withEntry('row', ref('row')->unpack())
+            ->renameAll('row.', '')
+            ->withEntry('expanded', array_expand(ref('array'), ArrayExpand::BOTH))
+            ->drop('row', 'array')
+            ->write(To::memory($memory = new ArrayMemory()))
+            ->run();
+
+        $this->assertSame(
+            [
+                ['id' => 1, 'expanded' => ['a' => 1]],
+                ['id' => 1, 'expanded' => ['b' => 2]],
+                ['id' => 1, 'expanded' => ['c' => 3]],
+            ],
+            $memory->data
+        );
+    }
+
+    public function test_expand_keys() : void
+    {
+        (new Flow())
+            ->read(
+                From::array(
+                    [
+                        ['id' => 1, 'array' => ['a' => 1, 'b' => 2, 'c' => 3]],
+                    ]
+                )
+            )
+            ->withEntry('row', ref('row')->unpack())
+            ->renameAll('row.', '')
+            ->withEntry('expanded', array_expand(ref('array'), ArrayExpand::KEYS))
+            ->drop('row', 'array')
+            ->write(To::memory($memory = new ArrayMemory()))
+            ->run();
+
+        $this->assertSame(
+            [
+                ['id' => 1, 'expanded' => 'a'],
+                ['id' => 1, 'expanded' => 'b'],
+                ['id' => 1, 'expanded' => 'c'],
+            ],
+            $memory->data
+        );
+    }
+
+    public function test_expand_values() : void
+    {
+        (new Flow())
+            ->read(
+                From::array(
+                    [
+                        ['id' => 1, 'array' => ['a' => 1, 'b' => 2, 'c' => 3]],
+                    ]
+                )
+            )
+            ->withEntry('row', ref('row')->unpack())
+            ->renameAll('row.', '')
+            ->withEntry('expanded', array_expand(ref('array')))
+            ->drop('row', 'array')
+            ->write(To::memory($memory = new ArrayMemory()))
+            ->run();
+
+        $this->assertSame(
+            [
+                ['id' => 1, 'expanded' => 1],
+                ['id' => 1, 'expanded' => 2],
+                ['id' => 1, 'expanded' => 3],
+            ],
+            $memory->data
+        );
+    }
+}

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Reference/Expression/ArrayExpandTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Reference/Expression/ArrayExpandTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Tests\Unit\Row\Reference\Expression;
+
+use function Flow\ETL\DSL\array_expand;
+use function Flow\ETL\DSL\ref;
+use Flow\ETL\DSL\Entry;
+use Flow\ETL\Exception\RuntimeException;
+use Flow\ETL\Row;
+use Flow\ETL\Row\Reference\Expression\ArrayExpand\ArrayExpand;
+use PHPUnit\Framework\TestCase;
+
+final class ArrayExpandTest extends TestCase
+{
+    public function test_expand_both() : void
+    {
+        $row = Row::create(
+            Entry::array('array', ['a' => 1, 'b' => 2, 'c' => 3]),
+        );
+
+        $this->assertSame(
+            [
+                ['a' => 1],
+                ['b' => 2],
+                ['c' => 3],
+            ],
+            array_expand(ref('array'), ArrayExpand::BOTH)->eval($row)
+        );
+    }
+
+    public function test_expand_keys() : void
+    {
+        $row = Row::create(
+            Entry::array('array', ['a' => 1, 'b' => 2, 'c' => 3]),
+        );
+
+        $this->assertSame(
+            ['a', 'b', 'c'],
+            array_expand(ref('array'), ArrayExpand::KEYS)->eval($row)
+        );
+    }
+
+    public function test_expand_values() : void
+    {
+        $row = Row::create(
+            Entry::array('array', ['a' => 1, 'b' => 2, 'c' => 3]),
+        );
+
+        $this->assertSame(
+            ['a' => 1, 'b' => 2, 'c' => 3],
+            array_expand(ref('array'))->eval($row)
+        );
+    }
+
+    public function test_for_not_array_entry() : void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Flow\ETL\Row\EntryReference is not an array, got: integer');
+
+        array_expand(ref('integer_entry'))->eval(Row::create(Entry::int('integer_entry', 1)));
+    }
+}


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <li>Add options to `array_expand` expression</li>
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

Cases covered by integration & unit tests.

Fixes #513 .