### PR TITLE
Prevent using `strlen` & `count` on empty input

### DIFF
--- a/src/adapter/etl-adapter-amphp/src/Flow/ETL/Async/Amp/Worker/ChildProcessLauncher.php
+++ b/src/adapter/etl-adapter-amphp/src/Flow/ETL/Async/Amp/Worker/ChildProcessLauncher.php
@@ -36,7 +36,7 @@ final class ChildProcessLauncher implements WorkerLauncher
 
         while (null !== $chunk = $stdout->read()) {
             foreach (\explode("\n", $chunk) as $chunkLine) {
-                if (\strlen($chunkLine)) {
+                if ('' !== $chunkLine) {
                     $this->logger->debug($chunkLine);
                 }
             }
@@ -44,7 +44,7 @@ final class ChildProcessLauncher implements WorkerLauncher
 
         while (null !== $chunk = $stderr->read()) {
             foreach (\explode("\n", $chunk) as $chunkLine) {
-                if (\strlen($chunkLine)) {
+                if ('' !== $chunkLine) {
                     $this->logger->error($chunkLine);
                 }
             }

--- a/src/adapter/etl-adapter-avro/src/Flow/ETL/Adapter/Avro/FlixTech/AvroExtractor.php
+++ b/src/adapter/etl-adapter-avro/src/Flow/ETL/Adapter/Avro/FlixTech/AvroExtractor.php
@@ -65,7 +65,7 @@ final class AvroExtractor implements Extractor
             }
         }
 
-        if (\count($rows) > 0) {
+        if ([] !== $rows) {
             yield new Rows(...$rows);
         }
     }

--- a/src/adapter/etl-adapter-csv/src/Flow/ETL/Adapter/CSV/CSVExtractor.php
+++ b/src/adapter/etl-adapter-csv/src/Flow/ETL/Adapter/CSV/CSVExtractor.php
@@ -101,7 +101,7 @@ final class CSVExtractor implements Extractor
                 $rowData = \fgetcsv($stream->resource(), $this->charactersReadInLine, $this->separator, $this->enclosure, $this->escape);
             }
 
-            if (\count($rows)) {
+            if ([] !== $rows) {
                 yield new Rows(...$rows);
             }
 

--- a/src/adapter/etl-adapter-google-sheet/src/Flow/ETL/Adapter/GoogleSheet/Columns.php
+++ b/src/adapter/etl-adapter-google-sheet/src/Flow/ETL/Adapter/GoogleSheet/Columns.php
@@ -13,7 +13,7 @@ final class Columns
         public readonly string $startColumn,
         public readonly string $endColumn,
     ) {
-        if (\strlen($sheetName) === 0) {
+        if ('' === $sheetName) {
             throw new InvalidArgumentException('Sheet name can\'t be empty');
         }
 

--- a/src/adapter/etl-adapter-parquet/src/Flow/ETL/Adapter/Parquet/Codename/ParquetExtractor.php
+++ b/src/adapter/etl-adapter-parquet/src/Flow/ETL/Adapter/Parquet/Codename/ParquetExtractor.php
@@ -37,7 +37,7 @@ final class ParquetExtractor implements Extractor
                 $data = [];
 
                 foreach ($dataFields as $field) {
-                    if (\count($this->fields) && !\in_array($field->name, $this->fields, true)) {
+                    if ([] !== $this->fields && !\in_array($field->name, $this->fields, true)) {
                         continue;
                     }
 

--- a/src/adapter/etl-adapter-reactphp/src/Flow/ETL/Async/ReactPHP/Worker/ChildProcessLauncher.php
+++ b/src/adapter/etl-adapter-reactphp/src/Flow/ETL/Async/ReactPHP/Worker/ChildProcessLauncher.php
@@ -33,7 +33,7 @@ final class ChildProcessLauncher implements WorkerLauncher
 
             $process->stderr->on('data', function ($chunk) : void {
                 foreach (\explode("\n", $chunk) as $chunkLine) {
-                    if (\strlen($chunkLine)) {
+                    if ('' !== $chunkLine) {
                         $this->logger->error($chunkLine);
                     }
                 }
@@ -41,7 +41,7 @@ final class ChildProcessLauncher implements WorkerLauncher
 
             $process->stdout->on('data', function ($chunk) : void {
                 foreach (\explode("\n", $chunk) as $chunkLine) {
-                    if (\strlen($chunkLine)) {
+                    if ('' !== $chunkLine) {
                         $this->logger->debug($chunkLine);
                     }
                 }

--- a/src/adapter/etl-adapter-text/src/Flow/ETL/Adapter/Text/TextExtractor.php
+++ b/src/adapter/etl-adapter-text/src/Flow/ETL/Adapter/Text/TextExtractor.php
@@ -55,7 +55,7 @@ final class TextExtractor implements Extractor
                 $rowData = \fgets($fileStream->resource());
             }
 
-            if (\count($rows)) {
+            if ([] !== $rows) {
                 yield new Rows(...$rows);
             }
         }

--- a/src/adapter/etl-adapter-xml/src/Flow/ETL/Adapter/XML/XMLReaderExtractor.php
+++ b/src/adapter/etl-adapter-xml/src/Flow/ETL/Adapter/XML/XMLReaderExtractor.php
@@ -90,7 +90,7 @@ final class XMLReaderExtractor implements Extractor
 
             $xmlReader->close();
 
-            if (\count($rows)) {
+            if ([] !== $rows) {
                 yield new Rows(...$rows);
             }
         }

--- a/src/core/etl/src/Flow/ETL/Async/Socket/Worker/Processor.php
+++ b/src/core/etl/src/Flow/ETL/Async/Socket/Worker/Processor.php
@@ -58,7 +58,7 @@ final class Processor
             ->mode(SaveMode::Append)
             ->threadSafe();
 
-        if (\count($this->partitionEntries)) {
+        if ([] !== $this->partitionEntries) {
             $dataFrame = $dataFrame->partitionBy(...$this->partitionEntries);
         }
 

--- a/src/core/etl/src/Flow/ETL/DSL/functions.php
+++ b/src/core/etl/src/Flow/ETL/DSL/functions.php
@@ -16,7 +16,7 @@ use Flow\ETL\Row\StructureReference;
 
 function col(string $entry, string ...$entries) : Reference
 {
-    if (\count($entries)) {
+    if ([] !== $entries) {
         return new StructureReference($entry, ...$entries);
     }
 

--- a/src/core/etl/src/Flow/ETL/Filesystem/Path.php
+++ b/src/core/etl/src/Flow/ETL/Filesystem/Path.php
@@ -73,7 +73,7 @@ final class Path implements Serializable
     public static function realpath(string $path, array $options = []) : self
     {
         // ""  - empty path is current, local directory
-        if (!\strlen($path)) {
+        if ('' === $path) {
             /** @phpstan-ignore-next-line */
             return new self(\getcwd(), $options);
         }
@@ -124,7 +124,7 @@ final class Path implements Serializable
             }
 
             if ($part === '..') {
-                if (\count($absoluteParts)) {
+                if ([] !== $absoluteParts) {
                     \array_pop($absoluteParts);
                 }
 

--- a/src/core/etl/src/Flow/ETL/GroupBy.php
+++ b/src/core/etl/src/Flow/ETL/GroupBy.php
@@ -101,7 +101,7 @@ final class GroupBy
                 $entries = $entries->add($aggregator->result());
             }
 
-            if (\count($entries)) {
+            if ($entries->count()) {
                 $rows = $rows->add(new Row($entries));
             }
         }

--- a/src/core/etl/src/Flow/ETL/Partition.php
+++ b/src/core/etl/src/Flow/ETL/Partition.php
@@ -19,11 +19,11 @@ final class Partition implements Serializable
 
     public function __construct(public readonly string $name, public readonly string $value)
     {
-        if (!\strlen($this->name)) {
+        if ('' === $this->name) {
             throw new InvalidArgumentException("Partition name can't be empty");
         }
 
-        if (!\strlen($this->value)) {
+        if ('' === $this->value) {
             throw new InvalidArgumentException("Partition value can't be empty");
         }
 

--- a/src/core/etl/src/Flow/ETL/Row/Entries.php
+++ b/src/core/etl/src/Flow/ETL/Row/Entries.php
@@ -28,7 +28,7 @@ final class Entries implements \ArrayAccess, \Countable, \IteratorAggregate, Ser
     {
         $this->entries = [];
 
-        if (\count($entries)) {
+        if ([] !== $entries) {
             foreach ($entries as $entry) {
                 $this->entries[$entry->name()] = $entry;
             }

--- a/src/core/etl/src/Flow/ETL/Row/Entry/ArrayEntry.php
+++ b/src/core/etl/src/Flow/ETL/Row/Entry/ArrayEntry.php
@@ -26,7 +26,7 @@ final class ArrayEntry implements \Stringable, Entry
         private readonly string $name,
         private readonly array $value
     ) {
-        if (!\strlen($name)) {
+        if ('' === $name) {
             throw InvalidArgumentException::because('Entry name cannot be empty');
         }
     }

--- a/src/core/etl/src/Flow/ETL/Row/Entry/BooleanEntry.php
+++ b/src/core/etl/src/Flow/ETL/Row/Entry/BooleanEntry.php
@@ -21,7 +21,7 @@ final class BooleanEntry implements \Stringable, Entry
      */
     public function __construct(private readonly string $name, private readonly bool $value)
     {
-        if (!\strlen($name)) {
+        if ('' === $name) {
             throw InvalidArgumentException::because('Entry name cannot be empty');
         }
     }

--- a/src/core/etl/src/Flow/ETL/Row/Entry/FloatEntry.php
+++ b/src/core/etl/src/Flow/ETL/Row/Entry/FloatEntry.php
@@ -21,7 +21,7 @@ final class FloatEntry implements \Stringable, Entry
      */
     public function __construct(private readonly string $name, private readonly float $value, private readonly int $precision = 6)
     {
-        if (!\strlen($name)) {
+        if ('' === $name) {
             throw InvalidArgumentException::because('Entry name cannot be empty');
         }
     }

--- a/src/core/etl/src/Flow/ETL/Row/Entry/IntegerEntry.php
+++ b/src/core/etl/src/Flow/ETL/Row/Entry/IntegerEntry.php
@@ -21,7 +21,7 @@ final class IntegerEntry implements \Stringable, Entry
      */
     public function __construct(private readonly string $name, private readonly int $value)
     {
-        if (!\strlen($name)) {
+        if ('' === $name) {
             throw InvalidArgumentException::because('Entry name cannot be empty');
         }
     }

--- a/src/core/etl/src/Flow/ETL/Row/Entry/JsonEntry.php
+++ b/src/core/etl/src/Flow/ETL/Row/Entry/JsonEntry.php
@@ -28,7 +28,7 @@ final class JsonEntry implements \Stringable, Entry
      */
     public function __construct(private readonly string $name, private readonly array $value)
     {
-        if (!\strlen($name)) {
+        if ('' === $name) {
             throw InvalidArgumentException::because('Entry name cannot be empty');
         }
 

--- a/src/core/etl/src/Flow/ETL/Row/Entry/ListEntry.php
+++ b/src/core/etl/src/Flow/ETL/Row/Entry/ListEntry.php
@@ -34,11 +34,11 @@ final class ListEntry implements Entry, TypedCollection
         private readonly Type $type,
         private readonly array $value
     ) {
-        if (!\strlen($name)) {
+        if ('' === $name) {
             throw InvalidArgumentException::because('Entry name cannot be empty');
         }
 
-        if (\count($value) && !\array_is_list($value)) {
+        if ([] !== $value && !\array_is_list($value)) {
             throw new InvalidArgumentException('Expected list of ' . $type->toString() . ' got array with not sequential integer indexes');
         }
 

--- a/src/core/etl/src/Flow/ETL/Row/Entry/NullEntry.php
+++ b/src/core/etl/src/Flow/ETL/Row/Entry/NullEntry.php
@@ -21,7 +21,7 @@ final class NullEntry implements \Stringable, Entry
      */
     public function __construct(private readonly string $name)
     {
-        if (!\strlen($name)) {
+        if ('' === $name) {
             throw InvalidArgumentException::because('Entry name cannot be empty');
         }
     }

--- a/src/core/etl/src/Flow/ETL/Row/Entry/ObjectEntry.php
+++ b/src/core/etl/src/Flow/ETL/Row/Entry/ObjectEntry.php
@@ -21,7 +21,7 @@ final class ObjectEntry implements \Stringable, Entry
      */
     public function __construct(private readonly string $name, private readonly object $value)
     {
-        if (!\strlen($name)) {
+        if ('' === $name) {
             throw InvalidArgumentException::because('Entry name cannot be empty');
         }
     }

--- a/src/core/etl/src/Flow/ETL/Row/Entry/StringEntry.php
+++ b/src/core/etl/src/Flow/ETL/Row/Entry/StringEntry.php
@@ -21,7 +21,7 @@ final class StringEntry implements \Stringable, Entry
      */
     public function __construct(private readonly string $name, private string $value)
     {
-        if (!\strlen($name)) {
+        if ('' === $name) {
             throw InvalidArgumentException::because('Entry name cannot be empty');
         }
     }

--- a/src/core/etl/src/Flow/ETL/Row/Entry/StructureEntry.php
+++ b/src/core/etl/src/Flow/ETL/Row/Entry/StructureEntry.php
@@ -27,7 +27,7 @@ final class StructureEntry implements \Stringable, Entry
      */
     public function __construct(private readonly string $name, Entry ...$entries)
     {
-        if (!\strlen($name)) {
+        if ('' === $name) {
             throw InvalidArgumentException::because('Entry name cannot be empty');
         }
 

--- a/src/core/etl/src/Flow/ETL/Rows.php
+++ b/src/core/etl/src/Flow/ETL/Rows.php
@@ -228,7 +228,7 @@ final class Rows implements \ArrayAccess, \Countable, \IteratorAggregate, Serial
             }
         }
 
-        if (\count($rows)) {
+        if ([] !== $rows) {
             return \current($rows);
         }
 

--- a/src/lib/array-dot/src/Flow/ArrayDot/array_dot.php
+++ b/src/lib/array-dot/src/Flow/ArrayDot/array_dot.php
@@ -16,7 +16,7 @@ use Flow\ArrayDot\Exception\InvalidPathException;
  */
 function array_dot_steps(string $path) : array
 {
-    if (!\strlen($path)) {
+    if ('' === $path) {
         throw new InvalidPathException("Path can't be empty.");
     }
 
@@ -119,7 +119,7 @@ function array_dot_set(array $array, string $path, $value) : array
  */
 function array_dot_get(array $array, string $path) : mixed
 {
-    if (\count($array) === 0) {
+    if ([] === $array) {
         if (\str_starts_with($path, '?')) {
             return null;
         }

--- a/src/lib/doctrine-dbal-bulk/src/Flow/Doctrine/Bulk/Columns.php
+++ b/src/lib/doctrine-dbal-bulk/src/Flow/Doctrine/Bulk/Columns.php
@@ -15,7 +15,7 @@ final class Columns
 
     public function __construct(string ...$columns)
     {
-        if (\count($columns) === 0) {
+        if ([] === $columns) {
             throw new RuntimeException('Columns cannot be empty');
         }
 


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Prevent using `strlen` & `count` on empty input</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

Reference:
- `[] === $array` vs `\count($array)` - [big array](https://3v4l.org/5udiR), [empty](https://3v4l.org/bT9Ge)
```
#1
Time taken for strict comparison: 0.00032615661621094 seconds
Time taken for count function: 0.00045299530029297 seconds
#2
Time taken for strict comparison: 0.0095489025115967 seconds
Time taken for count function: 0.012413024902344 seconds
```
- `'' === $string` vs `\strlen($string)` - [some string](https://3v4l.org/tuB2q), [empty](https://3v4l.org/Uubet)
```
#1
Time taken for strict comparison: 0.018247127532959 seconds
Time taken for strlen function: 0.019370079040527 seconds
#2
Time taken for strict comparison: 0.014430046081543 seconds
Time taken for strlen function: 0.023833036422729 seconds
```

