### PR TITLE
Adjust `size` expression to behave similarly to the `count` one

### DIFF
--- a/src/core/etl/src/Flow/ETL/Row/Reference/Expression/Size.php
+++ b/src/core/etl/src/Flow/ETL/Row/Reference/Expression/Size.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Row\Reference\Expression;
 
-use Flow\ETL\Exception\RuntimeException;
 use Flow\ETL\Row;
 use Flow\ETL\Row\Reference\Expression;
 
@@ -19,10 +18,14 @@ final class Size implements Expression
         /** @var mixed $value */
         $value = $this->ref->eval($row);
 
-        return match (\gettype($value)) {
-            'array' => \count($value),
-            'string' => \mb_strlen($value),
-            default => throw new RuntimeException('Cannot get size of value ' . \gettype($value)),
-        };
+        if (\is_string($value)) {
+            return \mb_strlen($value);
+        }
+
+        if (\is_countable($value)) {
+            return \count($value);
+        }
+
+        return null;
     }
 }

--- a/src/core/etl/tests/Flow/ETL/Tests/Integration/Row/Reference/Expression/SizeTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Integration/Row/Reference/Expression/SizeTest.php
@@ -7,7 +7,6 @@ namespace Flow\ETL\Tests\Integration\Row\Reference\Expression;
 use function Flow\ETL\DSL\ref;
 use Flow\ETL\DSL\From;
 use Flow\ETL\DSL\To;
-use Flow\ETL\Exception\RuntimeException;
 use Flow\ETL\Flow;
 use Flow\ETL\Memory\ArrayMemory;
 use PHPUnit\Framework\TestCase;
@@ -41,8 +40,6 @@ final class SizeTest extends TestCase
 
     public function test_size_on_non_string_key() : void
     {
-        $this->expectException(RuntimeException::class);
-
         (new Flow())
             ->read(
                 From::array(
@@ -55,7 +52,15 @@ final class SizeTest extends TestCase
             ->renameAll('row.', '')
             ->drop('row')
             ->withEntry('size', ref('id')->size())
+            ->write(To::memory($memory = new ArrayMemory()))
             ->run();
+
+        $this->assertSame(
+            [
+                ['id' => 1, 'size' => null],
+            ],
+            $memory->data
+        );
     }
 
     public function test_size_on_string() : void

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Reference/Expression/SizeTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Reference/Expression/SizeTest.php
@@ -21,9 +21,9 @@ final class SizeTest extends TestCase
 
     public function test_size_expression_on_integer_value() : void
     {
-        $this->expectExceptionMessage('Cannot get size of value integer');
-
-        size(lit(1))->eval(Row::create());
+        $this->assertNull(
+            size(lit(1))->eval(Row::create())
+        );
     }
 
     public function test_size_expression_on_string_value() : void


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Adjust the `size` expression to behave similarly to the `count` one</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

Now, the `size` expression will return `null` when calling it on non-string & non-countable values, similarly to what's done for the `count` expression.
