### PR TITLE
Rework expressions to return `null` instead of throwing exception on failure

### DIFF
--- a/src/core/etl/src/Flow/ETL/Row/Reference/Expression/ArrayExpand.php
+++ b/src/core/etl/src/Flow/ETL/Row/Reference/Expression/ArrayExpand.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Row\Reference\Expression;
 
-use Flow\ETL\Exception\RuntimeException;
 use Flow\ETL\Row;
 use Flow\ETL\Row\Reference\ExpandResults;
 use Flow\ETL\Row\Reference\Expression;
@@ -20,7 +19,7 @@ final class ArrayExpand implements ExpandResults, Expression
         $array = $this->ref->eval($row);
 
         if (!\is_array($array)) {
-            throw new RuntimeException(\get_class($this->ref) . ' is not an array, got: ' . \gettype($array));
+            return null;
         }
 
         if ($this->expand === ArrayExpand\ArrayExpand::KEYS) {

--- a/src/core/etl/src/Flow/ETL/Row/Reference/Expression/ArrayGetCollection.php
+++ b/src/core/etl/src/Flow/ETL/Row/Reference/Expression/ArrayGetCollection.php
@@ -7,7 +7,6 @@ namespace Flow\ETL\Row\Reference\Expression;
 use function Flow\ArrayDot\array_dot_get;
 use Flow\ArrayDot\Exception\InvalidPathException;
 use Flow\ETL\Exception\InvalidArgumentException;
-use Flow\ETL\Exception\RuntimeException;
 use Flow\ETL\Row;
 use Flow\ETL\Row\Reference\Expression;
 
@@ -45,11 +44,11 @@ final class ArrayGetCollection implements Expression
 
                 $extractedValues = array_dot_get($array, $path);
             } catch (InvalidPathException) {
-                throw new RuntimeException(\get_class($this->ref) . ' must be an array of array (collection of arrays) but it seems to be a regular array.');
+                return null;
             }
 
             if (!\is_array($extractedValues)) {
-                throw new RuntimeException("Extracted value from path \"{$path}\" is not array but " . \gettype($extractedValues));
+                return null;
             }
 
             return $extractedValues;

--- a/src/core/etl/src/Flow/ETL/Row/Reference/Expression/ArrayKeysStyleConvert.php
+++ b/src/core/etl/src/Flow/ETL/Row/Reference/Expression/ArrayKeysStyleConvert.php
@@ -26,7 +26,7 @@ final class ArrayKeysStyleConvert implements Expression
         $array = $this->ref->eval($row);
 
         if (!\is_array($array)) {
-            throw new RuntimeException(\get_class($this->ref) . ' is not an array, got: ' . \gettype($array));
+            return null;
         }
 
         $converter = (new StyleConverter\ArrayKeyConverter(

--- a/src/core/etl/src/Flow/ETL/Row/Reference/Expression/ArrayMergeCollection.php
+++ b/src/core/etl/src/Flow/ETL/Row/Reference/Expression/ArrayMergeCollection.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Row\Reference\Expression;
 
-use Flow\ETL\Exception\RuntimeException;
 use Flow\ETL\Row;
 use Flow\ETL\Row\Reference\Expression;
 
@@ -23,11 +22,9 @@ final class ArrayMergeCollection implements Expression
             return null;
         }
 
-        foreach ($value as $index => $element) {
+        foreach ($value as $element) {
             if (!\is_array($element)) {
-                $type = \gettype($element);
-
-                throw new RuntimeException(\get_class($this->ref) . " must be an array of arrays, instead element at position \"{$index}\" is {$type}");
+                return null;
             }
         }
 

--- a/src/core/etl/src/Flow/ETL/Row/Reference/Expression/ArrayUnpack.php
+++ b/src/core/etl/src/Flow/ETL/Row/Reference/Expression/ArrayUnpack.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Row\Reference\Expression;
 
-use Flow\ETL\Exception\RuntimeException;
 use Flow\ETL\Row;
 use Flow\ETL\Row\Reference\Expression;
 
@@ -22,7 +21,7 @@ final class ArrayUnpack implements Expression, Row\Reference\UnpackResults
         $array = $this->ref->eval($row);
 
         if (!\is_array($array)) {
-            throw new RuntimeException(\get_class($this->ref) . ' is not an array, got: ' . \gettype($array));
+            return null;
         }
 
         $values = [];

--- a/src/core/etl/src/Flow/ETL/Row/Reference/Expression/Cast.php
+++ b/src/core/etl/src/Flow/ETL/Row/Reference/Expression/Cast.php
@@ -52,11 +52,10 @@ final class Cast implements Expression
             'bool', 'boolean' => (bool) $value,
             'array' => $this->toArray($value),
             'object' => (object) $value,
-            'null' => null,
             'json' => \json_encode($value, JSON_THROW_ON_ERROR),
             'json_pretty' => \json_encode($value, JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT),
             'xml' => $this->toXML($value),
-            default => throw new InvalidArgumentException("Unknown cast type '{$this->type}'")
+            default => null
         };
     }
 
@@ -69,13 +68,13 @@ final class Cast implements Expression
         return (array) $data;
     }
 
-    private function toXML(mixed $value) : \DOMDocument
+    private function toXML(mixed $value) : null|\DOMDocument
     {
         if (\is_string($value)) {
             $doc = new \DOMDocument();
 
             if (!@$doc->load($value)) {
-                throw new InvalidArgumentException('Invalid XML string given: ' . $value);
+                return null;
             }
 
             return $doc;
@@ -85,6 +84,6 @@ final class Cast implements Expression
             return $value;
         }
 
-        throw new InvalidArgumentException(\sprintf('Cannot cast %s to XML', \gettype($value)));
+        return null;
     }
 }

--- a/src/core/etl/src/Flow/ETL/Row/Reference/Expression/DateTimeFormat.php
+++ b/src/core/etl/src/Flow/ETL/Row/Reference/Expression/DateTimeFormat.php
@@ -20,7 +20,7 @@ final class DateTimeFormat implements Expression
         $value = $this->ref->eval($row);
 
         if (!$value instanceof \DateTimeInterface) {
-            throw new \InvalidArgumentException('Entry ' . \gettype($value) . ' is not a DateTimeEntry');
+            return null;
         }
 
         return $value->format($this->format);

--- a/src/core/etl/src/Flow/ETL/Row/Reference/Expression/ToDate.php
+++ b/src/core/etl/src/Flow/ETL/Row/Reference/Expression/ToDate.php
@@ -26,26 +26,23 @@ final class ToDate implements Expression
         $value = $this->ref->eval($row);
 
         if (\is_object($value)) {
-            return match (\get_class($value)) {
-                \DateTimeImmutable::class, \DateTime::class => $value->setTimezone($this->timeZone)->setTime(0, 0, 0, 0),
-                default => throw new \InvalidArgumentException('Entry ' . \get_class($value) . ' is not a DateTimeImmutable|DateTime')
-            };
+            if (\is_a($value, \DateTimeImmutable::class) || \is_a($value, \DateTime::class)) {
+                return $value->setTimezone($this->timeZone)->setTime(0, 0, 0, 0);
+            }
+
+            return null;
         }
 
         if (\is_int($value)) {
-            /**
-             * @phpstan-ignore-next-line
-             */
+            /** @phpstan-ignore-next-line */
             return \DateTimeImmutable::createFromFormat('U', (string) $value, $this->timeZone)->setTime(0, 0, 0, 0);
         }
 
         if (\is_string($value)) {
-            /**
-             * @phpstan-ignore-next-line
-             */
+            /** @phpstan-ignore-next-line */
             return \DateTimeImmutable::createFromFormat($this->format, $value, $this->timeZone)->setTime(0, 0, 0, 0);
         }
 
-        throw new \InvalidArgumentException('Value ' . \gettype($value) . ' is not a DateTimeImmutable|DateTime|string|int');
+        return null;
     }
 }

--- a/src/core/etl/src/Flow/ETL/Row/Reference/Expression/ToDateTime.php
+++ b/src/core/etl/src/Flow/ETL/Row/Reference/Expression/ToDateTime.php
@@ -26,10 +26,11 @@ final class ToDateTime implements Expression
         $value = $this->ref->eval($row);
 
         if (\is_object($value)) {
-            return match (\get_class($value)) {
-                \DateTimeImmutable::class, \DateTime::class => $value->setTimezone($this->timeZone),
-                default => throw new \InvalidArgumentException('Entry ' . \get_class($value) . ' is not a DateTimeImmutable|DateTime')
-            };
+            if (\is_a($value, \DateTimeImmutable::class) || \is_a($value, \DateTime::class)) {
+                return $value->setTimezone($this->timeZone)->setTime(0, 0, 0, 0);
+            }
+
+            return null;
         }
 
         if (\is_int($value)) {
@@ -40,6 +41,6 @@ final class ToDateTime implements Expression
             return \DateTimeImmutable::createFromFormat($this->format, $value, $this->timeZone);
         }
 
-        throw new \InvalidArgumentException('Value ' . \gettype($value) . ' is not a DateTimeImmutable|DateTime|string|int');
+        return null;
     }
 }

--- a/src/core/etl/src/Flow/ETL/Row/Reference/Expression/Trim.php
+++ b/src/core/etl/src/Flow/ETL/Row/Reference/Expression/Trim.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Row\Reference\Expression;
 
-use Flow\ETL\Exception\InvalidArgumentException;
 use Flow\ETL\Row;
 use Flow\ETL\Row\Reference\Expression;
 
@@ -34,6 +33,6 @@ final class Trim implements Expression
             }
         }
 
-        throw new InvalidArgumentException("Unsupported trim method: {$value}");
+        return null;
     }
 }

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Reference/Expression/ArrayExpandTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Reference/Expression/ArrayExpandTest.php
@@ -7,7 +7,6 @@ namespace Flow\ETL\Tests\Unit\Row\Reference\Expression;
 use function Flow\ETL\DSL\array_expand;
 use function Flow\ETL\DSL\ref;
 use Flow\ETL\DSL\Entry;
-use Flow\ETL\Exception\RuntimeException;
 use Flow\ETL\Row;
 use Flow\ETL\Row\Reference\Expression\ArrayExpand\ArrayExpand;
 use PHPUnit\Framework\TestCase;
@@ -56,9 +55,8 @@ final class ArrayExpandTest extends TestCase
 
     public function test_for_not_array_entry() : void
     {
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Flow\ETL\Row\EntryReference is not an array, got: integer');
-
-        array_expand(ref('integer_entry'))->eval(Row::create(Entry::int('integer_entry', 1)));
+        $this->assertNull(
+            array_expand(ref('integer_entry'))->eval(Row::create(Entry::int('integer_entry', 1)))
+        );
     }
 }

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Reference/Expression/ArrayGetCollectionTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Reference/Expression/ArrayGetCollectionTest.php
@@ -8,7 +8,6 @@ use function Flow\ETL\DSL\array_get_collection;
 use function Flow\ETL\DSL\array_get_collection_first;
 use function Flow\ETL\DSL\ref;
 use Flow\ETL\DSL\Entry;
-use Flow\ETL\Exception\RuntimeException;
 use Flow\ETL\Row;
 use PHPUnit\Framework\TestCase;
 
@@ -37,10 +36,7 @@ final class ArrayGetCollectionTest extends TestCase
             ),
         );
 
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Flow\ETL\Row\EntryReference must be an array of array (collection of arrays) but it seems to be a regular array.');
-
-        array_get_collection(ref('array_entry'), 'id', 'status')->eval($row);
+        $this->assertNull(array_get_collection(ref('array_entry'), 'id', 'status')->eval($row));
     }
 
     public function test_getting_specific_keys_from_collection_of_array() : void

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Reference/Expression/ArrayKeysStyleConverterTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Reference/Expression/ArrayKeysStyleConverterTest.php
@@ -8,7 +8,6 @@ use function Flow\ETL\DSL\array_keys_style_convert;
 use function Flow\ETL\DSL\ref;
 use Flow\ETL\DSL\Entry;
 use Flow\ETL\Exception\InvalidArgumentException;
-use Flow\ETL\Exception\RuntimeException;
 use Flow\ETL\Row;
 use PHPUnit\Framework\TestCase;
 
@@ -28,14 +27,11 @@ final class ArrayKeysStyleConverterTest extends TestCase
 
     public function test_for_not_array_entry() : void
     {
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Flow\ETL\Row\EntryReference is not an array, got: integer');
-
         $row = Row::create(
             Entry::integer('invalid_entry', 1),
         );
 
-        array_keys_style_convert(ref('invalid_entry'), 'snake')->eval($row);
+        $this->assertNull(array_keys_style_convert(ref('invalid_entry'), 'snake')->eval($row));
     }
 
     public function test_transforms_case_style_for_all_keys_in_array_entry() : void

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Reference/Expression/ArrayMergeCollectionTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Reference/Expression/ArrayMergeCollectionTest.php
@@ -7,7 +7,6 @@ namespace Flow\ETL\Tests\Unit\Row\Reference\Expression;
 use function Flow\ETL\DSL\array_merge_collection;
 use function Flow\ETL\DSL\ref;
 use Flow\ETL\DSL\Entry;
-use Flow\ETL\Exception\RuntimeException;
 use Flow\ETL\Row;
 use PHPUnit\Framework\TestCase;
 
@@ -25,10 +24,7 @@ final class ArrayMergeCollectionTest extends TestCase
             ),
         );
 
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Flow\ETL\Row\EntryReference must be an array of arrays, instead element at position "1" is integer');
-
-        array_merge_collection(ref('array_entry'))->eval($row);
+        $this->assertNull(array_merge_collection(ref('array_entry'))->eval($row));
     }
 
     public function test_for_not_array_entry() : void

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Reference/Expression/CastTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Reference/Expression/CastTest.php
@@ -6,7 +6,6 @@ namespace Flow\ETL\Tests\Unit\Row\Reference\Expression;
 
 use function Flow\ETL\DSL\cast;
 use function Flow\ETL\DSL\ref;
-use Flow\ETL\Exception\InvalidArgumentException;
 use Flow\ETL\Row;
 use Flow\ETL\Row\Factory\NativeEntryFactory;
 use PHPUnit\Framework\TestCase;
@@ -57,17 +56,15 @@ final class CastTest extends TestCase
 
     public function test_casting_integer_to_xml() : void
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Cannot cast integer to XML');
-
-        ref('value')->cast('xml')->eval(Row::create((new NativeEntryFactory())->create('value', 1)));
+        $this->assertNull(
+            ref('value')->cast('xml')->eval(Row::create((new NativeEntryFactory())->create('value', 1)))
+        );
     }
 
     public function test_casting_non_xml_string_to_xml() : void
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid XML string given: foo');
-
-        ref('value')->cast('xml')->eval(Row::create((new NativeEntryFactory())->create('value', 'foo')));
+        $this->assertNull(
+            ref('value')->cast('xml')->eval(Row::create((new NativeEntryFactory())->create('value', 'foo')))
+        );
     }
 }

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Reference/Expression/CombineTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Reference/Expression/CombineTest.php
@@ -15,7 +15,7 @@ final class CombineTest extends TestCase
     {
         $this->assertSame(
             ['a' => 1, 'b' => 2, 'c' => 3],
-            combine(lit(['a', 'b', 'c']), lit([1, 2, 3]), )->eval(Row::create()),
+            combine(lit(['a', 'b', 'c']), lit([1, 2, 3]))->eval(Row::create()),
         );
     }
 
@@ -23,15 +23,14 @@ final class CombineTest extends TestCase
     {
         $this->assertSame(
             [],
-            combine(lit([]), lit([]), )->eval(Row::create()),
+            combine(lit([]), lit([]))->eval(Row::create()),
         );
     }
 
     public function test_array_combine_when_keys_are_not_array() : void
     {
-        $this->assertSame(
-            null,
-            combine(lit('a'), lit([1, 2, 3]), )->eval(Row::create()),
+        $this->assertNull(
+            combine(lit('a'), lit([1, 2, 3]))->eval(Row::create()),
         );
     }
 
@@ -39,15 +38,14 @@ final class CombineTest extends TestCase
     {
         $this->assertSame(
             ['a' => 4, 'b' => 2, 'c' => 3],
-            combine(lit(['a', 'b', 'c', 'a']), lit([1, 2, 3, 4]), )->eval(Row::create()),
+            combine(lit(['a', 'b', 'c', 'a']), lit([1, 2, 3, 4]))->eval(Row::create()),
         );
     }
 
     public function test_array_combine_when_one_of_arrays_is_empty() : void
     {
-        $this->assertSame(
-            null,
-            combine(lit(['a', 'b', 'c']), lit([]), )->eval(Row::create()),
+        $this->assertNull(
+            combine(lit(['a', 'b', 'c']), lit([]))->eval(Row::create()),
         );
     }
 }


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Rework expressions to return `null` instead of throwing exception on failure</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

Fixes #555 
