### PR TITLE
Block running incompatible examples via PHAR

### DIFF
--- a/examples/topics/async/bootstrap.php
+++ b/examples/topics/async/bootstrap.php
@@ -8,7 +8,7 @@ if ('' !== \Phar::running(false)) {
 
 require __DIR__ . '/../../bootstrap.php';
 
-const __FLOW_AUTOLOAD__ =  __DIR__ . '/../vendor/autoload.php';
+const __FLOW_AUTOLOAD__ =  __DIR__ . '/../../../vendor/autoload.php';
 
 // library autoload for all dependencies
 require __FLOW_AUTOLOAD__;

--- a/examples/topics/async/bootstrap.php
+++ b/examples/topics/async/bootstrap.php
@@ -1,5 +1,11 @@
 <?php declare(strict_types=1);
 
+if ('' !== \Phar::running(false)) {
+    print 'This example cannot be run in PHAR, please use CLI approach.';
+
+    exit(1);
+}
+
 require __DIR__ . '/../../bootstrap.php';
 
 const __FLOW_AUTOLOAD__ =  __DIR__ . '/../vendor/autoload.php';

--- a/examples/topics/db/db_clean.php
+++ b/examples/topics/db/db_clean.php
@@ -1,6 +1,12 @@
 #!/usr/bin/env php
 <?php
 
+if ('' !== \Phar::running(false)) {
+    print 'This example cannot be run in PHAR, please use CLI approach.';
+
+    exit(1);
+}
+
 use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\Table;

--- a/examples/topics/db/db_source.php
+++ b/examples/topics/db/db_source.php
@@ -1,6 +1,12 @@
 #!/usr/bin/env php
 <?php
 
+if ('' !== \Phar::running(false)) {
+    print 'This example cannot be run in PHAR, please use CLI approach.';
+
+    exit(1);
+}
+
 use function Flow\ETL\DSL\ref;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Schema\Column;

--- a/examples/topics/db/db_to_db_sync.php
+++ b/examples/topics/db/db_to_db_sync.php
@@ -1,5 +1,11 @@
 <?php declare(strict_types=1);
 
+if ('' !== \Phar::running(false)) {
+    print 'This example cannot be run in PHAR, please use CLI approach.';
+
+    exit(1);
+}
+
 use function Flow\ETL\DSL\concat;
 use function Flow\ETL\DSL\lit;
 use function Flow\ETL\DSL\ref;

--- a/examples/topics/fs/remote/json_remote_stream.php
+++ b/examples/topics/fs/remote/json_remote_stream.php
@@ -1,5 +1,11 @@
 <?php declare(strict_types=1);
 
+if ('' !== \Phar::running(false)) {
+    print 'This example cannot be run in PHAR, please use CLI approach.';
+
+    exit(1);
+}
+
 use function Flow\ETL\DSL\concat;
 use function Flow\ETL\DSL\lit;
 use function Flow\ETL\DSL\ref;

--- a/examples/topics/fs/remote/json_remote_stream_glob.php
+++ b/examples/topics/fs/remote/json_remote_stream_glob.php
@@ -1,5 +1,11 @@
 <?php declare(strict_types=1);
 
+if ('' !== \Phar::running(false)) {
+    print 'This example cannot be run in PHAR, please use CLI approach.';
+
+    exit(1);
+}
+
 use function Flow\ETL\DSL\concat;
 use function Flow\ETL\DSL\lit;
 use function Flow\ETL\DSL\ref;


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>Fix broken path to autoloader in async examples</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Block running incompatible examples via PHAR</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

Some of the examples are too complex to be run via PHAR.
