### PR TITLE
Prevent fatal error with aggregate avg on empty group

### DIFF
--- a/src/core/etl/src/Flow/ETL/GroupBy/Aggregator/Average.php
+++ b/src/core/etl/src/Flow/ETL/GroupBy/Aggregator/Average.php
@@ -46,8 +46,13 @@ final class Average implements Aggregator
             $this->ref->as($this->ref->to() . '_avg');
         }
 
-        $result = $this->sum / $this->count;
-        $resultInt = (int) $result;
+        if (0 !== $this->count) {
+            $result = $this->sum / $this->count;
+            $resultInt = (int) $result;
+        } else {
+            $result = 0.0;
+            $resultInt = 0;
+        }
 
         if ($result - $resultInt === 0.0) {
             return \Flow\ETL\DSL\Entry::integer($this->ref->name(), (int) $result);

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/GroupBy/Aggregator/AverageTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/GroupBy/Aggregator/AverageTest.php
@@ -72,4 +72,14 @@ final class AverageTest extends TestCase
             $aggregator->result()->value()
         );
     }
+
+    public function test_average_with_zero_result() : void
+    {
+        $aggregator = new Average('int');
+
+        $this->assertSame(
+            0,
+            $aggregator->result()->value()
+        );
+    }
 }


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>Prevent fatal error with aggregate avg on empty group</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

Error:
```
PHP Fatal error:  Uncaught DivisionByZeroError: Division by zero in /Users/stloyd/Documents/flow/src/core/etl/src/Flow/ETL/GroupBy/Aggregator/Average.php:49
Stack trace:
#0 /Users/stloyd/Documents/flow/src/core/etl/src/Flow/ETL/GroupBy.php(101): Flow\ETL\GroupBy\Aggregator\Average->result()
#1 /Users/stloyd/Documents/flow/src/core/etl/src/Flow/ETL/Pipeline/GroupByPipeline.php(62): Flow\ETL\GroupBy->result()
#2 /Users/stloyd/Documents/flow/src/core/etl/src/Flow/ETL/DataFrame.php(582): Flow\ETL\Pipeline\GroupByPipeline->process(Object(Flow\ETL\FlowContext))
#3 /Users/stloyd/Documents/flow/examples/topics/aggregations/power_plant_bar_chart.php(56): Flow\ETL\DataFrame->run()
#4 /Users/stloyd/Documents/flow/examples/run_examples.php(47): include('/Users/stloyd/D...')
#5 {main}
  thrown in /Users/stloyd/Documents/flow/src/core/etl/src/Flow/ETL/GroupBy/Aggregator/Average.php on line 49
```
