### PR TITLE
Remove "scripts" from `composer.json` in subpackages

### DIFF
--- a/src/adapter/etl-adapter-amphp/composer.json
+++ b/src/adapter/etl-adapter-amphp/composer.json
@@ -37,31 +37,6 @@
             "Flow\\": "tests/Flow"
         }
     },
-    "scripts": {
-        "build": [
-            "@static:analyze",
-            "@test",
-            "@test:mutation"
-        ],
-        "test": [
-            "tools/vendor/bin/phpunit"
-        ],
-        "test:mutation": [
-            "tools/vendor/bin/infection -j2"
-        ],
-        "static:analyze": [
-            "tools/vendor/bin/phpstan analyze -c phpstan.neon",
-            "tools/vendor/bin/php-cs-fixer fix --dry-run"
-        ],
-        "cs:php:fix": "tools/vendor/bin/php-cs-fixer fix",
-        "tools:install": "composer install --working-dir=./tools",
-        "post-install-cmd": [
-            "@tools:install"
-        ],
-        "post-update-cmd": [
-            "@tools:install"
-        ]
-    },
     "minimum-stability": "dev",
     "prefer-stable": true
 }

--- a/src/adapter/etl-adapter-avro/composer.json
+++ b/src/adapter/etl-adapter-avro/composer.json
@@ -33,28 +33,6 @@
             "Flow\\": "tests/Flow"
         }
     },
-    "scripts": {
-        "build": [
-            "@static:analyze",
-            "@test"
-        ],
-        "test": [
-            "tools/vendor/bin/phpunit"
-        ],
-        "static:analyze": [
-            "tools/vendor/bin/psalm --output-format=compact",
-            "tools/vendor/bin/phpstan analyze -c phpstan.neon",
-            "tools/vendor/bin/php-cs-fixer fix --dry-run"
-        ],
-        "cs:php:fix": "tools/vendor/bin/php-cs-fixer fix",
-        "tools:install": "composer install --working-dir=./tools",
-        "post-install-cmd": [
-            "@tools:install"
-        ],
-        "post-update-cmd": [
-            "@tools:install"
-        ]
-    },
     "minimum-stability": "dev",
     "prefer-stable": true
 }

--- a/src/adapter/etl-adapter-chartjs/composer.json
+++ b/src/adapter/etl-adapter-chartjs/composer.json
@@ -31,28 +31,6 @@
             "Flow\\": "tests/Flow"
         }
     },
-    "scripts": {
-        "build": [
-            "@static:analyze",
-            "@test"
-        ],
-        "test": [
-            "tools/vendor/bin/phpunit"
-        ],
-        "static:analyze": [
-            "tools/vendor/bin/psalm --output-format=compact",
-            "tools/vendor/bin/phpstan analyze -c phpstan.neon",
-            "tools/vendor/bin/php-cs-fixer fix --dry-run"
-        ],
-        "cs:php:fix": "tools/vendor/bin/php-cs-fixer fix",
-        "tools:install": "composer install --working-dir=./tools",
-        "post-install-cmd": [
-            "@tools:install"
-        ],
-        "post-update-cmd": [
-            "@tools:install"
-        ]
-    },
     "minimum-stability": "dev",
     "prefer-stable": true
 }

--- a/src/adapter/etl-adapter-csv/composer.json
+++ b/src/adapter/etl-adapter-csv/composer.json
@@ -31,28 +31,6 @@
             "Flow\\": "tests/Flow"
         }
     },
-    "scripts": {
-        "build": [
-            "@static:analyze",
-            "@test"
-        ],
-        "test": [
-            "tools/vendor/bin/phpunit"
-        ],
-        "static:analyze": [
-            "tools/vendor/bin/psalm --output-format=compact",
-            "tools/vendor/bin/phpstan analyze -c phpstan.neon",
-            "tools/vendor/bin/php-cs-fixer fix --dry-run"
-        ],
-        "cs:php:fix": "tools/vendor/bin/php-cs-fixer fix",
-        "tools:install": "composer install --working-dir=./tools",
-        "post-install-cmd": [
-            "@tools:install"
-        ],
-        "post-update-cmd": [
-            "@tools:install"
-        ]
-    },
     "minimum-stability": "dev",
     "prefer-stable": true
 }

--- a/src/adapter/etl-adapter-doctrine/composer.json
+++ b/src/adapter/etl-adapter-doctrine/composer.json
@@ -33,32 +33,6 @@
         "optimize-autoloader": true,
         "sort-packages": true
     },
-    "scripts": {
-        "tools:install": "composer install --working-dir=./tools",
-        "cs:php:fix": "tools/vendor/bin/php-cs-fixer fix",
-        "build": [
-            "@static:analyze",
-            "@test",
-            "@test:mutation"
-        ],
-        "static:analyze": [
-            "tools/vendor/bin/psalm",
-            "tools/vendor/bin/phpstan analyze -c phpstan.neon",
-            "tools/vendor/bin/php-cs-fixer fix --dry-run"
-        ],
-        "test": [
-            "tools/vendor/bin/phpunit"
-        ],
-        "test:mutation": [
-            "tools/vendor/bin/infection -j2"
-        ],
-        "post-install-cmd": [
-            "@tools:install"
-        ],
-        "post-update-cmd": [
-            "@tools:install"
-        ]
-    },
     "minimum-stability": "dev",
     "prefer-stable": true
 }

--- a/src/adapter/etl-adapter-elasticsearch/composer.json
+++ b/src/adapter/etl-adapter-elasticsearch/composer.json
@@ -34,28 +34,6 @@
             "Flow\\": "tests/Flow"
         }
     },
-    "scripts": {
-        "build": [
-            "@static:analyze",
-            "@test"
-        ],
-        "test": [
-            "tools/vendor/bin/phpunit"
-        ],
-        "static:analyze": [
-            "tools/vendor/bin/psalm --output-format=compact",
-            "tools/vendor/bin/phpstan analyze -c phpstan.neon",
-            "tools/vendor/bin/php-cs-fixer fix --dry-run"
-        ],
-        "cs:php:fix": "tools/vendor/bin/php-cs-fixer fix",
-        "tools:install": "composer install --working-dir=./tools",
-        "post-install-cmd": [
-            "@tools:install"
-        ],
-        "post-update-cmd": [
-            "@tools:install"
-        ]
-    },
     "minimum-stability": "dev",
     "prefer-stable": true
 }

--- a/src/adapter/etl-adapter-google-sheet/composer.json
+++ b/src/adapter/etl-adapter-google-sheet/composer.json
@@ -33,29 +33,6 @@
             "Flow\\": "tests/Flow"
         }
     },
-    "scripts": {
-        "build": [
-            "@static:analyze",
-            "@test"
-        ],
-        "test": [
-            "tools/vendor/bin/phpunit"
-        ],
-        "static:analyze": [
-            "tools/vendor/bin/psalm --output-format=compact",
-            "tools/vendor/bin/phpstan analyze -c phpstan.neon",
-            "tools/vendor/bin/php-cs-fixer fix --dry-run"
-        ],
-        "cs:php:fix": "tools/vendor/bin/php-cs-fixer fix",
-        "tools:install": "composer install --working-dir=./tools",
-        "pre-autoload-dump": "Google\\Task\\Composer::cleanup",
-        "post-install-cmd": [
-            "@tools:install"
-        ],
-        "post-update-cmd": [
-            "@tools:install"
-        ]
-    },
     "extra": {
         "google/apiclient-services": [
             "Sheets"

--- a/src/adapter/etl-adapter-http/composer.json
+++ b/src/adapter/etl-adapter-http/composer.json
@@ -36,32 +36,6 @@
             "Flow\\": "tests/Flow"
         }
     },
-    "scripts": {
-        "build": [
-            "@static:analyze",
-            "@test",
-            "@test:mutation"
-        ],
-        "test": [
-            "tools/vendor/bin/phpunit"
-        ],
-        "test:mutation": [
-            "tools/vendor/bin/infection -j2"
-        ],
-        "static:analyze": [
-            "tools/vendor/bin/psalm --output-format=compact",
-            "tools/vendor/bin/phpstan analyze -c phpstan.neon",
-            "tools/vendor/bin/php-cs-fixer fix --dry-run"
-        ],
-        "cs:php:fix": "tools/vendor/bin/php-cs-fixer fix",
-        "tools:install": "composer install --working-dir=./tools",
-        "post-install-cmd": [
-            "@tools:install"
-        ],
-        "post-update-cmd": [
-            "@tools:install"
-        ]
-    },
     "minimum-stability": "dev",
     "prefer-stable": true
 }

--- a/src/adapter/etl-adapter-json/composer.json
+++ b/src/adapter/etl-adapter-json/composer.json
@@ -33,28 +33,6 @@
             "Flow\\": "tests/Flow"
         }
     },
-    "scripts": {
-        "build": [
-            "@static:analyze",
-            "@test"
-        ],
-        "test": [
-            "tools/vendor/bin/phpunit"
-        ],
-        "static:analyze": [
-            "tools/vendor/bin/psalm --output-format=compact",
-            "tools/vendor/bin/phpstan analyze -c phpstan.neon",
-            "tools/vendor/bin/php-cs-fixer fix --dry-run"
-        ],
-        "cs:php:fix": "tools/vendor/bin/php-cs-fixer fix",
-        "tools:install": "composer install --working-dir=./tools",
-        "post-install-cmd": [
-            "@tools:install"
-        ],
-        "post-update-cmd": [
-            "@tools:install"
-        ]
-    },
     "minimum-stability": "dev",
     "prefer-stable": true
 }

--- a/src/adapter/etl-adapter-logger/composer.json
+++ b/src/adapter/etl-adapter-logger/composer.json
@@ -35,32 +35,6 @@
             "Flow\\": "tests/Flow"
         }
     },
-    "scripts": {
-        "build": [
-            "@static:analyze",
-            "@test",
-            "@test:mutation"
-        ],
-        "test": [
-            "tools/vendor/bin/phpunit"
-        ],
-        "test:mutation": [
-            "tools/vendor/bin/infection -j2"
-        ],
-        "static:analyze": [
-            "tools/vendor/bin/psalm --output-format=compact",
-            "tools/vendor/bin/phpstan analyze -c phpstan.neon",
-            "tools/vendor/bin/php-cs-fixer fix --dry-run"
-        ],
-        "cs:php:fix": "tools/vendor/bin/php-cs-fixer fix",
-        "tools:install": "composer install --working-dir=./tools",
-        "post-install-cmd": [
-            "@tools:install"
-        ],
-        "post-update-cmd": [
-            "@tools:install"
-        ]
-    },
     "minimum-stability": "dev",
     "prefer-stable": true
 }

--- a/src/adapter/etl-adapter-meilisearch/composer.json
+++ b/src/adapter/etl-adapter-meilisearch/composer.json
@@ -34,28 +34,6 @@
             "Flow\\": "tests/Flow"
         }
     },
-    "scripts": {
-        "build": [
-            "@static:analyze",
-            "@test"
-        ],
-        "test": [
-            "tools/vendor/bin/phpunit"
-        ],
-        "static:analyze": [
-            "tools/vendor/bin/psalm --output-format=compact",
-            "tools/vendor/bin/phpstan analyze -c phpstan.neon",
-            "tools/vendor/bin/php-cs-fixer fix --dry-run"
-        ],
-        "cs:php:fix": "tools/vendor/bin/php-cs-fixer fix",
-        "tools:install": "composer install --working-dir=./tools",
-        "post-install-cmd": [
-            "@tools:install"
-        ],
-        "post-update-cmd": [
-            "@tools:install"
-        ]
-    },
     "minimum-stability": "dev",
     "prefer-stable": true
 }

--- a/src/adapter/etl-adapter-parquet/composer.json
+++ b/src/adapter/etl-adapter-parquet/composer.json
@@ -33,28 +33,6 @@
             "Flow\\": "tests/Flow"
         }
     },
-    "scripts": {
-        "build": [
-            "@static:analyze",
-            "@test"
-        ],
-        "test": [
-            "tools/vendor/bin/phpunit"
-        ],
-        "static:analyze": [
-            "tools/vendor/bin/psalm --output-format=compact",
-            "tools/vendor/bin/phpstan analyze -c phpstan.neon",
-            "tools/vendor/bin/php-cs-fixer fix --dry-run"
-        ],
-        "cs:php:fix": "tools/vendor/bin/php-cs-fixer fix",
-        "tools:install": "composer install --working-dir=./tools",
-        "post-install-cmd": [
-            "@tools:install"
-        ],
-        "post-update-cmd": [
-            "@tools:install"
-        ]
-    },
     "minimum-stability": "dev",
     "prefer-stable": true
 }

--- a/src/adapter/etl-adapter-reactphp/composer.json
+++ b/src/adapter/etl-adapter-reactphp/composer.json
@@ -37,31 +37,6 @@
             "Flow\\": "tests/Flow"
         }
     },
-    "scripts": {
-        "build": [
-            "@static:analyze",
-            "@test",
-            "@test:mutation"
-        ],
-        "test": [
-            "tools/vendor/bin/phpunit"
-        ],
-        "test:mutation": [
-            "tools/vendor/bin/infection -j2"
-        ],
-        "static:analyze": [
-            "tools/vendor/bin/phpstan analyze -c phpstan.neon",
-            "tools/vendor/bin/php-cs-fixer fix --dry-run"
-        ],
-        "cs:php:fix": "tools/vendor/bin/php-cs-fixer fix",
-        "tools:install": "composer install --working-dir=./tools",
-        "post-install-cmd": [
-            "@tools:install"
-        ],
-        "post-update-cmd": [
-            "@tools:install"
-        ]
-    },
     "minimum-stability": "dev",
     "prefer-stable": true
 }

--- a/src/adapter/etl-adapter-text/composer.json
+++ b/src/adapter/etl-adapter-text/composer.json
@@ -31,28 +31,6 @@
             "Flow\\": "tests/Flow"
         }
     },
-    "scripts": {
-        "build": [
-            "@static:analyze",
-            "@test"
-        ],
-        "test": [
-            "tools/vendor/bin/phpunit"
-        ],
-        "static:analyze": [
-            "tools/vendor/bin/psalm --output-format=compact",
-            "tools/vendor/bin/phpstan analyze -c phpstan.neon",
-            "tools/vendor/bin/php-cs-fixer fix --dry-run"
-        ],
-        "cs:php:fix": "tools/vendor/bin/php-cs-fixer fix",
-        "tools:install": "composer install --working-dir=./tools",
-        "post-install-cmd": [
-            "@tools:install"
-        ],
-        "post-update-cmd": [
-            "@tools:install"
-        ]
-    },
     "minimum-stability": "dev",
     "prefer-stable": true
 }

--- a/src/adapter/etl-adapter-xml/composer.json
+++ b/src/adapter/etl-adapter-xml/composer.json
@@ -33,28 +33,6 @@
             "Flow\\": "tests/Flow"
         }
     },
-    "scripts": {
-        "build": [
-            "@static:analyze",
-            "@test"
-        ],
-        "test": [
-            "tools/vendor/bin/phpunit"
-        ],
-        "static:analyze": [
-            "tools/vendor/bin/psalm --output-format=compact",
-            "tools/vendor/bin/phpstan analyze -c phpstan.neon",
-            "tools/vendor/bin/php-cs-fixer fix --dry-run"
-        ],
-        "cs:php:fix": "tools/vendor/bin/php-cs-fixer fix",
-        "tools:install": "composer install --working-dir=./tools",
-        "post-install-cmd": [
-            "@tools:install"
-        ],
-        "post-update-cmd": [
-            "@tools:install"
-        ]
-    },
     "minimum-stability": "dev",
     "prefer-stable": true
 }

--- a/src/core/etl/composer.json
+++ b/src/core/etl/composer.json
@@ -51,33 +51,6 @@
             "Flow\\": "tests/Flow"
         }
     },
-    "scripts": {
-        "build": [
-            "@static:analyze",
-            "@test",
-            "@test:mutation"
-        ],
-        "test": [
-            "tools/vendor/bin/phpunit"
-        ],
-        "test:mutation": [
-            "tools/vendor/bin/infection -j2"
-        ],
-        "static:analyze": [
-            "tools/vendor/bin/psalm --output-format=compact",
-            "tools/vendor/bin/phpstan analyze -c phpstan.neon",
-            "tools/vendor/bin/php-cs-fixer fix --dry-run"
-        ],
-        "cs:php:fix": "tools/vendor/bin/php-cs-fixer fix",
-        "tools:install": "composer install --working-dir=./tools",
-        "pre-autoload-dump": "Aws\\Script\\Composer\\Composer::removeUnusedServices",
-        "post-install-cmd": [
-            "@tools:install"
-        ],
-        "post-update-cmd": [
-            "@tools:install"
-        ]
-    },
     "extra": {
         "aws/aws-sdk-php": [
             "S3"

--- a/src/lib/array-dot/composer.json
+++ b/src/lib/array-dot/composer.json
@@ -34,28 +34,6 @@
             "Flow\\": "tests/Flow"
         }
     },
-    "scripts": {
-        "build": [
-            "@static:analyze",
-            "@test"
-        ],
-        "test": [
-            "tools/vendor/bin/phpunit"
-        ],
-        "static:analyze": [
-            "tools/vendor/bin/psalm --output-format=compact",
-            "tools/vendor/bin/phpstan analyze -c phpstan.neon",
-            "tools/vendor/bin/php-cs-fixer fix --dry-run"
-        ],
-        "cs:php:fix": "tools/vendor/bin/php-cs-fixer fix",
-        "tools:install": "composer install --working-dir=./tools",
-        "post-install-cmd": [
-            "@tools:install"
-        ],
-        "post-update-cmd": [
-            "@tools:install"
-        ]
-    },
     "minimum-stability": "dev",
     "prefer-stable": true
 }

--- a/src/lib/doctrine-dbal-bulk/composer.json
+++ b/src/lib/doctrine-dbal-bulk/composer.json
@@ -32,31 +32,5 @@
         "optimize-autoloader": true,
         "sort-packages": true
     },
-    "scripts": {
-        "tools:install": "composer install --working-dir=./tools",
-        "build": [
-            "@static:analyze",
-            "@test",
-            "@test:mutation"
-        ],
-        "static:analyze": [
-            "tools/vendor/bin/psalm",
-            "tools/vendor/bin/phpstan analyze -c phpstan.neon",
-            "tools/vendor/bin/php-cs-fixer fix --dry-run"
-        ],
-        "test": [
-            "tools/vendor/bin/phpunit"
-        ],
-        "test:mutation": [
-            "tools/vendor/bin/infection -j2"
-        ],
-        "cs:php:fix": "tools/vendor/bin/php-cs-fixer fix",
-        "post-install-cmd": [
-            "@tools:install"
-        ],
-        "post-update-cmd": [
-            "@tools:install"
-        ]
-    },
     "prefer-stable": true
 }


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <li>Remove "scripts" from `composer.json` in subpackages</li>
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

As we're using a mono-repository, we don't have to run scripts on sub-packages, as the central repository has those defined already.

Extracted from: #576
