### PR TITLE
Fix warning when bytes are missing in Parquet `BinaryBufferReader`

### DIFF
--- a/src/lib/parquet/src/Flow/Parquet/BinaryReader/BinaryBufferReader.php
+++ b/src/lib/parquet/src/Flow/Parquet/BinaryReader/BinaryBufferReader.php
@@ -58,7 +58,7 @@ final class BinaryBufferReader implements BinaryReader
         $currentBytes = \substr($this->buffer, $bytePosition, $bytesNeeded);
 
         for ($i = 0; $i < $bytesNeeded; $i++) {
-            $byte = \ord($currentBytes[$i]);
+            $byte = \ord($currentBytes[$i] ?? '');
 
             for ($j = $bitOffset; $j < 8; $j++) {
                 $bits[] = ($byte >> $j) & 1;
@@ -240,9 +240,9 @@ final class BinaryBufferReader implements BinaryReader
     /**
      * @return array<int>
      */
-    public function readInts32(int $count) : array
+    public function readInts32(int $total) : array
     {
-        $intBytes = \array_chunk($this->readBytes(4 * $count)->toArray(), 4);
+        $intBytes = \array_chunk($this->readBytes(4 * $total)->toArray(), 4);
         $ints = [];
 
         foreach ($intBytes as $bytes) {
@@ -256,9 +256,9 @@ final class BinaryBufferReader implements BinaryReader
         return $ints;
     }
 
-    public function readInts64(int $count) : array
+    public function readInts64(int $total) : array
     {
-        $intBytes = \array_chunk($this->readBytes(8 * $count)->toArray(), 8);
+        $intBytes = \array_chunk($this->readBytes(8 * $total)->toArray(), 8);
 
         $ints = [];
 

--- a/src/lib/parquet/src/Flow/Parquet/BinaryReader/BinaryStreamReader.php
+++ b/src/lib/parquet/src/Flow/Parquet/BinaryReader/BinaryStreamReader.php
@@ -17,6 +17,9 @@ final class BinaryStreamReader implements BinaryReader
 
     private int $fileLength;
 
+    /**
+     * @param resource $handle
+     */
     public function __construct(private $handle, private readonly ByteOrder $byteOrder = ByteOrder::LITTLE_ENDIAN)
     {
         if (!\is_resource($handle)) {
@@ -30,7 +33,7 @@ final class BinaryStreamReader implements BinaryReader
         }
 
         \fseek($this->handle, 0, SEEK_END);
-        $this->fileLength = \ftell($this->handle);
+        $this->fileLength = \ftell($this->handle) ?: 0;
         \fseek($this->handle, 0, SEEK_SET);
 
         $this->bitPosition = 0;
@@ -53,7 +56,7 @@ final class BinaryStreamReader implements BinaryReader
         }
 
         \fseek($this->handle, \intdiv($this->bitPosition, 8));
-        $byte = \ord(\fread($this->handle, 1));
+        $byte = \ord(\fread($this->handle, 1) ?: '');
         $bit = ($byte >> ($this->bitPosition % 8)) & 1;
 
         $this->bitPosition++;
@@ -72,7 +75,7 @@ final class BinaryStreamReader implements BinaryReader
         \fseek($this->handle, $bytePosition);
 
         while ($total > 0) {
-            $byte = \ord(\fread($this->handle, 1));
+            $byte = \ord(\fread($this->handle, 1) ?: '');
 
             for ($bitOffset = $this->bitPosition % 8; $bitOffset < 8; $bitOffset++) {
                 $bits[] = ($byte >> $bitOffset) & 1;
@@ -105,7 +108,7 @@ final class BinaryStreamReader implements BinaryReader
         }
 
         \fseek($this->handle, $this->bitPosition / 8);
-        $byte = \ord(\fread($this->handle, 1));
+        $byte = \ord(\fread($this->handle, 1) ?: '');
         $this->bitPosition += 8;
 
         return $byte;
@@ -127,10 +130,10 @@ final class BinaryStreamReader implements BinaryReader
         }
 
         \fseek($this->handle, $this->bitPosition / 8);
-        $bytes = \fread($this->handle, $total);
+        $bytes = \fread($this->handle, $total) ?: '';
         $this->bitPosition += 8 * \strlen($bytes);
 
-        return new Bytes(\array_values(\unpack('C*', $bytes)));
+        return new Bytes(\array_values(\unpack('C*', $bytes) ?: []));
     }
 
     public function readDouble() : float
@@ -193,7 +196,7 @@ final class BinaryStreamReader implements BinaryReader
         }
 
         \fseek($this->handle, $this->bitPosition / 8);
-        $bytes = \array_values(\unpack('C*', \fread($this->handle, 8)));
+        $bytes = \array_values(\unpack('C*', \fread($this->handle, 8) ?: '') ?: []);
         $this->bitPosition += 64;
 
         return $this->byteOrder === ByteOrder::LITTLE_ENDIAN
@@ -203,7 +206,7 @@ final class BinaryStreamReader implements BinaryReader
             | ($bytes[4] << 24) | ($bytes[5] << 16) | ($bytes[6] << 8) | $bytes[7];
     }
 
-    public function readInt96() : string
+    public function readInt96() : array
     {
         throw new RuntimeException('Not implemented yet.');
     }
@@ -214,6 +217,11 @@ final class BinaryStreamReader implements BinaryReader
     }
 
     public function readInts64(int $total) : array
+    {
+        throw new RuntimeException('Not implemented yet.');
+    }
+
+    public function readInts96(int $total) : array
     {
         throw new RuntimeException('Not implemented yet.');
     }
@@ -236,7 +244,7 @@ final class BinaryStreamReader implements BinaryReader
         }
 
         \fseek($this->handle, $this->bitPosition / 8);
-        $bytes = \array_values(\unpack('C*', \fread($this->handle, 4)));
+        $bytes = \array_values(\unpack('C*', \fread($this->handle, 4) ?: '') ?: []);
         $this->bitPosition += 32;
 
         return $this->byteOrder === ByteOrder::LITTLE_ENDIAN
@@ -270,7 +278,7 @@ final class BinaryStreamReader implements BinaryReader
             }
 
             \fseek($this->handle, $this->bitPosition / 8);
-            $byte = \ord(\fread($this->handle, 1));
+            $byte = \ord(\fread($this->handle, 1) ?: '');
             $this->bitPosition += 8;
 
             $result |= ($byte & 0x7F) << $shift;


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>Fix warning when bytes are missing in Parquet `BinaryBufferReader`</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

Detected by PHPUnit (with options: `stopOnWarning="true" displayDetailsOnTestsThatTriggerWarnings="true"` - ref #584) - https://github.com/flow-php/flow/actions/runs/6512389583/job/17689920950?pr=584#step:10:44
```
1) /Users/stloyd/Documents/flow/src/lib/parquet/src/Flow/Parquet/BinaryReader/BinaryBufferReader.php:61
Uninitialized string offset 13

Triggered by:

* Flow\Parquet\Tests\Integration\ListsReadingTest::test_reading_list_of_structures_column
  /Users/stloyd/Documents/flow/src/lib/parquet/tests/Flow/Parquet/Tests/Integration/ListsReadingTest.php:96

...

37) /Users/stloyd/Documents/flow/src/lib/parquet/src/Flow/Parquet/BinaryReader/BinaryBufferReader.php:61
Uninitialized string offset 49

Triggered by:

* Flow\Parquet\Tests\Integration\ListsReadingTest::test_reading_list_of_structures_column
  /Users/stloyd/Documents/flow/src/lib/parquet/tests/Flow/Parquet/Tests/Integration/ListsReadingTest.php:96
```
