### PR TITLE
Improved support for structures

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,7 @@
     },
     "require-dev": {
         "aeon-php/calendar": "^1.0",
+        "fakerphp/faker": "^1.23",
         "fig/log-test": "^1.1",
         "jawira/case-converter": "^3.4",
         "laravel/serializable-closure": "^1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "de28f6799b1475e489d12f20e7926842",
+    "content-hash": "41a1fc4ec242f2b855417993c828b028",
     "packages": [
         {
             "name": "amphp/amp",
@@ -5420,6 +5420,74 @@
                 }
             ],
             "time": "2023-01-15T23:15:59+00:00"
+        },
+        {
+            "name": "fakerphp/faker",
+            "version": "v1.23.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/FakerPHP/Faker.git",
+                "reference": "e3daa170d00fde61ea7719ef47bb09bb8f1d9b01"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/FakerPHP/Faker/zipball/e3daa170d00fde61ea7719ef47bb09bb8f1d9b01",
+                "reference": "e3daa170d00fde61ea7719ef47bb09bb8f1d9b01",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0",
+                "psr/container": "^1.0 || ^2.0",
+                "symfony/deprecation-contracts": "^2.2 || ^3.0"
+            },
+            "conflict": {
+                "fzaninotto/faker": "*"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.4.1",
+                "doctrine/persistence": "^1.3 || ^2.0",
+                "ext-intl": "*",
+                "phpunit/phpunit": "^9.5.26",
+                "symfony/phpunit-bridge": "^5.4.16"
+            },
+            "suggest": {
+                "doctrine/orm": "Required to use Faker\\ORM\\Doctrine",
+                "ext-curl": "Required by Faker\\Provider\\Image to download images.",
+                "ext-dom": "Required by Faker\\Provider\\HtmlLorem for generating random HTML.",
+                "ext-iconv": "Required by Faker\\Provider\\ru_RU\\Text::realText() for generating real Russian text.",
+                "ext-mbstring": "Required for multibyte Unicode string functionality."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "v1.21-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Faker\\": "src/Faker/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "François Zaninotto"
+                }
+            ],
+            "description": "Faker is a PHP library that generates fake data for you.",
+            "keywords": [
+                "data",
+                "faker",
+                "fixtures"
+            ],
+            "support": {
+                "issues": "https://github.com/FakerPHP/Faker/issues",
+                "source": "https://github.com/FakerPHP/Faker/tree/v1.23.0"
+            },
+            "time": "2023-06-12T08:44:38+00:00"
         },
         {
             "name": "fig/log-test",

--- a/src/adapter/etl-adapter-avro/tests/Flow/ETL/Adapter/Avro/FlixTech/Tests/Integration/AvroTest.php
+++ b/src/adapter/etl-adapter-avro/tests/Flow/ETL/Adapter/Avro/FlixTech/Tests/Integration/AvroTest.php
@@ -113,7 +113,19 @@ final class AvroTest extends TestCase
                             Entry::json_object('json_object', ['id' => 1, 'name' => 'test']),
                             Entry::json('json', [['id' => 1, 'name' => 'test'], ['id' => 2, 'name' => 'test']]),
                             Entry::list_of_string('list_of_strings', ['a', 'b', 'c']),
-                            Entry::list_of_datetime('list_of_datetimes', [new \DateTimeImmutable(), new \DateTimeImmutable(), new \DateTimeImmutable()])
+                            Entry::list_of_datetime('list_of_datetimes', [new \DateTimeImmutable(), new \DateTimeImmutable(), new \DateTimeImmutable()]),
+                            Entry::structure(
+                                'address',
+                                Entry::string('street', 'street_' . $i),
+                                Entry::string('city', 'city_' . $i),
+                                Entry::string('zip', 'zip_' . $i),
+                                Entry::string('country', 'country_' . $i),
+                                Entry::structure(
+                                    'location',
+                                    Entry::float('lat', 1.5),
+                                    Entry::float('lon', 1.5)
+                                )
+                            ),
                         );
                     }, \range(1, 100))
                 )

--- a/src/adapter/etl-adapter-json/src/Flow/ETL/Adapter/JSON/JSONMachine/JsonExtractor.php
+++ b/src/adapter/etl-adapter-json/src/Flow/ETL/Adapter/JSON/JSONMachine/JsonExtractor.php
@@ -11,6 +11,7 @@ use Flow\ETL\Filesystem\Stream\Mode;
 use Flow\ETL\FlowContext;
 use Flow\ETL\Row;
 use JsonMachine\Items;
+use JsonMachine\JsonDecoder\ExtJsonDecoder;
 
 final class JsonExtractor implements Extractor
 {
@@ -51,11 +52,13 @@ final class JsonExtractor implements Extractor
     }
 
     /**
-     * @return array{pointer?: string}
+     * @return array{pointer?: string, decoder: ExtJsonDecoder}
      */
     private function readerOptions() : array
     {
-        $options = [];
+        $options = [
+            'decoder' => new ExtJsonDecoder(true),
+        ];
 
         if ($this->pointer !== null) {
             $options['pointer'] = $this->pointer;

--- a/src/adapter/etl-adapter-json/src/Flow/ETL/Adapter/JSON/JsonLoader.php
+++ b/src/adapter/etl-adapter-json/src/Flow/ETL/Adapter/JSON/JsonLoader.php
@@ -46,7 +46,9 @@ final class JsonLoader implements Closure, Loader, Loader\FileLoader
     public function closure(Rows $rows, FlowContext $context) : void
     {
         foreach ($context->streams() as $stream) {
-            $this->close($stream);
+            if ($stream->path()->extension() === 'json') {
+                $this->close($stream);
+            }
         }
 
         $context->streams()->close($this->path);

--- a/src/adapter/etl-adapter-parquet/src/Flow/ETL/DSL/Parquet.php
+++ b/src/adapter/etl-adapter-parquet/src/Flow/ETL/DSL/Parquet.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Flow\ETL\DSL;
 
+use codename\parquet\ParquetOptions;
 use Flow\ETL\Adapter\Parquet\Codename\ParquetLoader;
 use Flow\ETL\Adapter\Parquet\ParquetExtractor;
 use Flow\ETL\Exception\MissingDependencyException;
@@ -74,13 +75,20 @@ class Parquet
      */
     final public static function to(
         string|Path $path,
-        int $rows_in_group = 1000,
-        Schema $schema = null
+        int $rows_in_group = 10000,
+        Schema $schema = null,
+        ParquetOptions $options = null
     ) : Loader {
+        if ($options === null) {
+            $options = new ParquetOptions();
+            $options->TreatByteArrayAsString = true;
+        }
+
         return new ParquetLoader(
             \is_string($path) ? Path::realpath($path) : $path,
             $rows_in_group,
-            $schema
+            $schema,
+            $options
         );
     }
 }

--- a/src/adapter/etl-adapter-parquet/tests/Flow/ETL/Adapter/Parquet/Tests/Integration/Codename/ParquetTest.php
+++ b/src/adapter/etl-adapter-parquet/tests/Flow/ETL/Adapter/Parquet/Tests/Integration/Codename/ParquetTest.php
@@ -42,7 +42,19 @@ final class ParquetTest extends TestCase
                             Entry::json_object('json_object', ['id' => 1, 'name' => 'test']),
                             Entry::json('json', [['id' => 1, 'name' => 'test'], ['id' => 2, 'name' => 'test']]),
                             Entry::list_of_string('list_of_strings', ['a', 'b', 'c']),
-                            Entry::list_of_datetime('list_of_datetimes', [new \DateTimeImmutable(), new \DateTimeImmutable(), new \DateTimeImmutable()])
+                            Entry::list_of_datetime('list_of_datetimes', [new \DateTimeImmutable(), new \DateTimeImmutable(), new \DateTimeImmutable()]),
+                            Entry::structure(
+                                'address',
+                                Entry::string('street', 'street_' . $i),
+                                Entry::string('city', 'city_' . $i),
+                                Entry::string('zip', 'zip_' . $i),
+                                Entry::string('country', 'country_' . $i),
+                                Entry::structure(
+                                    'location',
+                                    Entry::float('lat', 1.5),
+                                    Entry::float('lon', 1.5)
+                                )
+                            ),
                         );
                     }, \range(1, 100))
                 )
@@ -83,7 +95,19 @@ final class ParquetTest extends TestCase
                             Entry::json_object('json_object', ['id' => 1, 'name' => 'test']),
                             Entry::json('json', [['id' => 1, 'name' => 'test'], ['id' => 2, 'name' => 'test']]),
                             Entry::list_of_string('list_of_strings', ['a', 'b', 'c']),
-                            Entry::list_of_datetime('list_of_datetimes', [new \DateTimeImmutable(), new \DateTimeImmutable(), new \DateTimeImmutable()])
+                            Entry::list_of_datetime('list_of_datetimes', [new \DateTimeImmutable(), new \DateTimeImmutable(), new \DateTimeImmutable()]),
+                            Entry::structure(
+                                'address',
+                                Entry::string('street', 'street_' . $i),
+                                Entry::string('city', 'city_' . $i),
+                                Entry::string('zip', 'zip_' . $i),
+                                Entry::string('country', 'country_' . $i),
+                                Entry::structure(
+                                    'location',
+                                    Entry::float('lat', 1.5),
+                                    Entry::float('lon', 1.5)
+                                )
+                            ),
                         );
                     }, \range(1, 100))
                 )

--- a/src/core/etl/src/Flow/ETL/DSL/functions.php
+++ b/src/core/etl/src/Flow/ETL/DSL/functions.php
@@ -367,3 +367,50 @@ function array_to_rows(array $data, EntryFactory $entryFactory = new NativeEntry
 
     return new Rows(...$rows);
 }
+
+/**
+ * @psalm-suppress MixedAssignment
+ */
+function array_is_structure(array $array) : bool
+{
+    if (\array_is_list($array)) {
+        return false;
+    }
+
+    if (!\count($array)) {
+        return false;
+    }
+
+    foreach ($array as $key => $value) {
+        if (!\is_string($key)) {
+            return false;
+        }
+
+        if (\is_array($value)) {
+            if (!array_is_structure($value)) {
+                return false;
+            }
+        }
+    }
+
+    return true;
+}
+
+/**
+ * @psalm-suppress MixedArgumentTypeCoercion
+ * @psalm-suppress MixedAssignment
+ */
+function array_to_structure(string $name, array $array, EntryFactory $entry_factory = new NativeEntryFactory()) : Row\Entry\StructureEntry
+{
+    $structureEntries = [];
+
+    foreach ($array as $key => $value) {
+        if (\is_array($value)) {
+            $structureEntries[] = array_to_structure($key, $value, $entry_factory);
+        } else {
+            $structureEntries[] = $entry_factory->create($key, $value);
+        }
+    }
+
+    return new Row\Entry\StructureEntry($name, ...$structureEntries);
+}

--- a/src/core/etl/src/Flow/ETL/Row/Factory/NativeEntryFactory.php
+++ b/src/core/etl/src/Flow/ETL/Row/Factory/NativeEntryFactory.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Row\Factory;
 
+use function Flow\ETL\DSL\array_is_structure;
+use function Flow\ETL\DSL\array_to_structure;
 use Flow\ETL\DSL\Entry as EntryDSL;
 use Flow\ETL\Exception\InvalidArgumentException;
 use Flow\ETL\Row;
@@ -107,6 +109,10 @@ final class NativeEntryFactory implements EntryFactory
         if (\is_array($value)) {
             if ([] === $value) {
                 return new Row\Entry\ArrayEntry($entryName, $value);
+            }
+
+            if (array_is_structure($value)) {
+                return array_to_structure($entryName, $value);
             }
 
             if (!\array_is_list($value)) {

--- a/src/core/etl/src/Flow/ETL/Row/Schema/FlowMetadata.php
+++ b/src/core/etl/src/Flow/ETL/Row/Schema/FlowMetadata.php
@@ -11,4 +11,6 @@ final class FlowMetadata
     public const METADATA_ENUM_CLASS = 'flow_enum_class';
 
     public const METADATA_LIST_ENTRY_TYPE = 'flow_list_entry_type';
+
+    public const METADATA_STRUCTURE_DEFINITIONS = 'flow_structure_definitions';
 }

--- a/src/core/etl/src/Flow/ETL/Row/Schema/Formatter/ASCIISchemaFormatter.php
+++ b/src/core/etl/src/Flow/ETL/Row/Schema/Formatter/ASCIISchemaFormatter.php
@@ -4,32 +4,66 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Row\Schema\Formatter;
 
+use Flow\ETL\Row\Entry\StructureEntry;
 use Flow\ETL\Row\Schema;
+use Flow\ETL\Row\Schema\Definition;
+use Flow\ETL\Row\Schema\FlowMetadata;
 use Flow\ETL\Row\Schema\SchemaFormatter;
 
 final class ASCIISchemaFormatter implements SchemaFormatter
 {
     public function format(Schema $schema) : string
     {
-        /** @var array<string, string> $entries */
-        $entries = [];
+        /** @var array<string, string> $buffer */
+        $buffer = [];
 
         foreach ($schema->definitions() as $definition) {
-            $entry = $definition->entry()->name();
-
-            $type = match (\count($definition->types())) {
-                1 => $definition->types()[0],
-                default => '[' . \implode(', ', $definition->types()) . ']'
-            };
-
-            $entries[$entry] = '|-- ' . $entry . ': ' . $type . ' (nullable = ' . ($definition->isNullable() ? 'true' : 'false') . ')';
+            $buffer = $this->formatEntry($definition, $buffer);
         }
 
-        \ksort($entries);
+        \ksort($buffer);
 
         $output = "schema\n";
-        $output .= \implode("\n", $entries);
+        $output .= \implode("\n", $buffer);
 
         return $output . "\n";
+    }
+
+    /**
+     * @param array<string> $buffer
+     *
+     * @return array<string>
+     */
+    private function formatEntry(Schema\Definition $definition, array $buffer, int $level = 0) : array
+    {
+        $entry = $definition->entry()->name();
+
+        $type = match (\count($definition->types())) {
+            1 => $definition->types()[0],
+            default => '[' . \implode(', ', $definition->types()) . ']'
+        };
+
+        $indention = \str_repeat('    ', $level);
+
+        if ($indention !== '') {
+            $indention = '|' . $indention;
+        }
+
+        $buffer[] = $indention . '|-- ' . $entry . ': ' . $type . ' (nullable = ' . ($definition->isNullable() ? 'true' : 'false') . ')';
+
+        if (\in_array(StructureEntry::class, $definition->types(), true)) {
+            /** @var array<Definition> $structureEntries */
+            $structureEntries = $definition->metadata()->get(FlowMetadata::METADATA_STRUCTURE_DEFINITIONS);
+
+            $fields = [];
+
+            foreach ($structureEntries as $structEntry) {
+                $fields += $this->formatEntry($structEntry, $fields, $level + 1);
+            }
+
+            $buffer = \array_merge($buffer, $fields);
+        }
+
+        return $buffer;
     }
 }

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/DataFrameTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/DataFrameTest.php
@@ -1451,13 +1451,13 @@ ASCII,
         $this->assertStringContainsString(
             <<<ASCII
 schema
-|-- age: Flow\ETL\Row\Entry\IntegerEntry (nullable = false)
-|-- country: Flow\ETL\Row\Entry\StringEntry (nullable = false)
 |-- id: Flow\ETL\Row\Entry\IntegerEntry (nullable = false)
+|-- country: Flow\ETL\Row\Entry\StringEntry (nullable = false)
+|-- age: Flow\ETL\Row\Entry\IntegerEntry (nullable = false)
 schema
-|-- age: Flow\ETL\Row\Entry\IntegerEntry (nullable = false)
-|-- country: Flow\ETL\Row\Entry\StringEntry (nullable = false)
 |-- id: Flow\ETL\Row\Entry\IntegerEntry (nullable = false)
+|-- country: Flow\ETL\Row\Entry\StringEntry (nullable = false)
+|-- age: Flow\ETL\Row\Entry\IntegerEntry (nullable = false)
 |-- salary: [Flow\ETL\Row\Entry\IntegerEntry, Flow\ETL\Row\Entry\NullEntry] (nullable = true)
 ASCII,
             $output

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/EntriesTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/EntriesTest.php
@@ -371,10 +371,6 @@ final class EntriesTest extends TestCase
                 'items',
                 new IntegerEntry('item-id', 1),
                 new StringEntry('name', 'one'),
-                new IntegerEntry('item-id', 2),
-                new StringEntry('name', 'two'),
-                new IntegerEntry('item-id', 3),
-                new StringEntry('name', 'three')
             )
         );
 
@@ -389,10 +385,6 @@ final class EntriesTest extends TestCase
                     'items',
                     new IntegerEntry('item-id', 1),
                     new StringEntry('name', 'one'),
-                    new IntegerEntry('item-id', 2),
-                    new StringEntry('name', 'two'),
-                    new IntegerEntry('item-id', 3),
-                    new StringEntry('name', 'three')
                 ),
                 $phase = new NullEntry('phase')
             ),
@@ -411,10 +403,6 @@ final class EntriesTest extends TestCase
                 'items',
                 new IntegerEntry('item-id', 1),
                 new StringEntry('name', 'one'),
-                new IntegerEntry('item-id', 2),
-                new StringEntry('name', 'two'),
-                new IntegerEntry('item-id', 3),
-                new StringEntry('name', 'three')
             ),
             new EnumEntry('enum', BasicEnum::three)
         );
@@ -426,12 +414,8 @@ final class EntriesTest extends TestCase
                 'created-at' => $createdAt,
                 'phase' => null,
                 'items' => [
-                    new IntegerEntry('item-id', 1),
-                    new StringEntry('name', 'one'),
-                    new IntegerEntry('item-id', 2),
-                    new StringEntry('name', 'two'),
-                    new IntegerEntry('item-id', 3),
-                    new StringEntry('name', 'three'),
+                    'item-id' => 1,
+                    'name' => 'one',
                 ],
                 'enum' => BasicEnum::three,
             ],

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Entry/StructureEntryTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Entry/StructureEntryTest.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Tests\Unit\Row\Entry;
 
+use Flow\ETL\DSL\Entry;
 use Flow\ETL\Row\Entry\ArrayEntry;
 use Flow\ETL\Row\Entry\IntegerEntry;
 use Flow\ETL\Row\Entry\StringEntry;
 use Flow\ETL\Row\Entry\StructureEntry;
+use Flow\ETL\Row\Schema\Definition;
 use PHPUnit\Framework\TestCase;
 
 final class StructureEntryTest extends TestCase
@@ -44,6 +46,32 @@ final class StructureEntryTest extends TestCase
             new StructureEntry('name', new StructureEntry('json', new IntegerEntry('5', 5), new IntegerEntry('2', 2), new IntegerEntry('3', 3))),
             new StructureEntry('name', new StructureEntry('json', new IntegerEntry('1', 1), new IntegerEntry('2', 2), new IntegerEntry('3', 3))),
         ];
+    }
+
+    public function test_definition() : void
+    {
+        $entry = Entry::structure(
+            'items',
+            Entry::integer('id', 1),
+            Entry::string('name', 'one'),
+            Entry::structure('address', Entry::string('street', 'foo'), Entry::string('city', 'bar'))
+        );
+
+        $this->assertEquals(
+            Definition::structure(
+                'items',
+                [
+                    'id' => Definition::integer('id', false),
+                    'name' => Definition::string('name', false),
+                    'address' => [
+                        'street' => Definition::string('street', false),
+                        'city' => Definition::string('city', false),
+                    ],
+                ],
+                false
+            ),
+            $entry->definition()
+        );
     }
 
     public function test_entry_name_can_be_zero() : void
@@ -95,20 +123,12 @@ final class StructureEntryTest extends TestCase
             'items',
             new IntegerEntry('item-id', 1),
             new StringEntry('name', 'one'),
-            new IntegerEntry('item-id', 2),
-            new StringEntry('name', 'two'),
-            new IntegerEntry('item-id', 3),
-            new StringEntry('name', 'three')
         );
 
         $this->assertEquals(
             [
-                new IntegerEntry('item-id', 1),
-                new StringEntry('name', 'one'),
-                new IntegerEntry('item-id', 2),
-                new StringEntry('name', 'two'),
-                new IntegerEntry('item-id', 3),
-                new StringEntry('name', 'three'),
+                'item-id' => 1,
+                'name' => 'one',
             ],
             $entry->value()
         );

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Factory/NativeEntryFactoryTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Factory/NativeEntryFactoryTest.php
@@ -18,7 +18,7 @@ final class NativeEntryFactoryTest extends TestCase
     public function test_array() : void
     {
         $this->assertEquals(
-            Entry::array('e', ['a' => 1, 'b' => 2]),
+            Entry::structure('e', Entry::int('a', 1), Entry::int('b', 2)),
             (new NativeEntryFactory())->create('e', ['a' => 1, 'b' => 2])
         );
     }
@@ -247,6 +247,32 @@ final class NativeEntryFactoryTest extends TestCase
         );
     }
 
+    public function test_nested_structure() : void
+    {
+        $this->assertEquals(
+            Entry::structure(
+                'address',
+                Entry::string('city', 'Krakow'),
+                Entry::structure(
+                    'geo',
+                    Entry::float('lat', 50.06143),
+                    Entry::float('lon', 19.93658)
+                ),
+                Entry::string('street', 'Floriańska'),
+                Entry::string('zip', '31-021')
+            ),
+            (new NativeEntryFactory())->create('address', [
+                'city' => 'Krakow',
+                'geo' => [
+                    'lat' => 50.06143,
+                    'lon' => 19.93658,
+                ],
+                'street' => 'Floriańska',
+                'zip' => '31-021',
+            ])
+        );
+    }
+
     public function test_null() : void
     {
         $this->assertEquals(
@@ -298,6 +324,19 @@ final class NativeEntryFactoryTest extends TestCase
         $this->assertEquals(
             Entry::string('e', 'string'),
             (new NativeEntryFactory(new Schema(Schema\Definition::string('e'))))->create('e', 'string')
+        );
+    }
+
+    public function test_structure() : void
+    {
+        $this->assertEquals(
+            Entry::structure(
+                'address',
+                Entry::string('city', 'Krakow'),
+                Entry::string('street', 'Floriańska'),
+                Entry::string('zip', '31-021')
+            ),
+            (new NativeEntryFactory())->create('address', ['city' => 'Krakow', 'street' => 'Floriańska', 'zip' => '31-021'])
         );
     }
 

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Schema/Constraint/NotEmptyTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Schema/Constraint/NotEmptyTest.php
@@ -21,7 +21,6 @@ final class NotEmptyTest extends TestCase
         $this->assertFalse($constraint->isSatisfiedBy(Entry::json('e', [])));
         $this->assertFalse($constraint->isSatisfiedBy(Entry::json_object('e', [])));
         $this->assertFalse($constraint->isSatisfiedBy(Entry::list_of_int('e', [])));
-        $this->assertFalse($constraint->isSatisfiedBy(Entry::structure('e')));
     }
 
     public function test_not_empty_is_satisfied() : void

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Schema/DefinitionTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Schema/DefinitionTest.php
@@ -197,6 +197,32 @@ final class DefinitionTest extends TestCase
         $this->assertFalse(Definition::string('id', true)->isUnion());
     }
 
+    public function test_structure_definition_metadata() : void
+    {
+        $address = Entry::structure(
+            'address',
+            $street = Entry::string('street', 'street'),
+            $city = Entry::string('city', 'city'),
+            Entry::structure(
+                'location',
+                $lat = Entry::float('lat', 1.0),
+                $lng = Entry::float('lng', 1.0),
+            ),
+        );
+
+        $this->assertEquals(
+            [
+                'street' => $street->definition(),
+                'city' => $city->definition(),
+                'location' => [
+                    'lat' => $lat->definition(),
+                    'lng' => $lng->definition(),
+                ],
+            ],
+            $address->definition()->metadata()->get(FlowMetadata::METADATA_STRUCTURE_DEFINITIONS)
+        );
+    }
+
     public function test_union_type_definition() : void
     {
         $def = Definition::union('test', [IntegerEntry::class, StringEntry::class]);

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Schema/Formatter/ASCIISchemaFormatterTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Schema/Formatter/ASCIISchemaFormatterTest.php
@@ -12,6 +12,44 @@ use PHPUnit\Framework\TestCase;
 
 final class ASCIISchemaFormatterTest extends TestCase
 {
+    public function test_format_nested_schema() : void
+    {
+        $schema = new Schema(
+            Schema\Definition::structure('user', [
+                Schema\Definition::string('name', nullable: true),
+                Schema\Definition::integer('age', nullable: false),
+                Schema\Definition::structure('address', [
+                    Schema\Definition::string('street', nullable: true),
+                    Schema\Definition::string('city', nullable: true),
+                    Schema\Definition::string('country', nullable: true),
+                ]),
+            ]),
+            Schema\Definition::string('name', nullable: true),
+            Schema\Definition::array('tags', nullable: false),
+            Schema\Definition::boolean('active', false),
+            Schema\Definition::xml('xml', false)
+        );
+
+        $this->assertSame(
+            <<<SCHEMA
+schema
+|-- user: Flow\ETL\Row\Entry\StructureEntry (nullable = false)
+|    |-- name: [Flow\ETL\Row\Entry\StringEntry, Flow\ETL\Row\Entry\NullEntry] (nullable = true)
+|    |-- age: Flow\ETL\Row\Entry\IntegerEntry (nullable = false)
+|    |-- address: Flow\ETL\Row\Entry\StructureEntry (nullable = false)
+|        |-- street: [Flow\ETL\Row\Entry\StringEntry, Flow\ETL\Row\Entry\NullEntry] (nullable = true)
+|        |-- city: [Flow\ETL\Row\Entry\StringEntry, Flow\ETL\Row\Entry\NullEntry] (nullable = true)
+|        |-- country: [Flow\ETL\Row\Entry\StringEntry, Flow\ETL\Row\Entry\NullEntry] (nullable = true)
+|-- name: [Flow\ETL\Row\Entry\StringEntry, Flow\ETL\Row\Entry\NullEntry] (nullable = true)
+|-- tags: Flow\ETL\Row\Entry\ArrayEntry (nullable = false)
+|-- active: Flow\ETL\Row\Entry\BooleanEntry (nullable = false)
+|-- xml: Flow\ETL\Row\Entry\XMLEntry (nullable = false)
+
+SCHEMA,
+            (new ASCIISchemaFormatter())->format($schema)
+        );
+    }
+
     public function test_format_schema() : void
     {
         $schema = new Schema(
@@ -25,10 +63,10 @@ final class ASCIISchemaFormatterTest extends TestCase
         $this->assertSame(
             <<<SCHEMA
 schema
-|-- active: Flow\ETL\Row\Entry\BooleanEntry (nullable = false)
-|-- name: [Flow\ETL\Row\Entry\StringEntry, Flow\ETL\Row\Entry\NullEntry] (nullable = true)
 |-- number: [Flow\ETL\Row\Entry\IntegerEntry, Flow\ETL\Row\Entry\FloatEntry] (nullable = false)
+|-- name: [Flow\ETL\Row\Entry\StringEntry, Flow\ETL\Row\Entry\NullEntry] (nullable = true)
 |-- tags: Flow\ETL\Row\Entry\ArrayEntry (nullable = false)
+|-- active: Flow\ETL\Row\Entry\BooleanEntry (nullable = false)
 |-- xml: Flow\ETL\Row\Entry\XMLEntry (nullable = false)
 
 SCHEMA,

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/RowTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/RowTest.php
@@ -89,7 +89,7 @@ final class RowTest extends TestCase
                 Row\Schema\Definition::dateTime('created-at'),
                 Row\Schema\Definition::null('phase'),
                 Row\Schema\Definition::array('array'),
-                Row\Schema\Definition::structure('items'),
+                Row\Schema\Definition::structure('items', ['item-id' => Entry::integer('item-id', 1)->definition(), 'name' => Entry::string('name', 'one')->definition()]),
                 Row\Schema\Definition::collection('tags'),
                 Row\Schema\Definition::object('object'),
             ),
@@ -133,10 +133,6 @@ final class RowTest extends TestCase
                 'items',
                 new IntegerEntry('item-id', 1),
                 new StringEntry('name', 'one'),
-                new IntegerEntry('item-id', 2),
-                new StringEntry('name', 'two'),
-                new IntegerEntry('item-id', 3),
-                new StringEntry('name', 'three')
             )
         );
 
@@ -147,12 +143,8 @@ final class RowTest extends TestCase
                 'created-at' => $createdAt,
                 'phase' => null,
                 'items' => [
-                    new IntegerEntry('item-id', 1),
-                    new StringEntry('name', 'one'),
-                    new IntegerEntry('item-id', 2),
-                    new StringEntry('name', 'two'),
-                    new IntegerEntry('item-id', 3),
-                    new StringEntry('name', 'three'),
+                    'item-id' => 1,
+                    'name' => 'one',
                 ],
             ],
             $row->toArray(),

--- a/src/lib/parquet/src/Flow/Parquet/Options.php
+++ b/src/lib/parquet/src/Flow/Parquet/Options.php
@@ -12,7 +12,7 @@ final class Options
     public function __construct()
     {
         $this->options = [
-            Option::BYTE_ARRAY_TO_STRING->name => false,
+            Option::BYTE_ARRAY_TO_STRING->name => true,
             Option::ROUND_NANOSECONDS->name => false,
             Option::INT_96_AS_DATETIME->name => true,
         ];


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <li>NativeEntryFactory structures detection</li>
    <li>Metadata to StructureEntry Definition</li>
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>JsonLoader closing not only json streams</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Schema Formatter - support for structures</li>
    <li>Parquet Loader - simplified with support for Structure Entry</li>
    <li>Avro Loader - simplified with support for Structure Entry</li>
    <li>Parquet Extractor - default options</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

Uhm this turned out to be way bigger than I initially expected, but it's all connected and touching one thing, affected few others... 

All of this in order to make those two scenarios possible: 

```php
<?php

use Flow\ETL\DSL\CSV;
use Flow\ETL\DSL\From;
use Flow\ETL\DSL\Json;
use Flow\ETL\DSL\Parquet;
use Flow\ETL\Filesystem\SaveMode;
use Flow\ETL\Flow;
use Flow\ETL\DSL\Avro;
use function Flow\ETL\DSL\ref;

include __DIR__ . '/../../vendor/autoload.php';

$faker = Faker\Factory::create();
$orders = array_map(
    static fn (int $i) : array => [
        'order_id' => $faker->uuid,
        'created_at' => $faker->dateTimeThisYear->format(\DateTimeInterface::RFC3339),
        'updated_at' => $faker->dateTimeThisMonth->format(\DateTimeInterface::RFC3339),
        'total_price' => $faker->randomFloat(2, 0, 500),
        'discount' => $faker->randomFloat(2, 0, 50),
        'customer' => [
            'name' => $faker->firstName,
            'last_name' => $faker->lastName,
            'email' => $faker->email,
        ],
        'address' => [
            'street' => $faker->streetAddress,
            'city' => $faker->city,
            'zip' => $faker->postcode,
            'country' => $faker->country,
        ],
        'notes' => \array_map(
            static fn ($i) => $faker->sentence,
            \range(1, $faker->numberBetween(1, 5))
        )
    ],
    range(1, 10)
);

(new Flow())
    ->read(From::array($orders))
    ->mode(SaveMode::Overwrite)
    ->write(Parquet::to(__DIR__ . '/orders_flow.parquet', rows_in_group: 20_000))
    ->write(Json::to(__DIR__ . '/orders_flow.json'))
    ->write(Avro::to(__DIR__ . '/orders_flow.avro'))
    ->withEntry('order_id', ref('order_id')->cast('string'))
    ->withEntry('customer', ref('customer')->cast('string'))
    ->withEntry('address', ref('customer')->cast('string'))
    ->withEntry('notes', ref('customer')->cast('string'))
    ->write(CSV::to(__DIR__ . '/orders_flow.csv'))
    ->run()
;
```

```php
<?php

use Flow\ETL\DSL\Avro;
use Flow\ETL\DSL\CSV;
use Flow\ETL\DSL\Json;
use Flow\ETL\DSL\Parquet;
use Flow\ETL\DSL\To;
use Flow\ETL\Flow;
use Flow\ETL\Loader\StreamLoader\Output;

include __DIR__ . '/../../vendor/autoload.php';

echo "JSON: \n";
(new Flow())
    ->read(Json::from(__DIR__ . '/orders_flow.json', rows_in_batch: 10))
    ->limit(10)
    ->write(To::output(true, output: Output::rows_and_schema))
->run();

echo "\n------------------\n";

echo "Avro: \n";

(new Flow())
    ->read(Avro::from(__DIR__ . '/orders_flow.avro', rows_in_batch: 10))
    ->limit(10)
    ->write(To::output(true, output: Output::rows_and_schema))
    ->run();

echo "\n------------------\n";

echo "Parquet: \n";

(new Flow())
    ->read(Parquet::from(__DIR__ . '/orders_flow.parquet', rows_in_batch: 10))
    ->limit(10)
    ->write(To::output(true, output: Output::rows_and_schema))
    ->run();

echo "\n------------------\n";

echo "CSV: \n";

(new Flow())
    ->read(CSV::from(__DIR__ . '/orders_flow.csv', rows_in_batch: 10))
    ->limit(10)
    ->write(To::output(true, output: Output::rows_and_schema))
    ->run();
```

Output: 
```console
JSON: 
+----------+----------------------+----------------------+-------------+----------+----------------------+----------------------+----------------------+
| order_id |           created_at |           updated_at | total_price | discount |             customer |              address |                notes |
+----------+----------------------+----------------------+-------------+----------+----------------------+----------------------+----------------------+
|       [] | 2023-08-18T01:43:56+ | 2023-09-19T00:17:01+ |      357.32 |    17.88 | {"name":"Kylie","las | {"street":"8964 Joan | ["Nihil nihil reicie |
|       [] | 2023-03-01T07:11:43+ | 2023-10-08T19:45:52+ |      366.12 |    16.77 | {"name":"Josefina"," | {"street":"840 Lang  | ["Nobis laudantium n |
|       [] | 2023-09-05T03:52:54+ | 2023-09-17T21:16:37+ |      263.06 |    31.22 | {"name":"Casimir","l | {"street":"6134 Melv | ["Ab eligendi molest |
|       [] | 2023-10-13T17:33:07+ | 2023-09-23T03:08:11+ |       81.18 |    29.39 | {"name":"Jeanette"," | {"street":"984 Cayla | ["Modi iure atque vo |
|       [] | 2023-10-06T02:10:35+ | 2023-09-24T15:16:01+ |      364.05 |    18.78 | {"name":"Grayson","l | {"street":"43591 Lit | ["Qui aut voluptatem |
|       [] | 2023-03-07T16:08:08+ | 2023-09-25T02:27:29+ |      389.21 |    34.77 | {"name":"Garfield"," | {"street":"17268 Wil | ["Iure dolorem quas  |
|       [] | 2023-05-31T11:37:15+ | 2023-09-27T17:00:01+ |       93.31 |    25.44 | {"name":"Marques","l | {"street":"6963 Gay  | ["Laboriosam dolorem |
|       [] | 2023-03-24T16:24:06+ | 2023-09-20T21:10:58+ |       47.78 |     43.6 | {"name":"Twila","las | {"street":"9071 Era  | ["Cum quia dolor rer |
|       [] | 2023-02-21T06:56:54+ | 2023-09-24T23:46:32+ |       256.6 |    34.86 | {"name":"Ollie","las | {"street":"831 Nicol | ["Recusandae consect |
|       [] | 2023-10-13T19:49:59+ | 2023-09-18T14:45:44+ |      171.01 |     4.88 | {"name":"King","last | {"street":"760 Ferry | ["Voluptates eveniet |
+----------+----------------------+----------------------+-------------+----------+----------------------+----------------------+----------------------+
10 rows

schema
|-- order_id: Flow\ETL\Row\Entry\ArrayEntry (nullable = false)
|-- created_at: Flow\ETL\Row\Entry\StringEntry (nullable = false)
|-- updated_at: Flow\ETL\Row\Entry\StringEntry (nullable = false)
|-- total_price: Flow\ETL\Row\Entry\FloatEntry (nullable = false)
|-- discount: Flow\ETL\Row\Entry\FloatEntry (nullable = false)
|-- customer: Flow\ETL\Row\Entry\StructureEntry (nullable = false)
|    |-- name: Flow\ETL\Row\Entry\StringEntry (nullable = false)
|    |-- last_name: Flow\ETL\Row\Entry\StringEntry (nullable = false)
|    |-- email: Flow\ETL\Row\Entry\StringEntry (nullable = false)
|-- address: Flow\ETL\Row\Entry\StructureEntry (nullable = false)
|    |-- street: Flow\ETL\Row\Entry\StringEntry (nullable = false)
|    |-- city: Flow\ETL\Row\Entry\StringEntry (nullable = false)
|    |-- zip: Flow\ETL\Row\Entry\StringEntry (nullable = false)
|    |-- country: Flow\ETL\Row\Entry\StringEntry (nullable = false)
|-- notes: Flow\ETL\Row\Entry\ListEntry (nullable = false)

------------------
Avro: 
+----------------------+----------------------+----------------------+-----------------+-----------------+----------------------+----------------------+----------------------+
|             order_id |           created_at |           updated_at |     total_price |        discount |             customer |              address |                notes |
+----------------------+----------------------+----------------------+-----------------+-----------------+----------------------+----------------------+----------------------+
| 127dd8e7-6b54-36c5-9 | 2023-08-18T01:43:56+ | 2023-09-19T00:17:01+ | 357.32000732422 | 17.879999160767 | {"name":"Kylie","las | {"street":"8964 Joan | ["Nihil nihil reicie |
| 0ca30307-9a5b-30fb-a | 2023-03-01T07:11:43+ | 2023-10-08T19:45:52+ | 366.11999511719 | 16.770000457764 | {"name":"Josefina"," | {"street":"840 Lang  | ["Nobis laudantium n |
| fe7dda3b-0026-3955-8 | 2023-09-05T03:52:54+ | 2023-09-17T21:16:37+ | 263.05999755859 | 31.219999313354 | {"name":"Casimir","l | {"street":"6134 Melv | ["Ab eligendi molest |
| 9b6deceb-f28e-3d5f-9 | 2023-10-13T17:33:07+ | 2023-09-23T03:08:11+ | 81.180000305176 | 29.389999389648 | {"name":"Jeanette"," | {"street":"984 Cayla | ["Modi iure atque vo |
| 82da96a2-440a-3075-a | 2023-10-06T02:10:35+ | 2023-09-24T15:16:01+ | 364.04998779297 | 18.780000686646 | {"name":"Grayson","l | {"street":"43591 Lit | ["Qui aut voluptatem |
| e16bf5d1-b403-3b01-8 | 2023-03-07T16:08:08+ | 2023-09-25T02:27:29+ | 389.20999145508 | 34.770000457764 | {"name":"Garfield"," | {"street":"17268 Wil | ["Iure dolorem quas  |
| 737f39a9-5d30-33b5-8 | 2023-05-31T11:37:15+ | 2023-09-27T17:00:01+ | 93.309997558594 | 25.440000534058 | {"name":"Marques","l | {"street":"6963 Gay  | ["Laboriosam dolorem |
| ccb5e191-9e10-3d46-a | 2023-03-24T16:24:06+ | 2023-09-20T21:10:58+ | 47.779998779297 | 43.599998474121 | {"name":"Twila","las | {"street":"9071 Era  | ["Cum quia dolor rer |
| 19a158ad-10e3-39a1-8 | 2023-02-21T06:56:54+ | 2023-09-24T23:46:32+ | 256.60000610352 | 34.860000610352 | {"name":"Ollie","las | {"street":"831 Nicol | ["Recusandae consect |
| e8b5468e-0efc-3d3e-b | 2023-10-13T19:49:59+ | 2023-09-18T14:45:44+ | 171.00999450684 | 4.8800001144409 | {"name":"King","last | {"street":"760 Ferry | ["Voluptates eveniet |
+----------------------+----------------------+----------------------+-----------------+-----------------+----------------------+----------------------+----------------------+
10 rows

schema
|-- order_id: Flow\ETL\Row\Entry\UuidEntry (nullable = false)
|-- created_at: Flow\ETL\Row\Entry\StringEntry (nullable = false)
|-- updated_at: Flow\ETL\Row\Entry\StringEntry (nullable = false)
|-- total_price: Flow\ETL\Row\Entry\FloatEntry (nullable = false)
|-- discount: Flow\ETL\Row\Entry\FloatEntry (nullable = false)
|-- customer: Flow\ETL\Row\Entry\StructureEntry (nullable = false)
|    |-- name: Flow\ETL\Row\Entry\StringEntry (nullable = false)
|    |-- last_name: Flow\ETL\Row\Entry\StringEntry (nullable = false)
|    |-- email: Flow\ETL\Row\Entry\StringEntry (nullable = false)
|-- address: Flow\ETL\Row\Entry\StructureEntry (nullable = false)
|    |-- street: Flow\ETL\Row\Entry\StringEntry (nullable = false)
|    |-- city: Flow\ETL\Row\Entry\StringEntry (nullable = false)
|    |-- zip: Flow\ETL\Row\Entry\StringEntry (nullable = false)
|    |-- country: Flow\ETL\Row\Entry\StringEntry (nullable = false)
|-- notes: Flow\ETL\Row\Entry\ListEntry (nullable = false)

------------------
Parquet: 
+----------------------+----------------------+----------------------+-----------------+-----------------+----------------------+----------------------+----------------------+
|             order_id |           created_at |           updated_at |     total_price |        discount |             customer |              address |                notes |
+----------------------+----------------------+----------------------+-----------------+-----------------+----------------------+----------------------+----------------------+
| 127dd8e7-6b54-36c5-9 | 2023-08-18T01:43:56+ | 2023-09-19T00:17:01+ | 357.32000732422 | 17.879999160767 | {"name":"Kylie","las | {"street":"8964 Joan | ["Nihil nihil reicie |
| 0ca30307-9a5b-30fb-a | 2023-03-01T07:11:43+ | 2023-10-08T19:45:52+ | 366.11999511719 | 16.770000457764 | {"name":"Josefina"," | {"street":"840 Lang  | ["Nobis laudantium n |
| fe7dda3b-0026-3955-8 | 2023-09-05T03:52:54+ | 2023-09-17T21:16:37+ | 263.05999755859 | 31.219999313354 | {"name":"Casimir","l | {"street":"6134 Melv | ["Ab eligendi molest |
| 9b6deceb-f28e-3d5f-9 | 2023-10-13T17:33:07+ | 2023-09-23T03:08:11+ | 81.180000305176 | 29.389999389648 | {"name":"Jeanette"," | {"street":"984 Cayla | ["Modi iure atque vo |
| 82da96a2-440a-3075-a | 2023-10-06T02:10:35+ | 2023-09-24T15:16:01+ | 364.04998779297 | 18.780000686646 | {"name":"Grayson","l | {"street":"43591 Lit | ["Qui aut voluptatem |
| e16bf5d1-b403-3b01-8 | 2023-03-07T16:08:08+ | 2023-09-25T02:27:29+ | 389.20999145508 | 34.770000457764 | {"name":"Garfield"," | {"street":"17268 Wil | ["Iure dolorem quas  |
| 737f39a9-5d30-33b5-8 | 2023-05-31T11:37:15+ | 2023-09-27T17:00:01+ | 93.309997558594 | 25.440000534058 | {"name":"Marques","l | {"street":"6963 Gay  | ["Laboriosam dolorem |
| ccb5e191-9e10-3d46-a | 2023-03-24T16:24:06+ | 2023-09-20T21:10:58+ | 47.779998779297 | 43.599998474121 | {"name":"Twila","las | {"street":"9071 Era  | ["Cum quia dolor rer |
| 19a158ad-10e3-39a1-8 | 2023-02-21T06:56:54+ | 2023-09-24T23:46:32+ | 256.60000610352 | 34.860000610352 | {"name":"Ollie","las | {"street":"831 Nicol | ["Recusandae consect |
| e8b5468e-0efc-3d3e-b | 2023-10-13T19:49:59+ | 2023-09-18T14:45:44+ | 171.00999450684 | 4.8800001144409 | {"name":"King","last | {"street":"760 Ferry | ["Voluptates eveniet |
+----------------------+----------------------+----------------------+-----------------+-----------------+----------------------+----------------------+----------------------+
10 rows

schema
|-- order_id: Flow\ETL\Row\Entry\UuidEntry (nullable = false)
|-- created_at: Flow\ETL\Row\Entry\StringEntry (nullable = false)
|-- updated_at: Flow\ETL\Row\Entry\StringEntry (nullable = false)
|-- total_price: Flow\ETL\Row\Entry\FloatEntry (nullable = false)
|-- discount: Flow\ETL\Row\Entry\FloatEntry (nullable = false)
|-- customer: Flow\ETL\Row\Entry\StructureEntry (nullable = false)
|    |-- name: Flow\ETL\Row\Entry\StringEntry (nullable = false)
|    |-- last_name: Flow\ETL\Row\Entry\StringEntry (nullable = false)
|    |-- email: Flow\ETL\Row\Entry\StringEntry (nullable = false)
|-- address: Flow\ETL\Row\Entry\StructureEntry (nullable = false)
|    |-- street: Flow\ETL\Row\Entry\StringEntry (nullable = false)
|    |-- city: Flow\ETL\Row\Entry\StringEntry (nullable = false)
|    |-- zip: Flow\ETL\Row\Entry\StringEntry (nullable = false)
|    |-- country: Flow\ETL\Row\Entry\StringEntry (nullable = false)
|-- notes: Flow\ETL\Row\Entry\ListEntry (nullable = false)

------------------
CSV: 
+----------------------+----------------------+----------------------+-------------+----------+----------------------+----------------------+----------------------+
|             order_id |           created_at |           updated_at | total_price | discount |             customer |              address |                notes |
+----------------------+----------------------+----------------------+-------------+----------+----------------------+----------------------+----------------------+
| 127dd8e7-6b54-36c5-9 | 2023-08-18T01:43:56+ | 2023-09-19T00:17:01+ |      357.32 |    17.88 | {"name":"Kylie","las | {"name":"Kylie","las | {"name":"Kylie","las |
| 0ca30307-9a5b-30fb-a | 2023-03-01T07:11:43+ | 2023-10-08T19:45:52+ |      366.12 |    16.77 | {"name":"Josefina"," | {"name":"Josefina"," | {"name":"Josefina"," |
| fe7dda3b-0026-3955-8 | 2023-09-05T03:52:54+ | 2023-09-17T21:16:37+ |      263.06 |    31.22 | {"name":"Casimir","l | {"name":"Casimir","l | {"name":"Casimir","l |
| 9b6deceb-f28e-3d5f-9 | 2023-10-13T17:33:07+ | 2023-09-23T03:08:11+ |       81.18 |    29.39 | {"name":"Jeanette"," | {"name":"Jeanette"," | {"name":"Jeanette"," |
| 82da96a2-440a-3075-a | 2023-10-06T02:10:35+ | 2023-09-24T15:16:01+ |      364.05 |    18.78 | {"name":"Grayson","l | {"name":"Grayson","l | {"name":"Grayson","l |
| e16bf5d1-b403-3b01-8 | 2023-03-07T16:08:08+ | 2023-09-25T02:27:29+ |      389.21 |    34.77 | {"name":"Garfield"," | {"name":"Garfield"," | {"name":"Garfield"," |
| 737f39a9-5d30-33b5-8 | 2023-05-31T11:37:15+ | 2023-09-27T17:00:01+ |       93.31 |    25.44 | {"name":"Marques","l | {"name":"Marques","l | {"name":"Marques","l |
| ccb5e191-9e10-3d46-a | 2023-03-24T16:24:06+ | 2023-09-20T21:10:58+ |       47.78 |     43.6 | {"name":"Twila","las | {"name":"Twila","las | {"name":"Twila","las |
| 19a158ad-10e3-39a1-8 | 2023-02-21T06:56:54+ | 2023-09-24T23:46:32+ |       256.6 |    34.86 | {"name":"Ollie","las | {"name":"Ollie","las | {"name":"Ollie","las |
| e8b5468e-0efc-3d3e-b | 2023-10-13T19:49:59+ | 2023-09-18T14:45:44+ |      171.01 |     4.88 | {"name":"King","last | {"name":"King","last | {"name":"King","last |
+----------------------+----------------------+----------------------+-------------+----------+----------------------+----------------------+----------------------+
10 rows

schema
|-- order_id: Flow\ETL\Row\Entry\UuidEntry (nullable = false)
|-- created_at: Flow\ETL\Row\Entry\StringEntry (nullable = false)
|-- updated_at: Flow\ETL\Row\Entry\StringEntry (nullable = false)
|-- total_price: Flow\ETL\Row\Entry\StringEntry (nullable = false)
|-- discount: Flow\ETL\Row\Entry\StringEntry (nullable = false)
|-- customer: Flow\ETL\Row\Entry\JsonEntry (nullable = false)
|-- address: Flow\ETL\Row\Entry\JsonEntry (nullable = false)
|-- notes: Flow\ETL\Row\Entry\JsonEntry (nullable = false)
```