### PR TITLE
Update minimum required version of Flow in all packages

### DIFF
--- a/src/adapter/etl-adapter-amphp/composer.json
+++ b/src/adapter/etl-adapter-amphp/composer.json
@@ -14,7 +14,7 @@
         "php": "~8.1 || ~8.2",
         "amphp/process": "^2",
         "amphp/socket": "^2",
-        "flow-php/etl": "^0.2 || 1.x-dev",
+        "flow-php/etl": "^0.4 || 1.x-dev",
         "monolog/monolog": "^3.0"
     },
     "config": {

--- a/src/adapter/etl-adapter-avro/composer.json
+++ b/src/adapter/etl-adapter-avro/composer.json
@@ -14,7 +14,7 @@
         "php": "~8.1 || ~8.2",
         "ext-json": "*",
         "flix-tech/avro-php": "~4.2.0 || ~4.3.0",
-        "flow-php/etl": "^0.2 || 1.x-dev"
+        "flow-php/etl": "^0.4 || 1.x-dev"
     },
     "config": {
         "optimize-autoloader": true,

--- a/src/adapter/etl-adapter-chartjs/composer.json
+++ b/src/adapter/etl-adapter-chartjs/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": "~8.1 || ~8.2",
-        "flow-php/etl": "^0.2 || 1.x-dev"
+        "flow-php/etl": "^0.4 || 1.x-dev"
     },
     "config": {
         "optimize-autoloader": true,

--- a/src/adapter/etl-adapter-csv/composer.json
+++ b/src/adapter/etl-adapter-csv/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": "~8.1 || ~8.2",
-        "flow-php/etl": "^0.2 || 1.x-dev"
+        "flow-php/etl": "^0.4 || 1.x-dev"
     },
     "config": {
         "optimize-autoloader": true,

--- a/src/adapter/etl-adapter-doctrine/composer.json
+++ b/src/adapter/etl-adapter-doctrine/composer.json
@@ -14,8 +14,8 @@
     ],
     "require": {
         "php": "~8.1 || ~8.2",
-        "flow-php/doctrine-dbal-bulk": "^0.2 || 1.x-dev",
-        "flow-php/etl": "^0.2 || 1.x-dev"
+        "flow-php/doctrine-dbal-bulk": "^0.4 || 1.x-dev",
+        "flow-php/etl": "^0.4 || 1.x-dev"
     },
     "autoload": {
         "psr-4": {

--- a/src/adapter/etl-adapter-elasticsearch/composer.json
+++ b/src/adapter/etl-adapter-elasticsearch/composer.json
@@ -15,7 +15,7 @@
         "ext-hash": "*",
         "ext-json": "*",
         "elasticsearch/elasticsearch": "^7.6|^8.0",
-        "flow-php/etl": "^0.2 || 1.x-dev"
+        "flow-php/etl": "^0.4 || 1.x-dev"
     },
     "config": {
         "optimize-autoloader": true,

--- a/src/adapter/etl-adapter-google-sheet/composer.json
+++ b/src/adapter/etl-adapter-google-sheet/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": "~8.1 || ~8.2",
-        "flow-php/etl": "^0.2 || 1.x-dev",
+        "flow-php/etl": "^0.4 || 1.x-dev",
         "google/apiclient": "^2.13"
     },
     "config": {

--- a/src/adapter/etl-adapter-http/composer.json
+++ b/src/adapter/etl-adapter-http/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": "~8.1 || ~8.2",
         "ext-json": "*",
-        "flow-php/etl": "^0.2 || 1.x-dev",
+        "flow-php/etl": "^0.4 || 1.x-dev",
         "psr/http-client": "^1.0"
     },
     "require-dev": {

--- a/src/adapter/etl-adapter-json/composer.json
+++ b/src/adapter/etl-adapter-json/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": "~8.1 || ~8.2",
         "ext-json": "*",
-        "flow-php/etl": "^0.2 || 1.x-dev",
+        "flow-php/etl": "^0.4 || 1.x-dev",
         "halaxa/json-machine": "^1.0"
     },
     "config": {

--- a/src/adapter/etl-adapter-logger/composer.json
+++ b/src/adapter/etl-adapter-logger/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": "~8.1 || ~8.2",
-        "flow-php/etl": "^0.2 || 1.x-dev",
+        "flow-php/etl": "^0.4 || 1.x-dev",
         "psr/log": "^2.0 || ^3.0"
     },
     "require-dev": {

--- a/src/adapter/etl-adapter-meilisearch/composer.json
+++ b/src/adapter/etl-adapter-meilisearch/composer.json
@@ -15,7 +15,7 @@
         "ext-hash": "*",
         "ext-json": "*",
         "meilisearch/meilisearch-php": "^1.1",
-        "flow-php/etl": "^0.2 || 1.x-dev"
+        "flow-php/etl": "^0.4 || 1.x-dev"
     },
     "config": {
         "optimize-autoloader": true,

--- a/src/adapter/etl-adapter-parquet/composer.json
+++ b/src/adapter/etl-adapter-parquet/composer.json
@@ -14,7 +14,7 @@
         "php": "~8.1 || ~8.2",
         "ext-json": "*",
         "codename/parquet": "~0.6.2 || ~0.7.0",
-        "flow-php/etl": "^0.2 || 1.x-dev"
+        "flow-php/etl": "^0.4 || 1.x-dev"
     },
     "config": {
         "optimize-autoloader": true,

--- a/src/adapter/etl-adapter-reactphp/composer.json
+++ b/src/adapter/etl-adapter-reactphp/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": "~8.1 || ~8.2",
-        "flow-php/etl": "^0.2 || 1.x-dev",
+        "flow-php/etl": "^0.4 || 1.x-dev",
         "monolog/monolog": "^3.0",
         "react/child-process": "^0.6.4",
         "react/socket": "^1.11"

--- a/src/adapter/etl-adapter-text/composer.json
+++ b/src/adapter/etl-adapter-text/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": "~8.1 || ~8.2",
-        "flow-php/etl": "^0.2 || 1.x-dev"
+        "flow-php/etl": "^0.4 || 1.x-dev"
     },
     "config": {
         "optimize-autoloader": true,

--- a/src/adapter/etl-adapter-xml/composer.json
+++ b/src/adapter/etl-adapter-xml/composer.json
@@ -14,7 +14,7 @@
         "php": "~8.1 || ~8.2",
         "ext-dom": "*",
         "ext-xmlreader": "*",
-        "flow-php/etl": "^0.2 || 1.x-dev"
+        "flow-php/etl": "^0.4 || 1.x-dev"
     },
     "config": {
         "optimize-autoloader": true,

--- a/src/core/etl/composer.json
+++ b/src/core/etl/composer.json
@@ -12,7 +12,7 @@
         "php": "~8.1 || ~8.2",
         "ext-json": "*",
         "ext-mbstring": "*",
-        "flow-php/array-dot": "^0.2 || 1.x-dev",
+        "flow-php/array-dot": "^0.4 || 1.x-dev",
         "league/flysystem": "^3.0",
         "psr/simple-cache": "^1.0 || ^2.0 || ^3.0"
     },


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Update minimum required version of Flow in all packages</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

Due to BC breaks introduced in `0.4`, we cannot use versions lower than that as dependencies.

Fixes https://github.com/flow-php/etl-adapter-xml/issues/113
