### PR TITLE
Skip JSON & XML checks for string that doesn't look as this type of data

### DIFF
--- a/src/core/etl/src/Flow/ETL/Row/Factory/NativeEntryFactory.php
+++ b/src/core/etl/src/Flow/ETL/Row/Factory/NativeEntryFactory.php
@@ -54,15 +54,17 @@ final class NativeEntryFactory implements EntryFactory
 
         if (\is_string($value)) {
             if ('' !== $value) {
-                if ($this->isJson($value)) {
+                $trimmedValue = \trim($value);
+
+                if ($this->isJson($trimmedValue)) {
                     return Row\Entry\JsonEntry::fromJsonString($entryName, $value);
                 }
 
-                if ($this->isUuid($value)) {
+                if ($this->isUuid($trimmedValue)) {
                     return new Row\Entry\UuidEntry($entryName, Entry\Type\Uuid::fromString($value));
                 }
 
-                if ($this->isXML($value)) {
+                if ($this->isXML($trimmedValue)) {
                     return new Entry\XMLEntry($entryName, $value);
                 }
             }
@@ -304,6 +306,10 @@ final class NativeEntryFactory implements EntryFactory
 
     private function isJson(string $string) : bool
     {
+        if ('{' !== $string[0] && '[' !== $string[0]) {
+            return false;
+        }
+
         if (
             (!\str_starts_with($string, '{') || !\str_ends_with($string, '}'))
             &&
@@ -330,6 +336,10 @@ final class NativeEntryFactory implements EntryFactory
 
     private function isXML(string $string) : bool
     {
+        if ('<' !== $string[0]) {
+            return false;
+        }
+
         if (\preg_match('/<(.+?)>(.+?)<\/(.+?)>/', $string) === 1) {
             try {
                 \libxml_use_internal_errors(true);


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Skip JSON & XML checks for a string that doesn't look like this type of data</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

Thanks to Blackfire, I can confirm that adding simple string checks for JSON & XML improves the performance of `NativeEntityFactory`.

<img width="616" alt="Zrzut ekranu 2023-10-16 o 14 20 20" src="https://github.com/flow-php/flow/assets/67402/522072db-c5fa-4c3a-8156-7d28e64eef83">
