### PR TITLE
Replace hashing algorithm from `sha256` to `xxh128`

### DIFF
--- a/src/core/etl/src/Flow/ETL/Cache/LocalFilesystemCache.php
+++ b/src/core/etl/src/Flow/ETL/Cache/LocalFilesystemCache.php
@@ -90,6 +90,6 @@ final class LocalFilesystemCache implements Cache
 
     private function cachePath(string $id) : string
     {
-        return \rtrim($this->path, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . \hash('sha256', $id);
+        return \rtrim($this->path, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . \hash('xxh128', $id);
     }
 }

--- a/src/core/etl/src/Flow/ETL/GroupBy.php
+++ b/src/core/etl/src/Flow/ETL/GroupBy.php
@@ -120,12 +120,12 @@ final class GroupBy
         /** @var mixed $value */
         foreach ($values as $value) {
             if ($value === null) {
-                $stringValues[] =\hash('sha256', 'null');
+                $stringValues[] =\hash('xxh128', 'null');
             } elseif (\is_scalar($value)) {
                 $stringValues[] = (string) $value;
             }
         }
 
-        return \hash('sha256', \implode('', $stringValues));
+        return \hash('xxh128', \implode('', $stringValues));
     }
 }

--- a/src/core/etl/tests/Flow/ETL/Tests/Integration/FlowTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Integration/FlowTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Tests\Integration;
 
-use function Flow\ETL\DSL\col;
 use function Flow\ETL\DSL\ref;
 use Flow\ETL\Cache\PSRSimpleCache;
 use Flow\ETL\Config;
@@ -27,7 +26,7 @@ final class FlowTest extends IntegrationTestCase
 
         $cacheContent = \array_values(\array_diff(\scandir($this->cacheDir), ['..', '.']));
 
-        $this->assertContains(\hash('sha256', 'test_etl_cache'), $cacheContent);
+        $this->assertContains(\hash('xxh128', 'test_etl_cache'), $cacheContent);
     }
 
     public function test_etl_psr_cache() : void
@@ -84,7 +83,7 @@ final class FlowTest extends IntegrationTestCase
                 ->id($id = 'test_etl_sort_by_in_memory')
                 ->cache($cacheSpy = new CacheSpy(Config::default()->cache()))
         )->extract(new AllRowTypesFakeExtractor($rowsets = 20, $rows = 2))
-            ->sortBy(col('id'))
+            ->sortBy(ref('id'))
             ->fetch();
 
         $cache = \array_diff(\scandir($this->cacheDir), ['..', '.']);


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Replace hashing algorithm from `sha256` to `xxh128`</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

`xx128` is faster than `sha256`.
