### PR TITLE
Reduce the amount of test data in ElasticSearch tests

### DIFF
--- a/src/adapter/etl-adapter-elasticsearch/tests/Flow/ETL/Adapter/Elasticsearch/Tests/Integration/ElasticsearchPHP/ElasticsearchExtractorTest.php
+++ b/src/adapter/etl-adapter-elasticsearch/tests/Flow/ETL/Adapter/Elasticsearch/Tests/Integration/ElasticsearchPHP/ElasticsearchExtractorTest.php
@@ -85,7 +85,7 @@ final class ElasticsearchExtractorTest extends TestCase
                     new Row\Entry\StringEntry('name', 'id_' . $i),
                     new Row\Entry\BooleanEntry('active', (bool) \random_int(0, 1))
                 ),
-                \range(1, 10_005)
+                \range(1, 2000)
             ),
         ), new FlowContext(Config::default()));
 
@@ -109,7 +109,7 @@ final class ElasticsearchExtractorTest extends TestCase
             ->transform(Elasticsearch::hits_to_rows(DocumentDataSource::fields))
             ->fetch();
 
-        $this->assertCount(10_000, $results);
+        $this->assertCount(2000, $results);
         $this->assertArrayHasKey('id', $results->first()->toArray());
         $this->assertArrayHasKey('position', $results->first()->toArray());
         $this->assertArrayNotHasKey('active', $results->first()->toArray());
@@ -128,7 +128,7 @@ final class ElasticsearchExtractorTest extends TestCase
                     new Row\Entry\StringEntry('name', 'id_' . $i),
                     new Row\Entry\BooleanEntry('active', (bool) \random_int(0, 1))
                 ),
-                \range(1, 10_005)
+                \range(1, 2005)
             ),
         ), new FlowContext(Config::default()));
 
@@ -149,7 +149,7 @@ final class ElasticsearchExtractorTest extends TestCase
             ->extract(Elasticsearch::search($this->elasticsearchContext->clientConfig(), $params))
             ->fetch();
 
-        $this->assertCount(10, $results);
+        $this->assertCount(3, $results);
     }
 
     public function test_extraction_index_with_search_after_with_point_in_time() : void
@@ -164,7 +164,7 @@ final class ElasticsearchExtractorTest extends TestCase
                     new Row\Entry\StringEntry('name', 'id_' . $i),
                     new Row\Entry\BooleanEntry('active', (bool) \random_int(0, 1))
                 ),
-                \range(1, 10_005)
+                \range(1, 2005)
             ),
         ), new FlowContext(Config::default()));
 
@@ -190,7 +190,7 @@ final class ElasticsearchExtractorTest extends TestCase
             ->extract(Elasticsearch::search($this->elasticsearchContext->clientConfig(), $params, $pitParams))
             ->fetch();
 
-        $this->assertCount(10, $results);
+        $this->assertCount(3, $results);
     }
 
     public function test_extraction_whole_index_with_point_in_time() : void
@@ -205,7 +205,7 @@ final class ElasticsearchExtractorTest extends TestCase
                     new Row\Entry\StringEntry('name', 'id_' . $i),
                     new Row\Entry\BooleanEntry('active', (bool) \random_int(0, 1))
                 ),
-                \range(1, 10_005)
+                \range(1, 2005)
             ),
         ), new FlowContext(Config::default()));
 
@@ -231,6 +231,6 @@ final class ElasticsearchExtractorTest extends TestCase
             ->extract(Elasticsearch::search($this->elasticsearchContext->clientConfig(), $params, $pitParams))
             ->fetch();
 
-        $this->assertCount(10, $results);
+        $this->assertCount(3, $results);
     }
 }

--- a/src/adapter/etl-adapter-elasticsearch/tests/Flow/ETL/Adapter/Elasticsearch/Tests/Integration/ElasticsearchPHP/IntegrationTest.php
+++ b/src/adapter/etl-adapter-elasticsearch/tests/Flow/ETL/Adapter/Elasticsearch/Tests/Integration/ElasticsearchPHP/IntegrationTest.php
@@ -46,7 +46,7 @@ final class IntegrationTest extends TestCase
                         new Row\Entry\StringEntry('name', 'id_' . $i),
                         new Row\Entry\BooleanEntry('active', false)
                     ),
-                    \range(1, 10_005)
+                    \range(1, 2005)
                 ),
             ),
             self::SOURCE_INDEX,


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Reduce the amount of test data in ElasticSearch tests</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

We don't need such heavy load integration tests, thus reducing the amount of rows from 10k to 2k.
