### PR TITLE
Fix Avro adapter handling nullable values

### DIFF
--- a/src/adapter/etl-adapter-avro/src/Flow/ETL/Adapter/Avro/FlixTech/ValueConverter.php
+++ b/src/adapter/etl-adapter-avro/src/Flow/ETL/Adapter/Avro/FlixTech/ValueConverter.php
@@ -35,7 +35,7 @@ final class ValueConverter
             $avroType = $this->type($entry);
 
             if ($avroType !== null && \is_array($avroType[\AvroSchema::TYPE_ATTR])) {
-                if ($avroType[\AvroSchema::TYPE_ATTR][\AvroSchema::TYPE_ATTR] === \AvroSchema::LONG_TYPE
+                if (($avroType[\AvroSchema::TYPE_ATTR][\AvroSchema::TYPE_ATTR] ?? null) === \AvroSchema::LONG_TYPE
                     && \array_key_exists(\AvroSchema::LOGICAL_TYPE_ATTR, $avroType)
                     && $avroType[\AvroSchema::LOGICAL_TYPE_ATTR] === 'timestamp-micros'
                 ) {
@@ -43,7 +43,7 @@ final class ValueConverter
                         'U.u',
                         \implode('.', \str_split((string) $value, 10))
                     );
-                } elseif ($avroType[\AvroSchema::TYPE_ATTR][\AvroSchema::TYPE_ATTR] === \AvroSchema::ARRAY_SCHEMA
+                } elseif (($avroType[\AvroSchema::TYPE_ATTR][\AvroSchema::TYPE_ATTR] ?? null) === \AvroSchema::ARRAY_SCHEMA
                     && \array_key_exists(\AvroSchema::LOGICAL_TYPE_ATTR, $avroType[\AvroSchema::TYPE_ATTR])
                     && $avroType[\AvroSchema::TYPE_ATTR][\AvroSchema::LOGICAL_TYPE_ATTR] === 'timestamp-micros'
                 ) {
@@ -74,14 +74,12 @@ final class ValueConverter
 
     private function type(string $entry) : ?array
     {
-        $type = null;
-
         foreach ($this->avroSchema[\AvroSchema::FIELDS_ATTR] as $avroType) {
             if ($avroType[\AvroSchema::NAME_ATTR] === $entry) {
                 return $avroType;
             }
         }
 
-        return $type;
+        return null;
     }
 }

--- a/src/adapter/etl-adapter-avro/tests/Flow/ETL/Adapter/Avro/Tests/Integration/AvroTest.php
+++ b/src/adapter/etl-adapter-avro/tests/Flow/ETL/Adapter/Avro/Tests/Integration/AvroTest.php
@@ -107,7 +107,7 @@ final class AvroTest extends TestCase
                         return Row::create(
                             Entry::integer('integer', $i),
                             Entry::float('float', 1.5),
-                            Entry::string('string', 'name_' . $i),
+                            $i % 10 === 0 ? Entry::null('string') : Entry::string('string', 'name_' . $i),
                             Entry::boolean('boolean', true),
                             Entry::datetime('datetime', new \DateTimeImmutable()),
                             Entry::json_object('json_object', ['id' => 1, 'name' => 'test']),


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>Fix Avro adapter handling nullable values</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

Without this fix adjusted test for Avro fails:
```console
There was 1 error:

1) Flow\ETL\Adapter\Avro\Tests\Integration\AvroTest::test_writing_and_reading_avro_with_all_supported_types
AvroIOTypeException: The datum array (
  'integer' => 10,
  'float' => 1.5,
  'string' => NULL,
  'boolean' => true,
  'datetime' => 1697475815694710,
  'json_object' => '{"id":1,"name":"test"}',
  'json' => '[{"id":1,"name":"test"},{"id":2,"name":"test"}]',
  'list_of_strings' => 
  array (
    0 => 'a',
    1 => 'b',
    2 => 'c',
  ),
  'list_of_datetimes' => 
  array (
    0 => 1697475815694711,
    1 => 1697475815694712,
    2 => 1697475815694712,
  ),
  'address' => 
  array (
    'street' => 'street_10',
    'city' => 'city_10',
    'zip' => 'zip_10',
    'country' => 'country_10',
    'location' => 
    array (
      'lat' => 1.5,
      'lon' => 1.5,
    ),
  ),
) is not an example of schema {"type":"record","name":"row","fields":[{"name":"integer","type":{"type":"int"}},{"name":"float","type":{"type":"float"}},{"name":"string","type":{"type":"string"}},{"name":"boolean","type":{"type":"boolean"}},{"name":"datetime","type":{"type":"long"},"logicalType":"timestamp-micros"},{"name":"json_object","type":{"type":"string"}},{"name":"json","type":{"type":"string"}},{"name":"list_of_strings","type":{"type":"array","items":{"type":"string"}}},{"name":"list_of_datetimes","type":{"type":"array","items":{"type":"long"},"logicalType":"timestamp-micros"}},{"name":"address","type":{"type":"record","name":"Address","fields":[{"name":"street","type":{"type":"string"}},{"name":"city","type":{"type":"string"}},{"name":"zip","type":{"type":"string"}},{"name":"country","type":{"type":"string"}},{"name":"location","type":{"type":"record","name":"Location","fields":[{"name":"lat","type":{"type":"float"}},{"name":"lon","type":{"type":"float"}}]}}]}}]}

/Users/stloyd/Documents/flow/vendor/flix-tech/avro-php/lib/avro/datum.php:101
/Users/stloyd/Documents/flow/vendor/flix-tech/avro-php/lib/avro/datum.php:147
/Users/stloyd/Documents/flow/vendor/flix-tech/avro-php/lib/avro/data_file.php:543
/Users/stloyd/Documents/flow/src/adapter/etl-adapter-avro/src/Flow/ETL/Adapter/Avro/FlixTech/AvroLoader.php:98
/Users/stloyd/Documents/flow/src/core/etl/src/Flow/ETL/Pipeline/SynchronousPipeline.php:81
/Users/stloyd/Documents/flow/src/core/etl/src/Flow/ETL/DataFrame.php:582
/Users/stloyd/Documents/flow/src/adapter/etl-adapter-avro/tests/Flow/ETL/Adapter/Avro/Tests/Integration/AvroTest.php:135
