### PR TITLE
Adjust benchmark report to be more useful

### DIFF
--- a/.github/workflows/benchmark-tag.yml
+++ b/.github/workflows/benchmark-tag.yml
@@ -51,17 +51,9 @@ jobs:
           fi
 
       - name: "Checkout to specific ref"
-        uses: "actions/checkout@v2"
+        uses: "actions/checkout@v4"
         with:
           ref: ${{ env.GIT_REF }}
-
-      - name: "Install PHP"
-        uses: "shivammathur/setup-php@v2"
-        with:
-          coverage: none
-          tools: composer:v2
-          php-version: "${{ matrix.php-version }}"
-          ini-values: memory_limit=-1
 
       - name: "Install PHP"
         uses: "shivammathur/setup-php@v2"

--- a/.github/workflows/test-benchmark.yml
+++ b/.github/workflows/test-benchmark.yml
@@ -8,6 +8,7 @@ on:
       - 'src/core/**'
       - 'src/lib/**'
       - 'tools/**'
+      - 'composer.json'
       - 'composer.lock'
 
 jobs:

--- a/composer.json
+++ b/composer.json
@@ -165,7 +165,7 @@
             "tools/phpunit/vendor/bin/phpunit"
         ],
         "test:benchmark": [
-            "tools/phpbench/vendor/bin/phpbench run --report=aggregate --retry-threshold=5"
+            "tools/phpbench/vendor/bin/phpbench run --report=flow-report"
         ],
         "test:mutation": [
             "tools/infection/vendor/bin/infection -j2"

--- a/phpbench.json
+++ b/phpbench.json
@@ -1,6 +1,19 @@
 {
   "$schema": "./tools/phpbench/vendor/phpbench/phpbench/phpbench.schema.json",
   "runner.bootstrap": "vendor/autoload.php",
+  "report.generators": {
+    "flow-report": {
+      "generator": "expression",
+      "cols": {
+        "benchmark": null,
+        "subject": null,
+        "revs": null,
+        "its": null,
+        "mem_peak": null,
+        "mode": null
+      }
+    }
+  },
   "runner.path": [
     "src/adapter/etl-adapter-avro/tests/Flow/ETL/Adapter/Avro/Tests/Benchmark/",
     "src/adapter/etl-adapter-csv/tests/Flow/ETL/Adapter/CSV/Tests/Benchmark/",
@@ -11,5 +24,6 @@
     "src/core/etl/tests/Flow/ETL/Tests/Benchmark/"
   ],
   "runner.progress": "dots",
+  "runner.retry_threshold": 5,
   "storage.xml_storage_path": "var/phpbench"
 }


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Adjust benchmark report to be more useful</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

https://github.com/flow-php/flow/actions/runs/6545138453?pr=604

```console
> tools/phpbench/vendor/bin/phpbench run --report=flow-report --ref=original
PHPBench (1.2.14) running benchmarks... #standwithukraine
with configuration file: /Users/stloyd/Documents/flow/phpbench.json
with PHP version 8.1.24, xdebug ❌, opcache ❌
comparing [actual vs. original]

............. 

Subjects: 13, Assertions: 0, Failures: 0, Errors: 0
+-------------------------------------+----------------------------+------+-----+-----------------+------------------+
| benchmark                           | subject                    | revs | its | mem_peak        | mode             |
+-------------------------------------+----------------------------+------+-----+-----------------+------------------+
| AvroExtractorBench                  | bench_extract_10k          | 5    | 3   | 44.538mb 0.00%  | 440.248ms -3.23% |
| CSVExtractorBench                   | bench_extract_10k          | 5    | 3   | 14.258mb 0.00%  | 180.898ms -0.35% |
| JsonExtractorBench                  | bench_extract_10k          | 5    | 3   | 18.920mb 0.00%  | 715.750ms +4.00% |
| ParquetExtractorBench               | bench_extract_10k          | 5    | 3   | 31.655mb 0.00%  | 408.619ms -2.13% |
| TextExtractorBench                  | bench_extract              | 5    | 3   | 6.203mb 0.00%   | 2.512ms +0.02%   |
| XmlExtractorBench                   | bench_extract              | 5    | 3   | 4.992mb 0.00%   | 1.176ms +1.50%   |
| RenameEntryTransformerBench         | bench_transform            | 1000 | 5   | 4.206mb 0.00%   | 5.922μs -4.75%   |
| EntryExpressionEvalTransformerBench | bench_transform_json_row   | 1000 | 5   | 4.206mb 0.00%   | 17.676μs -6.06%  |
| EntryExpressionEvalTransformerBench | bench_transform_string_row | 1000 | 5   | 4.206mb 0.00%   | 14.404μs -8.54%  |
| EntryExpressionEvalTransformerBench | bench_transform_xml_row    | 1000 | 5   | 4.206mb 0.00%   | 41.956μs -5.54%  |
| NativeEntryFactoryBench             | bench_10k_rows             | 5    | 5   | 84.169mb -0.03% | 131.111ms -4.87% |
| NativeEntryFactoryBench             | bench_1k_rows              | 5    | 5   | 45.689mb +0.03% | 13.517ms -3.19%  |
| NativeEntryFactoryBench             | bench_5k_rows              | 5    | 5   | 62.943mb +0.02% | 65.128ms -2.34%  |
+-------------------------------------+----------------------------+------+-----+-----------------+------------------+
