### PR TITLE
Added RLEBigPackingHybrid encode function

### DIFF
--- a/src/lib/dremel/src/Flow/Dremel/Dremel.php
+++ b/src/lib/dremel/src/Flow/Dremel/Dremel.php
@@ -142,7 +142,7 @@ final class Dremel
     {
         if (\count($repetitions) !== 0) {
             if (\count(\array_unique([\count($repetitions), \count($definitions)])) !== 1) {
-                throw new InvalidArgumentException('repetitions, definitions and values count must be exactly the same');
+                throw new InvalidArgumentException('repetitions, definitions and values count must be exactly the same, repetitions: ' . \count($repetitions) . ', definitions: ' . \count($definitions));
             }
         }
 

--- a/src/lib/parquet/src/Flow/Parquet/BinaryWriter.php
+++ b/src/lib/parquet/src/Flow/Parquet/BinaryWriter.php
@@ -1,0 +1,43 @@
+<?php declare(strict_types=1);
+
+namespace Flow\Parquet;
+
+interface BinaryWriter
+{
+    public function length() : DataSize;
+
+    /**
+     * @param array<int> $bits
+     */
+    public function writeBits(array $bits) : void;
+
+    /**
+     * @param array<bool> $values
+     */
+    public function writeBooleans(array $values) : void;
+
+    /**
+     * @param array<int> $bytes
+     */
+    public function writeBytes(array $bytes) : void;
+
+    /**
+     * @param array<int> $ints
+     */
+    public function writeInts32(array $ints) : void;
+
+    /**
+     * @param array<int> $ints
+     */
+    public function writeInts64(array $ints) : void;
+
+    /**
+     * @param array<string> $strings
+     */
+    public function writeStrings(array $strings) : void;
+
+    /**
+     * @param array<int> $values
+     */
+    public function writeVarInts32(array $values) : void;
+}

--- a/src/lib/parquet/src/Flow/Parquet/BinaryWriter/BinaryBufferWriter.php
+++ b/src/lib/parquet/src/Flow/Parquet/BinaryWriter/BinaryBufferWriter.php
@@ -1,0 +1,119 @@
+<?php declare(strict_types=1);
+
+namespace Flow\Parquet\BinaryWriter;
+
+use Flow\Parquet\BinaryWriter;
+use Flow\Parquet\ByteOrder;
+use Flow\Parquet\DataSize;
+
+final class BinaryBufferWriter implements BinaryWriter
+{
+    private DataSize $length;
+
+    public function __construct(private string &$buffer, private readonly ByteOrder $byteOrder = ByteOrder::LITTLE_ENDIAN)
+    {
+        $this->buffer = '';
+        $this->length = new DataSize(0);
+    }
+
+    public function length() : DataSize
+    {
+        return $this->length;
+    }
+
+    public function writeBits(array $bits) : void
+    {
+        $byte = 0;
+        $bitIndex = 0;
+
+        foreach ($bits as $bit) {
+            if ($bit) {
+                $byte |= (1 << $bitIndex);
+            }
+
+            $bitIndex++;
+
+            if ($bitIndex === 8) {
+                $this->buffer .= \chr($byte);
+                $this->length->addBytes(1); // Assume addBytes is a method to add to the length
+                $byte = 0;
+                $bitIndex = 0;
+            }
+        }
+
+        // If there are remaining bits that don't fill a byte
+        if ($bitIndex > 0) {
+            $this->buffer .= \chr($byte);
+            $this->length->addBytes(1);
+        }
+    }
+
+    public function writeBooleans(array $values) : void
+    {
+        $bits = [];
+
+        foreach ($values as $value) {
+            $bits[] = $value ? 1 : 0;
+        }
+        $this->writeBits($bits);
+    }
+
+    public function writeBytes(array $bytes) : void
+    {
+        foreach ($bytes as $byte) {
+            $this->buffer .= \chr($byte);
+        }
+        $this->length->addBytes(\count($bytes));
+    }
+
+    public function writeInts32(array $ints) : void
+    {
+        $format = $this->byteOrder === ByteOrder::BIG_ENDIAN ? 'N' : 'V';
+
+        foreach ($ints as $int) {
+            $this->buffer .= \pack($format, $int);
+        }
+        $this->length->addBytes(\count($ints) * 4);
+    }
+
+    public function writeInts64(array $ints) : void
+    {
+        $format = $this->byteOrder === ByteOrder::BIG_ENDIAN ? 'J' : 'P';
+
+        foreach ($ints as $int) {
+            $this->buffer .= \pack($format, $int);
+        }
+        $this->length->addBytes(\count($ints) * 8);
+    }
+
+    /**
+     * @param array<string> $strings
+     */
+    public function writeStrings(array $strings) : void
+    {
+        $format = $this->byteOrder === ByteOrder::BIG_ENDIAN ? 'N' : 'V';
+
+        foreach ($strings as $string) {
+            $length = \strlen($string);
+            $this->buffer .= \pack($format, $length);
+            $this->buffer .= $string;
+        }
+        $this->length->addBytes(\array_sum(\array_map('strlen', $strings)) + (4 * \count($strings)));
+    }
+
+    public function writeVarInts32(array $values) : void
+    {
+        foreach ($values as $value) {
+            do {
+                $temp = $value & 0x7F;
+                $value >>= 7;
+
+                if ($value) {
+                    $temp |= 0x80;
+                }
+                $this->buffer .= \chr($temp);
+                $this->length->addBytes(1);
+            } while ($value);
+        }
+    }
+}

--- a/src/lib/parquet/src/Flow/Parquet/DataSize.php
+++ b/src/lib/parquet/src/Flow/Parquet/DataSize.php
@@ -10,6 +10,11 @@ final class DataSize
     {
     }
 
+    public static function fromBytes(int $bytes) : self
+    {
+        return new self($bytes * 8);
+    }
+
     public function add(int|self $bits) : void
     {
         if ($bits instanceof self) {
@@ -21,6 +26,11 @@ final class DataSize
 
         $this->bits += $bits;
         $this->bytes = (int) \round($this->bits / 8, 0, PHP_ROUND_HALF_DOWN);
+    }
+
+    public function addBytes(int $bytes) : void
+    {
+        $this->add($bytes * 8);
     }
 
     public function bits() : int
@@ -48,5 +58,10 @@ final class DataSize
 
         $this->bits -= $bits;
         $this->bytes = (int) \round($this->bits / 8, 0, PHP_ROUND_HALF_DOWN);
+    }
+
+    public function subBytes(int $bytes) : void
+    {
+        $this->sub($bytes * 8);
     }
 }

--- a/src/lib/parquet/src/Flow/Parquet/ParquetFile/Data/BitWidth.php
+++ b/src/lib/parquet/src/Flow/Parquet/ParquetFile/Data/BitWidth.php
@@ -1,0 +1,44 @@
+<?php declare(strict_types=1);
+
+namespace Flow\Parquet\ParquetFile\Data;
+
+final class BitWidth
+{
+    public static function calculate(int $value) : int
+    {
+        return (int) \ceil(\log($value + 1, 2));
+    }
+
+    /**
+     * @param array<int> $ints
+     */
+    public static function fromArray(array $ints) : int
+    {
+        if (!\count($ints)) {
+            return 0;
+        }
+
+        $maxInt = \max($ints);
+
+        if ($maxInt === 0) {
+            return 0;
+        }
+
+        return self::calculate($maxInt);
+    }
+
+    /**
+     * @return array<int>
+     */
+    public static function toBytes(int $value, int $bitWidth) : array
+    {
+        $bytes = [];
+        $width = (int) (($bitWidth + 7) / 8);
+
+        for ($i = 0; $i < $width; $i++) {
+            $bytes[] = ($value >> ($i * 8)) & 0xFF;
+        }
+
+        return $bytes;
+    }
+}

--- a/src/lib/parquet/tests/Flow/Parquet/Tests/Integration/IO/ListsReadingTest.php
+++ b/src/lib/parquet/tests/Flow/Parquet/Tests/Integration/IO/ListsReadingTest.php
@@ -1,16 +1,16 @@
 <?php declare(strict_types=1);
 
-namespace Flow\Parquet\Tests\Integration;
+namespace Flow\Parquet\Tests\Integration\IO;
 
 use Flow\Parquet\ParquetFile\Schema\PhysicalType;
 use Flow\Parquet\Reader;
 
-final class ListsReadingTest extends ParquetIntegrationTestCase
+final class ListsReadingTest extends ParquetFunctionalTestCase
 {
     public function test_reading_list_column() : void
     {
         $reader = new Reader(logger: $this->getLogger());
-        $file = $reader->read(__DIR__ . '/../Fixtures/lists.parquet');
+        $file = $reader->read(__DIR__ . '/../../Fixtures/lists.parquet');
 
         $this->assertEquals(PhysicalType::BOOLEAN, $file->metadata()->schema()->get('list')->type());
         $this->assertEquals('LIST', $file->metadata()->schema()->get('list')->logicalType()->name());
@@ -30,7 +30,7 @@ final class ListsReadingTest extends ParquetIntegrationTestCase
     public function test_reading_list_column_with_limit() : void
     {
         $reader = new Reader(logger: $this->getLogger());
-        $file = $reader->read(__DIR__ . '/../Fixtures/lists.parquet');
+        $file = $reader->read(__DIR__ . '/../../Fixtures/lists.parquet');
 
         $this->assertEquals(PhysicalType::BOOLEAN, $file->metadata()->schema()->get('list')->type());
         $this->assertEquals('LIST', $file->metadata()->schema()->get('list')->logicalType()->name());
@@ -49,7 +49,7 @@ final class ListsReadingTest extends ParquetIntegrationTestCase
     public function test_reading_list_nested_column() : void
     {
         $reader = new Reader(logger: $this->getLogger());
-        $file = $reader->read(__DIR__ . '/../Fixtures/lists.parquet');
+        $file = $reader->read(__DIR__ . '/../../Fixtures/lists.parquet');
 
         $this->assertEquals(PhysicalType::BOOLEAN, $file->metadata()->schema()->get('list_nested')->type());
         $this->assertEquals('LIST', $file->metadata()->schema()->get('list_nested')->logicalType()->name());
@@ -72,7 +72,7 @@ final class ListsReadingTest extends ParquetIntegrationTestCase
     public function test_reading_list_nullable_column() : void
     {
         $reader = new Reader(logger: $this->getLogger());
-        $file = $reader->read(__DIR__ . '/../Fixtures/lists.parquet');
+        $file = $reader->read(__DIR__ . '/../../Fixtures/lists.parquet');
 
         $this->assertEquals(PhysicalType::BOOLEAN, $file->metadata()->schema()->get('list_nullable')->type());
         $this->assertEquals('LIST', $file->metadata()->schema()->get('list_nullable')->logicalType()->name());
@@ -96,7 +96,7 @@ final class ListsReadingTest extends ParquetIntegrationTestCase
     public function test_reading_list_of_structures_column() : void
     {
         $reader = new Reader(logger: $this->getLogger());
-        $file = $reader->read(__DIR__ . '/../Fixtures/lists.parquet');
+        $file = $reader->read(__DIR__ . '/../../Fixtures/lists.parquet');
 
         $this->assertEquals(PhysicalType::BOOLEAN, $file->metadata()->schema()->get('list_mixed_types')->type());
         $this->assertEquals('LIST', $file->metadata()->schema()->get('list_mixed_types')->logicalType()->name());

--- a/src/lib/parquet/tests/Flow/Parquet/Tests/Integration/IO/MapsReadingTest.php
+++ b/src/lib/parquet/tests/Flow/Parquet/Tests/Integration/IO/MapsReadingTest.php
@@ -1,16 +1,16 @@
 <?php declare(strict_types=1);
 
-namespace Flow\Parquet\Tests\Integration;
+namespace Flow\Parquet\Tests\Integration\IO;
 
 use Flow\Parquet\ParquetFile\Schema\PhysicalType;
 use Flow\Parquet\Reader;
 
-final class MapsReadingTest extends ParquetIntegrationTestCase
+final class MapsReadingTest extends ParquetFunctionalTestCase
 {
     public function test_reading_map_column() : void
     {
         $reader = new Reader(logger: $this->getLogger());
-        $file = $reader->read(__DIR__ . '/../Fixtures/maps.parquet');
+        $file = $reader->read(__DIR__ . '/../../Fixtures/maps.parquet');
 
         $this->assertEquals(PhysicalType::BOOLEAN, $file->metadata()->schema()->get('map')->type());
         $this->assertEquals('MAP', $file->metadata()->schema()->get('map')->logicalType()->name());
@@ -29,7 +29,7 @@ final class MapsReadingTest extends ParquetIntegrationTestCase
     public function test_reading_map_nullable_column() : void
     {
         $reader = new Reader(logger: $this->getLogger());
-        $file = $reader->read(__DIR__ . '/../Fixtures/maps.parquet');
+        $file = $reader->read(__DIR__ . '/../../Fixtures/maps.parquet');
 
         $this->assertEquals(PhysicalType::BOOLEAN, $file->metadata()->schema()->get('map_nullable')->type());
         $this->assertEquals('MAP', $file->metadata()->schema()->get('map_nullable')->logicalType()->name());
@@ -52,7 +52,7 @@ final class MapsReadingTest extends ParquetIntegrationTestCase
     public function test_reading_map_of_complex_lists() : void
     {
         $reader = new Reader(logger: $this->getLogger());
-        $file = $reader->read(__DIR__ . '/../Fixtures/maps.parquet');
+        $file = $reader->read(__DIR__ . '/../../Fixtures/maps.parquet');
 
         $this->assertEquals(PhysicalType::BOOLEAN, $file->metadata()->schema()->get('map_of_complex_lists')->type());
         $this->assertEquals('MAP', $file->metadata()->schema()->get('map_of_complex_lists')->logicalType()->name());
@@ -74,7 +74,7 @@ final class MapsReadingTest extends ParquetIntegrationTestCase
     public function test_reading_map_of_list_of_map_of_lists() : void
     {
         $reader = new Reader(logger: $this->getLogger());
-        $file = $reader->read(__DIR__ . '/../Fixtures/maps.parquet');
+        $file = $reader->read(__DIR__ . '/../../Fixtures/maps.parquet');
 
         $this->assertEquals(PhysicalType::BOOLEAN, $file->metadata()->schema()->get('map_of_list_of_map_of_lists')->type());
         $this->assertEquals('MAP', $file->metadata()->schema()->get('map_of_list_of_map_of_lists')->logicalType()->name());
@@ -97,7 +97,7 @@ final class MapsReadingTest extends ParquetIntegrationTestCase
     public function test_reading_map_of_lists() : void
     {
         $reader = new Reader(logger: $this->getLogger());
-        $file = $reader->read(__DIR__ . '/../Fixtures/maps.parquet');
+        $file = $reader->read(__DIR__ . '/../../Fixtures/maps.parquet');
 
         $this->assertEquals(PhysicalType::BOOLEAN, $file->metadata()->schema()->get('map_of_lists')->type());
         $this->assertEquals('MAP', $file->metadata()->schema()->get('map_of_lists')->logicalType()->name());
@@ -118,7 +118,7 @@ final class MapsReadingTest extends ParquetIntegrationTestCase
     public function test_reading_map_of_maps_column() : void
     {
         $reader = new Reader(logger: $this->getLogger());
-        $file = $reader->read(__DIR__ . '/../Fixtures/maps.parquet');
+        $file = $reader->read(__DIR__ . '/../../Fixtures/maps.parquet');
 
         $this->assertEquals(PhysicalType::BOOLEAN, $file->metadata()->schema()->get('map_of_maps')->type());
         $this->assertEquals('MAP', $file->metadata()->schema()->get('map_of_maps')->logicalType()->name());
@@ -138,7 +138,7 @@ final class MapsReadingTest extends ParquetIntegrationTestCase
     public function test_reading_map_of_struct_of_structs_column() : void
     {
         $reader = new Reader(logger: $this->getLogger());
-        $file = $reader->read(__DIR__ . '/../Fixtures/maps.parquet');
+        $file = $reader->read(__DIR__ . '/../../Fixtures/maps.parquet');
 
         $this->assertEquals(PhysicalType::BOOLEAN, $file->metadata()->schema()->get('map_of_struct_of_structs')->type());
         $this->assertEquals('MAP', $file->metadata()->schema()->get('map_of_struct_of_structs')->logicalType()->name());
@@ -159,7 +159,7 @@ final class MapsReadingTest extends ParquetIntegrationTestCase
     public function test_reading_map_of_struct_of_structs_column_with_limit() : void
     {
         $reader = new Reader(logger: $this->getLogger());
-        $file = $reader->read(__DIR__ . '/../Fixtures/maps.parquet');
+        $file = $reader->read(__DIR__ . '/../../Fixtures/maps.parquet');
 
         $this->assertEquals(PhysicalType::BOOLEAN, $file->metadata()->schema()->get('map_of_struct_of_structs')->type());
         $this->assertEquals('MAP', $file->metadata()->schema()->get('map_of_struct_of_structs')->logicalType()->name());
@@ -179,7 +179,7 @@ final class MapsReadingTest extends ParquetIntegrationTestCase
     public function test_reading_map_of_structs_column() : void
     {
         $reader = new Reader(logger: $this->getLogger());
-        $file = $reader->read(__DIR__ . '/../Fixtures/maps.parquet');
+        $file = $reader->read(__DIR__ . '/../../Fixtures/maps.parquet');
 
         $this->assertEquals(PhysicalType::BOOLEAN, $file->metadata()->schema()->get('map_of_structs')->type());
         $this->assertEquals('MAP', $file->metadata()->schema()->get('map_of_structs')->logicalType()->name());

--- a/src/lib/parquet/tests/Flow/Parquet/Tests/Integration/IO/ParquetFunctionalTestCase.php
+++ b/src/lib/parquet/tests/Flow/Parquet/Tests/Integration/IO/ParquetFunctionalTestCase.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace Flow\Parquet\Tests\Integration;
+namespace Flow\Parquet\Tests\Integration\IO;
 
 use Monolog\Handler\StreamHandler;
 use Monolog\Level;
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 
-abstract class ParquetIntegrationTestCase extends TestCase
+abstract class ParquetFunctionalTestCase extends TestCase
 {
     protected function getLogger() : LoggerInterface
     {

--- a/src/lib/parquet/tests/Flow/Parquet/Tests/Integration/IO/SchemaReadingTest.php
+++ b/src/lib/parquet/tests/Flow/Parquet/Tests/Integration/IO/SchemaReadingTest.php
@@ -1,17 +1,17 @@
 <?php declare(strict_types=1);
 
-namespace Flow\Parquet\Tests\Integration;
+namespace Flow\Parquet\Tests\Integration\IO;
 
 use Flow\Parquet\Reader;
 
-final class SchemaReadingTest extends ParquetIntegrationTestCase
+final class SchemaReadingTest extends ParquetFunctionalTestCase
 {
     public function test_reading_lists_schema_ddl() : void
     {
         $reader = new Reader(logger: $this->getLogger());
         $this->assertJsonStringEqualsJsonFile(
-            __DIR__ . '/../Fixtures/lists.json',
-            \json_encode(($reader->read(__DIR__ . '/../Fixtures/lists.parquet'))->metadata()->schema()->toDDL())
+            __DIR__ . '/../../Fixtures/lists.json',
+            \json_encode(($reader->read(__DIR__ . '/../../Fixtures/lists.parquet'))->metadata()->schema()->toDDL())
         );
     }
 
@@ -19,8 +19,8 @@ final class SchemaReadingTest extends ParquetIntegrationTestCase
     {
         $reader = new Reader(logger: $this->getLogger());
         $this->assertJsonStringEqualsJsonFile(
-            __DIR__ . '/../Fixtures/maps.json',
-            \json_encode(($reader->read(__DIR__ . '/../Fixtures/maps.parquet'))->metadata()->schema()->toDDL())
+            __DIR__ . '/../../Fixtures/maps.json',
+            \json_encode(($reader->read(__DIR__ . '/../../Fixtures/maps.parquet'))->metadata()->schema()->toDDL())
         );
     }
 
@@ -28,8 +28,8 @@ final class SchemaReadingTest extends ParquetIntegrationTestCase
     {
         $reader = new Reader(logger: $this->getLogger());
         $this->assertJsonStringEqualsJsonFile(
-            __DIR__ . '/../Fixtures/primitives.json',
-            \json_encode(($reader->read(__DIR__ . '/../Fixtures/primitives.parquet'))->metadata()->schema()->toDDL())
+            __DIR__ . '/../../Fixtures/primitives.json',
+            \json_encode(($reader->read(__DIR__ . '/../../Fixtures/primitives.parquet'))->metadata()->schema()->toDDL())
         );
     }
 
@@ -37,8 +37,8 @@ final class SchemaReadingTest extends ParquetIntegrationTestCase
     {
         $reader = new Reader(logger: $this->getLogger());
         $this->assertJsonStringEqualsJsonFile(
-            __DIR__ . '/../Fixtures/structs.json',
-            \json_encode(($reader->read(__DIR__ . '/../Fixtures/structs.parquet'))->metadata()->schema()->toDDL())
+            __DIR__ . '/../../Fixtures/structs.json',
+            \json_encode(($reader->read(__DIR__ . '/../../Fixtures/structs.parquet'))->metadata()->schema()->toDDL())
         );
     }
 }

--- a/src/lib/parquet/tests/Flow/Parquet/Tests/Integration/IO/SimpleTypesReadingTest.php
+++ b/src/lib/parquet/tests/Flow/Parquet/Tests/Integration/IO/SimpleTypesReadingTest.php
@@ -1,16 +1,16 @@
 <?php declare(strict_types=1);
 
-namespace Flow\Parquet\Tests\Integration;
+namespace Flow\Parquet\Tests\Integration\IO;
 
 use Flow\Parquet\ParquetFile\Schema\PhysicalType;
 use Flow\Parquet\Reader;
 
-final class SimpleTypesReadingTest extends ParquetIntegrationTestCase
+final class SimpleTypesReadingTest extends ParquetFunctionalTestCase
 {
     public function test_reading_bool_column() : void
     {
         $reader = new Reader(logger: $this->getLogger());
-        $file = $reader->read(__DIR__ . '/../Fixtures/primitives.parquet');
+        $file = $reader->read(__DIR__ . '/../../Fixtures/primitives.parquet');
 
         $this->assertEquals(PhysicalType::BOOLEAN, $file->metadata()->schema()->get('bool')->type());
         $this->assertNull($file->metadata()->schema()->get('bool')->logicalType());
@@ -24,7 +24,7 @@ final class SimpleTypesReadingTest extends ParquetIntegrationTestCase
     public function test_reading_bool_column_with_limit() : void
     {
         $reader = new Reader(logger: $this->getLogger());
-        $file = $reader->read(__DIR__ . '/../Fixtures/primitives.parquet');
+        $file = $reader->read(__DIR__ . '/../../Fixtures/primitives.parquet');
 
         $this->assertEquals(PhysicalType::BOOLEAN, $file->metadata()->schema()->get('bool')->type());
         $this->assertNull($file->metadata()->schema()->get('bool')->logicalType());
@@ -37,7 +37,7 @@ final class SimpleTypesReadingTest extends ParquetIntegrationTestCase
     public function test_reading_bool_nullable_column() : void
     {
         $reader = new Reader(logger: $this->getLogger());
-        $file = $reader->read(__DIR__ . '/../Fixtures/primitives.parquet');
+        $file = $reader->read(__DIR__ . '/../../Fixtures/primitives.parquet');
 
         $this->assertEquals(PhysicalType::BOOLEAN, $file->metadata()->schema()->get('bool_nullable')->type());
         $this->assertNull($file->metadata()->schema()->get('bool_nullable')->logicalType());
@@ -52,7 +52,7 @@ final class SimpleTypesReadingTest extends ParquetIntegrationTestCase
     public function test_reading_bool_nullable_column_with_limit() : void
     {
         $reader = new Reader(logger: $this->getLogger());
-        $file = $reader->read(__DIR__ . '/../Fixtures/primitives.parquet');
+        $file = $reader->read(__DIR__ . '/../../Fixtures/primitives.parquet');
 
         $this->assertEquals(PhysicalType::BOOLEAN, $file->metadata()->schema()->get('bool_nullable')->type());
         $this->assertNull($file->metadata()->schema()->get('bool_nullable')->logicalType());
@@ -66,7 +66,7 @@ final class SimpleTypesReadingTest extends ParquetIntegrationTestCase
     public function test_reading_date_column() : void
     {
         $reader = new Reader(logger: $this->getLogger());
-        $file = $reader->read(__DIR__ . '/../Fixtures/primitives.parquet');
+        $file = $reader->read(__DIR__ . '/../../Fixtures/primitives.parquet');
 
         $this->assertEquals(PhysicalType::INT32, $file->metadata()->schema()->get('date')->type());
         $this->assertEquals('DATE', $file->metadata()->schema()->get('date')->logicalType()->name());
@@ -84,7 +84,7 @@ final class SimpleTypesReadingTest extends ParquetIntegrationTestCase
     public function test_reading_date_nullable_column() : void
     {
         $reader = new Reader(logger: $this->getLogger());
-        $file = $reader->read(__DIR__ . '/../Fixtures/primitives.parquet');
+        $file = $reader->read(__DIR__ . '/../../Fixtures/primitives.parquet');
 
         $this->assertEquals(PhysicalType::INT32, $file->metadata()->schema()->get('date_nullable')->type());
         $this->assertEquals('DATE', $file->metadata()->schema()->get('date_nullable')->logicalType()->name());
@@ -106,7 +106,7 @@ final class SimpleTypesReadingTest extends ParquetIntegrationTestCase
     public function test_reading_enum_column() : void
     {
         $reader = new Reader(logger: $this->getLogger());
-        $file = $reader->read(__DIR__ . '/../Fixtures/primitives.parquet');
+        $file = $reader->read(__DIR__ . '/../../Fixtures/primitives.parquet');
 
         $this->assertEquals(PhysicalType::BYTE_ARRAY, $file->metadata()->schema()->get('enum')->type());
         $this->assertEquals('STRING', $file->metadata()->schema()->get('enum')->logicalType()->name());
@@ -124,7 +124,7 @@ final class SimpleTypesReadingTest extends ParquetIntegrationTestCase
     public function test_reading_int32_column() : void
     {
         $reader = new Reader(logger: $this->getLogger());
-        $file = $reader->read(__DIR__ . '/../Fixtures/primitives.parquet');
+        $file = $reader->read(__DIR__ . '/../../Fixtures/primitives.parquet');
 
         $this->assertEquals(PhysicalType::INT32, $file->metadata()->schema()->get('int32')->type());
         $this->assertNull($file->metadata()->schema()->get('int32')->logicalType());
@@ -142,7 +142,7 @@ final class SimpleTypesReadingTest extends ParquetIntegrationTestCase
     public function test_reading_int32_nullable_column() : void
     {
         $reader = new Reader(logger: $this->getLogger());
-        $file = $reader->read(__DIR__ . '/../Fixtures/primitives.parquet');
+        $file = $reader->read(__DIR__ . '/../../Fixtures/primitives.parquet');
 
         $this->assertEquals(PhysicalType::INT32, $file->metadata()->schema()->get('int32_nullable')->type());
         $this->assertNull($file->metadata()->schema()->get('int32_nullable')->logicalType());
@@ -164,7 +164,7 @@ final class SimpleTypesReadingTest extends ParquetIntegrationTestCase
     public function test_reading_int64() : void
     {
         $reader = new Reader(logger: $this->getLogger());
-        $file = $reader->read(__DIR__ . '/../Fixtures/primitives.parquet');
+        $file = $reader->read(__DIR__ . '/../../Fixtures/primitives.parquet');
 
         $this->assertEquals(PhysicalType::INT64, $file->metadata()->schema()->get('int64')->type());
         $this->assertNull($file->metadata()->schema()->get('int64')->logicalType());
@@ -183,7 +183,7 @@ final class SimpleTypesReadingTest extends ParquetIntegrationTestCase
     public function test_reading_int64_nullable_column() : void
     {
         $reader = new Reader(logger: $this->getLogger());
-        $file = $reader->read(__DIR__ . '/../Fixtures/primitives.parquet');
+        $file = $reader->read(__DIR__ . '/../../Fixtures/primitives.parquet');
 
         $this->assertEquals(PhysicalType::INT64, $file->metadata()->schema()->get('int64_nullable')->type());
         $this->assertNull($file->metadata()->schema()->get('int64_nullable')->logicalType());
@@ -205,7 +205,7 @@ final class SimpleTypesReadingTest extends ParquetIntegrationTestCase
     public function test_reading_json_column() : void
     {
         $reader = new Reader(logger: $this->getLogger());
-        $file = $reader->read(__DIR__ . '/../Fixtures/primitives.parquet');
+        $file = $reader->read(__DIR__ . '/../../Fixtures/primitives.parquet');
 
         $this->assertEquals(PhysicalType::BYTE_ARRAY, $file->metadata()->schema()->get('json')->type());
         $this->assertEquals('STRING', $file->metadata()->schema()->get('json')->logicalType()->name());
@@ -223,7 +223,7 @@ final class SimpleTypesReadingTest extends ParquetIntegrationTestCase
     public function test_reading_json_nullable_column() : void
     {
         $reader = new Reader(logger: $this->getLogger());
-        $file = $reader->read(__DIR__ . '/../Fixtures/primitives.parquet');
+        $file = $reader->read(__DIR__ . '/../../Fixtures/primitives.parquet');
 
         $this->assertEquals(PhysicalType::BYTE_ARRAY, $file->metadata()->schema()->get('json_nullable')->type());
         $this->assertEquals('STRING', $file->metadata()->schema()->get('json_nullable')->logicalType()->name());
@@ -245,7 +245,7 @@ final class SimpleTypesReadingTest extends ParquetIntegrationTestCase
     public function test_reading_string_column() : void
     {
         $reader = new Reader(logger: $this->getLogger());
-        $file = $reader->read(__DIR__ . '/../Fixtures/primitives.parquet');
+        $file = $reader->read(__DIR__ . '/../../Fixtures/primitives.parquet');
 
         $this->assertEquals(PhysicalType::BYTE_ARRAY, $file->metadata()->schema()->get('string')->type());
         $this->assertEquals('STRING', $file->metadata()->schema()->get('string')->logicalType()->name());
@@ -263,7 +263,7 @@ final class SimpleTypesReadingTest extends ParquetIntegrationTestCase
     public function test_reading_string_nullable_column() : void
     {
         $reader = new Reader(logger: $this->getLogger());
-        $file = $reader->read(__DIR__ . '/../Fixtures/primitives.parquet');
+        $file = $reader->read(__DIR__ . '/../../Fixtures/primitives.parquet');
 
         $this->assertEquals(PhysicalType::BYTE_ARRAY, $file->metadata()->schema()->get('string_nullable')->type());
         $this->assertEquals('STRING', $file->metadata()->schema()->get('string_nullable')->logicalType()->name());
@@ -285,7 +285,7 @@ final class SimpleTypesReadingTest extends ParquetIntegrationTestCase
     public function test_reading_time_column() : void
     {
         $reader = new Reader(logger: $this->getLogger());
-        $file = $reader->read(__DIR__ . '/../Fixtures/primitives.parquet');
+        $file = $reader->read(__DIR__ . '/../../Fixtures/primitives.parquet');
 
         $this->assertEquals(PhysicalType::INT64, $file->metadata()->schema()->get('time')->type());
         $this->assertEquals('TIME', $file->metadata()->schema()->get('time')->logicalType()->name());
@@ -303,7 +303,7 @@ final class SimpleTypesReadingTest extends ParquetIntegrationTestCase
     public function test_reading_time_nullable_column() : void
     {
         $reader = new Reader(logger: $this->getLogger());
-        $file = $reader->read(__DIR__ . '/../Fixtures/primitives.parquet');
+        $file = $reader->read(__DIR__ . '/../../Fixtures/primitives.parquet');
 
         $this->assertEquals(PhysicalType::INT64, $file->metadata()->schema()->get('time_nullable')->type());
         $this->assertEquals('TIME', $file->metadata()->schema()->get('time_nullable')->logicalType()->name());
@@ -325,7 +325,7 @@ final class SimpleTypesReadingTest extends ParquetIntegrationTestCase
     public function test_reading_timestamp_column() : void
     {
         $reader = new Reader(logger: $this->getLogger());
-        $file = $reader->read(__DIR__ . '/../Fixtures/primitives.parquet');
+        $file = $reader->read(__DIR__ . '/../../Fixtures/primitives.parquet');
 
         $this->assertEquals(PhysicalType::INT64, $file->metadata()->schema()->get('timestamp')->type());
         $this->assertEquals('TIMESTAMP', $file->metadata()->schema()->get('timestamp')->logicalType()->name());
@@ -343,7 +343,7 @@ final class SimpleTypesReadingTest extends ParquetIntegrationTestCase
     public function test_reading_timestamp_nullable_column() : void
     {
         $reader = new Reader(logger: $this->getLogger());
-        $file = $reader->read(__DIR__ . '/../Fixtures/primitives.parquet');
+        $file = $reader->read(__DIR__ . '/../../Fixtures/primitives.parquet');
 
         $this->assertEquals(PhysicalType::INT64, $file->metadata()->schema()->get('timestamp_nullable')->type());
         $this->assertEquals('TIMESTAMP', $file->metadata()->schema()->get('timestamp_nullable')->logicalType()->name());
@@ -365,7 +365,7 @@ final class SimpleTypesReadingTest extends ParquetIntegrationTestCase
     public function test_reading_uuid_column() : void
     {
         $reader = new Reader(logger: $this->getLogger());
-        $file = $reader->read(__DIR__ . '/../Fixtures/primitives.parquet');
+        $file = $reader->read(__DIR__ . '/../../Fixtures/primitives.parquet');
 
         $this->assertEquals(PhysicalType::BYTE_ARRAY, $file->metadata()->schema()->get('uuid')->type());
         $this->assertEquals('STRING', $file->metadata()->schema()->get('uuid')->logicalType()->name());
@@ -383,7 +383,7 @@ final class SimpleTypesReadingTest extends ParquetIntegrationTestCase
     public function test_reading_uuid_nullable_column() : void
     {
         $reader = new Reader(logger: $this->getLogger());
-        $file = $reader->read(__DIR__ . '/../Fixtures/primitives.parquet');
+        $file = $reader->read(__DIR__ . '/../../Fixtures/primitives.parquet');
 
         $this->assertEquals(PhysicalType::BYTE_ARRAY, $file->metadata()->schema()->get('uuid_nullable')->type());
         $this->assertEquals('STRING', $file->metadata()->schema()->get('uuid_nullable')->logicalType()->name());

--- a/src/lib/parquet/tests/Flow/Parquet/Tests/Integration/IO/StructsReadingTest.php
+++ b/src/lib/parquet/tests/Flow/Parquet/Tests/Integration/IO/StructsReadingTest.php
@@ -1,16 +1,16 @@
 <?php declare(strict_types=1);
 
-namespace Flow\Parquet\Tests\Integration;
+namespace Flow\Parquet\Tests\Integration\IO;
 
 use Flow\Parquet\ParquetFile\Schema\PhysicalType;
 use Flow\Parquet\Reader;
 
-final class StructsReadingTest extends ParquetIntegrationTestCase
+final class StructsReadingTest extends ParquetFunctionalTestCase
 {
     public function test_reading_struct_deeply_nested_column() : void
     {
         $reader = new Reader(logger: $this->getLogger());
-        $file = $reader->read(__DIR__ . '/../Fixtures/structs.parquet');
+        $file = $reader->read(__DIR__ . '/../../Fixtures/structs.parquet');
 
         $this->assertEquals(PhysicalType::BOOLEAN, $file->metadata()->schema()->get('struct_deeply_nested')->type());
         $this->assertNull($file->metadata()->schema()->get('struct_deeply_nested')->logicalType());
@@ -38,7 +38,7 @@ final class StructsReadingTest extends ParquetIntegrationTestCase
     public function test_reading_struct_deeply_nested_column_with_limit() : void
     {
         $reader = new Reader(logger: $this->getLogger());
-        $file = $reader->read(__DIR__ . '/../Fixtures/structs.parquet');
+        $file = $reader->read(__DIR__ . '/../../Fixtures/structs.parquet');
 
         $this->assertEquals(PhysicalType::BOOLEAN, $file->metadata()->schema()->get('struct_deeply_nested')->type());
         $this->assertNull($file->metadata()->schema()->get('struct_deeply_nested')->logicalType());
@@ -65,7 +65,7 @@ final class StructsReadingTest extends ParquetIntegrationTestCase
     public function test_reading_struct_flat_column() : void
     {
         $reader = new Reader(logger: $this->getLogger());
-        $file = $reader->read(__DIR__ . '/../Fixtures/structs.parquet');
+        $file = $reader->read(__DIR__ . '/../../Fixtures/structs.parquet');
 
         $this->assertEquals(PhysicalType::BOOLEAN, $file->metadata()->schema()->get('struct_flat')->type());
         $this->assertNull($file->metadata()->schema()->get('struct_flat')->logicalType());
@@ -86,7 +86,7 @@ final class StructsReadingTest extends ParquetIntegrationTestCase
     public function test_reading_struct_nested_column() : void
     {
         $reader = new Reader(logger: $this->getLogger());
-        $file = $reader->read(__DIR__ . '/../Fixtures/structs.parquet');
+        $file = $reader->read(__DIR__ . '/../../Fixtures/structs.parquet');
 
         $this->assertEquals(PhysicalType::BOOLEAN, $file->metadata()->schema()->get('struct_nested')->type());
         $this->assertNull($file->metadata()->schema()->get('struct_nested')->logicalType());
@@ -108,7 +108,7 @@ final class StructsReadingTest extends ParquetIntegrationTestCase
     public function test_reading_struct_nested_with_list_of_lists_column() : void
     {
         $reader = new Reader(logger: $this->getLogger());
-        $file = $reader->read(__DIR__ . '/../Fixtures/structs.parquet');
+        $file = $reader->read(__DIR__ . '/../../Fixtures/structs.parquet');
 
         $this->assertEquals(PhysicalType::BOOLEAN, $file->metadata()->schema()->get('struct_nested_with_list_of_lists')->type());
         $this->assertNull($file->metadata()->schema()->get('struct_nested_with_list_of_lists')->logicalType());
@@ -129,7 +129,7 @@ final class StructsReadingTest extends ParquetIntegrationTestCase
     public function test_reading_struct_nested_with_list_of_maps_column() : void
     {
         $reader = new Reader(logger: $this->getLogger());
-        $file = $reader->read(__DIR__ . '/../Fixtures/structs.parquet');
+        $file = $reader->read(__DIR__ . '/../../Fixtures/structs.parquet');
 
         $this->assertEquals(PhysicalType::BOOLEAN, $file->metadata()->schema()->get('struct_nested_with_list_of_maps')->type());
         $this->assertNull($file->metadata()->schema()->get('struct_nested_with_list_of_maps')->logicalType());
@@ -150,7 +150,7 @@ final class StructsReadingTest extends ParquetIntegrationTestCase
     public function test_reading_struct_nested_with_map_of_list_of_ints_column() : void
     {
         $reader = new Reader(logger: $this->getLogger());
-        $file = $reader->read(__DIR__ . '/../Fixtures/structs.parquet');
+        $file = $reader->read(__DIR__ . '/../../Fixtures/structs.parquet');
 
         $this->assertEquals(PhysicalType::BOOLEAN, $file->metadata()->schema()->get('struct_nested_with_map_of_list_of_ints')->type());
         $this->assertNull($file->metadata()->schema()->get('struct_nested_with_map_of_list_of_ints')->logicalType());
@@ -172,7 +172,7 @@ final class StructsReadingTest extends ParquetIntegrationTestCase
     public function test_reading_struct_nested_with_map_of_string_map_of_string_string_column() : void
     {
         $reader = new Reader(logger: $this->getLogger());
-        $file = $reader->read(__DIR__ . '/../Fixtures/structs.parquet');
+        $file = $reader->read(__DIR__ . '/../../Fixtures/structs.parquet');
 
         $this->assertEquals(PhysicalType::BOOLEAN, $file->metadata()->schema()->get('struct_nested_with_map_of_string_map_of_string_string')->type());
         $this->assertNull($file->metadata()->schema()->get('struct_nested_with_map_of_string_map_of_string_string')->logicalType());
@@ -195,7 +195,7 @@ final class StructsReadingTest extends ParquetIntegrationTestCase
     public function test_reading_struct_nested_with_map_of_string_map_of_string_string_column_with_limit() : void
     {
         $reader = new Reader(logger: $this->getLogger());
-        $file = $reader->read(__DIR__ . '/../Fixtures/structs.parquet');
+        $file = $reader->read(__DIR__ . '/../../Fixtures/structs.parquet');
 
         $this->assertEquals(PhysicalType::BOOLEAN, $file->metadata()->schema()->get('struct_nested_with_map_of_string_map_of_string_string')->type());
         $this->assertNull($file->metadata()->schema()->get('struct_nested_with_map_of_string_map_of_string_string')->logicalType());
@@ -217,7 +217,7 @@ final class StructsReadingTest extends ParquetIntegrationTestCase
     public function test_reading_struct_with_list_and_map_of_structs_column() : void
     {
         $reader = new Reader(logger: $this->getLogger());
-        $file = $reader->read(__DIR__ . '/../Fixtures/structs.parquet');
+        $file = $reader->read(__DIR__ . '/../../Fixtures/structs.parquet');
 
         $this->assertEquals(PhysicalType::BOOLEAN, $file->metadata()->schema()->get('struct_with_list_and_map_of_structs')->type());
         $this->assertNull($file->metadata()->schema()->get('struct_with_list_and_map_of_structs')->logicalType());

--- a/src/lib/parquet/tests/Flow/Parquet/Tests/Integration/ParquetFile/Data/RLEBitPackedHybridTest.php
+++ b/src/lib/parquet/tests/Flow/Parquet/Tests/Integration/ParquetFile/Data/RLEBitPackedHybridTest.php
@@ -1,0 +1,108 @@
+<?php declare(strict_types=1);
+
+namespace Flow\Parquet\Tests\Integration\ParquetFile\Data;
+
+use Flow\Parquet\BinaryReader\BinaryBufferReader;
+use Flow\Parquet\BinaryWriter\BinaryBufferWriter;
+use Flow\Parquet\ParquetFile\Data\BitWidth;
+use Flow\Parquet\ParquetFile\Data\RLEBitPackedHybrid;
+use PHPUnit\Framework\TestCase;
+
+final class RLEBitPackedHybridTest extends TestCase
+{
+    public function test_bit_packing_with_not_a_full_sequence() : void
+    {
+        $values = [1, 2, 3, 1234];
+
+        $buffer = '';
+        (new RLEBitPackedHybrid())->encodeHybrid(new BinaryBufferWriter($buffer), $values);
+
+        $this->assertSame(
+            $values,
+            (new RLEBitPackedHybrid())->decodeHybrid(
+                new BinaryBufferReader($buffer),
+                BitWidth::fromArray($values),
+                \count($values)
+            )
+        );
+    }
+
+    public function test_bit_packing_with_two_sequences() : void
+    {
+        $values = [
+            1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25,
+            26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49,
+        ];
+
+        $buffer = '';
+        (new RLEBitPackedHybrid())->encodeHybrid(new BinaryBufferWriter($buffer), $values);
+
+        $this->assertSame(
+            $values,
+            (new RLEBitPackedHybrid())->decodeHybrid(
+                new BinaryBufferReader($buffer),
+                BitWidth::fromArray($values),
+                \count($values)
+            )
+        );
+    }
+
+    public function test_both_rle_and_bit_packed() : void
+    {
+        $values = [1, 2, 3, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 12, 13, 412, 5];
+
+        $buffer = '';
+        (new RLEBitPackedHybrid())->encodeHybrid(new BinaryBufferWriter($buffer), $values);
+
+        $this->assertSame(
+            $values,
+            (new RLEBitPackedHybrid())->decodeHybrid(
+                new BinaryBufferReader($buffer),
+                BitWidth::fromArray($values),
+                \count($values)
+            )
+        );
+    }
+
+    public function test_plain_rle_with_two_sequences() : void
+    {
+        $values = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1];
+
+        $buffer = '';
+        (new RLEBitPackedHybrid())->encodeHybrid(new BinaryBufferWriter($buffer), $values);
+
+        $this->assertSame(
+            $values,
+            (new RLEBitPackedHybrid())->decodeHybrid(
+                new BinaryBufferReader($buffer),
+                BitWidth::fromArray($values),
+                \count($values)
+            )
+        );
+    }
+
+    public function test_with_dynamically_generated_values() : void
+    {
+        for ($iteration = 0; $iteration < 100; $iteration++) {
+            $values = [];
+            $maxValues = \random_int(10, 1000);
+
+            for ($i = 0; $i < $maxValues; $i++) {
+                $values[] = \random_int(0, 1000);
+            }
+
+            $buffer = '';
+            (new RLEBitPackedHybrid())->encodeHybrid(new BinaryBufferWriter($buffer), $values);
+
+            $this->assertSame(
+                $values,
+                (new RLEBitPackedHybrid())->decodeHybrid(
+                    new BinaryBufferReader($buffer),
+                    BitWidth::fromArray($values),
+                    \count($values)
+                ),
+                'Failed to encode and decode RLEBitPackedHybrid: Iteration: ' . $iteration . ', values: ' . \json_encode($values, JSON_THROW_ON_ERROR)
+            );
+        }
+    }
+}


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <li>RLEBigPackingHybrid encode function</li>
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

We need this to implement parquet file writer, it's also a pretty cool standalone algo that can be used to reduce the amount of space needed for storing integers. 

More details here: https://parquet.apache.org/docs/file-format/data-pages/encodings/#RLE

I also slightly improved reading RLE_DICTIONARY encoded data pages by simplifying reading conditions that relays on the expected number of items rather than data length and item numbers.