### PR TITLE
Entry factory moved from extractors to `FlowContext`

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -5,6 +5,14 @@ Please follow the instructions for your specific version to ensure a smooth upgr
 
 ---
 
+## Upgrading from 0.4.x to 0.5.x
+
+### 1) Entry factory moved from extractors to `FlowContext`
+
+To improve code quality and reduce code coupling `EntryFactory` was removed from all constructors of extractors, in favor of passing it into `FlowContext` & re-using same entry factory in a whole pipeline.
+
+---
+
 ## Upgrading from 0.3.x to 0.4.x
 
 ### 1) Transformers replaced with expressions

--- a/src/adapter/etl-adapter-avro/src/Flow/ETL/Adapter/Avro/FlixTech/AvroExtractor.php
+++ b/src/adapter/etl-adapter-avro/src/Flow/ETL/Adapter/Avro/FlixTech/AvroExtractor.php
@@ -13,13 +13,9 @@ use Flow\ETL\Row;
 
 final class AvroExtractor implements Extractor
 {
-    /**
-     * @param Path $path
-     */
     public function __construct(
         private readonly Path $path,
-        private readonly int $rowsInBach = 1000,
-        private readonly Row\EntryFactory $entryFactory = new Row\Factory\NativeEntryFactory()
+        private readonly int $rowsInBach = 1000
     ) {
     }
 
@@ -56,7 +52,7 @@ final class AvroExtractor implements Extractor
                 }
 
                 if (\count($rows) >= $this->rowsInBach) {
-                    yield array_to_rows($rows, $this->entryFactory);
+                    yield array_to_rows($rows, $context->entryFactory());
                     /** @var array<Row> $rows */
                     $rows = [];
                 }
@@ -64,7 +60,7 @@ final class AvroExtractor implements Extractor
         }
 
         if ([] !== $rows) {
-            yield array_to_rows($rows, $this->entryFactory);
+            yield array_to_rows($rows, $context->entryFactory());
         }
     }
 }

--- a/src/adapter/etl-adapter-avro/src/Flow/ETL/DSL/Avro.php
+++ b/src/adapter/etl-adapter-avro/src/Flow/ETL/DSL/Avro.php
@@ -9,8 +9,6 @@ use Flow\ETL\Adapter\Avro\FlixTech\AvroLoader;
 use Flow\ETL\Extractor;
 use Flow\ETL\Filesystem\Path;
 use Flow\ETL\Loader;
-use Flow\ETL\Row\EntryFactory;
-use Flow\ETL\Row\Factory\NativeEntryFactory;
 use Flow\ETL\Row\Schema;
 
 /**
@@ -20,14 +18,10 @@ class Avro
 {
     /**
      * @param array<Path|string>|Path|string $path
-     * @param int $rows_in_batch
-     *
-     * @return Extractor
      */
     final public static function from(
         Path|string|array $path,
         int $rows_in_batch = 1000,
-        EntryFactory $entry_factory = new NativeEntryFactory()
     ) : Extractor {
         if (\is_array($path)) {
             /** @var array<Extractor> $extractors */
@@ -36,8 +30,7 @@ class Avro
             foreach ($path as $next_path) {
                 $extractors[] = new AvroExtractor(
                     \is_string($next_path) ? Path::realpath($next_path) : $next_path,
-                    $rows_in_batch,
-                    $entry_factory
+                    $rows_in_batch
                 );
             }
 
@@ -46,8 +39,7 @@ class Avro
 
         return new AvroExtractor(
             \is_string($path) ? Path::realpath($path) : $path,
-            $rows_in_batch,
-            $entry_factory
+            $rows_in_batch
         );
     }
 

--- a/src/adapter/etl-adapter-csv/src/Flow/ETL/Adapter/CSV/CSVExtractor.php
+++ b/src/adapter/etl-adapter-csv/src/Flow/ETL/Adapter/CSV/CSVExtractor.php
@@ -10,9 +10,6 @@ use Flow\ETL\Filesystem\Path;
 use Flow\ETL\Filesystem\Stream\Mode;
 use Flow\ETL\FlowContext;
 use Flow\ETL\Row;
-use Flow\ETL\Row\EntryFactory;
-
-use Flow\ETL\Row\Factory\NativeEntryFactory;
 
 final class CSVExtractor implements Extractor
 {
@@ -27,8 +24,7 @@ final class CSVExtractor implements Extractor
         private readonly string $separator = ',',
         private readonly string $enclosure = '"',
         private readonly string $escape = '\\',
-        private readonly int $charactersReadInLine = 1000,
-        private readonly EntryFactory $entryFactory = new NativeEntryFactory()
+        private readonly int $charactersReadInLine = 1000
     ) {
     }
 
@@ -94,7 +90,7 @@ final class CSVExtractor implements Extractor
                 }
 
                 if (\count($rows) >= $this->rowsInBatch) {
-                    yield array_to_rows($rows, $this->entryFactory);
+                    yield array_to_rows($rows, $context->entryFactory());
 
                     /** @var array<Row> $rows */
                     $rows = [];
@@ -104,7 +100,7 @@ final class CSVExtractor implements Extractor
             }
 
             if ([] !== $rows) {
-                yield array_to_rows($rows, $this->entryFactory);
+                yield array_to_rows($rows, $context->entryFactory());
             }
 
             if ($stream->isOpen()) {

--- a/src/adapter/etl-adapter-csv/src/Flow/ETL/DSL/CSV.php
+++ b/src/adapter/etl-adapter-csv/src/Flow/ETL/DSL/CSV.php
@@ -6,28 +6,18 @@ namespace Flow\ETL\DSL;
 
 use Flow\ETL\Adapter\CSV\CSVExtractor;
 use Flow\ETL\Adapter\CSV\CSVLoader;
+use Flow\ETL\Exception\InvalidArgumentException;
 use Flow\ETL\Extractor;
 use Flow\ETL\Filesystem\Path;
 use Flow\ETL\Loader;
-use Flow\ETL\Row\EntryFactory;
-use Flow\ETL\Row\Factory\NativeEntryFactory;
 
 class CSV
 {
     /**
      * @param array<Path|string>|Path|string $uri
-     * @param int $rows_in_batch
-     * @param bool $with_header
-     * @param bool $empty_to_null
-     * @param string $delimiter
-     * @param string $enclosure
-     * @param string $escape
      * @param int<0, max> $characters_read_in_line
-     * @param EntryFactory $entry_factory
      *
-     * @throws \Flow\ETL\Exception\InvalidArgumentException
-     *
-     * @return Extractor
+     * @throws InvalidArgumentException
      */
     final public static function from(
         string|Path|array $uri,
@@ -37,8 +27,7 @@ class CSV
         string $delimiter = ',',
         string $enclosure = '"',
         string $escape = '\\',
-        int $characters_read_in_line = 1000,
-        EntryFactory $entry_factory = new NativeEntryFactory()
+        int $characters_read_in_line = 1000
     ) : Extractor {
         if (\is_array($uri)) {
             $extractors = [];
@@ -53,7 +42,6 @@ class CSV
                     $enclosure,
                     $escape,
                     $characters_read_in_line,
-                    $entry_factory
                 );
             }
 
@@ -69,20 +57,9 @@ class CSV
             $enclosure,
             $escape,
             $characters_read_in_line,
-            $entry_factory
         );
     }
 
-    /**
-     * @param Path|string $uri
-     * @param bool $with_header
-     * @param string $separator
-     * @param string $enclosure
-     * @param string $escape
-     * @param string $new_line_separator
-     *
-     * @return Loader
-     */
     final public static function to(
         string|Path $uri,
         bool $with_header = true,

--- a/src/adapter/etl-adapter-doctrine/src/Flow/ETL/Adapter/Doctrine/DbalLimitOffsetExtractor.php
+++ b/src/adapter/etl-adapter-doctrine/src/Flow/ETL/Adapter/Doctrine/DbalLimitOffsetExtractor.php
@@ -10,7 +10,6 @@ use Doctrine\DBAL\Query\QueryBuilder;
 use Flow\ETL\Exception\InvalidArgumentException;
 use Flow\ETL\Extractor;
 use Flow\ETL\FlowContext;
-use Flow\ETL\Row;
 
 final class DbalLimitOffsetExtractor implements Extractor
 {
@@ -19,7 +18,6 @@ final class DbalLimitOffsetExtractor implements Extractor
         private readonly QueryBuilder $queryBuilder,
         private readonly int $pageSize = 1000,
         private readonly ?int $maximum = null,
-        private readonly Row\EntryFactory $entryFactory = new Row\Factory\NativeEntryFactory()
     ) {
     }
 
@@ -32,7 +30,6 @@ final class DbalLimitOffsetExtractor implements Extractor
         array $orderBy,
         int $pageSize = 1000,
         ?int $maximum = null,
-        Row\EntryFactory $entryFactory = new Row\Factory\NativeEntryFactory()
     ) : self {
         if (!\count($orderBy)) {
             throw new InvalidArgumentException('There must be at least one column to order by, zero given');
@@ -51,7 +48,6 @@ final class DbalLimitOffsetExtractor implements Extractor
             $queryBuilder,
             $pageSize,
             $maximum,
-            $entryFactory
         );
     }
 
@@ -98,7 +94,7 @@ final class DbalLimitOffsetExtractor implements Extractor
                 }
             }
 
-            yield array_to_rows($rows, $this->entryFactory);
+            yield array_to_rows($rows, $context->entryFactory());
         }
     }
 }

--- a/src/adapter/etl-adapter-doctrine/src/Flow/ETL/Adapter/Doctrine/DbalQueryExtractor.php
+++ b/src/adapter/etl-adapter-doctrine/src/Flow/ETL/Adapter/Doctrine/DbalQueryExtractor.php
@@ -9,7 +9,6 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Types\Type;
 use Flow\ETL\Extractor;
 use Flow\ETL\FlowContext;
-use Flow\ETL\Row;
 
 final class DbalQueryExtractor implements Extractor
 {
@@ -27,7 +26,6 @@ final class DbalQueryExtractor implements Extractor
         private readonly string $query,
         ParametersSet $parametersSet = null,
         private readonly array $types = [],
-        private readonly Row\EntryFactory $entryFactory = new Row\Factory\NativeEntryFactory()
     ) {
         $this->parametersSet = $parametersSet ?: new ParametersSet([]);
     }
@@ -36,9 +34,9 @@ final class DbalQueryExtractor implements Extractor
      * @param array<string, mixed>|list<mixed> $parameters
      * @param array<int, null|int|string|Type>|array<string, null|int|string|Type> $types
      */
-    public static function single(Connection $connection, string $query, array $parameters = [], array $types = [], Row\EntryFactory $entryFactory = new Row\Factory\NativeEntryFactory()) : self
+    public static function single(Connection $connection, string $query, array $parameters = [], array $types = []) : self
     {
-        return new self($connection, $query, new ParametersSet($parameters), $types, $entryFactory);
+        return new self($connection, $query, new ParametersSet($parameters), $types);
     }
 
     public function extract(FlowContext $context) : \Generator
@@ -50,7 +48,7 @@ final class DbalQueryExtractor implements Extractor
                 $rows[] = $row;
             }
 
-            yield array_to_rows($rows, $this->entryFactory);
+            yield array_to_rows($rows, $context->entryFactory());
         }
     }
 }

--- a/src/adapter/etl-adapter-doctrine/src/Flow/ETL/DSL/Dbal.php
+++ b/src/adapter/etl-adapter-doctrine/src/Flow/ETL/DSL/Dbal.php
@@ -19,8 +19,6 @@ use Flow\ETL\DataFrameFactory;
 use Flow\ETL\Exception\InvalidArgumentException;
 use Flow\ETL\Extractor;
 use Flow\ETL\Loader;
-use Flow\ETL\Row\EntryFactory;
-use Flow\ETL\Row\Factory\NativeEntryFactory;
 
 class Dbal
 {
@@ -47,7 +45,6 @@ class Dbal
      * @param array<OrderBy>|OrderBy $order_by
      * @param int $page_size
      * @param null|int $maximum
-     * @param EntryFactory $entry_factory
      *
      * @throws InvalidArgumentException
      *
@@ -59,7 +56,6 @@ class Dbal
         array|OrderBy $order_by,
         int $page_size = 1000,
         ?int $maximum = null,
-        EntryFactory $entry_factory = new NativeEntryFactory()
     ) : Extractor {
         return DbalLimitOffsetExtractor::table(
             $connection,
@@ -67,7 +63,6 @@ class Dbal
             $order_by instanceof OrderBy ? [$order_by] : $order_by,
             $page_size,
             $maximum,
-            $entry_factory
         );
     }
 
@@ -75,7 +70,6 @@ class Dbal
      * @param Connection $connection
      * @param int $page_size
      * @param null|int $maximum
-     * @param EntryFactory $entry_factory
      *
      * @throws InvalidArgumentException
      *
@@ -86,14 +80,12 @@ class Dbal
         QueryBuilder $queryBuilder,
         int $page_size = 1000,
         ?int $maximum = null,
-        EntryFactory $entry_factory = new NativeEntryFactory()
     ) : Extractor {
         return new DbalLimitOffsetExtractor(
             $connection,
             $queryBuilder,
             $page_size,
             $maximum,
-            $entry_factory
         );
     }
 
@@ -102,7 +94,6 @@ class Dbal
      * @param string $query
      * @param null|ParametersSet $parameters_set - each one parameters array will be evaluated as new query
      * @param array<int, null|int|string|Type>|array<string, null|int|string|Type> $types
-     * @param EntryFactory $entry_factory
      *
      * @return Extractor
      */
@@ -111,14 +102,12 @@ class Dbal
         string $query,
         ParametersSet $parameters_set = null,
         array $types = [],
-        EntryFactory $entry_factory = new NativeEntryFactory()
     ) : Extractor {
         return new DbalQueryExtractor(
             $connection,
             $query,
             $parameters_set,
             $types,
-            $entry_factory
         );
     }
 
@@ -127,7 +116,6 @@ class Dbal
      * @param string $query
      * @param array<string, mixed>|list<mixed> $parameters
      * @param array<int, null|int|string|Type>|array<string, null|int|string|Type> $types
-     * @param EntryFactory $entry_factory
      *
      * @return Extractor
      */
@@ -136,14 +124,12 @@ class Dbal
         string $query,
         array $parameters = [],
         array $types = [],
-        EntryFactory $entry_factory = new NativeEntryFactory()
     ) : Extractor {
         return DbalQueryExtractor::single(
             $connection,
             $query,
             $parameters,
             $types,
-            $entry_factory
         );
     }
 

--- a/src/adapter/etl-adapter-elasticsearch/src/Flow/ETL/Adapter/Elasticsearch/ElasticsearchPHP/ElasticsearchExtractor.php
+++ b/src/adapter/etl-adapter-elasticsearch/src/Flow/ETL/Adapter/Elasticsearch/ElasticsearchPHP/ElasticsearchExtractor.php
@@ -6,8 +6,6 @@ namespace Flow\ETL\Adapter\Elasticsearch\ElasticsearchPHP;
 
 use Flow\ETL\Extractor;
 use Flow\ETL\FlowContext;
-use Flow\ETL\Row;
-use Flow\ETL\Row\Factory\NativeEntryFactory;
 
 final class ElasticsearchExtractor implements Extractor
 {
@@ -37,7 +35,6 @@ final class ElasticsearchExtractor implements Extractor
         private readonly array $config,
         private readonly array $params,
         private readonly ?array $pointInTimeParams = null,
-        private readonly Row\EntryFactory $entryFactory = new NativeEntryFactory()
     ) {
         $this->client = null;
     }
@@ -79,7 +76,7 @@ final class ElasticsearchExtractor implements Extractor
             return;
         }
 
-        yield $results->toRows($this->entryFactory);
+        yield $results->toRows($context->entryFactory());
 
         // Go with search_after pagination
         if ($params->hasSort()) {
@@ -102,7 +99,7 @@ final class ElasticsearchExtractor implements Extractor
                     break;
                 }
 
-                yield $nextResults->toRows($this->entryFactory);
+                yield $nextResults->toRows($context->entryFactory());
             }
         } else {
             $fetched = $results->size();
@@ -140,7 +137,7 @@ final class ElasticsearchExtractor implements Extractor
 
                 $fetched += $nextResults->size();
 
-                yield $nextResults->toRows($this->entryFactory);
+                yield $nextResults->toRows($context->entryFactory());
             }
         }
 

--- a/src/adapter/etl-adapter-elasticsearch/src/Flow/ETL/Adapter/Elasticsearch/ElasticsearchPHP/HitsIntoRowsTransformer.php
+++ b/src/adapter/etl-adapter-elasticsearch/src/Flow/ETL/Adapter/Elasticsearch/ElasticsearchPHP/HitsIntoRowsTransformer.php
@@ -6,33 +6,28 @@ namespace Flow\ETL\Adapter\Elasticsearch\ElasticsearchPHP;
 
 use Flow\ETL\FlowContext;
 use Flow\ETL\Row;
-use Flow\ETL\Row\EntryFactory;
-use Flow\ETL\Row\Factory\NativeEntryFactory;
 use Flow\ETL\Rows;
 use Flow\ETL\Transformer;
 
 /**
- * @implements Transformer<array{entry_factory: EntryFactory, source: DocumentDataSource}>
+ * @implements Transformer<array{source: DocumentDataSource}>
  */
 final class HitsIntoRowsTransformer implements Transformer
 {
     public function __construct(
         private readonly DocumentDataSource $source = DocumentDataSource::source,
-        private readonly EntryFactory $entryFactory = new NativeEntryFactory()
     ) {
     }
 
     public function __serialize() : array
     {
         return [
-            'entry_factory' => $this->entryFactory,
             'source' => $this->source,
         ];
     }
 
     public function __unserialize(array $data) : void
     {
-        $this->entryFactory = $data['entry_factory'];
         $this->source = $data['source'];
     }
 
@@ -63,7 +58,7 @@ final class HitsIntoRowsTransformer implements Transformer
                  * @var mixed $value
                  */
                 foreach ($hit[$source] as $key => $value) {
-                    $entries[] = $this->entryFactory->create($key, $value);
+                    $entries[] = $context->entryFactory()->create($key, $value);
                 }
 
                 $newRows[] = Row::create(...$entries);

--- a/src/adapter/etl-adapter-elasticsearch/src/Flow/ETL/DSL/Elasticsearch.php
+++ b/src/adapter/etl-adapter-elasticsearch/src/Flow/ETL/DSL/Elasticsearch.php
@@ -11,8 +11,6 @@ use Flow\ETL\Adapter\Elasticsearch\ElasticsearchPHP\HitsIntoRowsTransformer;
 use Flow\ETL\Adapter\Elasticsearch\IdFactory;
 use Flow\ETL\Extractor;
 use Flow\ETL\Loader;
-use Flow\ETL\Row\EntryFactory;
-use Flow\ETL\Row\Factory\NativeEntryFactory;
 use Flow\ETL\Transformer;
 
 class Elasticsearch
@@ -82,13 +80,11 @@ class Elasticsearch
     /**
      * Transforms elasticsearch results into clear Flow Rows using ['hits']['hits'][x]['_source'].
      *
-     * @param EntryFactory $entry_factory
-     *
      * @return Transformer
      */
-    final public static function hits_to_rows(DocumentDataSource $source = DocumentDataSource::source, EntryFactory $entry_factory = new NativeEntryFactory()) : Transformer
+    final public static function hits_to_rows(DocumentDataSource $source = DocumentDataSource::source) : Transformer
     {
-        return new HitsIntoRowsTransformer($source, $entry_factory);
+        return new HitsIntoRowsTransformer($source);
     }
 
     /**

--- a/src/adapter/etl-adapter-google-sheet/src/Flow/ETL/Adapter/GoogleSheet/GoogleSheetExtractor.php
+++ b/src/adapter/etl-adapter-google-sheet/src/Flow/ETL/Adapter/GoogleSheet/GoogleSheetExtractor.php
@@ -8,8 +8,6 @@ use function Flow\ETL\DSL\array_to_rows;
 use Flow\ETL\Exception\InvalidArgumentException;
 use Flow\ETL\Extractor;
 use Flow\ETL\FlowContext;
-use Flow\ETL\Row\EntryFactory;
-use Flow\ETL\Row\Factory\NativeEntryFactory;
 use Google\Service\Sheets;
 
 final class GoogleSheetExtractor implements Extractor
@@ -26,7 +24,6 @@ final class GoogleSheetExtractor implements Extractor
         private readonly bool $withHeader,
         private readonly int $rowsInBatch,
         private readonly array $options = [],
-        private readonly EntryFactory $entryFactory = new NativeEntryFactory()
     ) {
         if ($this->rowsInBatch <= 0) {
             throw new InvalidArgumentException('Rows in batch must be greater than 0');
@@ -91,7 +88,7 @@ final class GoogleSheetExtractor implements Extractor
                     },
                     $values
                 ),
-                $this->entryFactory
+                $context->entryFactory()
             );
 
             if ($totalRows < $cellsRange->endRow) {

--- a/src/adapter/etl-adapter-google-sheet/src/Flow/ETL/DSL/GoogleSheet.php
+++ b/src/adapter/etl-adapter-google-sheet/src/Flow/ETL/DSL/GoogleSheet.php
@@ -7,8 +7,6 @@ namespace Flow\ETL\DSL;
 use Flow\ETL\Adapter\GoogleSheet\Columns;
 use Flow\ETL\Adapter\GoogleSheet\GoogleSheetExtractor;
 use Flow\ETL\Extractor;
-use Flow\ETL\Row\EntryFactory;
-use Flow\ETL\Row\Factory\NativeEntryFactory;
 use Google\Client;
 use Google\Service\Sheets;
 
@@ -29,7 +27,6 @@ class GoogleSheet
         bool $with_header = true,
         int $rows_in_batch = 1000,
         array $options = [],
-        EntryFactory $entry_factory = new NativeEntryFactory()
     ) : Extractor {
         if ($auth_config instanceof Sheets) {
             $sheets = $auth_config;
@@ -47,7 +44,6 @@ class GoogleSheet
             $with_header,
             $rows_in_batch,
             $options,
-            $entry_factory
         );
     }
 
@@ -68,7 +64,6 @@ class GoogleSheet
         bool $with_header = true,
         int $rows_in_batch = 1000,
         array $options = [],
-        EntryFactory $entry_factory = new NativeEntryFactory()
     ) : Extractor {
         if ($auth_config instanceof Sheets) {
             $sheets = $auth_config;
@@ -86,7 +81,6 @@ class GoogleSheet
             $with_header,
             $rows_in_batch,
             $options,
-            $entry_factory
         );
     }
 }

--- a/src/adapter/etl-adapter-json/src/Flow/ETL/Adapter/JSON/JSONMachine/JsonExtractor.php
+++ b/src/adapter/etl-adapter-json/src/Flow/ETL/Adapter/JSON/JSONMachine/JsonExtractor.php
@@ -9,7 +9,6 @@ use Flow\ETL\Extractor;
 use Flow\ETL\Filesystem\Path;
 use Flow\ETL\Filesystem\Stream\Mode;
 use Flow\ETL\FlowContext;
-use Flow\ETL\Row;
 use JsonMachine\Items;
 use JsonMachine\JsonDecoder\ExtJsonDecoder;
 
@@ -19,7 +18,6 @@ final class JsonExtractor implements Extractor
         private readonly Path $path,
         private readonly int $rowsInBatch = 1000,
         private readonly ?string $pointer = null,
-        private readonly Row\EntryFactory $entryFactory = new Row\Factory\NativeEntryFactory()
     ) {
     }
 
@@ -41,14 +39,14 @@ final class JsonExtractor implements Extractor
                 }
 
                 if (\count($rows) >= $this->rowsInBatch) {
-                    yield array_to_rows($rows, $this->entryFactory);
+                    yield array_to_rows($rows, $context->entryFactory());
 
                     $rows = [];
                 }
             }
 
             if ([] !== $rows) {
-                yield array_to_rows($rows, $this->entryFactory);
+                yield array_to_rows($rows, $context->entryFactory());
             }
         }
     }

--- a/src/adapter/etl-adapter-json/src/Flow/ETL/DSL/Json.php
+++ b/src/adapter/etl-adapter-json/src/Flow/ETL/DSL/Json.php
@@ -9,8 +9,6 @@ use Flow\ETL\Adapter\JSON\JSONMachine\JsonExtractor;
 use Flow\ETL\Extractor;
 use Flow\ETL\Filesystem\Path;
 use Flow\ETL\Loader;
-use Flow\ETL\Row\EntryFactory;
-use Flow\ETL\Row\Factory\NativeEntryFactory;
 
 class Json
 {
@@ -25,7 +23,6 @@ class Json
         string|Path|array $path,
         int $rows_in_batch = 1000,
         string $pointer = null,
-        EntryFactory $entry_factory = new NativeEntryFactory()
     ) : Extractor {
         if (\is_array($path)) {
             $extractors = [];
@@ -35,7 +32,6 @@ class Json
                     \is_string($file) ? Path::realpath($file) : $file,
                     $rows_in_batch,
                     $pointer,
-                    $entry_factory
                 );
             }
 
@@ -46,7 +42,6 @@ class Json
             \is_string($path) ? Path::realpath($path) : $path,
             $rows_in_batch,
             $pointer,
-            $entry_factory
         );
     }
 

--- a/src/adapter/etl-adapter-meilisearch/src/Flow/ETL/Adapter/Meilisearch/MeilisearchPHP/HitsIntoRowsTransformer.php
+++ b/src/adapter/etl-adapter-meilisearch/src/Flow/ETL/Adapter/Meilisearch/MeilisearchPHP/HitsIntoRowsTransformer.php
@@ -6,31 +6,25 @@ namespace Flow\ETL\Adapter\Meilisearch\MeilisearchPHP;
 
 use Flow\ETL\FlowContext;
 use Flow\ETL\Row;
-use Flow\ETL\Row\EntryFactory;
-use Flow\ETL\Row\Factory\NativeEntryFactory;
 use Flow\ETL\Rows;
 use Flow\ETL\Transformer;
 
 /**
- * @implements Transformer<array{entry_factory: EntryFactory}>
+ * @implements Transformer<array>
  */
 final class HitsIntoRowsTransformer implements Transformer
 {
     public function __construct(
-        private readonly EntryFactory $entryFactory = new NativeEntryFactory()
     ) {
     }
 
     public function __serialize() : array
     {
-        return [
-            'entry_factory' => $this->entryFactory,
-        ];
+        return [];
     }
 
     public function __unserialize(array $data) : void
     {
-        $this->entryFactory = $data['entry_factory'];
     }
 
     public function transform(Rows $rows, FlowContext $context) : Rows
@@ -41,7 +35,7 @@ final class HitsIntoRowsTransformer implements Transformer
             $entries = [];
 
             foreach ($row->toArray() as $key => $value) {
-                $entries[] = $this->entryFactory->create((string) $key, $value);
+                $entries[] = $context->entryFactory()->create((string) $key, $value);
             }
 
             $newRows[] = Row::create(...$entries);

--- a/src/adapter/etl-adapter-meilisearch/src/Flow/ETL/Adapter/Meilisearch/MeilisearchPHP/MeilisearchExtractor.php
+++ b/src/adapter/etl-adapter-meilisearch/src/Flow/ETL/Adapter/Meilisearch/MeilisearchPHP/MeilisearchExtractor.php
@@ -6,8 +6,6 @@ namespace Flow\ETL\Adapter\Meilisearch\MeilisearchPHP;
 
 use Flow\ETL\Extractor;
 use Flow\ETL\FlowContext;
-use Flow\ETL\Row;
-use Flow\ETL\Row\Factory\NativeEntryFactory;
 use Meilisearch\Client;
 
 final class MeilisearchExtractor implements Extractor
@@ -22,7 +20,6 @@ final class MeilisearchExtractor implements Extractor
         private readonly array $config,
         private readonly array $params,
         private readonly string $index,
-        private readonly Row\EntryFactory $entryFactory = new NativeEntryFactory()
     ) {
     }
 
@@ -36,7 +33,7 @@ final class MeilisearchExtractor implements Extractor
             return;
         }
 
-        yield $results->toRows($this->entryFactory);
+        yield $results->toRows($context->entryFactory());
 
         $fetched = $results->size();
 
@@ -58,7 +55,7 @@ final class MeilisearchExtractor implements Extractor
 
             $fetched += $nextResults->size();
 
-            yield $nextResults->toRows($this->entryFactory);
+            yield $nextResults->toRows($context->entryFactory());
         }
     }
 

--- a/src/adapter/etl-adapter-meilisearch/src/Flow/ETL/DSL/Meilisearch.php
+++ b/src/adapter/etl-adapter-meilisearch/src/Flow/ETL/DSL/Meilisearch.php
@@ -9,8 +9,6 @@ use Flow\ETL\Adapter\Meilisearch\MeilisearchPHP\MeilisearchExtractor;
 use Flow\ETL\Adapter\Meilisearch\MeilisearchPHP\MeilisearchLoader;
 use Flow\ETL\Extractor;
 use Flow\ETL\Loader;
-use Flow\ETL\Row\EntryFactory;
-use Flow\ETL\Row\Factory\NativeEntryFactory;
 use Flow\ETL\Transformer;
 
 class Meilisearch
@@ -38,9 +36,9 @@ class Meilisearch
     /**
      * Transforms Meilisearch results into clear Flow Rows.
      */
-    final public static function hits_to_rows(EntryFactory $entry_factory = new NativeEntryFactory()) : Transformer
+    final public static function hits_to_rows() : Transformer
     {
-        return new HitsIntoRowsTransformer($entry_factory);
+        return new HitsIntoRowsTransformer();
     }
 
     /**

--- a/src/adapter/etl-adapter-parquet/src/Flow/ETL/Adapter/Parquet/Codename/ParquetExtractor.php
+++ b/src/adapter/etl-adapter-parquet/src/Flow/ETL/Adapter/Parquet/Codename/ParquetExtractor.php
@@ -10,7 +10,6 @@ use Flow\ETL\Extractor;
 use Flow\ETL\Filesystem\Path;
 use Flow\ETL\Filesystem\Stream\Mode;
 use Flow\ETL\FlowContext;
-use Flow\ETL\Row;
 
 /**
  * @deprecated Use \Flow\ETL\Adapter\Parquet\ParquetExtractor instead
@@ -24,7 +23,6 @@ final class ParquetExtractor implements Extractor
     public function __construct(
         private readonly Path $path,
         private readonly array $fields = [],
-        private readonly Row\EntryFactory $entryFactory = new Row\Factory\NativeEntryFactory()
     ) {
     }
 
@@ -77,7 +75,7 @@ final class ParquetExtractor implements Extractor
                     }
                 }
 
-                yield array_to_rows($rows, $this->entryFactory);
+                yield array_to_rows($rows, $context->entryFactory());
             }
         }
     }

--- a/src/adapter/etl-adapter-parquet/src/Flow/ETL/Adapter/Parquet/ParquetExtractor.php
+++ b/src/adapter/etl-adapter-parquet/src/Flow/ETL/Adapter/Parquet/ParquetExtractor.php
@@ -7,8 +7,6 @@ use Flow\ETL\Extractor;
 use Flow\ETL\Filesystem\Path;
 use Flow\ETL\Filesystem\Stream\Mode;
 use Flow\ETL\FlowContext;
-use Flow\ETL\Row\EntryFactory;
-use Flow\ETL\Row\Factory\NativeEntryFactory;
 use Flow\Parquet\ByteOrder;
 use Flow\Parquet\Options;
 use Flow\Parquet\ParquetFile;
@@ -26,7 +24,6 @@ final class ParquetExtractor implements Extractor
         private readonly ByteOrder $byteOrder = ByteOrder::LITTLE_ENDIAN,
         private readonly array $columns = [],
         private readonly int $rowsInBatch = 1000,
-        private readonly EntryFactory $entryFactory = new NativeEntryFactory()
     ) {
     }
 
@@ -48,13 +45,13 @@ final class ParquetExtractor implements Extractor
                 }
 
                 if (\count($rows) >= $this->rowsInBatch) {
-                    yield array_to_rows($rows, $this->entryFactory);
+                    yield array_to_rows($rows, $context->entryFactory());
                     $rows = [];
                 }
             }
 
             if (\count($rows)) {
-                yield array_to_rows($rows, $this->entryFactory);
+                yield array_to_rows($rows, $context->entryFactory());
             }
         }
     }

--- a/src/adapter/etl-adapter-parquet/src/Flow/ETL/DSL/Parquet.php
+++ b/src/adapter/etl-adapter-parquet/src/Flow/ETL/DSL/Parquet.php
@@ -11,8 +11,6 @@ use Flow\ETL\Exception\MissingDependencyException;
 use Flow\ETL\Extractor;
 use Flow\ETL\Filesystem\Path;
 use Flow\ETL\Loader;
-use Flow\ETL\Row\EntryFactory;
-use Flow\ETL\Row\Factory\NativeEntryFactory;
 use Flow\ETL\Row\Schema;
 use Flow\Parquet\ByteOrder;
 use Flow\Parquet\Options;
@@ -25,7 +23,6 @@ class Parquet
     /**
      * @param array<Path>|Path|string $uri
      * @param array<string> $fields
-     * @param EntryFactory $entry_factory
      *
      * @return Extractor
      */
@@ -35,7 +32,6 @@ class Parquet
         Options $options = new Options(),
         ByteOrder $byte_order = ByteOrder::LITTLE_ENDIAN,
         int $rows_in_batch = 1000,
-        EntryFactory $entry_factory = new NativeEntryFactory()
     ) : Extractor {
         if (\is_array($uri)) {
             $extractors = [];
@@ -47,7 +43,6 @@ class Parquet
                     $byte_order,
                     $fields,
                     $rows_in_batch,
-                    $entry_factory
                 );
             }
 
@@ -60,7 +55,6 @@ class Parquet
             $byte_order,
             $fields,
             $rows_in_batch,
-            $entry_factory
         );
     }
 

--- a/src/adapter/etl-adapter-text/src/Flow/ETL/Adapter/Text/TextExtractor.php
+++ b/src/adapter/etl-adapter-text/src/Flow/ETL/Adapter/Text/TextExtractor.php
@@ -16,7 +16,6 @@ final class TextExtractor implements Extractor
     public function __construct(
         private readonly Path $path,
         private readonly int $rowsInBatch = 1000,
-        private readonly Row\EntryFactory $entryFactory = new Row\Factory\NativeEntryFactory()
     ) {
     }
 
@@ -44,7 +43,7 @@ final class TextExtractor implements Extractor
                 }
 
                 if (\count($rows) >= $this->rowsInBatch) {
-                    yield array_to_rows($rows, $this->entryFactory);
+                    yield array_to_rows($rows, $context->entryFactory());
 
                     /** @var array<Row> $rows */
                     $rows = [];
@@ -54,7 +53,7 @@ final class TextExtractor implements Extractor
             }
 
             if ([] !== $rows) {
-                yield array_to_rows($rows, $this->entryFactory);
+                yield array_to_rows($rows, $context->entryFactory());
             }
         }
     }

--- a/src/adapter/etl-adapter-text/src/Flow/ETL/DSL/Text.php
+++ b/src/adapter/etl-adapter-text/src/Flow/ETL/DSL/Text.php
@@ -9,8 +9,6 @@ use Flow\ETL\Adapter\Text\TextLoader;
 use Flow\ETL\Extractor;
 use Flow\ETL\Filesystem\Path;
 use Flow\ETL\Loader;
-use Flow\ETL\Row\EntryFactory;
-use Flow\ETL\Row\Factory\NativeEntryFactory;
 
 class Text
 {
@@ -23,7 +21,6 @@ class Text
     final public static function from(
         string|Path|array $path,
         int $rows_in_batch = 1000,
-        EntryFactory $entry_factory = new NativeEntryFactory()
     ) : Extractor {
         if (\is_array($path)) {
             $extractors = [];
@@ -32,7 +29,6 @@ class Text
                 $extractors[] = new TextExtractor(
                     \is_string($file_path) ? Path::realpath($file_path) : $file_path,
                     $rows_in_batch,
-                    $entry_factory
                 );
             }
 
@@ -42,7 +38,6 @@ class Text
         return new TextExtractor(
             \is_string($path) ? Path::realpath($path) : $path,
             $rows_in_batch,
-            $entry_factory
         );
     }
 

--- a/src/core/etl/src/Flow/ETL/Config.php
+++ b/src/core/etl/src/Flow/ETL/Config.php
@@ -6,6 +6,7 @@ namespace Flow\ETL;
 
 use Flow\ETL\Filesystem\FilesystemStreams;
 use Flow\ETL\Pipeline\Execution\Processors;
+use Flow\ETL\Row\EntryFactory;
 use Flow\Serializer\Serializer;
 
 /**
@@ -25,7 +26,8 @@ final class Config
         private readonly Serializer $serializer,
         private readonly FilesystemStreams $filesystemStreams,
         private readonly Processors $processors,
-        private readonly bool $putInputIntoRows
+        private readonly bool $putInputIntoRows,
+        private readonly EntryFactory $entryFactory
     ) {
     }
 
@@ -42,6 +44,11 @@ final class Config
     public function cache() : Cache
     {
         return $this->cache;
+    }
+
+    public function entryFactory() : EntryFactory
+    {
+        return $this->entryFactory;
     }
 
     public function externalSort() : ExternalSort

--- a/src/core/etl/src/Flow/ETL/ConfigBuilder.php
+++ b/src/core/etl/src/Flow/ETL/ConfigBuilder.php
@@ -11,6 +11,7 @@ use Flow\ETL\Filesystem\FlysystemFS;
 use Flow\ETL\Monitoring\Memory\Unit;
 use Flow\ETL\Pipeline\Execution\Processor\FilesystemProcessor;
 use Flow\ETL\Pipeline\Execution\Processors;
+use Flow\ETL\Row\Factory\NativeEntryFactory;
 use Flow\Serializer\CompressingSerializer;
 use Flow\Serializer\Serializer;
 
@@ -67,7 +68,8 @@ final class ConfigBuilder
             new Processors(
                 new FilesystemProcessor()
             ),
-            $this->putInputIntoRows
+            $this->putInputIntoRows,
+            new NativeEntryFactory()
         );
     }
 

--- a/src/core/etl/src/Flow/ETL/DSL/From.php
+++ b/src/core/etl/src/Flow/ETL/DSL/From.php
@@ -11,8 +11,6 @@ use Flow\ETL\Extractor\ProcessExtractor;
 use Flow\ETL\Memory\ArrayMemory;
 use Flow\ETL\Memory\Memory;
 use Flow\ETL\Pipeline;
-use Flow\ETL\Row\EntryFactory;
-use Flow\ETL\Row\Factory\NativeEntryFactory;
 use Flow\ETL\Rows;
 
 /**
@@ -32,9 +30,9 @@ class From
      * @param array<array<string, mixed>> $array
      * @param int<1, max> $batch_size
      */
-    final public static function array(array $array, int $batch_size = 100, EntryFactory $entry_factory = new NativeEntryFactory()) : Extractor
+    final public static function array(array $array, int $batch_size = 100) : Extractor
     {
-        return new MemoryExtractor(new ArrayMemory($array), $batch_size, $entry_factory);
+        return new MemoryExtractor(new ArrayMemory($array), $batch_size);
     }
 
     final public static function buffer(Extractor $extractor, int $max_row_size) : Extractor
@@ -68,9 +66,9 @@ class From
      *
      * @return Extractor
      */
-    final public static function memory(Memory $memory, int $chunk_size = 100, EntryFactory $entry_factory = new NativeEntryFactory()) : Extractor
+    final public static function memory(Memory $memory, int $chunk_size = 100) : Extractor
     {
-        return new MemoryExtractor($memory, $chunk_size, $entry_factory);
+        return new MemoryExtractor($memory, $chunk_size);
     }
 
     final public static function pipeline(Pipeline $pipeline) : Extractor

--- a/src/core/etl/src/Flow/ETL/Extractor/MemoryExtractor.php
+++ b/src/core/etl/src/Flow/ETL/Extractor/MemoryExtractor.php
@@ -8,7 +8,6 @@ use function Flow\ETL\DSL\array_to_rows;
 use Flow\ETL\Extractor;
 use Flow\ETL\FlowContext;
 use Flow\ETL\Memory\Memory;
-use Flow\ETL\Row;
 
 final class MemoryExtractor implements Extractor
 {
@@ -21,7 +20,6 @@ final class MemoryExtractor implements Extractor
     public function __construct(
         private readonly Memory $memory,
         private readonly int $chunkSize = self::CHUNK_SIZE,
-        private readonly Row\EntryFactory $entryFactory = new Row\Factory\NativeEntryFactory()
     ) {
     }
 
@@ -37,7 +35,7 @@ final class MemoryExtractor implements Extractor
                 $rows[] = $chunkEntry;
             }
 
-            yield array_to_rows($rows, $this->entryFactory);
+            yield array_to_rows($rows, $context->entryFactory());
         }
     }
 }

--- a/src/core/etl/src/Flow/ETL/Extractor/SequenceExtractor.php
+++ b/src/core/etl/src/Flow/ETL/Extractor/SequenceExtractor.php
@@ -14,7 +14,6 @@ final class SequenceExtractor implements Extractor
     public function __construct(
         private readonly SequenceGenerator\SequenceGenerator $generator,
         private readonly string $entryName = 'entry',
-        private readonly Row\EntryFactory $entryFactory = new Row\Factory\NativeEntryFactory()
     ) {
     }
 
@@ -22,7 +21,7 @@ final class SequenceExtractor implements Extractor
     {
         /** @var mixed $item */
         foreach ($this->generator->generate() as $item) {
-            yield new Rows(Row::create($this->entryFactory->create($this->entryName, $item)));
+            yield new Rows(Row::create($context->entryFactory()->create($this->entryName, $item)));
         }
     }
 }

--- a/src/core/etl/src/Flow/ETL/FlowContext.php
+++ b/src/core/etl/src/Flow/ETL/FlowContext.php
@@ -9,6 +9,7 @@ use Flow\ETL\Filesystem\FilesystemStreams;
 use Flow\ETL\Filesystem\SaveMode;
 use Flow\ETL\Partition\NoopFilter;
 use Flow\ETL\Partition\PartitionFilter;
+use Flow\ETL\Row\EntryFactory;
 use Flow\ETL\Row\Reference;
 use Flow\ETL\Row\References;
 use Flow\Serializer\Serializer;
@@ -39,6 +40,11 @@ final class FlowContext
     public function cache() : Cache
     {
         return $this->config->cache();
+    }
+
+    public function entryFactory() : EntryFactory
+    {
+        return $this->config->entryFactory();
     }
 
     public function errorHandler() : ErrorHandler

--- a/src/core/etl/src/Flow/ETL/Transformer/WindowFunctionTransformer.php
+++ b/src/core/etl/src/Flow/ETL/Transformer/WindowFunctionTransformer.php
@@ -7,21 +7,18 @@ namespace Flow\ETL\Transformer;
 use Flow\ETL\Exception\InvalidArgumentException;
 use Flow\ETL\Exception\RuntimeException;
 use Flow\ETL\FlowContext;
-use Flow\ETL\Row\EntryFactory;
-use Flow\ETL\Row\Factory\NativeEntryFactory;
 use Flow\ETL\Rows;
 use Flow\ETL\Transformer;
 use Flow\ETL\Window;
 
 /**
- * @implements Transformer<array{entry_name: string, window: Window, entry_factory: EntryFactory}>
+ * @implements Transformer<array{entry_name: string, window: Window}>
  */
 final class WindowFunctionTransformer implements Transformer
 {
     public function __construct(
         private readonly string $entryName,
         private readonly Window $window,
-        private readonly EntryFactory $entryFactory = new NativeEntryFactory()
     ) {
     }
 
@@ -30,7 +27,6 @@ final class WindowFunctionTransformer implements Transformer
         return [
             'entry_name' => $this->entryName,
             'window' => $this->window,
-            'entry_factory' => $this->entryFactory,
         ];
     }
 
@@ -38,7 +34,6 @@ final class WindowFunctionTransformer implements Transformer
     {
         $this->entryName = $data['entry_name'];
         $this->window = $data['window'];
-        $this->entryFactory = $data['entry_factory'];
     }
 
     /**
@@ -52,7 +47,7 @@ final class WindowFunctionTransformer implements Transformer
 
         foreach ($rows as $row) {
             $newRows = $newRows->add(
-                $row->add($this->entryFactory->create($this->entryName, $this->window->function()->apply($row, $rows, $this->window)))
+                $row->add($context->entryFactory()->create($this->entryName, $this->window->function()->apply($row, $rows, $this->window)))
             );
         }
 


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Entry factory moved from extractors to `FlowContext`</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

To improve code quality and reduce code coupling `EntryFactory` was removed from all constructors of extractors, in favor of passing it into `FlowContext` & re-using same entry factory in a whole pipeline.
