### PR TITLE
Invalid schema has no fallback in `NativeEntryFactory`

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -11,6 +11,10 @@ Please follow the instructions for your specific version to ensure a smooth upgr
 
 To improve code quality and reduce code coupling `EntryFactory` was removed from all constructors of extractors, in favor of passing it into `FlowContext` & re-using same entry factory in a whole pipeline.
 
+### 2) Invalid schema has no fallback in `NativeEntryFactory`
+
+Before, passing `Schema` into `NativeEntryFactory::create()` had fallback when the given entry was not found in a passed schema, now the schema has higher priority & fallback is no longer available, instead when the definition is missing in a passed schema, `InvalidArgumentException` will be thrown.
+
 ---
 
 ## Upgrading from 0.3.x to 0.4.x

--- a/src/core/etl/src/Flow/ETL/Row/Factory/NativeEntryFactory.php
+++ b/src/core/etl/src/Flow/ETL/Row/Factory/NativeEntryFactory.php
@@ -43,12 +43,7 @@ final class NativeEntryFactory implements EntryFactory
      */
     public function create(string $entryName, mixed $value) : Entry
     {
-        if ($this->schema !== null && $this->schema->findDefinition($entryName) !== null) {
-            /**
-             * @psalm-suppress PossiblyNullArgument
-             *
-             * @phpstan-ignore-next-line
-             */
+        if ($this->schema !== null) {
             return $this->fromDefinition($this->schema->getDefinition($entryName), $value);
         }
 

--- a/src/core/etl/src/Flow/ETL/Row/Schema.php
+++ b/src/core/etl/src/Flow/ETL/Row/Schema.php
@@ -89,21 +89,12 @@ final class Schema implements \Countable, Serializable
         return $this->definitions[$ref];
     }
 
-    public function getDefinition(string|EntryReference $ref) : ?Definition
+    /**
+     * @throws InvalidArgumentException
+     */
+    public function getDefinition(string|EntryReference $ref) : Definition
     {
-        if ($ref instanceof EntryReference) {
-            if (!\array_key_exists($ref->name(), $this->definitions)) {
-                throw new InvalidArgumentException("There is no definition for \"{$ref->name()}\" in the schema.");
-            }
-
-            return $this->definitions[$ref->name()];
-        }
-
-        if (!\array_key_exists($ref, $this->definitions)) {
-            throw new InvalidArgumentException("There is no definition for \"{$ref}\" in the schema.");
-        }
-
-        return $this->definitions[$ref];
+        return $this->findDefinition($ref) ?: throw new InvalidArgumentException("There is no definition for \"{$ref}\" in the schema.");
     }
 
     public function merge(self $schema) : self

--- a/src/core/etl/src/Flow/ETL/Row/Schema/SelectiveValidator.php
+++ b/src/core/etl/src/Flow/ETL/Row/Schema/SelectiveValidator.php
@@ -27,7 +27,6 @@ final class SelectiveValidator implements SchemaValidator
     public function isValid(Rows $rows, Schema $schema) : bool
     {
         foreach ($schema->entries() as $ref) {
-            /** @var Definition $definition */
             $definition = $schema->getDefinition($ref);
 
             foreach ($rows as $row) {

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Factory/NativeEntryFactoryTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Factory/NativeEntryFactoryTest.php
@@ -368,6 +368,24 @@ final class NativeEntryFactoryTest extends TestCase
         );
     }
 
+    public function test_with_empty_schema() : void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('There is no definition for "e" in the schema.');
+
+        (new NativeEntryFactory(new Schema()))
+            ->create('e', '1');
+    }
+
+    public function test_with_schema_for_different_entry() : void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('There is no definition for "diff" in the schema.');
+
+        (new NativeEntryFactory(new Schema(Schema\Definition::string('e'))))
+            ->create('diff', '1');
+    }
+
     public function test_xml_from_dom_document() : void
     {
         $doc = new \DOMDocument();


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Invalid schema has no fallback in `NativeEntryFactory`</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

Before, passing `Schema` into `NativeEntryFactory::create()` had fallback when the given entry was not found in a passed schema, now the schema has higher priority & fallback is no longer available, instead when the definition is missing in a passed schema, `InvalidArgumentException` will be thrown.
