### PR TITLE
Remove `array_merge()` when adding input into rows

### DIFF
--- a/src/adapter/etl-adapter-avro/src/Flow/ETL/Adapter/Avro/FlixTech/AvroExtractor.php
+++ b/src/adapter/etl-adapter-avro/src/Flow/ETL/Adapter/Avro/FlixTech/AvroExtractor.php
@@ -45,11 +45,13 @@ final class AvroExtractor implements Extractor
             $valueConverter = new ValueConverter(\json_decode($reader->metadata['avro.schema'], true));
 
             foreach ($reader->data() as $rowData) {
+                $row = $valueConverter->convert($rowData);
+
                 if ($shouldPutInputIntoRows) {
-                    $rows[] = \array_merge($valueConverter->convert($rowData), ['_input_file_uri' => $filePath->uri()]);
-                } else {
-                    $rows[] = $valueConverter->convert($rowData);
+                    $row['_input_file_uri'] = $filePath->uri();
                 }
+
+                $rows[] = $row;
 
                 if (\count($rows) >= $this->rowsInBach) {
                     yield array_to_rows($rows, $context->entryFactory());

--- a/src/adapter/etl-adapter-csv/src/Flow/ETL/Adapter/CSV/CSVExtractor.php
+++ b/src/adapter/etl-adapter-csv/src/Flow/ETL/Adapter/CSV/CSVExtractor.php
@@ -83,11 +83,13 @@ final class CSVExtractor implements Extractor
                     continue;
                 }
 
+                $row = \array_combine($headers, $rowData);
+
                 if ($shouldPutInputIntoRows) {
-                    $rows[] = \array_merge(\array_combine($headers, $rowData), ['_input_file_uri' => $stream->path()->uri()]);
-                } else {
-                    $rows[] = \array_combine($headers, $rowData);
+                    $row['_input_file_uri'] = $stream->path()->uri();
                 }
+
+                $rows[] = $row;
 
                 if (\count($rows) >= $this->rowsInBatch) {
                     yield array_to_rows($rows, $context->entryFactory());

--- a/src/adapter/etl-adapter-google-sheet/src/Flow/ETL/Adapter/GoogleSheet/GoogleSheetExtractor.php
+++ b/src/adapter/etl-adapter-google-sheet/src/Flow/ETL/Adapter/GoogleSheet/GoogleSheetExtractor.php
@@ -77,14 +77,14 @@ final class GoogleSheetExtractor implements Extractor
                         /** @var int $totalRows */
                         $totalRows++;
 
+                        $row = \array_combine($headers, $rowData);
+
                         if ($shouldPutInputIntoRows) {
-                            return \array_merge(
-                                \array_combine($headers, $rowData),
-                                ['spread_sheet_id' =>  $this->spreadsheetId, 'sheet_name' => $this->columnRange->sheetName]
-                            );
+                            $row['_spread_sheet_id'] = $this->spreadsheetId;
+                            $row['_sheet_name'] = $this->columnRange->sheetName;
                         }
 
-                        return \array_combine($headers, $rowData);
+                        return $row;
                     },
                     $values
                 ),

--- a/src/adapter/etl-adapter-google-sheet/tests/Flow/ETL/Adapter/GoogleSheet/Tests/Unit/GoogleSheetExtractorTest.php
+++ b/src/adapter/etl-adapter-google-sheet/tests/Flow/ETL/Adapter/GoogleSheet/Tests/Unit/GoogleSheetExtractorTest.php
@@ -28,8 +28,8 @@ final class GoogleSheetExtractorTest extends TestCase
             true,
             2,
         );
-        $spreadSheetIdEntry = new StringEntry('spread_sheet_id', $spreadSheetId);
-        $sheetNameEntry = new StringEntry('sheet_name', $sheetName);
+        $spreadSheetIdEntry = new StringEntry('_spread_sheet_id', $spreadSheetId);
+        $sheetNameEntry = new StringEntry('_sheet_name', $sheetName);
         $firstValueRangeMock = $this->createMock(Sheets\ValueRange::class);
         $firstValueRangeMock->method('getValues')->willReturn([
             ['header'],

--- a/src/adapter/etl-adapter-json/src/Flow/ETL/Adapter/JSON/JSONMachine/JsonExtractor.php
+++ b/src/adapter/etl-adapter-json/src/Flow/ETL/Adapter/JSON/JSONMachine/JsonExtractor.php
@@ -32,11 +32,13 @@ final class JsonExtractor implements Extractor
              * @var array|object $row
              */
             foreach (Items::fromStream($context->streams()->fs()->open($filePath, Mode::READ)->resource(), $this->readerOptions())->getIterator() as $row) {
+                $row = (array) $row;
+
                 if ($shouldPutInputIntoRows) {
-                    $rows[] = \array_merge((array) $row, ['_input_file_uri' => $filePath->uri()]);
-                } else {
-                    $rows[] = (array) $row;
+                    $row['_input_file_uri'] = $filePath->uri();
                 }
+
+                $rows[] = $row;
 
                 if (\count($rows) >= $this->rowsInBatch) {
                     yield array_to_rows($rows, $context->entryFactory());

--- a/src/adapter/etl-adapter-parquet/src/Flow/ETL/Adapter/Parquet/Codename/ParquetExtractor.php
+++ b/src/adapter/etl-adapter-parquet/src/Flow/ETL/Adapter/Parquet/Codename/ParquetExtractor.php
@@ -69,10 +69,10 @@ final class ParquetExtractor implements Extractor
 
                 foreach ($data as $rowData) {
                     if ($shouldPutInputIntoRows) {
-                        $rows[] = \array_merge($rowData, ['_input_file_uri' => $readerData['uri']]);
-                    } else {
-                        $rows[] = $rowData;
+                        $rowData['_input_file_uri'] = $readerData['uri'];
                     }
+
+                    $rows[] = $rowData;
                 }
 
                 yield array_to_rows($rows, $context->entryFactory());

--- a/src/adapter/etl-adapter-parquet/src/Flow/ETL/Adapter/Parquet/ParquetExtractor.php
+++ b/src/adapter/etl-adapter-parquet/src/Flow/ETL/Adapter/Parquet/ParquetExtractor.php
@@ -36,13 +36,10 @@ final class ParquetExtractor implements Extractor
 
             foreach ($fileData['file']->values($this->columns) as $row) {
                 if ($shouldPutInputIntoRows) {
-                    $rows[] = \array_merge(
-                        $row,
-                        ['_input_file_uri' => $fileData['uri']]
-                    );
-                } else {
-                    $rows[] = $row;
+                    $row['_input_file_uri'] = $fileData['uri'];
                 }
+
+                $rows[] = $row;
 
                 if (\count($rows) >= $this->rowsInBatch) {
                     yield array_to_rows($rows, $context->entryFactory());


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Remove `array_merge()` when adding input into rows</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

Performance is not visible, but the code is IMO simpler & cleaner.
