### PR TITLE
Remove `array_merge()` from constructors when not needed

### DIFF
--- a/src/core/etl/src/Flow/ETL/DSL/functions.php
+++ b/src/core/etl/src/Flow/ETL/DSL/functions.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Flow\ETL\DSL;
 
-use Flow\ETL\Exception\InvalidArgumentException;
 use Flow\ETL\Row;
 use Flow\ETL\Row\EntryFactory;
 use Flow\ETL\Row\EntryReference;
@@ -47,13 +46,7 @@ function optional(Expression $expression) : Expression
 
 function struct(string ...$entries) : StructureReference
 {
-    if (!\count($entries)) {
-        throw new InvalidArgumentException('struct (StructureReference) require at least one entry');
-    }
-
-    $entry = \array_shift($entries);
-
-    return new StructureReference($entry, ...$entries);
+    return new StructureReference(...$entries);
 }
 
 function lit(mixed $value) : Expression

--- a/src/core/etl/src/Flow/ETL/Join/Comparison/All.php
+++ b/src/core/etl/src/Flow/ETL/Join/Comparison/All.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Join\Comparison;
 
+use Flow\ETL\Exception\InvalidArgumentException;
 use Flow\ETL\Join\Comparison;
 use Flow\ETL\Row;
 use Flow\ETL\Row\EntryReference;
@@ -18,9 +19,13 @@ final class All implements Comparison
      */
     private array $comparisons;
 
-    public function __construct(Comparison $comparison, Comparison ...$comparisons)
+    public function __construct(Comparison ...$comparisons)
     {
-        $this->comparisons = \array_merge([$comparison], $comparisons);
+        if (!$comparisons) {
+            throw new InvalidArgumentException('All comparison requires at least one comparison');
+        }
+
+        $this->comparisons = $comparisons;
     }
 
     public function __serialize() : array

--- a/src/core/etl/src/Flow/ETL/Join/Comparison/Any.php
+++ b/src/core/etl/src/Flow/ETL/Join/Comparison/Any.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Join\Comparison;
 
+use Flow\ETL\Exception\InvalidArgumentException;
 use Flow\ETL\Join\Comparison;
 use Flow\ETL\Row;
 use Flow\ETL\Row\EntryReference;
@@ -18,9 +19,13 @@ final class Any implements Comparison
      */
     private array $comparisons;
 
-    public function __construct(Comparison $comparison, Comparison ...$comparisons)
+    public function __construct(Comparison ...$comparisons)
     {
-        $this->comparisons = \array_merge([$comparison], $comparisons);
+        if (!$comparisons) {
+            throw new InvalidArgumentException('Any comparison requires at least one comparison');
+        }
+
+        $this->comparisons = $comparisons;
     }
 
     public function __serialize() : array

--- a/src/core/etl/src/Flow/ETL/Row/StructureReference.php
+++ b/src/core/etl/src/Flow/ETL/Row/StructureReference.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Row;
 
+use Flow\ETL\Exception\InvalidArgumentException;
+
 /**
  * @implements Reference<array{entries: array<string>, alias: ?string}>
  */
@@ -14,9 +16,13 @@ final class StructureReference implements Reference
     /** @var array<string> */
     private readonly array $entries;
 
-    public function __construct(string $entry, string ...$entries)
+    public function __construct(string ...$entries)
     {
-        $this->entries = \array_merge([$entry], $entries);
+        if (!$entries) {
+            throw new InvalidArgumentException('StructureReference requires at least one entry');
+        }
+
+        $this->entries = $entries;
     }
 
     public function __serialize() : array

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Join/Comparison/AllTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Join/Comparison/AllTest.php
@@ -6,12 +6,21 @@ namespace Flow\ETL\Tests\Unit\Join\Comparison;
 
 use Flow\ETL\Adapter\Elasticsearch\Tests\Integration\TestCase;
 use Flow\ETL\DSL\Entry;
+use Flow\ETL\Exception\InvalidArgumentException;
 use Flow\ETL\Join\Comparison;
 use Flow\ETL\Join\Comparison\All;
 use Flow\ETL\Row;
 
 final class AllTest extends TestCase
 {
+    public function test_empty_comparisons() : void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('All comparison requires at least one comparison');
+
+        new All();
+    }
+
     public function test_failure() : void
     {
         $comparison1 = $this->createStub(Comparison::class);

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Join/Comparison/AnyTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Join/Comparison/AnyTest.php
@@ -6,12 +6,21 @@ namespace Flow\ETL\Tests\Unit\Join\Comparison;
 
 use Flow\ETL\Adapter\Elasticsearch\Tests\Integration\TestCase;
 use Flow\ETL\DSL\Entry;
+use Flow\ETL\Exception\InvalidArgumentException;
 use Flow\ETL\Join\Comparison;
 use Flow\ETL\Join\Comparison\Any;
 use Flow\ETL\Row;
 
 final class AnyTest extends TestCase
 {
+    public function test_empty_comparisons() : void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Any comparison requires at least one comparison');
+
+        new Any();
+    }
+
     public function test_failure() : void
     {
         $comparison1 = $this->createStub(Comparison::class);


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <li>Remove `array_merge()` from constructors when not needed</li>
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

<!-- Please provide a short description of changes in this section, feel free to use markdown syntax -->
