### PR TITLE
Added possibility to easily identify schema root in Parquet Schema

### DIFF
--- a/src/lib/parquet/src/Flow/Parquet/ParquetFile/Schema/Column.php
+++ b/src/lib/parquet/src/Flow/Parquet/ParquetFile/Schema/Column.php
@@ -30,7 +30,7 @@ interface Column
 
     public function normalize() : array;
 
-    public function parent() : ?self;
+    public function parent() : ?NestedColumn;
 
     public function repetition() : ?Repetition;
 

--- a/src/lib/parquet/src/Flow/Parquet/ParquetFile/Schema/FlatColumn.php
+++ b/src/lib/parquet/src/Flow/Parquet/ParquetFile/Schema/FlatColumn.php
@@ -134,16 +134,24 @@ final class FlatColumn implements Column
 
     public function flatPath() : string
     {
-        $path = [$this->name];
         $parent = $this->parent();
+
+        if ($parent?->schemaRoot) {
+            return $this->name;
+        }
+
+        $path = [$this->name];
 
         while ($parent) {
             $path[] = $parent->name();
             $parent = $parent->parent();
+
+            if ($parent && $parent->schemaRoot) {
+                break;
+            }
         }
 
         $path = \array_reverse($path);
-        \array_shift($path);
 
         return \implode('.', $path);
     }
@@ -281,7 +289,7 @@ final class FlatColumn implements Column
         ];
     }
 
-    public function parent() : ?Column
+    public function parent() : ?NestedColumn
     {
         return $this->parent;
     }

--- a/src/lib/parquet/tests/Flow/Parquet/Tests/Unit/ParquetFile/Schema/NestedColumnTest.php
+++ b/src/lib/parquet/tests/Flow/Parquet/Tests/Unit/ParquetFile/Schema/NestedColumnTest.php
@@ -1,0 +1,44 @@
+<?php declare(strict_types=1);
+
+namespace Flow\Parquet\Tests\Unit\ParquetFile\Schema;
+
+use Flow\Parquet\ParquetFile\Schema;
+use PHPUnit\Framework\TestCase;
+
+final class NestedColumnTest extends TestCase
+{
+    public function test_children_flat() : void
+    {
+        $column = Schema\NestedColumn::create('nested', [
+            Schema\NestedColumn::create('nested', [
+                Schema\NestedColumn::create('nested', [
+                    Schema\FlatColumn::int32('int'),
+                    Schema\FlatColumn::string('string'),
+                    Schema\FlatColumn::boolean('bool'),
+                ]),
+            ]),
+        ]);
+
+        $this->assertSame(
+            [
+                'nested.nested.nested.int',
+                'nested.nested.nested.string',
+                'nested.nested.nested.bool',
+            ],
+            \array_keys($column->childrenFlat())
+        );
+    }
+
+    public function test_flat_path_for_direct_root_child() : void
+    {
+        $schema = Schema::with(
+            Schema\FlatColumn::int32('int'),
+            Schema\FlatColumn::string('string'),
+            Schema\FlatColumn::boolean('bool'),
+        );
+
+        $this->assertSame('int', $schema->get('int')->flatPath());
+        $this->assertSame('string', $schema->get('string')->flatPath());
+        $this->assertSame('bool', $schema->get('bool')->flatPath());
+    }
+}

--- a/src/lib/parquet/tests/Flow/Parquet/Tests/Unit/ParquetFile/SchemaTest.php
+++ b/src/lib/parquet/tests/Flow/Parquet/Tests/Unit/ParquetFile/SchemaTest.php
@@ -30,13 +30,13 @@ final class SchemaTest extends TestCase
             ),
         );
 
-        $this->assertSame(2, $schema->get('int')->maxDefinitionsLevel());
+        $this->assertSame(1, $schema->get('int')->maxDefinitionsLevel());
         $this->assertSame(0, $schema->get('int')->maxRepetitionsLevel());
-        $this->assertSame(3, $schema->get('nested.int')->maxDefinitionsLevel());
+        $this->assertSame(2, $schema->get('nested.int')->maxDefinitionsLevel());
         $this->assertSame(0, $schema->get('nested.int')->maxRepetitionsLevel());
-        $this->assertSame(4, $schema->get('nested.nested.bool')->maxDefinitionsLevel());
+        $this->assertSame(3, $schema->get('nested.nested.bool')->maxDefinitionsLevel());
         $this->assertSame(0, $schema->get('nested.nested.bool')->maxRepetitionsLevel());
-        $this->assertSame(5, $schema->get('nested.list_of_ints.list.element')->maxDefinitionsLevel());
+        $this->assertSame(4, $schema->get('nested.list_of_ints.list.element')->maxDefinitionsLevel());
         $this->assertSame(1, $schema->get('nested.list_of_ints.list.element')->maxRepetitionsLevel());
     }
 }


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <li>Added possibility to easily identify schema root in Parquet Schema</li>
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Simplified Schema cache</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

<!-- Please provide a short description of changes in this section, feel free to use markdown syntax -->
