### PR TITLE
Remove dead `array_merge_recursive()` function from Parquet

### DIFF
--- a/src/lib/parquet/src/Flow/Parquet/functions.php
+++ b/src/lib/parquet/src/Flow/Parquet/functions.php
@@ -5,26 +5,6 @@ declare(strict_types=1);
 namespace Flow\Parquet;
 
 /**
- * @psalm-suppress MixedAssignment
- * @psalm-suppress DocblockTypeContradiction
- * @psalm-suppress MixedArrayOffset
- */
-function array_merge_recursive(array $array1, array $array2) : array
-{
-    $merged = $array1;
-
-    foreach ($array2 as $key => &$value) {
-        if (\is_array($value) && isset($merged[$key]) && \is_array($merged[$key])) {
-            $merged[$key] = array_merge_recursive($merged[$key], $value);
-        } else {
-            $merged[$key] = $value;
-        }
-    }
-
-    return $merged;
-}
-
-/**
  * @psalm-suppress MixedArrayOffset
  * @psalm-suppress MixedAssignment
  */

--- a/src/lib/parquet/tests/Flow/Parquet/Tests/Unit/FunctionsTest.php
+++ b/src/lib/parquet/tests/Flow/Parquet/Tests/Unit/FunctionsTest.php
@@ -2,38 +2,31 @@
 
 namespace Flow\Parquet\Tests\Unit;
 
+use function Flow\Parquet\array_combine_recursive;
 use PHPUnit\Framework\TestCase;
 
 final class FunctionsTest extends TestCase
 {
-    public function test_array_merge_recursive() : void
+    public function test_array_combine_recursive() : void
     {
         $this->assertSame(
             [
-                'members' => [
-                    0 => [
-                        'addresses' => [
-                            0 => ['street' => 'Street_2_0_0'],
-                            1 => ['street' => 'Street_2_0_1'],
-                        ],
-                    ],
-                    1 => [
-                        'addresses' => [
-                            0 => ['street' => 'Street_2_1_0'],
-                        ],
+                [
+                    [
+                        ['street' => 'Street_2_0_1'],
                     ],
                 ],
             ],
-            \Flow\Parquet\array_merge_recursive(
+            array_combine_recursive(
                 [
                     'members' => [
-                        0 => ['addresses' => [0 => ['street' => 'Street_2_0_0']]],
+                        ['addresses' => ['street']],
                     ],
                 ],
                 [
                     'members' => [
-                        0 => ['addresses' => [1 => ['street' => 'Street_2_0_1']]],
-                        1 => ['addresses' => [0 => ['street' => 'Street_2_1_0']]],
+                        ['addresses' => ['Street_2_0_1']],
+                        ['addresses' => ['Street_2_1_0']],
                     ],
                 ]
             )


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <li>Remove dead `array_merge_recursive()` function from Parquet</li>
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

There is a native function in PHP: https://www.php.net/manual/en/function.array-merge-recursive.php, as well this code is never called in the codebase.
