### PR TITLE
Add missing tools to the dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,11 @@ updates:
       interval: "daily"
 
   - package-ecosystem: "composer"
+    directory: "/tools/box"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "composer"
     directory: "/tools/cs-fixer"
     schedule:
       interval: "daily"
@@ -21,6 +26,11 @@ updates:
       interval: "daily"
 
   - package-ecosystem: "composer"
+    directory: "/tools/phpbench"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "composer"
     directory: "/tools/phpstan"
     schedule:
       interval: "daily"
@@ -32,5 +42,10 @@ updates:
 
   - package-ecosystem: "composer"
     directory: "/tools/psalm"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "composer"
+    directory: "/tools/rector"
     schedule:
       interval: "daily"


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <li>Add missing tools to the dependabot config</li>
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

New tools were not covered by auto-update: Box, PHPBench & Rector.
