### PR TITLE
Added support for date and datetime types in parquet writer

### DIFF
--- a/src/lib/parquet/src/Flow/Parquet/ParquetFile/RowGroupBuilder/DataPagesBuilder.php
+++ b/src/lib/parquet/src/Flow/Parquet/ParquetFile/RowGroupBuilder/DataPagesBuilder.php
@@ -5,6 +5,7 @@ namespace Flow\Parquet\ParquetFile\RowGroupBuilder;
 use Flow\Dremel\DataShredded;
 use Flow\Dremel\Dremel;
 use Flow\Parquet\BinaryWriter\BinaryBufferWriter;
+use Flow\Parquet\Exception\RuntimeException;
 use Flow\Parquet\ParquetFile\Data\RLEBitPackedHybrid;
 use Flow\Parquet\ParquetFile\Encodings;
 use Flow\Parquet\ParquetFile\Page\Header\DataPageHeader;
@@ -83,6 +84,47 @@ final class DataPagesBuilder
     }
 
     /**
+     * @param array<int, \DateTime|\DateTimeImmutable> $dates
+     */
+    private function convertToDaysSinceUnix(array $dates) : array
+    {
+        $days = [];
+
+        foreach ($dates as $date) {
+            $epoch = new \DateTimeImmutable('1970-01-01 00:00:00 UTC');
+            $interval = $epoch->diff($date->setTime(0, 0, 0, 0));
+            $days[] = (int) $interval->format('%a');
+        }
+
+        return $days;
+    }
+
+    /**
+     * @psalm-suppress ArgumentTypeCoercion
+     *
+     * @param array<int, \DateTimeInterface> $dates
+     */
+    private function convertToTimestamps(array $dates, LogicalType\Timestamp $timeUnit) : array
+    {
+        $timestamps = [];
+
+        foreach ($dates as $date) {
+            if ($timeUnit->millis()) {
+                throw new RuntimeException('Milliseconds precision is not supported yet');
+            }
+
+            if ($timeUnit->micros()) {
+                $microseconds = \bcadd(\bcmul($date->format('U'), '1000000'), $date->format('u'));
+                $timestamps[] = (int) $microseconds;
+            } elseif ($timeUnit->nanos()) {
+                throw new RuntimeException('Nanoseconds precision is not supported in PHP');
+            }
+        }
+
+        return $timestamps;
+    }
+
+    /**
      * @psalm-suppress PossiblyNullArgument
      */
     private function writeData(FlatColumn $column, string $valuesBuffer, DataShredded $shredded) : string
@@ -95,11 +137,30 @@ final class DataPagesBuilder
 
                 break;
             case PhysicalType::INT32:
-                (new BinaryBufferWriter($valuesBuffer))->writeInts32($values);
+                switch ($column->logicalType()?->name()) {
+                    case LogicalType::DATE:
+                        (new BinaryBufferWriter($valuesBuffer))->writeInts32($this->convertToDaysSinceUnix($values));
+
+                        break;
+                    case null;
+                    (new BinaryBufferWriter($valuesBuffer))->writeInts32($values);
+
+                    break;
+                }
 
                 break;
             case PhysicalType::INT64:
-                (new BinaryBufferWriter($valuesBuffer))->writeInts64($values);
+                switch ($column->logicalType()?->name()) {
+                    case LogicalType::TIMESTAMP:
+                        /** @phpstan-ignore-next-line */
+                        (new BinaryBufferWriter($valuesBuffer))->writeInts64($this->convertToTimestamps($values, $column->logicalType()?->timestampData()));
+
+                        break;
+                    case null;
+                    (new BinaryBufferWriter($valuesBuffer))->writeInts64($values);
+
+                    break;
+                }
 
                 break;
             case PhysicalType::FLOAT:
@@ -128,7 +189,6 @@ final class DataPagesBuilder
                     case LogicalType::JSON:
                     case LogicalType::UUID:
                     case LogicalType::STRING:
-
                         (new BinaryBufferWriter($valuesBuffer))->writeStrings($values);
 
                         break;

--- a/src/lib/parquet/src/Flow/Parquet/ParquetFile/Schema/FlatColumn.php
+++ b/src/lib/parquet/src/Flow/Parquet/ParquetFile/Schema/FlatColumn.php
@@ -36,9 +36,13 @@ final class FlatColumn implements Column
         return new self($name, PhysicalType::INT32, new LogicalType(LogicalType::DATE), Repetition::OPTIONAL);
     }
 
-    public static function dateTime(string $name) : self
+    public static function dateTime(string $name, TimeUnit $timeUnit = TimeUnit::MICROSECONDS) : self
     {
-        return new self($name, PhysicalType::INT64, new LogicalType(LogicalType::TIMESTAMP, new Timestamp(false, false, true, false)), Repetition::OPTIONAL);
+        $timestamp = match ($timeUnit) {
+            TimeUnit::MICROSECONDS => new Timestamp(false, false, true, false),
+        };
+
+        return new self($name, PhysicalType::INT64, new LogicalType(LogicalType::TIMESTAMP, $timestamp), Repetition::OPTIONAL);
     }
 
     public static function decimal(string $name, int $precision = 10, int $scale = 2) : self

--- a/src/lib/parquet/src/Flow/Parquet/ParquetFile/Schema/ListElement.php
+++ b/src/lib/parquet/src/Flow/Parquet/ParquetFile/Schema/ListElement.php
@@ -18,9 +18,9 @@ final class ListElement
         return new self(FlatColumn::date('element'));
     }
 
-    public static function datetime() : self
+    public static function datetime(TimeUnit $timeUnit = TimeUnit::MICROSECONDS) : self
     {
-        return new self(FlatColumn::dateTime('element'));
+        return new self(FlatColumn::dateTime('element', $timeUnit));
     }
 
     public static function decimal(int $precision, int $scale) : self

--- a/src/lib/parquet/src/Flow/Parquet/ParquetFile/Schema/MapKey.php
+++ b/src/lib/parquet/src/Flow/Parquet/ParquetFile/Schema/MapKey.php
@@ -18,9 +18,9 @@ final class MapKey
         return new self(FlatColumn::date('key')->makeRequired());
     }
 
-    public static function datetime() : self
+    public static function datetime(TimeUnit $timeUnit = TimeUnit::MICROSECONDS) : self
     {
-        return new self(FlatColumn::dateTime('key')->makeRequired());
+        return new self(FlatColumn::dateTime('key', $timeUnit)->makeRequired());
     }
 
     public static function decimal(int $precision, int $scale) : self

--- a/src/lib/parquet/src/Flow/Parquet/ParquetFile/Schema/MapValue.php
+++ b/src/lib/parquet/src/Flow/Parquet/ParquetFile/Schema/MapValue.php
@@ -18,9 +18,9 @@ final class MapValue
         return new self(FlatColumn::date('value'));
     }
 
-    public static function datetime() : self
+    public static function datetime(TimeUnit $timeUnit = TimeUnit::MICROSECONDS) : self
     {
-        return new self(FlatColumn::dateTime('value'));
+        return new self(FlatColumn::dateTime('value', $timeUnit));
     }
 
     public static function decimal(int $precision, int $scale) : self

--- a/src/lib/parquet/src/Flow/Parquet/ParquetFile/Schema/TimeUnit.php
+++ b/src/lib/parquet/src/Flow/Parquet/ParquetFile/Schema/TimeUnit.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+
+namespace Flow\Parquet\ParquetFile\Schema;
+
+enum TimeUnit
+{
+    // case MILLISECONDS; Not Implemented yet
+    case MICROSECONDS;
+    // case NANOSECONDS; PHP Does not support nanoseconds
+}

--- a/src/lib/parquet/tests/Flow/Parquet/Tests/Integration/IO/WriterTest.php
+++ b/src/lib/parquet/tests/Flow/Parquet/Tests/Integration/IO/WriterTest.php
@@ -27,6 +27,9 @@ final class WriterTest extends ParquetIntegrationTestCase
             FlatColumn::double('double'),
             FlatColumn::decimal('decimal'),
             FlatColumn::string('string'),
+            FlatColumn::date('date'),
+            FlatColumn::dateTime('datetime'),
+            NestedColumn::list('list_of_datetimes', ListElement::dateTime()),
             NestedColumn::map('map_of_ints', MapKey::string(), MapValue::int32()),
             NestedColumn::list('list_of_strings', ListElement::string())
         );
@@ -40,6 +43,13 @@ final class WriterTest extends ParquetIntegrationTestCase
                 'double' => 2.2,
                 'decimal' => 10.24,
                 'string' => 'string',
+                'date' => (new \DateTimeImmutable())->setTime(0, 0),
+                'datetime' => new \DateTimeImmutable(),
+                'list_of_datetimes' => [
+                    new \DateTimeImmutable('+1 second'),
+                    new \DateTimeImmutable('+2 second'),
+                    new \DateTimeImmutable('+3 second'),
+                ],
                 'map_of_ints' => [
                     'a' => 0,
                     'b' => 1,
@@ -55,6 +65,13 @@ final class WriterTest extends ParquetIntegrationTestCase
                 'double' => 2.2,
                 'decimal' => 10.24,
                 'string' => 'string',
+                'date' => (new \DateTimeImmutable())->setTime(0, 0),
+                'datetime' => new \DateTimeImmutable(),
+                'list_of_datetimes' => [
+                    new \DateTimeImmutable('+1 second'),
+                    new \DateTimeImmutable('+2 second'),
+                    new \DateTimeImmutable('+3 second'),
+                ],
                 'map_of_ints' => [
                     'd' => 3,
                     'e' => 4,


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <li>date and datetime support for parquet writter</li>
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>
Ref: #575

<!-- Please provide a short description of changes in this section, feel free to use markdown syntax -->

Currently, the writer supports only Microseconds precision. 

- milliseconds are not allowed because they provide values with lower precision than \DateTimeImmutable
- nanoseconds are not supported by PHP at all  