### PR TITLE
Fixed bug in RLE/bitpacking hybrid algorithm

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -54,6 +54,7 @@
       <directory>src/adapter/etl-adapter-xml/tests/Flow/ETL/Adapter/XML/Tests/Integration</directory>
       <directory>src/core/etl/tests/Flow/ETL/Tests/Integration</directory>
       <directory>src/lib/parquet/tests/Flow/Parquet/Tests/Integration</directory>
+      <directory>src/lib/dremel/tests/Flow/Dremel/Tests/Integration</directory>
       <directory>src/lib/snappy/tests/Flow/Snappy/Tests/Integration</directory>
     </testsuite>
     <testsuite name="integration-services">

--- a/src/lib/dremel/tests/Flow/Dremel/Tests/Integration/DremelTest.php
+++ b/src/lib/dremel/tests/Flow/Dremel/Tests/Integration/DremelTest.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+
+namespace Flow\Dremel\Tests\Integration;
+
+use Flow\Dremel\Dremel;
+use PHPUnit\Framework\TestCase;
+
+final class DremelTest extends TestCase
+{
+    public function test_dremel_shredding_and_assembling() : void
+    {
+        $repetitions = [0, 1, 0, 1, 1, 0, 1, 1, 0, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 0, 1, 1, 0, 1, 1, 1, 1];
+        $definitions = [3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3];
+        $values = [['Suscipit officiis dolorum ea omnis est id magnam.', 'Ea rerum saepe a minima non iusto.'], ['Id dolor et et repellendus.', 'Cumque facilis aut quos et.', 'Sit illum ipsam dolor voluptatem est.'], ['Commodi dicta rerum quas omnis sunt dolor.', 'Architecto sint corrupti nihil soluta nesciunt.', 'Accusamus libero aliquam rerum.'], ['Eum molestias reiciendis cumque ad animi.', 'Sunt ad magnam quas dolores possimus sint aut.', 'Quidem cupiditate doloremque aut esse non.', 'Consequatur nobis delectus aut.', 'Quo fuga fugiat nulla dolor non fugit dolorum.', 'Voluptate ex culpa deleniti est eum qui.', 'Quia sunt quia ut consequatur et optio et.'], ['Aut soluta corrupti laborum qui.', 'Officia maiores natus voluptatem provident aut.', 'Voluptatem modi sequi molestiae aut molestiae.', 'Cumque qui voluptas quia.', 'Quis esse ut odio commodi quae.', 'Voluptatem est accusantium est et eum.', 'Ratione et ut fuga qui atque sed et.', 'Et aut ut quidem provident excepturi placeat.'], ['Rerum molestiae dicta libero dolorem.', 'Expedita fuga sequi a maiores quasi.', 'Nesciunt qui similique et.', 'Architecto perferendis qui sequi sint qui nemo.', 'Sequi in atque tenetur.', 'Voluptatem quod et placeat cupiditate.', 'Qui qui laborum consequatur quos cum totam.', 'Saepe sit quae eos accusamus.', 'Qui illum dolor vel consequuntur nihil.'], ['Vel tenetur velit quas.', 'Natus autem ab beatae nihil recusandae.', 'Ut quasi voluptatum qui dolore ut.', 'Ducimus et minima voluptatem cum sint non.', 'Rerum tenetur sunt quidem est et modi et.', 'Vitae sit eum eius rerum possimus.', 'Eos ipsa est a aliquid impedit doloremque nisi.', 'Aut illum quam sit asperiores.'], ['Repellat dolore sit ad amet sed repudiandae.', 'Quam nemo cum quo culpa.', 'Omnis sed minima vero.', 'Esse qui quo cumque earum eius nulla.', 'Sed in adipisci quas fuga.', 'Dolor est aliquid tempora.', 'Ut expedita id suscipit ut voluptatem.'], ['Sint ipsa et autem ut id vitae.', 'Sapiente ut ab qui.', 'Ullam sit numquam qui perferendis aut.'], ['Qui illum id nam quia quibusdam vero.', 'Quas laboriosam perferendis temporibus vero.', 'Numquam quas deserunt est et eius.', 'Voluptas debitis incidunt ea minus.', 'Pariatur ipsa ipsa sequi ut est dolor adipisci.']];
+
+        $dremel = new Dremel();
+        $shredded = $dremel->shred($values, \max($definitions));
+
+        $this->assertSame($repetitions, $shredded->repetitions);
+        $this->assertSame($definitions, $shredded->definitions);
+
+        $assembledValues = \iterator_to_array($dremel->assemble($shredded->repetitions, $shredded->definitions, $shredded->values));
+
+        $this->assertSame($values, $assembledValues);
+    }
+}

--- a/src/lib/parquet/src/Flow/Parquet/BinaryReader/BinaryBufferReader.php
+++ b/src/lib/parquet/src/Flow/Parquet/BinaryReader/BinaryBufferReader.php
@@ -158,7 +158,7 @@ final class BinaryBufferReader implements BinaryReader
         $floats = [];
 
         foreach ($floatBytes as $bytes) {
-            $floats[] = \unpack($this->byteOrder === ByteOrder::LITTLE_ENDIAN ? 'g' : 'G', \pack('C*', ...$bytes))[1];
+            $floats[] = \round(\unpack($this->byteOrder === ByteOrder::LITTLE_ENDIAN ? 'g' : 'G', \pack('C*', ...$bytes))[1], 7);
         }
 
         return $floats;

--- a/src/lib/parquet/src/Flow/Parquet/BinaryWriter/BinaryBufferWriter.php
+++ b/src/lib/parquet/src/Flow/Parquet/BinaryWriter/BinaryBufferWriter.php
@@ -106,8 +106,8 @@ final class BinaryBufferWriter implements BinaryWriter
 
         foreach ($doubles as $double) {
             $this->buffer .= \pack($format, $double);
-            $this->length->addBytes(8);
         }
+        $this->length->addBytes(\count($doubles) * 8);
     }
 
     public function writeFloats(array $floats) : void
@@ -116,8 +116,8 @@ final class BinaryBufferWriter implements BinaryWriter
 
         foreach ($floats as $float) {
             $this->buffer .= \pack($format, $float);
-            $this->length->addBytes(4);  // A float is 4 bytes
         }
+        $this->length->addBytes(\count($floats) * 4);
     }
 
     public function writeInts32(array $ints) : void

--- a/src/lib/parquet/src/Flow/Parquet/Consts.php
+++ b/src/lib/parquet/src/Flow/Parquet/Consts.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+
+namespace Flow\Parquet;
+
+final class Consts
+{
+    public const PHP_INT32_MAX = 2147483647;
+
+    public const PHP_INT64_MAX = 9223372036854775807;
+}

--- a/src/lib/parquet/src/Flow/Parquet/ParquetFile/Data/BytesConverter.php
+++ b/src/lib/parquet/src/Flow/Parquet/ParquetFile/Data/BytesConverter.php
@@ -9,10 +9,10 @@ final class BytesConverter
     public static function binToHex(string $binaryData, int $limit = null, string $glue = ' ') : string
     {
         if ($limit === null) {
-            return \implode($glue, \str_split(\bin2hex($binaryData), 2));
+            return \implode($glue, \str_split(\strtoupper(\bin2hex($binaryData)), 2));
         }
 
-        return \implode($glue, \array_slice(\str_split(\bin2hex($binaryData), 2), 0, $limit));
+        return \implode($glue, \array_slice(\str_split(\strtoupper(\bin2hex($binaryData)), 2), 0, $limit));
     }
 
     public static function intToBin(int $number, int $bits = 32, int $bitsPerGroup = 4) : string

--- a/src/lib/parquet/src/Flow/Parquet/ParquetFile/Data/DataBuilder.php
+++ b/src/lib/parquet/src/Flow/Parquet/ParquetFile/Data/DataBuilder.php
@@ -51,22 +51,6 @@ final class DataBuilder
             return null;
         }
 
-        if ($column->type() === PhysicalType::FLOAT) {
-            if (\is_float($value)) {
-                return \round($value, 7);
-            }
-
-            if (\is_array($value)) {
-                $enriched = [];
-
-                foreach ($value as $val) {
-                    $enriched[] = \round($val, 7);
-                }
-
-                return $enriched;
-            }
-        }
-
         if ($column->type() === PhysicalType::INT96 && $this->options->get(Option::INT_96_AS_DATETIME)) {
             if (\is_array($value) && \count($value) && !\is_array($value[0])) {
                 return $this->nanoToDateTimeImmutable($value);

--- a/src/lib/parquet/src/Flow/Parquet/ParquetFile/Data/RLEBitPackedHybrid.php
+++ b/src/lib/parquet/src/Flow/Parquet/ParquetFile/Data/RLEBitPackedHybrid.php
@@ -159,7 +159,7 @@ final class RLEBitPackedHybrid
 
         $previousValue = null;
 
-        foreach ($values as $value) {
+        foreach ($values as $i => $value) {
             if ($previousValue === null) {
                 $previousValue = $value;
                 $rleBuffer[] = $value;
@@ -167,17 +167,27 @@ final class RLEBitPackedHybrid
                 continue;
             }
 
-            // we always bit-pack a multiple of 8 values at a time, so we only store the number of values / 8
+            // we always bit-pack a multiple of 8 values at a time, so we only store the number of "values / 8"
             if (\count($bitPackedBuffer) > 0 && \count($bitPackedBuffer) < 8) {
                 $bitPackedBuffer[] = $value;
 
                 continue;
             }
 
+            if (\count($bitPackedBuffer) % 8 === 0) {
+                $this->encodeBitPacked($writer, $bitWidth, $bitPackedBuffer);
+                $bitPackedBuffer = [];
+            }
+
             if ($previousValue === $value) {
                 $rleBuffer[] = $value;
             } else {
                 if (\count($rleBuffer) >= 8) {
+                    if (\count($bitPackedBuffer)) {
+                        $this->encodeBitPacked($writer, $bitWidth, $bitPackedBuffer);
+                        $bitPackedBuffer = [];
+                    }
+
                     $this->encodeRLE($writer, $bitWidth, $rleBuffer);
                     $rleBuffer = [];
                 }

--- a/src/lib/parquet/src/Flow/Parquet/ParquetFile/RowGroupBuilder.php
+++ b/src/lib/parquet/src/Flow/Parquet/ParquetFile/RowGroupBuilder.php
@@ -48,9 +48,10 @@ final class RowGroupBuilder
         $chunkContainers = [];
 
         foreach ($this->chunkBuilders as $chunkBuilder) {
-            $chunkContainer = $chunkBuilder->flush($fileOffset);
-            $fileOffset += \strlen($chunkContainer->binaryBuffer);
-            $chunkContainers[] = $chunkContainer;
+            foreach ($chunkBuilder->flush($fileOffset) as $chunkContainer) {
+                $fileOffset += \strlen($chunkContainer->binaryBuffer);
+                $chunkContainers[] = $chunkContainer;
+            }
         }
 
         $buffer = '';

--- a/src/lib/parquet/src/Flow/Parquet/ParquetFile/RowGroupBuilder/DataPagesBuilder.php
+++ b/src/lib/parquet/src/Flow/Parquet/ParquetFile/RowGroupBuilder/DataPagesBuilder.php
@@ -26,6 +26,7 @@ final class DataPagesBuilder
     public function build(FlatColumn $column) : DataPageContainer
     {
         $shredded = (new Dremel())->shred($this->rows, $column->maxDefinitionsLevel());
+
         $rleBitPackedHybrid = new RLEBitPackedHybrid();
 
         $pageBuffer = '';

--- a/src/lib/parquet/tests/Flow/Parquet/Tests/Integration/Binary/BinaryReaderWriterTest.php
+++ b/src/lib/parquet/tests/Flow/Parquet/Tests/Integration/Binary/BinaryReaderWriterTest.php
@@ -50,6 +50,19 @@ final class BinaryReaderWriterTest extends TestCase
         );
     }
 
+    public function test_writing_and_reading_floats() : void
+    {
+        $buffer = '';
+        $floats = [1.1, 2.2, 3.3, 4.4, 9.1];
+
+        (new BinaryBufferWriter($buffer))->writeFloats($floats);
+        $this->assertEqualsWithDelta(
+            $floats,
+            (new BinaryBufferReader($buffer))->readFloats(\count($floats)),
+            0.000001,
+        );
+    }
+
     public function test_writing_and_reading_strings() : void
     {
         $buffer = '';

--- a/src/lib/parquet/tests/Flow/Parquet/Tests/Integration/ParquetFile/Data/RLEBitPackedHybridTest.php
+++ b/src/lib/parquet/tests/Flow/Parquet/Tests/Integration/ParquetFile/Data/RLEBitPackedHybridTest.php
@@ -10,6 +10,22 @@ use PHPUnit\Framework\TestCase;
 
 final class RLEBitPackedHybridTest extends TestCase
 {
+    public function test_flushing_buffers_when_they_are_dividable_by_8() : void
+    {
+        $values = [0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1];
+        $buffer = '';
+        (new RLEBitPackedHybrid())->encodeHybrid(new BinaryBufferWriter($buffer), $values);
+
+        $this->assertSame(
+            $values,
+            (new RLEBitPackedHybrid())->decodeHybrid(
+                new BinaryBufferReader($buffer),
+                BitWidth::fromArray($values),
+                \count($values)
+            )
+        );
+    }
+
     public function test_bit_packing_reading_with_extra_bytes_in_the_buffer() : void
     {
         $values = [3, 3, 3, 3];
@@ -63,9 +79,42 @@ final class RLEBitPackedHybridTest extends TestCase
         );
     }
 
+    public function test_bit_rle_reading_with_extra_bytes_in_the_buffer() : void
+    {
+        $values = [3, 3, 3, 3, 3, 3, 3, 3, 3, 3];
+        $buffer = '';
+        (new RLEBitPackedHybrid())->encodeHybrid($writer = new BinaryBufferWriter($buffer), $values);
+        $writer->writeBytes([1, 2, 3]);
+        $this->assertSame(
+            $values,
+            (new RLEBitPackedHybrid())->decodeHybrid(
+                new BinaryBufferReader($buffer),
+                BitWidth::fromArray($values),
+                \count($values)
+            )
+        );
+    }
+
     public function test_both_rle_and_bit_packed() : void
     {
         $values = [1, 2, 3, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 12, 13, 412, 5];
+
+        $buffer = '';
+        (new RLEBitPackedHybrid())->encodeHybrid(new BinaryBufferWriter($buffer), $values);
+
+        $this->assertSame(
+            $values,
+            (new RLEBitPackedHybrid())->decodeHybrid(
+                new BinaryBufferReader($buffer),
+                BitWidth::fromArray($values),
+                \count($values)
+            )
+        );
+    }
+
+    public function test_encoding_bit_pack_before_encoding_rle() : void
+    {
+        $values = [0, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1];
 
         $buffer = '';
         (new RLEBitPackedHybrid())->encodeHybrid(new BinaryBufferWriter($buffer), $values);

--- a/src/lib/parquet/tests/Flow/Parquet/Tests/Integration/ParquetFile/Data/RLEBitPackedHybridTest.php
+++ b/src/lib/parquet/tests/Flow/Parquet/Tests/Integration/ParquetFile/Data/RLEBitPackedHybridTest.php
@@ -10,22 +10,6 @@ use PHPUnit\Framework\TestCase;
 
 final class RLEBitPackedHybridTest extends TestCase
 {
-    public function test_flushing_buffers_when_they_are_dividable_by_8() : void
-    {
-        $values = [0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1];
-        $buffer = '';
-        (new RLEBitPackedHybrid())->encodeHybrid(new BinaryBufferWriter($buffer), $values);
-
-        $this->assertSame(
-            $values,
-            (new RLEBitPackedHybrid())->decodeHybrid(
-                new BinaryBufferReader($buffer),
-                BitWidth::fromArray($values),
-                \count($values)
-            )
-        );
-    }
-
     public function test_bit_packing_reading_with_extra_bytes_in_the_buffer() : void
     {
         $values = [3, 3, 3, 3];
@@ -116,6 +100,22 @@ final class RLEBitPackedHybridTest extends TestCase
     {
         $values = [0, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1];
 
+        $buffer = '';
+        (new RLEBitPackedHybrid())->encodeHybrid(new BinaryBufferWriter($buffer), $values);
+
+        $this->assertSame(
+            $values,
+            (new RLEBitPackedHybrid())->decodeHybrid(
+                new BinaryBufferReader($buffer),
+                BitWidth::fromArray($values),
+                \count($values)
+            )
+        );
+    }
+
+    public function test_flushing_buffers_when_they_are_dividable_by_8() : void
+    {
+        $values = [0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1];
         $buffer = '';
         (new RLEBitPackedHybrid())->encodeHybrid(new BinaryBufferWriter($buffer), $values);
 


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>bug in RLE/bitpacking hybrid algorithm</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>
Ref: #575

While progressing on the writer, I'm discovering some bugs, this PR started as a approach to split rows into multiple data pages when the size of a single one becomes too large according [to parquet recommendations](https://parquet.apache.org/docs/file-format/configurations/#data-page--size)