### PR TITLE
Feature/disable infection GitHub logger

### DIFF
--- a/.github/workflows/test-mutations.yml
+++ b/.github/workflows/test-mutations.yml
@@ -75,4 +75,4 @@ jobs:
         run: "composer install --no-interaction --no-progress --no-suggest"
 
       - name: "Mutation Tests"
-        run: "composer test:mutation"
+        run: "composer test:mutation -- --logger-github=false"

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -93,8 +93,14 @@ jobs:
           restore-keys: |
             php-${{ matrix.php-version }}-cache-psalm-
 
-      - name: "Static Analyze"
-        run: "composer static:analyze"
+      - name: "Static Analyze - CS Fixer"
+        run: "composer static:analyze:cs-fixer"
+
+      - name: "Static Analyze - PHPStan"
+        run: "composer static:analyze:phpstan -- --error-format=github"
+
+      - name: "Static Analyze - Psalm"
+        run: "composer static:analyze:psalm -- --output-format=github"
 
   tests:
     name: "Tests"

--- a/composer.json
+++ b/composer.json
@@ -172,11 +172,20 @@
             "tools/phpbench/vendor/bin/phpbench run --report=flow-report"
         ],
         "test:mutation": [
-            "tools/infection/vendor/bin/infection -j2 --logger-github=false"
+            "tools/infection/vendor/bin/infection -j2"
         ],
         "static:analyze": [
-            "tools/psalm/vendor/bin/psalm.phar --find-unused-psalm-suppress",
-            "tools/phpstan/vendor/bin/phpstan analyze -c phpstan.neon --memory-limit=-1",
+            "@static:analyze:cs-fixer",
+            "@static:analyze:psalm",
+            "@static:analyze:phpstan"
+        ],
+        "static:analyze:psalm": [
+            "tools/psalm/vendor/bin/psalm.phar --find-unused-psalm-suppress"
+        ],
+        "static:analyze:phpstan": [
+            "tools/phpstan/vendor/bin/phpstan analyze -c phpstan.neon --memory-limit=-1"
+        ],
+        "static:analyze:cs-fixer": [
             "tools/cs-fixer/vendor/bin/php-cs-fixer fix --dry-run"
         ],
         "cs:php:fix": [

--- a/composer.json
+++ b/composer.json
@@ -172,7 +172,7 @@
             "tools/phpbench/vendor/bin/phpbench run --report=flow-report"
         ],
         "test:mutation": [
-            "tools/infection/vendor/bin/infection -j2"
+            "tools/infection/vendor/bin/infection -j2 --logger-github=false"
         ],
         "static:analyze": [
             "tools/psalm/vendor/bin/psalm.phar --find-unused-psalm-suppress",


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Infection will no longer format output for GitHub</li>
    <li>PHPStan and Psalm will now report in GitHub format</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

<!-- Please provide a short description of changes in this section, feel free to use markdown syntax -->

Disabling infection and enabling phpstan/psalm will reduce the noise and let us focus on things that can be easily missed/fixed. 
