### PR TITLE
Parquet page viewer

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -11,7 +11,7 @@
 >
   <coverage cacheDirectory="./var/phpunit/">
     <report>
-      <html outputDirectory="var/phpunit/coverage/html" lowUpperBound="95" highLowerBound="100"/>
+      <html outputDirectory="var/phpunit/coverage/html" lowUpperBound="75" highLowerBound="95"/>
     </report>
   </coverage>
   <php>
@@ -70,5 +70,8 @@
       <directory suffix=".php">src/core/**/src</directory>
       <directory suffix=".php">src/lib/**/src</directory>
     </include>
+    <exclude>
+      <directory suffix=".php">src/lib/parquet/src/Flow/Parquet/Thrift</directory>
+    </exclude>
   </source>
 </phpunit>

--- a/src/lib/parquet/src/Flow/Parquet/ParquetFile/ColumnChunkReader/WholeChunkReader.php
+++ b/src/lib/parquet/src/Flow/Parquet/ParquetFile/ColumnChunkReader/WholeChunkReader.php
@@ -9,7 +9,6 @@ use Flow\Parquet\ParquetFile\Page\ColumnData;
 use Flow\Parquet\ParquetFile\Page\PageHeader;
 use Flow\Parquet\ParquetFile\PageReader;
 use Flow\Parquet\ParquetFile\RowGroup\ColumnChunk;
-use Flow\Parquet\ParquetFile\Schema\Column;
 use Flow\Parquet\ParquetFile\Schema\FlatColumn;
 use Flow\Parquet\ThriftStream\TPhpFileStream;
 use Psr\Log\LoggerInterface;
@@ -17,7 +16,7 @@ use Psr\Log\NullLogger;
 use Thrift\Protocol\TCompactProtocol;
 use Thrift\Transport\TBufferedTransport;
 
-final class WholeChunk implements ColumnChunkReader
+final class WholeChunkReader implements ColumnChunkReader
 {
     public function __construct(
         private readonly DataBuilder $dataBuilder,
@@ -28,6 +27,8 @@ final class WholeChunk implements ColumnChunkReader
 
     /**
      * @param resource $stream
+     *
+     * @return \Generator<array<mixed>>
      */
     public function read(ColumnChunk $columnChunk, FlatColumn $column, $stream, int $limit = null) : \Generator
     {
@@ -105,7 +106,7 @@ final class WholeChunk implements ColumnChunkReader
         try {
             \fseek($stream, $pageOffset);
             $thriftHeader = new \Flow\Parquet\Thrift\PageHeader();
-            $thriftHeader->read(new TCompactProtocol(new TBufferedTransport(new TPhpFileStream($stream))));
+            @$thriftHeader->read(new TCompactProtocol(new TBufferedTransport(new TPhpFileStream($stream))));
 
             if ($thriftHeader->type === null) {
                 return null;

--- a/src/lib/parquet/src/Flow/Parquet/ParquetFile/ColumnChunkViewer.php
+++ b/src/lib/parquet/src/Flow/Parquet/ParquetFile/ColumnChunkViewer.php
@@ -5,12 +5,10 @@ namespace Flow\Parquet\ParquetFile;
 use Flow\Parquet\ParquetFile\RowGroup\ColumnChunk;
 use Flow\Parquet\ParquetFile\Schema\FlatColumn;
 
-interface ColumnChunkReader
+interface ColumnChunkViewer
 {
     /**
      * @param resource $stream
-     *
-     * @return \Generator<array<mixed>>
      */
-    public function read(ColumnChunk $columnChunk, FlatColumn $column, $stream, int $limit = null) : \Generator;
+    public function view(ColumnChunk $columnChunk, FlatColumn $column, $stream) : \Generator;
 }

--- a/src/lib/parquet/src/Flow/Parquet/ParquetFile/ColumnChunkViewer/WholeChunkViewer.php
+++ b/src/lib/parquet/src/Flow/Parquet/ParquetFile/ColumnChunkViewer/WholeChunkViewer.php
@@ -1,0 +1,85 @@
+<?php declare(strict_types=1);
+
+namespace Flow\Parquet\ParquetFile\ColumnChunkViewer;
+
+use Flow\Parquet\Exception\RuntimeException;
+use Flow\Parquet\ParquetFile\ColumnChunkViewer;
+use Flow\Parquet\ParquetFile\Page\PageHeader;
+use Flow\Parquet\ParquetFile\RowGroup\ColumnChunk;
+use Flow\Parquet\ParquetFile\Schema\FlatColumn;
+use Flow\Parquet\ThriftStream\TPhpFileStream;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use Thrift\Protocol\TCompactProtocol;
+use Thrift\Transport\TBufferedTransport;
+
+final class WholeChunkViewer implements ColumnChunkViewer
+{
+    public function __construct(
+        private readonly LoggerInterface $logger = new NullLogger(),
+    ) {
+    }
+
+    /**
+     * @param resource $stream
+     */
+    public function view(ColumnChunk $columnChunk, FlatColumn $column, $stream) : \Generator
+    {
+        $this->logger->debug('[Parquet File][Read Column][Read Column Chunk]', ['chunk' => $columnChunk->normalize()]);
+        $offset = $columnChunk->pageOffset();
+
+        \fseek($stream, $offset);
+
+        if ($columnChunk->dictionaryPageOffset()) {
+            $dictionaryHeader = $this->readHeader($stream, $offset);
+
+            if ($dictionaryHeader === null) {
+                throw new RuntimeException('Dictionary page header not found in column chunk under offset: ' . $offset);
+            }
+
+            yield $dictionaryHeader;
+
+            $offset += $dictionaryHeader->compressedPageSize();
+        }
+
+        while (true) {
+            $dataHeader = $this->readHeader($stream, $offset);
+
+            /** There are no more pages in given column chunk */
+            if ($dataHeader === null || $dataHeader->type()->isDataPage() === false) {
+                break;
+            }
+
+            yield $dataHeader;
+
+            $offset += $dataHeader->compressedPageSize();
+        }
+    }
+
+    /**
+     * @param resource $stream
+     *
+     * @psalm-suppress DocblockTypeContradiction
+     */
+    private function readHeader($stream, int $pageOffset) : ?PageHeader
+    {
+        $currentOffset = \ftell($stream);
+
+        try {
+            \fseek($stream, $pageOffset);
+            $thriftHeader = new \Flow\Parquet\Thrift\PageHeader();
+            @$thriftHeader->read(new TCompactProtocol(new TBufferedTransport(new TPhpFileStream($stream))));
+
+            if ($thriftHeader->type === null) {
+                return null;
+            }
+
+            return PageHeader::fromThrift($thriftHeader);
+        } catch (\Throwable $e) {
+            /** @phpstan-ignore-next-line */
+            \fseek($stream, $currentOffset);
+
+            return null;
+        }
+    }
+}

--- a/src/lib/parquet/src/Flow/Parquet/ParquetFile/ColumnPageHeader.php
+++ b/src/lib/parquet/src/Flow/Parquet/ParquetFile/ColumnPageHeader.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace Flow\Parquet\ParquetFile;
+
+use Flow\Parquet\ParquetFile\Page\PageHeader;
+use Flow\Parquet\ParquetFile\Schema\FlatColumn;
+
+final class ColumnPageHeader
+{
+    public function __construct(
+        public readonly FlatColumn $column,
+        public readonly PageHeader $pageHeader,
+    ) {
+    }
+}

--- a/src/lib/parquet/src/Flow/Parquet/ParquetFile/Page/PageHeader.php
+++ b/src/lib/parquet/src/Flow/Parquet/ParquetFile/Page/PageHeader.php
@@ -16,6 +16,7 @@ final class PageHeader
     public function __construct(
         private readonly Type $type,
         private readonly int $compressedPageSize,
+        private readonly int $uncompressedPageSize,
         private readonly ?DataPageHeader $dataPageHeader,
         private readonly ?DataPageHeaderV2 $dataPageHeaderV2,
         private readonly ?DictionaryPageHeader $dictionaryPageHeader
@@ -30,6 +31,7 @@ final class PageHeader
         return new self(
             Type::from($thrift->type),
             $thrift->compressed_page_size,
+            $thrift->uncompressed_page_size,
             $thrift->data_page_header !== null ? DataPageHeader::fromThrift($thrift->data_page_header) : null,
             $thrift->data_page_header_v2 !== null ? DataPageHeaderV2::fromThrift($thrift->data_page_header_v2) : null,
             $thrift->dictionary_page_header !== null ? DictionaryPageHeader::fromThrift($thrift->dictionary_page_header) : null
@@ -112,7 +114,7 @@ final class PageHeader
         return new \Flow\Parquet\Thrift\PageHeader([
             'type' => $this->type->value,
             'compressed_page_size' => $this->compressedPageSize,
-            'uncompressed_page_size' => $this->compressedPageSize,
+            'uncompressed_page_size' => $this->uncompressedPageSize,
             'crc' => null,
             'data_page_header' => $this->dataPageHeader?->toThrift(),
             'data_page_header_v2' => null,
@@ -124,5 +126,10 @@ final class PageHeader
     public function type() : Type
     {
         return $this->type;
+    }
+
+    public function uncompressedPageSize() : int
+    {
+        return $this->uncompressedPageSize;
     }
 }

--- a/src/lib/parquet/src/Flow/Parquet/ParquetFile/RowGroupBuilder/DataPagesBuilder.php
+++ b/src/lib/parquet/src/Flow/Parquet/ParquetFile/RowGroupBuilder/DataPagesBuilder.php
@@ -23,7 +23,7 @@ final class DataPagesBuilder
     {
     }
 
-    public function build(FlatColumn $column, DataConverter $dataConverter) : DataPageContainer
+    public function build(FlatColumn $column, DataConverter $dataConverter) : PageContainer
     {
         $shredded = (new Dremel())->shred($this->rows, $column->maxDefinitionsLevel());
 
@@ -53,6 +53,7 @@ final class DataPagesBuilder
         $pageHeader = new PageHeader(
             Type::DATA_PAGE,
             \strlen($pageBuffer),
+            \strlen($pageBuffer),
             dataPageHeader: new DataPageHeader(
                 Encodings::PLAIN,
                 $this->valuesCount($this->rows),
@@ -62,7 +63,7 @@ final class DataPagesBuilder
         );
         $pageHeader->toThrift()->write(new TCompactProtocol($pageHeaderBuffer = new TMemoryBuffer()));
 
-        return new DataPageContainer(
+        return new PageContainer(
             $pageHeaderBuffer->getBuffer(),
             $pageBuffer,
             $pageHeader

--- a/src/lib/parquet/src/Flow/Parquet/ParquetFile/RowGroupBuilder/PageContainer.php
+++ b/src/lib/parquet/src/Flow/Parquet/ParquetFile/RowGroupBuilder/PageContainer.php
@@ -4,12 +4,17 @@ namespace Flow\Parquet\ParquetFile\RowGroupBuilder;
 
 use Flow\Parquet\ParquetFile\Page\PageHeader;
 
-final class DataPageContainer
+final class PageContainer
 {
     public function __construct(
         public readonly string $pageHeaderBuffer,
-        public readonly string $dataBuffer,
+        public readonly string $pageDataBuffer,
         public readonly PageHeader $pageHeader
     ) {
+    }
+
+    public function size() : int
+    {
+        return \strlen($this->pageHeaderBuffer) + \strlen($this->pageDataBuffer);
     }
 }

--- a/src/lib/parquet/tests/Flow/Parquet/Tests/Integration/IO/WriterTest.php
+++ b/src/lib/parquet/tests/Flow/Parquet/Tests/Integration/IO/WriterTest.php
@@ -29,15 +29,15 @@ final class WriterTest extends ParquetIntegrationTestCase
             FlatColumn::double('double'),
             FlatColumn::decimal('decimal'),
             FlatColumn::string('string'),
-//            FlatColumn::date('date'),
-//            FlatColumn::dateTime('datetime'),
-//            NestedColumn::list('list_of_datetimes', ListElement::dateTime()),
-//            NestedColumn::map('map_of_ints', MapKey::string(), MapValue::int32()),
-//            NestedColumn::list('list_of_strings', ListElement::string()),
-//            NestedColumn::struct('struct_flat', [
-//                FlatColumn::int32('id'),
-//                FlatColumn::string('name')
-//            ]),
+            FlatColumn::date('date'),
+            FlatColumn::dateTime('datetime'),
+            NestedColumn::list('list_of_datetimes', ListElement::dateTime()),
+            NestedColumn::map('map_of_ints', MapKey::string(), MapValue::int32()),
+            NestedColumn::list('list_of_strings', ListElement::string()),
+            NestedColumn::struct('struct_flat', [
+                FlatColumn::int32('id'),
+                FlatColumn::string('name'),
+            ]),
         );
 
         $faker = Factory::create();
@@ -52,26 +52,26 @@ final class WriterTest extends ParquetIntegrationTestCase
                     'double' => $faker->randomFloat(),
                     'decimal' => \round($faker->randomFloat(5), 2),
                     'string' => $faker->text(50),
-                    //                    'date' => \DateTimeImmutable::createFromMutable($faker->dateTime)->setTime(0, 0, 0, 0),
-                    //                    'datetime' => \DateTimeImmutable::createFromMutable($faker->dateTime),
-                    //                    'list_of_datetimes' => [
-                    //                        \DateTimeImmutable::createFromMutable($faker->dateTime),
-                    //                        \DateTimeImmutable::createFromMutable($faker->dateTime),
-                    //                        \DateTimeImmutable::createFromMutable($faker->dateTime),
-                    //                    ],
-                    //                    'map_of_ints' => [
-                    //                        'a' => $faker->numberBetween(0, Consts::PHP_INT32_MAX),
-                    //                        'b' => $faker->numberBetween(0, Consts::PHP_INT32_MAX),
-                    //                        'c' => $faker->numberBetween(0, Consts::PHP_INT32_MAX),
-                    //                    ],
-                    //                    'list_of_strings' => \array_map(static fn (int $i) => $faker->text(50), \range(0, \random_int(1, 10))),
-                    //                    'struct_flat' => [
-                    //                        'id' => $i,
-                    //                        'name' => 'name_' . \str_pad((string) $i, 5, '0', STR_PAD_LEFT)
-                    //                    ]
+                    'date' => \DateTimeImmutable::createFromMutable($faker->dateTime)->setTime(0, 0, 0, 0),
+                    'datetime' => \DateTimeImmutable::createFromMutable($faker->dateTime),
+                    'list_of_datetimes' => [
+                        \DateTimeImmutable::createFromMutable($faker->dateTime),
+                        \DateTimeImmutable::createFromMutable($faker->dateTime),
+                        \DateTimeImmutable::createFromMutable($faker->dateTime),
+                    ],
+                    'map_of_ints' => [
+                        'a' => $faker->numberBetween(0, Consts::PHP_INT32_MAX),
+                        'b' => $faker->numberBetween(0, Consts::PHP_INT32_MAX),
+                        'c' => $faker->numberBetween(0, Consts::PHP_INT32_MAX),
+                    ],
+                    'list_of_strings' => \array_map(static fn (int $i) => $faker->text(50), \range(0, \random_int(1, 10))),
+                    'struct_flat' => [
+                        'id' => $i,
+                        'name' => 'name_' . \str_pad((string) $i, 5, '0', STR_PAD_LEFT),
+                    ],
                 ],
             ];
-        }, \range(1, 5_000));
+        }, \range(1, 100));
 
         $inputData = \array_merge(...$inputData);
 

--- a/src/lib/parquet/tests/Flow/Parquet/Tests/Integration/IO/WriterTest.php
+++ b/src/lib/parquet/tests/Flow/Parquet/Tests/Integration/IO/WriterTest.php
@@ -29,11 +29,15 @@ final class WriterTest extends ParquetIntegrationTestCase
             FlatColumn::double('double'),
             FlatColumn::decimal('decimal'),
             FlatColumn::string('string'),
-            FlatColumn::date('date'),
-            FlatColumn::dateTime('datetime'),
-            NestedColumn::list('list_of_datetimes', ListElement::dateTime()),
-            NestedColumn::map('map_of_ints', MapKey::string(), MapValue::int32()),
-            NestedColumn::list('list_of_strings', ListElement::string())
+//            FlatColumn::date('date'),
+//            FlatColumn::dateTime('datetime'),
+//            NestedColumn::list('list_of_datetimes', ListElement::dateTime()),
+//            NestedColumn::map('map_of_ints', MapKey::string(), MapValue::int32()),
+//            NestedColumn::list('list_of_strings', ListElement::string()),
+//            NestedColumn::struct('struct_flat', [
+//                FlatColumn::int32('id'),
+//                FlatColumn::string('name')
+//            ]),
         );
 
         $faker = Factory::create();
@@ -48,22 +52,26 @@ final class WriterTest extends ParquetIntegrationTestCase
                     'double' => $faker->randomFloat(),
                     'decimal' => \round($faker->randomFloat(5), 2),
                     'string' => $faker->text(50),
-                    'date' => \DateTimeImmutable::createFromMutable($faker->dateTime)->setTime(0, 0, 0, 0),
-                    'datetime' => \DateTimeImmutable::createFromMutable($faker->dateTime),
-                    'list_of_datetimes' => [
-                        \DateTimeImmutable::createFromMutable($faker->dateTime),
-                        \DateTimeImmutable::createFromMutable($faker->dateTime),
-                        \DateTimeImmutable::createFromMutable($faker->dateTime),
-                    ],
-                    'map_of_ints' => [
-                        'a' => $faker->numberBetween(0, Consts::PHP_INT32_MAX),
-                        'b' => $faker->numberBetween(0, Consts::PHP_INT32_MAX),
-                        'c' => $faker->numberBetween(0, Consts::PHP_INT32_MAX),
-                    ],
-                    'list_of_strings' => \array_map(static fn (int $i) => $faker->text(50), \range(0, \random_int(1, 10))),
+                    //                    'date' => \DateTimeImmutable::createFromMutable($faker->dateTime)->setTime(0, 0, 0, 0),
+                    //                    'datetime' => \DateTimeImmutable::createFromMutable($faker->dateTime),
+                    //                    'list_of_datetimes' => [
+                    //                        \DateTimeImmutable::createFromMutable($faker->dateTime),
+                    //                        \DateTimeImmutable::createFromMutable($faker->dateTime),
+                    //                        \DateTimeImmutable::createFromMutable($faker->dateTime),
+                    //                    ],
+                    //                    'map_of_ints' => [
+                    //                        'a' => $faker->numberBetween(0, Consts::PHP_INT32_MAX),
+                    //                        'b' => $faker->numberBetween(0, Consts::PHP_INT32_MAX),
+                    //                        'c' => $faker->numberBetween(0, Consts::PHP_INT32_MAX),
+                    //                    ],
+                    //                    'list_of_strings' => \array_map(static fn (int $i) => $faker->text(50), \range(0, \random_int(1, 10))),
+                    //                    'struct_flat' => [
+                    //                        'id' => $i,
+                    //                        'name' => 'name_' . \str_pad((string) $i, 5, '0', STR_PAD_LEFT)
+                    //                    ]
                 ],
             ];
-        }, \range(1, 100));
+        }, \range(1, 5_000));
 
         $inputData = \array_merge(...$inputData);
 


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <li>Possibility to iterate through all parquet file column chunk page headers</li>
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>PHPUnit code coverage thresholds</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

Ref: #575

Even though this is not mandatory for the reader itself, I'm going to use it later for parquet viewer CLI app, for now I'm using this to quickly understand parquet files. 

This is how the viewer might look like in the future: 
<img width="971" alt="image" src="https://github.com/flow-php/flow/assets/1921950/dc1864b1-16fd-4c1a-99d5-f40c15839130">

