### PR TITLE
Fixed bug in calculating number of values when pages are encoded with dictionary

### DIFF
--- a/src/lib/parquet/src/Flow/Parquet/ParquetFile/RowGroup/ColumnChunk.php
+++ b/src/lib/parquet/src/Flow/Parquet/ParquetFile/RowGroup/ColumnChunk.php
@@ -64,6 +64,11 @@ final class ColumnChunk
         return $this->codec;
     }
 
+    public function dataPageOffset() : ?int
+    {
+        return $this->dataPageOffset;
+    }
+
     public function dictionaryPageOffset() : ?int
     {
         return $this->dictionaryPageOffset;

--- a/src/lib/parquet/src/Flow/Parquet/ParquetFile/RowGroupBuilder/ColumnChunkBuilder.php
+++ b/src/lib/parquet/src/Flow/Parquet/ParquetFile/RowGroupBuilder/ColumnChunkBuilder.php
@@ -43,15 +43,17 @@ final class ColumnChunkBuilder
         $dictionaryPageSize = null;
         $dictionaryPageOffset = null;
         $pageOffset = $offset;
+        $dictionaryPage = null;
 
         foreach ($pageContainers as $pageContainer) {
             if ($pageContainer->pageHeader->type() === Type::DICTIONARY_PAGE) {
-                if ($dictionaryPageSize !== null) {
+                if ($dictionaryPage !== null) {
                     throw new RuntimeException('There can be only one dictionary page in column chunk');
                 }
 
                 $dictionaryPageOffset = $pageOffset;
                 $dictionaryPageSize = $pageContainer->size();
+                $dictionaryPage = $pageContainer;
             }
 
             $buffer .= $pageContainer->pageHeaderBuffer . $pageContainer->pageBuffer;
@@ -60,6 +62,8 @@ final class ColumnChunkBuilder
             $size += $pageContainer->size();
             $pageOffset += $pageContainer->size();
         }
+
+        $valuesCount = $dictionaryPage ? \count($dictionaryPage->values) : $valuesCount;
 
         $encodings = \array_values(\array_unique($encodings));
         $encodings = \array_map(static fn (int $encoding) => Encodings::from($encoding), $encodings);

--- a/src/lib/parquet/src/Flow/Parquet/ParquetFile/RowGroupBuilder/ColumnChunkBuilder.php
+++ b/src/lib/parquet/src/Flow/Parquet/ParquetFile/RowGroupBuilder/ColumnChunkBuilder.php
@@ -3,10 +3,7 @@
 namespace Flow\Parquet\ParquetFile\RowGroupBuilder;
 
 use Flow\Parquet\Data\DataConverter;
-use Flow\Parquet\Exception\RuntimeException;
 use Flow\Parquet\ParquetFile\Compressions;
-use Flow\Parquet\ParquetFile\Encodings;
-use Flow\Parquet\ParquetFile\Page\Header\Type;
 use Flow\Parquet\ParquetFile\RowGroup\ColumnChunk;
 use Flow\Parquet\ParquetFile\Schema\FlatColumn;
 
@@ -25,62 +22,21 @@ final class ColumnChunkBuilder
 
     public function flush(int $fileOffset) : ColumnChunkContainer
     {
-        return $this->createColumnChunkContainer(
-            (new PagesBuilder($this->dataConverter))->build($this->column, $this->data),
-            $fileOffset
-        );
-    }
-
-    /**
-     * @param array<PageContainer> $pageContainers
-     */
-    private function createColumnChunkContainer(array $pageContainers, int $offset) : ColumnChunkContainer
-    {
-        $buffer = '';
-        $encodings = [];
-        $valuesCount = 0;
-        $size = 0;
-        $dictionaryPageSize = null;
-        $dictionaryPageOffset = null;
-        $pageOffset = $offset;
-        $dictionaryPage = null;
-
-        foreach ($pageContainers as $pageContainer) {
-            if ($pageContainer->pageHeader->type() === Type::DICTIONARY_PAGE) {
-                if ($dictionaryPage !== null) {
-                    throw new RuntimeException('There can be only one dictionary page in column chunk');
-                }
-
-                $dictionaryPageOffset = $pageOffset;
-                $dictionaryPageSize = $pageContainer->size();
-                $dictionaryPage = $pageContainer;
-            }
-
-            $buffer .= $pageContainer->pageHeaderBuffer . $pageContainer->pageBuffer;
-            $encodings[] = $pageContainer->pageHeader->encoding()->value;
-            $valuesCount += \count($pageContainer->values);
-            $size += $pageContainer->size();
-            $pageOffset += $pageContainer->size();
-        }
-
-        $valuesCount = $dictionaryPage ? \count($dictionaryPage->values) : $valuesCount;
-
-        $encodings = \array_values(\array_unique($encodings));
-        $encodings = \array_map(static fn (int $encoding) => Encodings::from($encoding), $encodings);
+        $pageContainers = (new PagesBuilder($this->dataConverter))->build($this->column, $this->data);
 
         return new ColumnChunkContainer(
-            $buffer,
+            $pageContainers->buffer(),
             new ColumnChunk(
                 type: $this->column->type(),
                 codec: Compressions::UNCOMPRESSED,
-                valuesCount: $valuesCount,
-                fileOffset: $offset,
+                valuesCount: $pageContainers->valuesCount(),
+                fileOffset: $fileOffset,
                 path: $this->column->path(),
-                encodings: $encodings,
-                totalCompressedSize: $size,
-                totalUncompressedSize: $size,
-                dictionaryPageOffset: $dictionaryPageOffset,
-                dataPageOffset: ($dictionaryPageOffset) ? $offset + $dictionaryPageSize : $offset,
+                encodings: $pageContainers->encodings(),
+                totalCompressedSize: $pageContainers->size(),
+                totalUncompressedSize: $pageContainers->size(),
+                dictionaryPageOffset: ($pageContainers->dictionaryPageContainer()) ? $fileOffset : null,
+                dataPageOffset: ($pageContainers->dictionaryPageContainer()) ? $fileOffset + $pageContainers->dictionaryPageContainer()->size() : $fileOffset,
                 indexPageOffset: null,
             )
         );

--- a/src/lib/parquet/src/Flow/Parquet/ParquetFile/RowGroupBuilder/PageContainers.php
+++ b/src/lib/parquet/src/Flow/Parquet/ParquetFile/RowGroupBuilder/PageContainers.php
@@ -1,0 +1,114 @@
+<?php declare(strict_types=1);
+
+namespace Flow\Parquet\ParquetFile\RowGroupBuilder;
+
+use Flow\Parquet\Exception\InvalidArgumentException;
+use Flow\Parquet\ParquetFile\Encodings;
+use Flow\Parquet\ParquetFile\Page\Header\Type;
+
+final class PageContainers
+{
+    /**
+     * @var array<PageContainer>
+     */
+    private array $dataPageContainers = [];
+
+    private ?PageContainer $dictionaryPageContainer = null;
+
+    public function __construct(array $containers = [])
+    {
+        foreach ($containers as $container) {
+            $this->add($container);
+        }
+    }
+
+    public function add(PageContainer $container) : void
+    {
+        if ($container->pageHeader->type() === Type::DICTIONARY_PAGE) {
+            if ($this->dictionaryPageContainer !== null) {
+                throw new InvalidArgumentException('Dictionary page container already set');
+            }
+
+            $this->dictionaryPageContainer = $container;
+
+            return;
+        }
+
+        $this->dataPageContainers[] = $container;
+    }
+
+    public function buffer() : string
+    {
+        $buffer = '';
+
+        if ($this->dictionaryPageContainer) {
+            $buffer .= $this->dictionaryPageContainer->pageHeaderBuffer;
+            $buffer .= $this->dictionaryPageContainer->pageBuffer;
+        }
+
+        foreach ($this->dataPageContainers as $pageContainer) {
+            $buffer .= $pageContainer->pageHeaderBuffer;
+            $buffer .= $pageContainer->pageBuffer;
+        }
+
+        return $buffer;
+    }
+
+    public function dataPageContainers() : array
+    {
+        return $this->dataPageContainers;
+    }
+
+    public function dictionaryPageContainer() : ?PageContainer
+    {
+        return $this->dictionaryPageContainer;
+    }
+
+    /**
+     * @return array<Encodings>
+     */
+    public function encodings() : array
+    {
+        $encodings = [];
+
+        if ($this->dictionaryPageContainer) {
+            $encodings[] = $this->dictionaryPageContainer->pageHeader->encoding()->value;
+        }
+
+        foreach ($this->dataPageContainers as $pageContainer) {
+            $encodings[] = $pageContainer->pageHeader->encoding()->value;
+        }
+
+        return \array_map(static fn (int $encoding) => Encodings::from($encoding), $encodings);
+    }
+
+    public function size() : int
+    {
+        $size = 0;
+
+        if ($this->dictionaryPageContainer) {
+            $size += $this->dictionaryPageContainer->size();
+        }
+
+        foreach ($this->dataPageContainers as $pageContainer) {
+            $size += $pageContainer->size();
+        }
+
+        return $size;
+    }
+
+    public function valuesCount() : int
+    {
+        if ($this->dictionaryPageContainer !== null) {
+            return \count($this->dictionaryPageContainer->values);
+        }
+
+        $count = 0;
+
+        foreach ($this->dataPageContainers as $pageContainer) {
+            $count += \count($pageContainer->values);
+        }
+
+        return $count;
+    }
+}

--- a/src/lib/parquet/src/Flow/Parquet/ParquetFile/RowGroupBuilder/PagesBuilder.php
+++ b/src/lib/parquet/src/Flow/Parquet/ParquetFile/RowGroupBuilder/PagesBuilder.php
@@ -14,20 +14,21 @@ final class PagesBuilder
     {
     }
 
-    /**
-     * @return array<PageContainer>
-     */
-    public function build(FlatColumn $column, array $rows) : array
+    public function build(FlatColumn $column, array $rows) : PageContainers
     {
+        $containers = new PageContainers();
+
         if ($column->logicalType()?->name() === LogicalType::STRING) {
             $dictionaryPageContainer = (new DictionaryPageBuilder())->build($column, $this->dataConverter, $rows);
 
-            return [
-                $dictionaryPageContainer,
-                (new DataPageBuilder($dictionaryPageContainer->values))->build($column, $this->dataConverter, $rows),
-            ];
+            $containers->add($dictionaryPageContainer);
+            $containers->add((new DataPageBuilder($dictionaryPageContainer->values))->build($column, $this->dataConverter, $rows));
+
+            return $containers;
         }
 
-        return [(new DataPageBuilder())->build($column, $this->dataConverter, $rows)];
+        $containers->add((new DataPageBuilder())->build($column, $this->dataConverter, $rows));
+
+        return $containers;
     }
 }

--- a/src/lib/parquet/tests/Flow/Parquet/Tests/Integration/IO/MapsWritingTest.php
+++ b/src/lib/parquet/tests/Flow/Parquet/Tests/Integration/IO/MapsWritingTest.php
@@ -1,0 +1,74 @@
+<?php declare(strict_types=1);
+
+namespace Flow\Parquet\Tests\Integration\IO;
+
+use Faker\Factory;
+use Flow\Parquet\Consts;
+use Flow\Parquet\ParquetFile\Schema;
+use Flow\Parquet\ParquetFile\Schema\MapKey;
+use Flow\Parquet\ParquetFile\Schema\MapValue;
+use Flow\Parquet\ParquetFile\Schema\NestedColumn;
+use Flow\Parquet\Reader;
+use Flow\Parquet\Writer;
+use PHPUnit\Framework\TestCase;
+
+final class MapsWritingTest extends TestCase
+{
+    public function test_writing_map_of_int_int() : void
+    {
+        $path = \sys_get_temp_dir() . '/test-writer' . \uniqid('parquet-test-', true) . '.parquet';
+
+        $writer = new Writer();
+        $schema = Schema::with(NestedColumn::map('map_int_int', MapKey::int32(), MapValue::int32()));
+
+        $faker = Factory::create();
+        $inputData = \array_merge(...\array_map(static function (int $i) use ($faker) : array {
+            return [
+                [
+                    'map_int_int' => \array_merge(
+                        ...\array_map(
+                            static fn ($i) => [$i => $faker->numberBetween(0, Consts::PHP_INT32_MAX)],
+                            \range(1, \random_int(2, 10))
+                        )
+                    ),
+                ],
+            ];
+        }, \range(1, 100)));
+
+        $writer->write($path, $schema, $inputData);
+
+        $this->assertSame(
+            $inputData,
+            \iterator_to_array((new Reader())->read($path)->values())
+        );
+    }
+
+    public function test_writing_map_of_int_string() : void
+    {
+        $path = \sys_get_temp_dir() . '/test-writer' . \uniqid('parquet-test-', true) . '.parquet';
+
+        $writer = new Writer();
+        $schema = Schema::with(NestedColumn::map('map_int_string', MapKey::int32(), MapValue::string()));
+
+        $faker = Factory::create();
+        $inputData = \array_merge(...\array_map(static function (int $i) use ($faker) : array {
+            return [
+                [
+                    'map_int_string' => \array_merge(
+                        ...\array_map(
+                            static fn ($i) => [$i => $faker->text(10)],
+                            \range(1, \random_int(2, 10))
+                        )
+                    ),
+                ],
+            ];
+        }, \range(1, 100)));
+
+        $writer->write($path, $schema, $inputData);
+
+        $this->assertSame(
+            $inputData,
+            \iterator_to_array((new Reader())->read($path)->values())
+        );
+    }
+}

--- a/src/lib/parquet/tests/Flow/Parquet/Tests/Integration/IO/StructsWritingTest.php
+++ b/src/lib/parquet/tests/Flow/Parquet/Tests/Integration/IO/StructsWritingTest.php
@@ -1,0 +1,60 @@
+<?php declare(strict_types=1);
+
+namespace Flow\Parquet\Tests\Integration\IO;
+
+use Faker\Factory;
+use Flow\Parquet\Consts;
+use Flow\Parquet\ParquetFile\Schema;
+use Flow\Parquet\ParquetFile\Schema\FlatColumn;
+use Flow\Parquet\ParquetFile\Schema\ListElement;
+use Flow\Parquet\ParquetFile\Schema\NestedColumn;
+use Flow\Parquet\Reader;
+use Flow\Parquet\Writer;
+use PHPUnit\Framework\TestCase;
+
+final class StructsWritingTest extends TestCase
+{
+    public function test_writing_flat_structure() : void
+    {
+        $path = \sys_get_temp_dir() . '/test-writer' . \uniqid('parquet-test-', true) . '.parquet';
+
+        $writer = new Writer();
+        $schema = Schema::with(NestedColumn::struct('struct', [
+            FlatColumn::int64('int64'),
+            FlatColumn::boolean('boolean'),
+            FlatColumn::string('string'),
+            FlatColumn::int32('int32'),
+            NestedColumn::list('list_of_int', ListElement::int32()),
+            NestedColumn::list('list_of_string', ListElement::string()),
+        ]));
+
+        $faker = Factory::create();
+        $inputData = \array_merge(...\array_map(static function (int $i) use ($faker) : array {
+            return [
+                [
+                    'struct' => [
+                        'int64' => $faker->numberBetween(0, Consts::PHP_INT64_MAX),
+                        'boolean' => $faker->boolean,
+                        'string' => $faker->text(150),
+                        'int32' => $faker->numberBetween(0, Consts::PHP_INT32_MAX),
+                        'list_of_int' => \array_map(
+                            static fn ($i) => $faker->numberBetween(0, Consts::PHP_INT32_MAX),
+                            \range(1, \random_int(2, 10))
+                        ),
+                        'list_of_string' => \array_map(
+                            static fn ($i) => $faker->text(10),
+                            \range(1, \random_int(2, 10))
+                        ),
+                    ],
+                ],
+            ];
+        }, \range(1, 100)));
+
+        $writer->write($path, $schema, $inputData);
+
+        $this->assertSame(
+            $inputData,
+            \iterator_to_array((new Reader())->read($path)->values())
+        );
+    }
+}

--- a/src/lib/parquet/tests/Flow/Parquet/Tests/Integration/ParquetFile/RowGroupBuilder/PagesBuilderTest.php
+++ b/src/lib/parquet/tests/Flow/Parquet/Tests/Integration/ParquetFile/RowGroupBuilder/PagesBuilderTest.php
@@ -23,12 +23,12 @@ final class PagesBuilderTest extends TestCase
 
         $pages = (new PagesBuilder(DataConverter::initialize(new Options())))->build($column, $values);
 
-        $this->assertCount(1, $pages);
+        $this->assertCount(1, $pages->dataPageContainers());
         $this->assertEquals(
             new PageHeader(
                 Type::DATA_PAGE,
-                \strlen($pages[0]->pageBuffer),
-                \strlen($pages[0]->pageBuffer),
+                \strlen($pages->dataPageContainers()[0]->pageBuffer),
+                \strlen($pages->dataPageContainers()[0]->pageBuffer),
                 new DataPageHeader(
                     Encodings::PLAIN,
                     \count($values),
@@ -36,7 +36,7 @@ final class PagesBuilderTest extends TestCase
                 null,
                 null
             ),
-            $pages[0]->pageHeader
+            $pages->dataPageContainers()[0]->pageHeader
         );
     }
 
@@ -48,26 +48,25 @@ final class PagesBuilderTest extends TestCase
 
         $pages = (new PagesBuilder(DataConverter::initialize(new Options())))->build($column, $values);
 
-        $this->assertCount(2, $pages);
         $this->assertEquals(
             new PageHeader(
                 Type::DICTIONARY_PAGE,
-                \strlen($pages[0]->pageBuffer),
-                \strlen($pages[0]->pageBuffer),
+                \strlen($pages->dictionaryPageContainer()->pageBuffer),
+                \strlen($pages->dictionaryPageContainer()->pageBuffer),
                 null,
                 null,
                 new DictionaryPageHeader(
                     Encodings::PLAIN,
-                    \count(\array_unique($values)),
+                    $pages->valuesCount(),
                 )
             ),
-            $pages[0]->pageHeader
+            $pages->dictionaryPageContainer()->pageHeader
         );
         $this->assertEquals(
             new PageHeader(
                 Type::DATA_PAGE,
-                \strlen($pages[1]->pageBuffer),
-                \strlen($pages[1]->pageBuffer),
+                \strlen($pages->dataPageContainers()[0]->pageBuffer),
+                \strlen($pages->dataPageContainers()[0]->pageBuffer),
                 new DataPageHeader(
                     Encodings::PLAIN_DICTIONARY,
                     \count($values),
@@ -75,7 +74,7 @@ final class PagesBuilderTest extends TestCase
                 null,
                 null
             ),
-            $pages[1]->pageHeader
+            $pages->dataPageContainers()[0]->pageHeader
         );
     }
 }

--- a/src/lib/parquet/tests/Flow/Parquet/Tests/Integration/ParquetFile/RowGroupBuilder/PagesBuilderTest.php
+++ b/src/lib/parquet/tests/Flow/Parquet/Tests/Integration/ParquetFile/RowGroupBuilder/PagesBuilderTest.php
@@ -1,0 +1,81 @@
+<?php declare(strict_types=1);
+
+namespace Flow\Parquet\Tests\Integration\ParquetFile\RowGroupBuilder;
+
+use Faker\Factory;
+use Flow\Parquet\Data\DataConverter;
+use Flow\Parquet\Options;
+use Flow\Parquet\ParquetFile\Encodings;
+use Flow\Parquet\ParquetFile\Page\Header\DataPageHeader;
+use Flow\Parquet\ParquetFile\Page\Header\DictionaryPageHeader;
+use Flow\Parquet\ParquetFile\Page\Header\Type;
+use Flow\Parquet\ParquetFile\Page\PageHeader;
+use Flow\Parquet\ParquetFile\RowGroupBuilder\PagesBuilder;
+use Flow\Parquet\ParquetFile\Schema\FlatColumn;
+use PHPUnit\Framework\TestCase;
+
+final class PagesBuilderTest extends TestCase
+{
+    public function test_building_pages_for_integer_column() : void
+    {
+        $column = FlatColumn::int32('int32');
+        $values = \array_map(static fn ($i) => $i, \range(0, 99));
+
+        $pages = (new PagesBuilder(DataConverter::initialize(new Options())))->build($column, $values);
+
+        $this->assertCount(1, $pages);
+        $this->assertEquals(
+            new PageHeader(
+                Type::DATA_PAGE,
+                \strlen($pages[0]->pageBuffer),
+                \strlen($pages[0]->pageBuffer),
+                new DataPageHeader(
+                    Encodings::PLAIN,
+                    \count($values),
+                ),
+                null,
+                null
+            ),
+            $pages[0]->pageHeader
+        );
+    }
+
+    public function test_building_pages_for_string_columns() : void
+    {
+        $column = FlatColumn::string('string');
+        $faker = Factory::create();
+        $values = \array_map(static fn ($i) => $faker->text(10), \range(0, 99));
+
+        $pages = (new PagesBuilder(DataConverter::initialize(new Options())))->build($column, $values);
+
+        $this->assertCount(2, $pages);
+        $this->assertEquals(
+            new PageHeader(
+                Type::DICTIONARY_PAGE,
+                \strlen($pages[0]->pageBuffer),
+                \strlen($pages[0]->pageBuffer),
+                null,
+                null,
+                new DictionaryPageHeader(
+                    Encodings::PLAIN,
+                    \count(\array_unique($values)),
+                )
+            ),
+            $pages[0]->pageHeader
+        );
+        $this->assertEquals(
+            new PageHeader(
+                Type::DATA_PAGE,
+                \strlen($pages[1]->pageBuffer),
+                \strlen($pages[1]->pageBuffer),
+                new DataPageHeader(
+                    Encodings::PLAIN_DICTIONARY,
+                    \count($values),
+                ),
+                null,
+                null
+            ),
+            $pages[1]->pageHeader
+        );
+    }
+}


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>bug in calculating number of values when pages are encoded with dictionary</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

Ref: #575
<!-- Please provide a short description of changes in this section, feel free to use markdown syntax -->
