### PR TITLE
Move more logical types to dictionary encoding

### DIFF
--- a/src/lib/parquet/src/Flow/Parquet/ParquetFile/RowGroupBuilder/PagesBuilder.php
+++ b/src/lib/parquet/src/Flow/Parquet/ParquetFile/RowGroupBuilder/PagesBuilder.php
@@ -18,7 +18,11 @@ final class PagesBuilder
     {
         $containers = new PageContainers();
 
-        if ($column->logicalType()?->name() === LogicalType::STRING) {
+        $logicalType = $column->logicalType()?->name();
+
+        $dictionaryTypes = [LogicalType::STRING, LogicalType::UUID, LogicalType::ENUM, LogicalType::JSON];
+
+        if ($logicalType !== null && \in_array($logicalType, $dictionaryTypes, true)) {
             $dictionaryPageContainer = (new DictionaryPageBuilder())->build($column, $this->dataConverter, $rows);
 
             $containers->add($dictionaryPageContainer);

--- a/src/lib/parquet/tests/Flow/Parquet/Tests/Integration/ParquetFile/RowGroupBuilder/PagesBuilderTest.php
+++ b/src/lib/parquet/tests/Flow/Parquet/Tests/Integration/ParquetFile/RowGroupBuilder/PagesBuilderTest.php
@@ -16,6 +16,49 @@ use PHPUnit\Framework\TestCase;
 
 final class PagesBuilderTest extends TestCase
 {
+    public function test_building_pages_for_enum_columns() : void
+    {
+        $column = FlatColumn::enum('enum');
+        $enum = [
+            0 => 'RED',
+            1 => 'GREEN',
+            2 => 'BLUE',
+        ];
+
+        $values = \array_map(static fn ($i) => $enum[\random_int(0, 2)], \range(0, 99));
+
+        $pages = (new PagesBuilder(DataConverter::initialize(new Options())))->build($column, $values);
+
+        $this->assertEquals(
+            new PageHeader(
+                Type::DICTIONARY_PAGE,
+                \strlen($pages->dictionaryPageContainer()->pageBuffer),
+                \strlen($pages->dictionaryPageContainer()->pageBuffer),
+                null,
+                null,
+                new DictionaryPageHeader(
+                    Encodings::PLAIN,
+                    $pages->valuesCount(),
+                )
+            ),
+            $pages->dictionaryPageContainer()->pageHeader
+        );
+        $this->assertEquals(
+            new PageHeader(
+                Type::DATA_PAGE,
+                \strlen($pages->dataPageContainers()[0]->pageBuffer),
+                \strlen($pages->dataPageContainers()[0]->pageBuffer),
+                new DataPageHeader(
+                    Encodings::PLAIN_DICTIONARY,
+                    \count($values),
+                ),
+                null,
+                null
+            ),
+            $pages->dataPageContainers()[0]->pageHeader
+        );
+    }
+
     public function test_building_pages_for_integer_column() : void
     {
         $column = FlatColumn::int32('int32');
@@ -40,11 +83,87 @@ final class PagesBuilderTest extends TestCase
         );
     }
 
+    public function test_building_pages_for_json_columns() : void
+    {
+        $column = FlatColumn::json('json');
+        $faker = Factory::create();
+        $values = \array_map(static fn ($i) => \json_encode(['id' => $faker->uuid], JSON_THROW_ON_ERROR), \range(0, 99));
+
+        $pages = (new PagesBuilder(DataConverter::initialize(new Options())))->build($column, $values);
+
+        $this->assertEquals(
+            new PageHeader(
+                Type::DICTIONARY_PAGE,
+                \strlen($pages->dictionaryPageContainer()->pageBuffer),
+                \strlen($pages->dictionaryPageContainer()->pageBuffer),
+                null,
+                null,
+                new DictionaryPageHeader(
+                    Encodings::PLAIN,
+                    $pages->valuesCount(),
+                )
+            ),
+            $pages->dictionaryPageContainer()->pageHeader
+        );
+        $this->assertEquals(
+            new PageHeader(
+                Type::DATA_PAGE,
+                \strlen($pages->dataPageContainers()[0]->pageBuffer),
+                \strlen($pages->dataPageContainers()[0]->pageBuffer),
+                new DataPageHeader(
+                    Encodings::PLAIN_DICTIONARY,
+                    \count($values),
+                ),
+                null,
+                null
+            ),
+            $pages->dataPageContainers()[0]->pageHeader
+        );
+    }
+
     public function test_building_pages_for_string_columns() : void
     {
         $column = FlatColumn::string('string');
         $faker = Factory::create();
         $values = \array_map(static fn ($i) => $faker->text(10), \range(0, 99));
+
+        $pages = (new PagesBuilder(DataConverter::initialize(new Options())))->build($column, $values);
+
+        $this->assertEquals(
+            new PageHeader(
+                Type::DICTIONARY_PAGE,
+                \strlen($pages->dictionaryPageContainer()->pageBuffer),
+                \strlen($pages->dictionaryPageContainer()->pageBuffer),
+                null,
+                null,
+                new DictionaryPageHeader(
+                    Encodings::PLAIN,
+                    $pages->valuesCount(),
+                )
+            ),
+            $pages->dictionaryPageContainer()->pageHeader
+        );
+        $this->assertEquals(
+            new PageHeader(
+                Type::DATA_PAGE,
+                \strlen($pages->dataPageContainers()[0]->pageBuffer),
+                \strlen($pages->dataPageContainers()[0]->pageBuffer),
+                new DataPageHeader(
+                    Encodings::PLAIN_DICTIONARY,
+                    \count($values),
+                ),
+                null,
+                null
+            ),
+            $pages->dataPageContainers()[0]->pageHeader
+        );
+    }
+
+    public function test_building_pages_for_uuid_columns() : void
+    {
+        $column = FlatColumn::string('uuid');
+        $faker = Factory::create();
+        $values = \array_map(static fn ($i) => $faker->uuid, \range(0, 99));
 
         $pages = (new PagesBuilder(DataConverter::initialize(new Options())))->build($column, $values);
 


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <li>JSON/UUID/ENUM - to dictionary encoding - Parquet</li>
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

Ref: #575 

<!-- Please provide a short description of changes in this section, feel free to use markdown syntax -->
