### PR TITLE
Calculate row group/page size on the fly in order to decide when to flush data to disk

### DIFF
--- a/src/lib/parquet/src/Flow/Parquet/Option.php
+++ b/src/lib/parquet/src/Flow/Parquet/Option.php
@@ -23,8 +23,25 @@ enum Option
     case INT_96_AS_DATETIME;
 
     /**
+     * PageBuilder is going to use this value to determine how many rows should be stored in one page.
+     * PageBuilder is not going to make it precisely equal to this value, but it will try to make it as close as possible.
+     * This should be considered as a threshold rather than a strict value.
+     *
+     * https://parquet.apache.org/docs/file-format/configurations/#data-page--size
+     */
+    case PAGE_SIZE_BYTES;
+
+    /**
      * Since PHP does not support nanoseconds precision for DateTime objects, when this options is set to true,
      * reader will round nanoseconds to microseconds.
      */
     case ROUND_NANOSECONDS;
+
+    /**
+     * RowGroupBuilder is going to use this value to determine for how long it should keep adding rows to the buffer
+     * before flushing it on disk.
+     *
+     * https://parquet.apache.org/docs/file-format/configurations/#row-group-size
+     */
+    case ROW_GROUP_SIZE_BYTES;
 }

--- a/src/lib/parquet/src/Flow/Parquet/Options.php
+++ b/src/lib/parquet/src/Flow/Parquet/Options.php
@@ -5,7 +5,7 @@ namespace Flow\Parquet;
 final class Options
 {
     /**
-     * @var array<string, bool>
+     * @var array<string, bool|int>
      */
     private array $options;
 
@@ -15,15 +15,22 @@ final class Options
             Option::BYTE_ARRAY_TO_STRING->name => true,
             Option::ROUND_NANOSECONDS->name => false,
             Option::INT_96_AS_DATETIME->name => true,
+            Option::PAGE_SIZE_BYTES->name => 1024 * 8,
+            Option::ROW_GROUP_SIZE_BYTES->name => 1024 * 1024 * 128,
         ];
     }
 
-    public function get(Option $option) : bool
+    public static function default() : self
+    {
+        return new self;
+    }
+
+    public function get(Option $option) : bool|int
     {
         return $this->options[$option->name];
     }
 
-    public function set(Option $option, bool $value = true) : self
+    public function set(Option $option, bool|int $value = true) : self
     {
         $this->options[$option->name] = $value;
 

--- a/src/lib/parquet/src/Flow/Parquet/ParquetFile/RowGroup.php
+++ b/src/lib/parquet/src/Flow/Parquet/ParquetFile/RowGroup.php
@@ -52,6 +52,11 @@ final class RowGroup
         $this->rowsCount = $rowsCount;
     }
 
+    public function totalByteSize() : int
+    {
+        return \array_sum(\array_map(static fn (ColumnChunk $chunk) => $chunk->totalUncompressedSize(), $this->columnChunks));
+    }
+
     public function toThrift() : \Flow\Parquet\Thrift\RowGroup
     {
         $fileOffset = \count($this->columnChunks) ? \current($this->columnChunks)->fileOffset() : 0;

--- a/src/lib/parquet/src/Flow/Parquet/ParquetFile/RowGroupBuilder/ColumnChunkStatistics.php
+++ b/src/lib/parquet/src/Flow/Parquet/ParquetFile/RowGroupBuilder/ColumnChunkStatistics.php
@@ -1,0 +1,121 @@
+<?php declare(strict_types=1);
+
+namespace Flow\Parquet\ParquetFile\RowGroupBuilder;
+
+use Flow\Parquet\Exception\RuntimeException;
+use Flow\Parquet\ParquetFile\Schema\ColumnPrimitiveType;
+use Flow\Parquet\ParquetFile\Schema\FlatColumn;
+use Flow\Parquet\ParquetFile\Schema\PhysicalType;
+
+final class ColumnChunkStatistics
+{
+    private int $distinctCount;
+
+    private int $nullCount;
+
+    private int $totalStringLength;
+
+    private int $valuesCount;
+
+    public function __construct(private readonly FlatColumn $column)
+    {
+        $this->nullCount = 0;
+        $this->distinctCount = 0;
+        $this->valuesCount = 0;
+        $this->totalStringLength = 0;
+    }
+
+    public function add(string|int|float|null|array|bool|object $value) : void
+    {
+        if (\is_array($value)) {
+            $this->valuesCount += \count($value);
+        } else {
+            $this->valuesCount++;
+        }
+
+        if ($value === null) {
+            $this->nullCount++;
+
+            return;
+        }
+
+        if ((\is_string($value) || \is_array($value)) && ColumnPrimitiveType::isString($this->column)) {
+            if (\is_string($value)) {
+                $this->totalStringLength += \strlen($value);
+            }
+
+            if (\is_array($value)) {
+                foreach ($value as $v) {
+                    if (\is_string($v)) {
+                        $this->totalStringLength += \strlen($v);
+                    }
+                }
+            }
+        }
+    }
+
+    public function avgStringLength() : int
+    {
+        return (int) \ceil($this->totalStringLength / $this->notNullCount());
+    }
+
+    public function distinctCount() : int
+    {
+        return $this->distinctCount;
+    }
+
+    public function notNullCount() : int
+    {
+        return $this->valuesCount - $this->nullCount;
+    }
+
+    public function nullCount() : int
+    {
+        return $this->nullCount;
+    }
+
+    public function reset() : void
+    {
+        $this->nullCount = 0;
+        $this->distinctCount = 0;
+        $this->valuesCount = 0;
+        $this->totalStringLength = 0;
+    }
+
+    public function totalStringLength() : int
+    {
+        return $this->totalStringLength;
+    }
+
+    public function uncompressedSize() : int
+    {
+        switch ($this->column->type()) {
+            case PhysicalType::BOOLEAN:
+                // Booleans are stored as bits, so we can fit 8 of them into a single byte
+                return (int) \ceil($this->notNullCount() / 8);
+            case PhysicalType::FLOAT:
+            case PhysicalType::INT32:
+                // Int32s are stored as 4 bytes
+                return $this->notNullCount() * 4;
+            case PhysicalType::DOUBLE:
+            case PhysicalType::INT64:
+                // Int64s are stored as 8 bytes
+                return $this->notNullCount() * 8;
+            case PhysicalType::INT96:
+                // Int96s are stored as 12 bytes
+                return $this->notNullCount() * 12;
+            case PhysicalType::FIXED_LEN_BYTE_ARRAY:
+                // Fixed length byte arrays are stored as their length
+                return $this->notNullCount() * $this->column->typeLength();
+            case PhysicalType::BYTE_ARRAY:
+                return $this->totalStringLength() + (4 * $this->notNullCount()); // each string starts with int32 length
+        }
+
+        throw new RuntimeException('Unknown column type');
+    }
+
+    public function valuesCount() : int
+    {
+        return $this->valuesCount;
+    }
+}

--- a/src/lib/parquet/src/Flow/Parquet/ParquetFile/RowGroupBuilder/PageBuilder/DictionaryPageBuilder.php
+++ b/src/lib/parquet/src/Flow/Parquet/ParquetFile/RowGroupBuilder/PageBuilder/DictionaryPageBuilder.php
@@ -26,10 +26,11 @@ final class DictionaryPageBuilder implements PageBuilder
         $dictionary = [];
 
         foreach (array_flatten($rows) as $value) {
-            if (!\in_array($value, $dictionary, true)) {
-                $dictionary[] = $value;
+            if (!\array_key_exists($value, $dictionary)) {
+                $dictionary[$value] = $value;
             }
         }
+        $dictionary = \array_values($dictionary);
 
         $pageBuffer = '';
         $pageWriter = new BinaryBufferWriter($pageBuffer);

--- a/src/lib/parquet/src/Flow/Parquet/ParquetFile/RowGroupBuilder/PageSizeCalculator.php
+++ b/src/lib/parquet/src/Flow/Parquet/ParquetFile/RowGroupBuilder/PageSizeCalculator.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types=1);
+
+namespace Flow\Parquet\ParquetFile\RowGroupBuilder;
+
+use Flow\Parquet\Option;
+use Flow\Parquet\Options;
+use Flow\Parquet\ParquetFile\Schema\FlatColumn;
+use Flow\Parquet\ParquetFile\Schema\PhysicalType;
+
+final class PageSizeCalculator
+{
+    public function __construct(private readonly Options $options)
+    {
+    }
+
+    public function rowsPerPage(FlatColumn $column, ColumnChunkStatistics $statistics) : int
+    {
+        $pageSize = (int) $this->options->get(Option::PAGE_SIZE_BYTES);
+
+        switch ($column->type()) {
+            case PhysicalType::BOOLEAN:
+                // Booleans are stored as bits, so we can fit 8 of them into a single byte
+                return $pageSize * 8;
+            case PhysicalType::FLOAT:
+            case PhysicalType::INT32:
+                // Int32s are stored as 4 bytes
+                return (int) \ceil($pageSize / 4);
+            case PhysicalType::DOUBLE:
+            case PhysicalType::INT64:
+                // Int64s are stored as 8 bytes
+                return (int) \ceil($pageSize / 8);
+            case PhysicalType::INT96:
+                // Int96s are stored as 12 bytes
+                return (int) \ceil($pageSize / 12);
+            case PhysicalType::FIXED_LEN_BYTE_ARRAY:
+                // Fixed length byte arrays are stored as their length
+                return (int) \floor($pageSize / $column->typeLength());
+            case PhysicalType::BYTE_ARRAY:
+                // Byte arrays (all string values) are stored as their length because we are anyway storing dictionary indices for them, not the actual values
+                return $statistics->valuesCount();
+
+            default:
+                return $statistics->valuesCount();
+        }
+    }
+}

--- a/src/lib/parquet/src/Flow/Parquet/ParquetFile/RowGroupBuilder/PagesBuilder.php
+++ b/src/lib/parquet/src/Flow/Parquet/ParquetFile/RowGroupBuilder/PagesBuilder.php
@@ -5,33 +5,38 @@ namespace Flow\Parquet\ParquetFile\RowGroupBuilder;
 use Flow\Parquet\Data\DataConverter;
 use Flow\Parquet\ParquetFile\RowGroupBuilder\PageBuilder\DataPageBuilder;
 use Flow\Parquet\ParquetFile\RowGroupBuilder\PageBuilder\DictionaryPageBuilder;
+use Flow\Parquet\ParquetFile\Schema\ColumnPrimitiveType;
 use Flow\Parquet\ParquetFile\Schema\FlatColumn;
-use Flow\Parquet\ParquetFile\Schema\LogicalType;
 
 final class PagesBuilder
 {
-    public function __construct(private readonly DataConverter $dataConverter)
-    {
+    public function __construct(
+        private readonly DataConverter $dataConverter,
+        private readonly PageSizeCalculator $pageSizeCalculator
+    ) {
     }
 
-    public function build(FlatColumn $column, array $rows) : PageContainers
+    public function build(FlatColumn $column, array $rows, ColumnChunkStatistics $statistics) : PageContainers
     {
         $containers = new PageContainers();
 
-        $logicalType = $column->logicalType()?->name();
-
-        $dictionaryTypes = [LogicalType::STRING, LogicalType::UUID, LogicalType::ENUM, LogicalType::JSON];
-
-        if ($logicalType !== null && \in_array($logicalType, $dictionaryTypes, true)) {
+        if (ColumnPrimitiveType::isString($column)) {
             $dictionaryPageContainer = (new DictionaryPageBuilder($this->dataConverter))->build($column, $rows);
 
             $containers->add($dictionaryPageContainer);
-            $containers->add((new DataPageBuilder($this->dataConverter, $dictionaryPageContainer->values))->build($column, $rows));
+
+            /* @phpstan-ignore-next-line */
+            foreach (\array_chunk($rows, $this->pageSizeCalculator->rowsPerPage($column, $statistics)) as $rowsChunk) {
+                $containers->add((new DataPageBuilder($this->dataConverter, $dictionaryPageContainer->values))->build($column, $rowsChunk));
+            }
 
             return $containers;
         }
 
-        $containers->add((new DataPageBuilder($this->dataConverter))->build($column, $rows));
+        /* @phpstan-ignore-next-line */
+        foreach (\array_chunk($rows, $this->pageSizeCalculator->rowsPerPage($column, $statistics)) as $rowsChunk) {
+            $containers->add((new DataPageBuilder($this->dataConverter))->build($column, $rowsChunk));
+        }
 
         return $containers;
     }

--- a/src/lib/parquet/src/Flow/Parquet/ParquetFile/RowGroupBuilder/RowGroupStatistics.php
+++ b/src/lib/parquet/src/Flow/Parquet/ParquetFile/RowGroupBuilder/RowGroupStatistics.php
@@ -1,0 +1,55 @@
+<?php declare(strict_types=1);
+
+namespace Flow\Parquet\ParquetFile\RowGroupBuilder;
+
+final class RowGroupStatistics
+{
+    private int $rowsCount = 0;
+
+    /**
+     * @param array<ColumnChunkStatistics> $statistics
+     */
+    public function __construct(
+        private readonly array $statistics
+    ) {
+    }
+
+    public static function fromBuilders(array $columnChunkBuilders) : self
+    {
+        return new self(
+            \array_map(static fn (ColumnChunkBuilder $columnChunkBuilder) => $columnChunkBuilder->statistics(), $columnChunkBuilders)
+        );
+    }
+
+    public function addRow() : void
+    {
+        $this->rowsCount++;
+    }
+
+    public function rowsCount() : int
+    {
+        return $this->rowsCount;
+    }
+
+    public function uncompressedSize() : int
+    {
+        $total = 0;
+
+        foreach ($this->statistics as $statistic) {
+            $total += $statistic->uncompressedSize();
+        }
+
+        return $total;
+    }
+
+    public function valuesCount() : int
+    {
+        $total = 0;
+
+        foreach ($this->statistics as $statistic) {
+            $total += $statistic->valuesCount();
+        }
+
+        return $total;
+    }
+}

--- a/src/lib/parquet/src/Flow/Parquet/ParquetFile/Schema/ColumnPrimitiveType.php
+++ b/src/lib/parquet/src/Flow/Parquet/ParquetFile/Schema/ColumnPrimitiveType.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types=1);
+
+namespace Flow\Parquet\ParquetFile\Schema;
+
+final class ColumnPrimitiveType
+{
+    public static function isString(FlatColumn $column) : bool
+    {
+        $logicalType = $column->logicalType();
+
+        if ($logicalType === null) {
+            return false;
+        }
+
+        return \in_array($logicalType->name(), [LogicalType::STRING, LogicalType::UUID, LogicalType::ENUM, LogicalType::JSON], true);
+    }
+}

--- a/src/lib/parquet/src/Flow/Parquet/ParquetFile/Schema/FlatColumn.php
+++ b/src/lib/parquet/src/Flow/Parquet/ParquetFile/Schema/FlatColumn.php
@@ -2,6 +2,7 @@
 
 namespace Flow\Parquet\ParquetFile\Schema;
 
+use Flow\Parquet\Consts;
 use Flow\Parquet\Exception\InvalidArgumentException;
 use Flow\Parquet\ParquetFile\Schema\LogicalType\Timestamp;
 use Flow\Parquet\Thrift\SchemaElement;
@@ -40,6 +41,10 @@ final class FlatColumn implements Column
 
     public static function dateTime(string $name, TimeUnit $timeUnit = TimeUnit::MICROSECONDS) : self
     {
+        if (PHP_INT_MAX !== Consts::PHP_INT64_MAX) {
+            throw new InvalidArgumentException('PHP_INT_MAX must be equal to ' . Consts::PHP_INT64_MAX . ' to support 64-bit timestamps.');
+        }
+
         $timestamp = match ($timeUnit) {
             TimeUnit::MICROSECONDS => new Timestamp(false, false, true, false),
         };
@@ -106,6 +111,10 @@ final class FlatColumn implements Column
 
     public static function int64(string $name) : self
     {
+        if (PHP_INT_MAX !== Consts::PHP_INT64_MAX) {
+            throw new InvalidArgumentException('PHP_INT_MAX must be equal to ' . Consts::PHP_INT64_MAX . ' to support 64-bit timestamps.');
+        }
+
         return new self($name, PhysicalType::INT64, null, Repetition::OPTIONAL);
     }
 

--- a/src/lib/parquet/tests/Flow/Parquet/Tests/Unit/ParquetFile/RowGroupBuilder/ColumnChunkSizeStatisticsTest.php
+++ b/src/lib/parquet/tests/Flow/Parquet/Tests/Unit/ParquetFile/RowGroupBuilder/ColumnChunkSizeStatisticsTest.php
@@ -1,0 +1,49 @@
+<?php declare(strict_types=1);
+
+namespace Flow\Parquet\Tests\Unit\ParquetFile\RowGroupBuilder;
+
+use Flow\Parquet\ParquetFile\RowGroupBuilder\ColumnChunkStatistics;
+use Flow\Parquet\ParquetFile\Schema\FlatColumn;
+use PHPUnit\Framework\TestCase;
+
+final class ColumnChunkSizeStatisticsTest extends TestCase
+{
+    public function test_int32_statistics() : void
+    {
+        $statistics = new ColumnChunkStatistics(FlatColumn::int32('int32'));
+
+        for ($i = 0; $i < 100; $i++) {
+            $statistics->add($i);
+        }
+
+        $this->assertSame(100, $statistics->valuesCount());
+        $this->assertSame(0, $statistics->nullCount());
+        $this->assertSame(4 * 100, $statistics->uncompressedSize());
+    }
+
+    public function test_int64_statistics() : void
+    {
+        $statistics = new ColumnChunkStatistics(FlatColumn::int64('int64'));
+
+        for ($i = 0; $i < 100; $i++) {
+            $statistics->add($i);
+        }
+
+        $this->assertSame(100, $statistics->valuesCount());
+        $this->assertSame(0, $statistics->nullCount());
+        $this->assertSame(8 * 100, $statistics->uncompressedSize());
+    }
+
+    public function test_string_statistics() : void
+    {
+        $statistics = new ColumnChunkStatistics(FlatColumn::string('int64'));
+
+        for ($i = 0; $i < 100; $i++) {
+            $statistics->add($string = 'string with a fixed length');
+        }
+
+        $this->assertSame(100, $statistics->valuesCount());
+        $this->assertSame(0, $statistics->nullCount());
+        $this->assertSame(\strlen($string) * $statistics->notNullCount() + (4 * $statistics->notNullCount()), $statistics->uncompressedSize());
+    }
+}


### PR DESCRIPTION

<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <li> Parquet - Calculate row group/page size on the fly in order to decide when to flush data to disk</li>
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

Ref: #575 

<!-- Please provide a short description of changes in this section, feel free to use markdown syntax -->

This is still early version of that feature, I'm going to work on calculating best page size a bit more, for example when string columns does not have too many unique values, it makes no sense to encode them with DICTIONARY as building the dictionary is becoming a bottleneck. I will need to adjust it and maybe make an option that would let user to decide that for example if 20% of values are duplicated, then use dictionary, otherwise plain text. 