### PR TITLE
Rework `GroupBy::result()` method to not recreate entries & rows in loop

### DIFF
--- a/src/core/etl/src/Flow/ETL/GroupBy.php
+++ b/src/core/etl/src/Flow/ETL/GroupBy.php
@@ -8,7 +8,6 @@ use Flow\ETL\Exception\InvalidArgumentException;
 use Flow\ETL\Exception\RuntimeException;
 use Flow\ETL\GroupBy\Aggregation;
 use Flow\ETL\GroupBy\Aggregator;
-use Flow\ETL\Row\Entries;
 use Flow\ETL\Row\Factory\NativeEntryFactory;
 use Flow\ETL\Row\Reference;
 use Flow\ETL\Row\References;
@@ -84,28 +83,26 @@ final class GroupBy
 
     public function result() : Rows
     {
-        $rows = new Rows();
+        $rows = [];
 
         foreach ($this->groups as $group) {
-            $entries = new Entries();
+            $entries = [];
 
-            if (\array_key_exists('values', $group)) {
-                /** @var mixed $value */
-                foreach ($group['values'] as $entry => $value) {
-                    $entries = $entries->add((new NativeEntryFactory)->create($entry, $value));
-                }
+            /** @var mixed $value */
+            foreach ($group['values'] ?? [] as $entry => $value) {
+                $entries[] = (new NativeEntryFactory)->create($entry, $value);
             }
 
             foreach ($group['aggregators'] as $aggregator) {
-                $entries = $entries->add($aggregator->result());
+                $entries[] = $aggregator->result();
             }
 
-            if ($entries->count()) {
-                $rows = $rows->add(new Row($entries));
+            if (\count($entries)) {
+                $rows[] = Row::create(...$entries);
             }
         }
 
-        return $rows;
+        return new Rows(...$rows);
     }
 
     /**

--- a/src/core/etl/src/Flow/ETL/GroupBy.php
+++ b/src/core/etl/src/Flow/ETL/GroupBy.php
@@ -8,7 +8,6 @@ use Flow\ETL\Exception\InvalidArgumentException;
 use Flow\ETL\Exception\RuntimeException;
 use Flow\ETL\GroupBy\Aggregation;
 use Flow\ETL\GroupBy\Aggregator;
-use Flow\ETL\Row\Factory\NativeEntryFactory;
 use Flow\ETL\Row\Reference;
 use Flow\ETL\Row\References;
 
@@ -81,7 +80,7 @@ final class GroupBy
         }
     }
 
-    public function result() : Rows
+    public function result(FlowContext $context) : Rows
     {
         $rows = [];
 
@@ -90,7 +89,7 @@ final class GroupBy
 
             /** @var mixed $value */
             foreach ($group['values'] ?? [] as $entry => $value) {
-                $entries[] = (new NativeEntryFactory)->create($entry, $value);
+                $entries[] = $context->entryFactory()->create($entry, $value);
             }
 
             foreach ($group['aggregators'] as $aggregator) {

--- a/src/core/etl/src/Flow/ETL/Pipeline/GroupByPipeline.php
+++ b/src/core/etl/src/Flow/ETL/Pipeline/GroupByPipeline.php
@@ -59,7 +59,7 @@ final class GroupByPipeline implements Pipeline
             $this->groupBy->group($nextRows);
         }
 
-        $this->nextPipeline->source(new Extractor\ProcessExtractor($this->groupBy->result()));
+        $this->nextPipeline->source(new Extractor\ProcessExtractor($this->groupBy->result($context)));
 
         foreach ($this->nextPipeline->process($context) as $nextRows) {
             yield $nextRows;

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/GroupByTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/GroupByTest.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Tests\Unit;
 
+use Flow\ETL\Config;
 use Flow\ETL\DSL\Entry;
 use Flow\ETL\Exception\InvalidArgumentException;
 use Flow\ETL\Exception\RuntimeException;
+use Flow\ETL\FlowContext;
 use Flow\ETL\GroupBy;
 use Flow\ETL\Row;
 use Flow\ETL\Rows;
@@ -44,7 +46,7 @@ final class GroupByTest extends TestCase
                 Row::create(Entry::null('type')),
                 Row::create(Entry::string('type', 'c'))
             ),
-            $groupBy->result()
+            $groupBy->result(new FlowContext(Config::default()))
         );
     }
 


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Rework `GroupBy::result()` method to not recreate entries & rows in loop</li>
    <li>Use `FlowContext` in `GroupBy`</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

This allows the removal of recreating entries and rows of objects in the loop, which is done in the `Rows::add()` & `Entries::add()` methods.
