### PR TITLE
Adjust `Rows::chunk()` to work on generators instead of arrays

### DIFF
--- a/.github/workflows/test-benchmark.yml
+++ b/.github/workflows/test-benchmark.yml
@@ -99,10 +99,10 @@ jobs:
             echo '  '
             echo '</details>'
             echo '  '
-            echo '<details><summary>Entry Factory</summary>'
+            echo '<details><summary>Building Blocks</summary>'
             echo '  '
             echo '```shell'
-            composer test:benchmark -- --ref=1.x --progress=none --group=entry_factory
+            composer test:benchmark -- --ref=1.x --progress=none --group=building_blocks
             echo '```'
             echo '  '
             echo '</details>'

--- a/src/adapter/etl-adapter-doctrine/src/Flow/ETL/Adapter/Doctrine/DbalLoader.php
+++ b/src/adapter/etl-adapter-doctrine/src/Flow/ETL/Adapter/Doctrine/DbalLoader.php
@@ -16,7 +16,7 @@ use Flow\ETL\Rows;
 /**
  * @implements Loader<array{
  *  table_name: string,
- *  chunk_size: int,
+ *  chunk_size: int<1, max>,
  *  connection_params: array<string, mixed>,
  *  operation: string,
  *  operation_options: array{
@@ -35,8 +35,7 @@ final class DbalLoader implements Loader
     private string $operation;
 
     /**
-     * @param string $tableName
-     * @param int $chunkSize
+     * @param int<1, max> $chunkSize
      * @param array<string, mixed> $connectionParams
      * @param array{
      *  skip_conflicts?: boolean,
@@ -45,7 +44,6 @@ final class DbalLoader implements Loader
      *  update_columns?: array<string>,
      *  primary_key_columns?: array<string>
      * } $operationOptions
-     * @param string $operation
      *
      * @throws InvalidArgumentException
      */
@@ -66,9 +64,7 @@ final class DbalLoader implements Loader
      * Since Connection::getParams() is marked as an internal method, please
      * use this constructor with caution.
      *
-     * @param Connection $connection
-     * @param string $tableName
-     * @param int $chunkSize
+     * @param int<1, max> $chunkSize
      * @param array{
      *  skip_conflicts?: boolean,
      *  constraint?: string,
@@ -76,7 +72,6 @@ final class DbalLoader implements Loader
      *  update_columns?: array<string>,
      *  primary_key_columns?: array<string>
      * } $operationOptions
-     * @param string $operation
      *
      * @throws InvalidArgumentException
      */

--- a/src/adapter/etl-adapter-doctrine/src/Flow/ETL/DSL/Dbal.php
+++ b/src/adapter/etl-adapter-doctrine/src/Flow/ETL/DSL/Dbal.php
@@ -71,8 +71,6 @@ class Dbal
      * @param int $page_size
      * @param null|int $maximum
      *
-     * @throws InvalidArgumentException
-     *
      * @return Extractor
      */
     final public static function from_limit_offset_qb(
@@ -135,8 +133,7 @@ class Dbal
 
     /**
      * @param array<string, mixed>|Connection $connection
-     * @param string $table
-     * @param int $chunk_size
+     * @param int<1, max> $chunk_size
      * @param array{
      *  skip_conflicts?: boolean,
      *  constraint?: string,
@@ -146,8 +143,6 @@ class Dbal
      * } $options
      *
      * @throws InvalidArgumentException
-     *
-     * @return Loader
      */
     final public static function to_table_insert(
         array|Connection $connection,
@@ -162,8 +157,7 @@ class Dbal
 
     /**
      * @param array<string, mixed>|Connection $connection
-     * @param string $table
-     * @param int $chunk_size
+     * @param int<1, max> $chunk_size
      * @param array{
      *  skip_conflicts?: boolean,
      *  constraint?: string,

--- a/src/adapter/etl-adapter-elasticsearch/src/Flow/ETL/Adapter/Elasticsearch/ElasticsearchPHP/ElasticsearchLoader.php
+++ b/src/adapter/etl-adapter-elasticsearch/src/Flow/ETL/Adapter/Elasticsearch/ElasticsearchPHP/ElasticsearchLoader.php
@@ -25,7 +25,7 @@ use Flow\ETL\Rows;
  *    elasticMetaHeader?: boolean,
  *    includePortInHostHeader?: boolean
  *  },
- *  chunk_size: int,
+ *  chunk_size: int<1, max>,
  *  index: string,
  *  id_factory: IdFactory,
  *  parameters: array<mixed>,
@@ -41,6 +41,7 @@ final class ElasticsearchLoader implements Loader
 
     /**
      * @param array{hosts?: array<string>, connectionParams?: array<mixed>, retries?: int, sniffOnStart?: boolean, sslCert?: array<string>, sslKey?: array<string>, sslVerification?: (boolean|string), elasticMetaHeader?: boolean, includePortInHostHeader?: boolean} $config
+     * @param int<1, max> $chunkSize
      * @param array<mixed> $parameters
      */
     public function __construct(
@@ -66,6 +67,7 @@ final class ElasticsearchLoader implements Loader
      *  elasticMetaHeader?: boolean,
      *  includePortInHostHeader?: boolean
      * } $clientConfig
+     * @param int<1, max> $chunkSize
      * @param array<mixed> $parameters
      */
     public static function update(array $clientConfig, int $chunkSize, string $index, IdFactory $idFactory, array $parameters = []) : self

--- a/src/adapter/etl-adapter-elasticsearch/src/Flow/ETL/DSL/Elasticsearch.php
+++ b/src/adapter/etl-adapter-elasticsearch/src/Flow/ETL/DSL/Elasticsearch.php
@@ -29,7 +29,7 @@ class Elasticsearch
      *  elasticMetaHeader?: boolean,
      *  includePortInHostHeader?: boolean
      * } $config
-     * @param int $chunk_size
+     * @param int<1, max> $chunk_size
      * @param string $index
      * @param IdFactory $id_factory
      * @param array<mixed> $parameters - https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-bulk.html
@@ -60,7 +60,7 @@ class Elasticsearch
      *  elasticMetaHeader?: boolean,
      *  includePortInHostHeader?: boolean
      * } $config
-     * @param int $chunk_size
+     * @param int<1, max> $chunk_size
      * @param string $index
      * @param IdFactory $id_factory
      * @param array<mixed> $parameters - https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-bulk.html

--- a/src/core/etl/src/Flow/ETL/DSL/From.php
+++ b/src/core/etl/src/Flow/ETL/DSL/From.php
@@ -35,6 +35,9 @@ class From
         return new MemoryExtractor(new ArrayMemory($array), $batch_size);
     }
 
+    /**
+     * @param int<1, max> $max_row_size
+     */
     final public static function buffer(Extractor $extractor, int $max_row_size) : Extractor
     {
         return new Extractor\BufferExtractor($extractor, $max_row_size);
@@ -50,6 +53,9 @@ class From
         return new Extractor\ChainExtractor(...$extractors);
     }
 
+    /**
+     * @param int<1, max> $chunk_size
+     */
     final public static function chunks_from(Extractor $extractor, int $chunk_size) : Extractor
     {
         return new Extractor\ChunkExtractor($extractor, $chunk_size);

--- a/src/core/etl/src/Flow/ETL/DSL/To.php
+++ b/src/core/etl/src/Flow/ETL/DSL/To.php
@@ -18,6 +18,9 @@ use Flow\ETL\Transformer;
  */
 class To
 {
+    /**
+     * @param int<1, max> $bufferSize
+     */
     final public static function buffer(Loader $overflowLoader, int $bufferSize) : Loader
     {
         return new Loader\BufferLoader($overflowLoader, $bufferSize);

--- a/src/core/etl/src/Flow/ETL/DataFrame.php
+++ b/src/core/etl/src/Flow/ETL/DataFrame.php
@@ -416,7 +416,7 @@ final class DataFrame
      *
      * @lazy
      *
-     * @throws InvalidArgumentException
+     * @param int<1, max> $chunks
      */
     public function parallelize(int $chunks) : self
     {

--- a/src/core/etl/src/Flow/ETL/ExternalSort/BufferCache.php
+++ b/src/core/etl/src/Flow/ETL/ExternalSort/BufferCache.php
@@ -17,6 +17,9 @@ final class BufferCache
      */
     private array $buffers = [];
 
+    /**
+     * @param int<1, max> $bufferSize
+     */
     public function __construct(
         private readonly Cache $overflowCache,
         private readonly int $bufferSize

--- a/src/core/etl/src/Flow/ETL/ExternalSort/CacheExternalSort.php
+++ b/src/core/etl/src/Flow/ETL/ExternalSort/CacheExternalSort.php
@@ -34,7 +34,7 @@ final class CacheExternalSort implements ExternalSort
     {
         /** @var array<string, \Generator<Rows>> $cachedPartsArray */
         $cachedPartsArray = [];
-        $maxRowsSize = 0;
+        $maxRowsSize = 1;
 
         /** @var int $i */
         foreach ($this->cache->read($this->id) as $i => $rows) {

--- a/src/core/etl/src/Flow/ETL/ExternalSort/MemorySort.php
+++ b/src/core/etl/src/Flow/ETL/ExternalSort/MemorySort.php
@@ -31,7 +31,7 @@ final class MemorySort implements ExternalSort
         private readonly Cache $cache,
         private Unit $maximumMemory
     ) {
-        $this->configuration = new Configuration($safetyBufferPercentage = 10);
+        $this->configuration = new Configuration(10);
 
         if ($this->configuration->isLessThan($maximumMemory) && !$this->configuration->isInfinite()) {
             /**
@@ -48,7 +48,7 @@ final class MemorySort implements ExternalSort
         $memoryConsumption = new Consumption();
 
         $mergedRows = new Rows();
-        $maxSize = 0;
+        $maxSize = 1;
 
         foreach ($this->cache->read($this->cacheId) as $rows) {
             $maxSize = \max($rows->count(), $maxSize);
@@ -64,6 +64,6 @@ final class MemorySort implements ExternalSort
 
         $this->cache->clear($this->cacheId);
 
-        return new Extractor\ProcessExtractor(...$mergedRows->sortBy(...$refs)->chunks($maxSize));
+        return new Extractor\ProcessExtractor(...\iterator_to_array($mergedRows->sortBy(...$refs)->chunks($maxSize)));
     }
 }

--- a/src/core/etl/src/Flow/ETL/ExternalSort/MemorySort.php
+++ b/src/core/etl/src/Flow/ETL/ExternalSort/MemorySort.php
@@ -64,6 +64,6 @@ final class MemorySort implements ExternalSort
 
         $this->cache->clear($this->cacheId);
 
-        return new Extractor\ProcessExtractor(...\iterator_to_array($mergedRows->sortBy(...$refs)->chunks($maxSize)));
+        return new Extractor\GeneratorExtractor($mergedRows->sortBy(...$refs)->chunks($maxSize));
     }
 }

--- a/src/core/etl/src/Flow/ETL/Extractor/BufferExtractor.php
+++ b/src/core/etl/src/Flow/ETL/Extractor/BufferExtractor.php
@@ -10,6 +10,9 @@ use Flow\ETL\Rows;
 
 final class BufferExtractor implements Extractor, OverridingExtractor
 {
+    /**
+     * @param int<1, max> $maxRowsSize
+     */
     public function __construct(
         private readonly Extractor $extractor,
         private readonly int $maxRowsSize

--- a/src/core/etl/src/Flow/ETL/Extractor/ChunkExtractor.php
+++ b/src/core/etl/src/Flow/ETL/Extractor/ChunkExtractor.php
@@ -9,6 +9,9 @@ use Flow\ETL\FlowContext;
 
 final class ChunkExtractor implements Extractor, OverridingExtractor
 {
+    /**
+     * @param int<1, max> $chunkSize
+     */
     public function __construct(
         private readonly Extractor $extractor,
         private readonly int $chunkSize

--- a/src/core/etl/src/Flow/ETL/Extractor/GeneratorExtractor.php
+++ b/src/core/etl/src/Flow/ETL/Extractor/GeneratorExtractor.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Extractor;
 
+use Flow\ETL\Exception\InvalidArgumentException;
 use Flow\ETL\Extractor;
 use Flow\ETL\FlowContext;
 use Flow\ETL\Rows;
@@ -22,6 +23,12 @@ final class GeneratorExtractor implements Extractor
 
     public function extract(FlowContext $context) : \Generator
     {
-        yield from $this->rows;
+        foreach ($this->rows as $row) {
+            if (!$row instanceof Rows) {
+                throw new InvalidArgumentException('Passed generator can contain only Rows class instances, given: ' . $row::class);
+            }
+
+            yield $row;
+        }
     }
 }

--- a/src/core/etl/src/Flow/ETL/Extractor/GeneratorExtractor.php
+++ b/src/core/etl/src/Flow/ETL/Extractor/GeneratorExtractor.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Extractor;
+
+use Flow\ETL\Extractor;
+use Flow\ETL\FlowContext;
+use Flow\ETL\Rows;
+
+/**
+ * @internal
+ */
+final class GeneratorExtractor implements Extractor
+{
+    /**
+     * @param \Generator<Rows> $rows
+     */
+    public function __construct(private readonly \Generator $rows)
+    {
+    }
+
+    public function extract(FlowContext $context) : \Generator
+    {
+        yield from $this->rows;
+    }
+}

--- a/src/core/etl/src/Flow/ETL/Loader/BufferLoader.php
+++ b/src/core/etl/src/Flow/ETL/Loader/BufferLoader.php
@@ -10,12 +10,15 @@ use Flow\ETL\Pipeline\Closure;
 use Flow\ETL\Rows;
 
 /**
- * @implements Loader<array{overflow_loader: Loader, buffer_size: int}>
+ * @implements Loader<array{overflow_loader: Loader, buffer_size: int<1, max>}>
  */
 final class BufferLoader implements Closure, Loader, OverridingLoader
 {
     private Rows $buffer;
 
+    /**
+     * @param int<1, max> $bufferSize
+     */
     public function __construct(private readonly Loader $overflowLoader, private readonly int $bufferSize)
     {
         $this->buffer = new Rows();

--- a/src/core/etl/src/Flow/ETL/Pipeline/ParallelizingPipeline.php
+++ b/src/core/etl/src/Flow/ETL/Pipeline/ParallelizingPipeline.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Flow\ETL\Pipeline;
 
 use Flow\ETL\DSL\From;
-use Flow\ETL\Exception\InvalidArgumentException;
 use Flow\ETL\Extractor;
 use Flow\ETL\FlowContext;
 use Flow\ETL\Loader;
@@ -20,14 +19,13 @@ final class ParallelizingPipeline implements Pipeline
 {
     private readonly Pipeline $nextPipeline;
 
+    /**
+     * @param int<1, max> $parallel
+     */
     public function __construct(
         private readonly Pipeline $pipeline,
         private readonly int $parallel
     ) {
-        if ($parallel < 1) {
-            throw new InvalidArgumentException("Parallel value can't be lower than 1.");
-        }
-
         $this->nextPipeline = $pipeline->cleanCopy();
     }
 

--- a/src/core/etl/src/Flow/ETL/Rows.php
+++ b/src/core/etl/src/Flow/ETL/Rows.php
@@ -59,26 +59,21 @@ final class Rows implements \ArrayAccess, \Countable, \IteratorAggregate, Serial
     public function add(Row ...$rows) : self
     {
         return new self(
-            ...\array_merge($this->rows, $rows)
+            ...$this->rows,
+            ...$rows
         );
     }
 
     /**
-     * @return Rows[]
+     * @param int<1, max> $size
+     *
+     * @return \Generator<Rows>
      */
-    public function chunks(int $size) : array
+    public function chunks(int $size) : \Generator
     {
-        if ($size < 1) {
-            throw InvalidArgumentException::because('Chunk size must be greater than 0');
-        }
-
-        $chunks = [];
-
         foreach (\array_chunk($this->rows, $size) as $chunk) {
-            $chunks[] = new self(...$chunk);
+            yield new self(...$chunk);
         }
-
-        return $chunks;
     }
 
     public function count() : int

--- a/src/core/etl/tests/Flow/ETL/Tests/Benchmark/EntryFactory/NativeEntryFactoryBench.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Benchmark/EntryFactory/NativeEntryFactoryBench.php
@@ -11,7 +11,7 @@ use PhpBench\Attributes\Iterations;
 use PhpBench\Attributes\Revs;
 
 #[Iterations(5)]
-#[Groups(['entry_factory'])]
+#[Groups(['building_blocks'])]
 final class NativeEntryFactoryBench
 {
     private array $rowsArray = [];

--- a/src/core/etl/tests/Flow/ETL/Tests/Benchmark/RowsBench.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Benchmark/RowsBench.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types=1);
+
+use Flow\ETL\Rows;
+use PhpBench\Attributes\Groups;
+use PhpBench\Attributes\Iterations;
+use PhpBench\Attributes\Revs;
+
+#[Iterations(5)]
+#[Groups(['rows'])]
+final class RowsBench
+{
+    private Rows $rows;
+
+    public function __construct()
+    {
+        $this->rows = Rows::fromArray(
+            \array_merge(...\array_map(static fn () : array => [
+                ['id' => 1, 'random' => false, 'text' => null, 'from' => 666],
+                ['id' => 2, 'random' => true, 'text' => null, 'from' => 666],
+                ['id' => 3, 'random' => false, 'text' => null, 'from' => 666],
+                ['id' => 4, 'random' => true, 'text' => null, 'from' => 666],
+                ['id' => 5, 'random' => false, 'text' => null, 'from' => 666],
+            ], \range(0, 10_000)))
+        );
+    }
+
+    #[Revs(5)]
+    public function bench_chunk_10() : void
+    {
+        foreach ($this->rows->chunks(10) as $chunk) {
+
+        }
+    }
+}

--- a/src/core/etl/tests/Flow/ETL/Tests/Benchmark/RowsBench.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Benchmark/RowsBench.php
@@ -6,7 +6,7 @@ use PhpBench\Attributes\Iterations;
 use PhpBench\Attributes\Revs;
 
 #[Iterations(5)]
-#[Groups(['rows'])]
+#[Groups(['building_blocks'])]
 final class RowsBench
 {
     private Rows $rows;

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/RowsTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/RowsTest.php
@@ -189,13 +189,6 @@ final class RowsTest extends TestCase
         );
     }
 
-    public function test_chunks_smaller_than_1() : void
-    {
-        $this->expectException(InvalidArgumentException::class);
-
-        (new Rows())->chunks(-1);
-    }
-
     public function test_chunks_with_less() : void
     {
         $rows = new Rows(
@@ -208,8 +201,10 @@ final class RowsTest extends TestCase
             Row::create(new IntegerEntry('id', 7)),
         );
 
-        $this->assertCount(1, $rows->chunks(10));
-        $this->assertSame([1, 2, 3, 4, 5, 6, 7], $rows->chunks(10)[0]->reduceToArray('id'));
+        $chunk = \iterator_to_array($rows->chunks(10));
+
+        $this->assertCount(1, $chunk);
+        $this->assertSame([1, 2, 3, 4, 5, 6, 7], $chunk[0]->reduceToArray('id'));
     }
 
     public function test_chunks_with_more_than_expected_in_chunk_rows() : void
@@ -227,9 +222,11 @@ final class RowsTest extends TestCase
             Row::create(new IntegerEntry('id', 10)),
         );
 
-        $this->assertCount(2, $rows->chunks(5));
-        $this->assertSame([1, 2, 3, 4, 5], $rows->chunks(5)[0]->reduceToArray('id'));
-        $this->assertSame([6, 7, 8, 9, 10], $rows->chunks(5)[1]->reduceToArray('id'));
+        $chunk = \iterator_to_array($rows->chunks(5));
+
+        $this->assertCount(2, $chunk);
+        $this->assertSame([1, 2, 3, 4, 5], $chunk[0]->reduceToArray('id'));
+        $this->assertSame([6, 7, 8, 9, 10], $chunk[1]->reduceToArray('id'));
     }
 
     public function test_drop() : void


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Adjust Rows::chunk() to work on generators instead of arrays</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

Old:
```console
+-----------------------------+--------------------------+------+-----+-----------+-----------+
| benchmark                   | subject                  | revs | its | mem_peak  | mode      |
+-----------------------------+--------------------------+------+-----+-----------+-----------+
| RowsBench                   | bench_chunk_10           | 5    | 5   | 60.408mb  | 3.335ms   |
+-----------------------------+--------------------------+------+-----+-----------+-----------+
```

New:
```console
+-----------------------------+--------------------------+------+-----+-----------+-----------+
| benchmark                   | subject                  | revs | its | mem_peak  | mode      |
+-----------------------------+--------------------------+------+-----+-----------+-----------+
| RowsBench                   | bench_chunk_10           | 5    | 5   | 57.885mb  | 1.600μs   |
+-----------------------------+--------------------------+------+-----+-----------+-----------+
```
