### PR TITLE
Prevent fatal error when no values are set in `ColumnChunkStatistics`

### DIFF
--- a/src/lib/parquet/src/Flow/Parquet/ParquetFile/RowGroupBuilder/ColumnChunkStatistics.php
+++ b/src/lib/parquet/src/Flow/Parquet/ParquetFile/RowGroupBuilder/ColumnChunkStatistics.php
@@ -63,16 +63,28 @@ final class ColumnChunkStatistics
 
     public function avgStringLength() : int
     {
+        if (0 === $this->notNullCount()) {
+            return 0;
+        }
+
         return (int) \ceil($this->totalStringLength / $this->notNullCount());
     }
 
     public function cardinalityRation() : float
     {
+        if (0 === $this->notNullCount()) {
+            return 0;
+        }
+
         return \round($this->distinctCount() / $this->notNullCount(), 2);
     }
 
     public function distinctCount() : int
     {
+        if ([] === $this->values) {
+            return 0;
+        }
+
         return \count(\array_unique($this->values));
     }
 


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>Prevent fatal error when no values are set in `ColumnChunkStatistics`</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

Code borrowed from: https://github.com/flow-php/flow/pull/653

Error:
```console
Fatal error: Uncaught DivisionByZeroError: Division by zero in /Users/stloyd/Documents/flow/src/lib/parquet/src/Flow/Parquet/ParquetFile/RowGroupBuilder/ColumnChunkStatistics.php:71
Stack trace:
#0 /Users/stloyd/Documents/flow/src/lib/parquet/src/Flow/Parquet/ParquetFile/RowGroupBuilder/PagesBuilder.php(25): Flow\Parquet\ParquetFile\RowGroupBuilder\ColumnChunkStatistics->cardinalityRation()
#1 /Users/stloyd/Documents/flow/src/lib/parquet/src/Flow/Parquet/ParquetFile/RowGroupBuilder/ColumnChunkBuilder.php(34): Flow\Parquet\ParquetFile\RowGroupBuilder\PagesBuilder->build(Object(Flow\Parquet\ParquetFile\Schema\FlatColumn), Array, Object(Flow\Parquet\ParquetFile\RowGroupBuilder\ColumnChunkStatistics))
#2 /Users/stloyd/Documents/flow/src/lib/parquet/src/Flow/Parquet/ParquetFile/RowGroupBuilder.php(63): Flow\Parquet\ParquetFile\RowGroupBuilder\ColumnChunkBuilder->flush(4)
#3 /Users/stloyd/Documents/flow/src/lib/parquet/src/Flow/Parquet/Writer.php(59): Flow\Parquet\ParquetFile\RowGroupBuilder->flush(4)
#4 /Users/stloyd/Documents/flow/var/profile.php(65): Flow\Parquet\Writer->write('/Users/stloyd/D...', Object(Flow\Parquet\ParquetFile\Schema), Array)
#5 {main}
  thrown in /Users/stloyd/Documents/flow/src/lib/parquet/src/Flow/Parquet/ParquetFile/RowGroupBuilder/ColumnChunkStatistics.php on line 71

