### PR TITLE
Prevent calling same class methods inside of schema files

### DIFF
--- a/src/lib/parquet/src/Flow/Parquet/ParquetFile/Schema/FlatColumn.php
+++ b/src/lib/parquet/src/Flow/Parquet/ParquetFile/Schema/FlatColumn.php
@@ -150,8 +150,8 @@ final class FlatColumn implements Column
     {
         return [
             /** @phpstan-ignore-next-line */
-            'type' => $this->type()->name . ($this->logicalType()?->name() !== null ? ' (' . $this->logicalType()?->name() . ')' : ''),
-            'optional' => $this->repetition()?->value === Repetition::OPTIONAL->value,
+            'type' => $this->type->name . ($this->logicalType?->name() !== null ? ' (' . $this->logicalType?->name() . ')' : ''),
+            'optional' => $this->repetition?->value === Repetition::OPTIONAL->value,
         ];
     }
 
@@ -161,7 +161,7 @@ final class FlatColumn implements Column
             return $this->flatPath;
         }
 
-        $parent = $this->parent();
+        $parent = $this->parent;
 
         if ($parent?->schemaRoot) {
             $this->flatPath = $this->name;
@@ -228,11 +228,11 @@ final class FlatColumn implements Column
             return true;
         }
 
-        if ($this->parent()?->parent()?->logicalType()?->name() === 'MAP') {
+        if ($this->parent->parent()?->logicalType()?->name() === 'MAP') {
             return true;
         }
 
-        if ($this->parent()?->parent()?->parent()?->logicalType()?->name() === 'MAP') {
+        if ($this->parent->parent()?->parent()?->logicalType()?->name() === 'MAP') {
             return true;
         }
 
@@ -297,13 +297,13 @@ final class FlatColumn implements Column
     {
         return [
             'type' => 'flat',
-            'name' => $this->name(),
+            'name' => $this->name,
             'flat_path' => $this->flatPath(),
-            'physical_type' => $this->type()->name,
-            'logical_type' => $this->logicalType()?->name(),
-            'repetition' => $this->repetition()?->name,
-            'precision' => $this->precision(),
-            'scale' => $this->scale(),
+            'physical_type' => $this->type->name,
+            'logical_type' => $this->logicalType?->name(),
+            'repetition' => $this->repetition?->name,
+            'precision' => $this->precision,
+            'scale' => $this->scale,
             'max_definition_level' => $this->maxDefinitionsLevel(),
             'max_repetition_level' => $this->maxRepetitionsLevel(),
             'children' => null,

--- a/src/lib/parquet/src/Flow/Parquet/ParquetFile/Schema/LogicalType.php
+++ b/src/lib/parquet/src/Flow/Parquet/ParquetFile/Schema/LogicalType.php
@@ -180,7 +180,7 @@ final class LogicalType
 
     public function is(string $logicalType) : bool
     {
-        return $this->name() === $logicalType;
+        return $this->name === $logicalType;
     }
 
     public function name() : string
@@ -199,8 +199,8 @@ final class LogicalType
             self::BSON => $this->is(self::BSON) ? new \Flow\Parquet\Thrift\BsonType() : null,
             self::DATE => $this->is(self::DATE) ? new \Flow\Parquet\Thrift\DateType() : null,
             self::DECIMAL => $this->is(self::DECIMAL) ? new \Flow\Parquet\Thrift\DecimalType([
-                'scale' => $this->decimalData()?->scale(),
-                'precision' => $this->decimalData()?->precision(),
+                'scale' => $this->decimal?->scale(),
+                'precision' => $this->decimal?->precision(),
             ]) : null,
             self::ENUM => $this->is(self::ENUM) ? new \Flow\Parquet\Thrift\EnumType() : null,
             self::INTEGER => $this->is(self::INTEGER) ? new \Flow\Parquet\Thrift\IntType() : null,
@@ -210,11 +210,11 @@ final class LogicalType
             self::STRING => $this->is(self::STRING) ? new \Flow\Parquet\Thrift\StringType() : null,
             self::TIME => $this->is(self::TIME) ? new \Flow\Parquet\Thrift\TimeType() : null,
             self::TIMESTAMP => $this->is(self::TIMESTAMP) ? new \Flow\Parquet\Thrift\TimestampType([
-                'isAdjustedToUTC' => $this->timestampData()?->isAdjustedToUTC(),
+                'isAdjustedToUTC' => $this->timestamp?->isAdjustedToUTC(),
                 'unit' => new TimeUnit([
-                    'MILLIS' => $this->timestampData()?->millis() ? new \Flow\Parquet\Thrift\MilliSeconds() : null,
-                    'MICROS' => $this->timestampData()?->micros() ? new \Flow\Parquet\Thrift\MicroSeconds() : null,
-                    'NANOS' => $this->timestampData()?->nanos() ? new \Flow\Parquet\Thrift\NanoSeconds() : null,
+                    'MILLIS' => $this->timestamp?->millis() ? new \Flow\Parquet\Thrift\MilliSeconds() : null,
+                    'MICROS' => $this->timestamp?->micros() ? new \Flow\Parquet\Thrift\MicroSeconds() : null,
+                    'NANOS' => $this->timestamp?->nanos() ? new \Flow\Parquet\Thrift\NanoSeconds() : null,
                 ]),
             ]) : null,
             self::UNKNOWN => $this->is(self::UNKNOWN) ? new \Flow\Parquet\Thrift\NullType() : null,

--- a/src/lib/parquet/src/Flow/Parquet/ParquetFile/Schema/NestedColumn.php
+++ b/src/lib/parquet/src/Flow/Parquet/ParquetFile/Schema/NestedColumn.php
@@ -138,7 +138,7 @@ final class NestedColumn implements Column
     {
         $ddlArray = [
             'type' => 'group',
-            'optional' => $this->repetition()?->value === Repetition::OPTIONAL->value,
+            'optional' => $this->repetition?->value === Repetition::OPTIONAL->value,
             'children' => [],
         ];
 
@@ -155,7 +155,7 @@ final class NestedColumn implements Column
             return $this->flatPath;
         }
 
-        $parent = $this->parent();
+        $parent = $this->parent;
 
         if ($parent?->schemaRoot) {
             $this->flatPath = $this->name;
@@ -187,7 +187,7 @@ final class NestedColumn implements Column
     {
         if ($this->isList()) {
             /** @phpstan-ignore-next-line */
-            return $this->children()[0]->children()[0];
+            return $this->children[0]->children()[0];
         }
 
         throw new InvalidArgumentException('Column ' . $this->flatPath() . ' is not a list');
@@ -200,7 +200,7 @@ final class NestedColumn implements Column
     {
         if ($this->isMap()) {
             /** @phpstan-ignore-next-line */
-            return $this->children()[0]->children()[0];
+            return $this->children[0]->children()[0];
         }
 
         throw new InvalidArgumentException('Column ' . $this->flatPath() . ' is not a map');
@@ -213,7 +213,7 @@ final class NestedColumn implements Column
     {
         if ($this->isMap()) {
             /** @phpstan-ignore-next-line */
-            return $this->children()[0]->children()[1];
+            return $this->children[0]->children()[1];
         }
 
         throw new InvalidArgumentException('Column ' . $this->flatPath() . ' is not a map');
@@ -221,7 +221,7 @@ final class NestedColumn implements Column
 
     public function isList() : bool
     {
-        return $this->logicalType()?->name() === 'LIST';
+        return $this->logicalType?->name() === 'LIST';
     }
 
     public function isListElement() : bool
@@ -243,7 +243,7 @@ final class NestedColumn implements Column
 
     public function isMap() : bool
     {
-        return $this->logicalType()?->name() === 'MAP';
+        return $this->logicalType?->name() === 'MAP';
     }
 
     public function isMapElement() : bool
@@ -252,11 +252,11 @@ final class NestedColumn implements Column
             return false;
         }
 
-        if ($this->parent()?->logicalType()?->name() === 'MAP') {
+        if ($this->parent->logicalType()?->name() === 'MAP') {
             return true;
         }
 
-        if ($this->parent()?->parent()?->logicalType()?->name() === 'MAP') {
+        if ($this->parent->parent()?->logicalType()?->name() === 'MAP') {
             return true;
         }
 
@@ -299,7 +299,7 @@ final class NestedColumn implements Column
         if ($this->repetition === null) {
             $level = 0;
         } else {
-            $level = $this->repetition() === Repetition::REQUIRED ? 0 : 1;
+            $level = $this->repetition === Repetition::REQUIRED ? 0 : 1;
         }
 
         return $this->parent ? $level + $this->parent->maxDefinitionsLevel() : $level;
@@ -310,7 +310,7 @@ final class NestedColumn implements Column
         if ($this->repetition === null) {
             $level = 0;
         } else {
-            $level = $this->repetition() === Repetition::REPEATED ? 1 : 0;
+            $level = $this->repetition === Repetition::REPEATED ? 1 : 0;
         }
 
         return $this->parent ? $level + $this->parent->maxRepetitionsLevel() : $level;
@@ -325,11 +325,11 @@ final class NestedColumn implements Column
     {
         return [
             'type' => 'nested',
-            'name' => $this->name(),
+            'name' => $this->name,
             'flat_path' => $this->flatPath(),
-            'physical_type' => $this->type()?->name,
-            'logical_type' => $this->logicalType()?->name(),
-            'repetition' => $this->repetition()?->name,
+            'physical_type' => null,
+            'logical_type' => $this->logicalType?->name(),
+            'repetition' => $this->repetition?->name,
             'max_definition_level' => $this->maxDefinitionsLevel(),
             'max_repetition_level' => $this->maxRepetitionsLevel(),
             'children' => $this->normalizeChildren(),
@@ -393,11 +393,11 @@ final class NestedColumn implements Column
     {
         $elements = [
             new SchemaElement([
-                'name' => $this->name(),
+                'name' => $this->name,
                 'num_children' => \count($this->children),
                 'converted_type' => null,
-                'repetition_type' => $this->repetition()?->value,
-                'logicalType' => $this->logicalType()?->toThrift(),
+                'repetition_type' => $this->repetition?->value,
+                'logicalType' => $this->logicalType?->toThrift(),
             ]),
         ];
 


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Prevent calling same class methods inside of schema files</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

Skipping calling additional methods in the matter of accessing internal variables in class improves performance.

See: https://3v4l.org/sOIct
