### PR TITLE
Rework benchmarks to set up test data in constructors

### DIFF
--- a/src/adapter/etl-adapter-avro/tests/Flow/ETL/Adapter/Avro/Tests/Benchmark/AvroExtractorBench.php
+++ b/src/adapter/etl-adapter-avro/tests/Flow/ETL/Adapter/Avro/Tests/Benchmark/AvroExtractorBench.php
@@ -5,6 +5,7 @@ namespace Flow\ETL\Adapter\Avro\Tests\Benchmark;
 use Flow\ETL\Config;
 use Flow\ETL\DSL\Avro;
 use Flow\ETL\FlowContext;
+use PhpBench\Attributes\BeforeMethods;
 use PhpBench\Attributes\Groups;
 use PhpBench\Attributes\Iterations;
 use PhpBench\Attributes\Revs;
@@ -13,10 +14,18 @@ use PhpBench\Attributes\Revs;
 #[Groups(['extractor'])]
 final class AvroExtractorBench
 {
+    private ?FlowContext $context = null;
+
+    public function setUp() : void
+    {
+        $this->context = new FlowContext(Config::default());
+    }
+
+    #[BeforeMethods(['setUp'])]
     #[Revs(5)]
     public function bench_extract_10k() : void
     {
-        foreach (Avro::from(__DIR__ . '/../Fixtures/orders_flow.avro')->extract(new FlowContext(Config::default())) as $rows) {
+        foreach (Avro::from(__DIR__ . '/../Fixtures/orders_flow.avro')->extract($this->context) as $rows) {
         }
     }
 }

--- a/src/adapter/etl-adapter-avro/tests/Flow/ETL/Adapter/Avro/Tests/Benchmark/AvroExtractorBench.php
+++ b/src/adapter/etl-adapter-avro/tests/Flow/ETL/Adapter/Avro/Tests/Benchmark/AvroExtractorBench.php
@@ -5,7 +5,6 @@ namespace Flow\ETL\Adapter\Avro\Tests\Benchmark;
 use Flow\ETL\Config;
 use Flow\ETL\DSL\Avro;
 use Flow\ETL\FlowContext;
-use PhpBench\Attributes\BeforeMethods;
 use PhpBench\Attributes\Groups;
 use PhpBench\Attributes\Iterations;
 use PhpBench\Attributes\Revs;
@@ -14,14 +13,13 @@ use PhpBench\Attributes\Revs;
 #[Groups(['extractor'])]
 final class AvroExtractorBench
 {
-    private ?FlowContext $context = null;
+    private FlowContext $context;
 
-    public function setUp() : void
+    public function __construct()
     {
         $this->context = new FlowContext(Config::default());
     }
 
-    #[BeforeMethods(['setUp'])]
     #[Revs(5)]
     public function bench_extract_10k() : void
     {

--- a/src/adapter/etl-adapter-avro/tests/Flow/ETL/Adapter/Avro/Tests/Benchmark/AvroLoaderBench.php
+++ b/src/adapter/etl-adapter-avro/tests/Flow/ETL/Adapter/Avro/Tests/Benchmark/AvroLoaderBench.php
@@ -6,7 +6,6 @@ use Flow\ETL\Config;
 use Flow\ETL\DSL\Avro;
 use Flow\ETL\FlowContext;
 use Flow\ETL\Rows;
-use PhpBench\Attributes\BeforeMethods;
 use PhpBench\Attributes\Groups;
 use PhpBench\Attributes\Iterations;
 use PhpBench\Attributes\Revs;
@@ -15,14 +14,13 @@ use PhpBench\Attributes\Revs;
 #[Groups(['loader'])]
 final class AvroLoaderBench
 {
-    private ?FlowContext $context = null;
+    private FlowContext $context;
 
-    private ?Rows $rows = null;
+    private Rows $rows;
 
-    public function setUp() : void
+    public function __construct()
     {
         $this->context = new FlowContext(Config::default());
-
         $this->rows = new Rows();
 
         foreach (Avro::from(__DIR__ . '/../Fixtures/orders_flow.avro')->extract($this->context) as $rows) {
@@ -30,7 +28,6 @@ final class AvroLoaderBench
         }
     }
 
-    #[BeforeMethods(['setUp'])]
     #[Revs(5)]
     public function bench_load_10k() : void
     {

--- a/src/adapter/etl-adapter-csv/tests/Flow/ETL/Adapter/CSV/Tests/Benchmark/CSVExtractorBench.php
+++ b/src/adapter/etl-adapter-csv/tests/Flow/ETL/Adapter/CSV/Tests/Benchmark/CSVExtractorBench.php
@@ -13,10 +13,17 @@ use PhpBench\Attributes\Revs;
 #[Groups(['extractor'])]
 final class CSVExtractorBench
 {
+    private FlowContext $context;
+
+    public function __construct()
+    {
+        $this->context = new FlowContext(Config::default());
+    }
+
     #[Revs(5)]
     public function bench_extract_10k() : void
     {
-        foreach (CSV::from(__DIR__ . '/../Fixtures/orders_flow.csv')->extract(new FlowContext(Config::default())) as $rows) {
+        foreach (CSV::from(__DIR__ . '/../Fixtures/orders_flow.csv')->extract($this->context) as $rows) {
         }
     }
 }

--- a/src/adapter/etl-adapter-csv/tests/Flow/ETL/Adapter/CSV/Tests/Benchmark/CSVLoaderBench.php
+++ b/src/adapter/etl-adapter-csv/tests/Flow/ETL/Adapter/CSV/Tests/Benchmark/CSVLoaderBench.php
@@ -6,7 +6,6 @@ use Flow\ETL\Config;
 use Flow\ETL\DSL\CSV;
 use Flow\ETL\FlowContext;
 use Flow\ETL\Rows;
-use PhpBench\Attributes\BeforeMethods;
 use PhpBench\Attributes\Groups;
 use PhpBench\Attributes\Iterations;
 use PhpBench\Attributes\Revs;
@@ -15,14 +14,13 @@ use PhpBench\Attributes\Revs;
 #[Groups(['loader'])]
 final class CSVLoaderBench
 {
-    private ?FlowContext $context = null;
+    private FlowContext $context;
 
-    private ?Rows $rows = null;
+    private Rows $rows;
 
-    public function setUp() : void
+    public function __construct()
     {
         $this->context = new FlowContext(Config::default());
-
         $this->rows = new Rows();
 
         foreach (CSV::from(__DIR__ . '/../Fixtures/orders_flow.csv')->extract($this->context) as $rows) {
@@ -30,7 +28,6 @@ final class CSVLoaderBench
         }
     }
 
-    #[BeforeMethods(['setUp'])]
     #[Revs(5)]
     public function bench_load_10k() : void
     {

--- a/src/adapter/etl-adapter-json/tests/Flow/ETL/Adapter/JSON/Tests/Benchmark/JsonExtractorBench.php
+++ b/src/adapter/etl-adapter-json/tests/Flow/ETL/Adapter/JSON/Tests/Benchmark/JsonExtractorBench.php
@@ -5,6 +5,7 @@ namespace Flow\ETL\Adapter\JSON\Tests\Benchmark;
 use Flow\ETL\Config;
 use Flow\ETL\DSL\Json;
 use Flow\ETL\FlowContext;
+use PhpBench\Attributes\BeforeMethods;
 use PhpBench\Attributes\Groups;
 use PhpBench\Attributes\Iterations;
 use PhpBench\Attributes\Revs;
@@ -13,10 +14,18 @@ use PhpBench\Attributes\Revs;
 #[Groups(['extractor'])]
 final class JsonExtractorBench
 {
+    private ?FlowContext $context = null;
+
+    public function setUp() : void
+    {
+        $this->context = new FlowContext(Config::default());
+    }
+
+    #[BeforeMethods(['setUp'])]
     #[Revs(5)]
     public function bench_extract_10k() : void
     {
-        foreach (Json::from(__DIR__ . '/../Fixtures/orders_flow.json')->extract(new FlowContext(Config::default())) as $rows) {
+        foreach (Json::from(__DIR__ . '/../Fixtures/orders_flow.json')->extract($this->context) as $rows) {
         }
     }
 }

--- a/src/adapter/etl-adapter-json/tests/Flow/ETL/Adapter/JSON/Tests/Benchmark/JsonExtractorBench.php
+++ b/src/adapter/etl-adapter-json/tests/Flow/ETL/Adapter/JSON/Tests/Benchmark/JsonExtractorBench.php
@@ -5,7 +5,6 @@ namespace Flow\ETL\Adapter\JSON\Tests\Benchmark;
 use Flow\ETL\Config;
 use Flow\ETL\DSL\Json;
 use Flow\ETL\FlowContext;
-use PhpBench\Attributes\BeforeMethods;
 use PhpBench\Attributes\Groups;
 use PhpBench\Attributes\Iterations;
 use PhpBench\Attributes\Revs;
@@ -14,14 +13,13 @@ use PhpBench\Attributes\Revs;
 #[Groups(['extractor'])]
 final class JsonExtractorBench
 {
-    private ?FlowContext $context = null;
+    private FlowContext $context;
 
-    public function setUp() : void
+    public function __construct()
     {
         $this->context = new FlowContext(Config::default());
     }
 
-    #[BeforeMethods(['setUp'])]
     #[Revs(5)]
     public function bench_extract_10k() : void
     {

--- a/src/adapter/etl-adapter-json/tests/Flow/ETL/Adapter/JSON/Tests/Benchmark/JsonLoaderBench.php
+++ b/src/adapter/etl-adapter-json/tests/Flow/ETL/Adapter/JSON/Tests/Benchmark/JsonLoaderBench.php
@@ -6,7 +6,6 @@ use Flow\ETL\Config;
 use Flow\ETL\DSL\Json;
 use Flow\ETL\FlowContext;
 use Flow\ETL\Rows;
-use PhpBench\Attributes\BeforeMethods;
 use PhpBench\Attributes\Groups;
 use PhpBench\Attributes\Iterations;
 use PhpBench\Attributes\Revs;
@@ -15,14 +14,13 @@ use PhpBench\Attributes\Revs;
 #[Groups(['loader'])]
 final class JsonLoaderBench
 {
-    private ?FlowContext $context = null;
+    private FlowContext $context;
 
-    private ?Rows $rows = null;
+    private Rows $rows;
 
-    public function setUp() : void
+    public function __construct()
     {
         $this->context = new FlowContext(Config::default());
-
         $this->rows = new Rows();
 
         foreach (Json::from(__DIR__ . '/../Fixtures/orders_flow.json')->extract($this->context) as $rows) {
@@ -30,7 +28,6 @@ final class JsonLoaderBench
         }
     }
 
-    #[BeforeMethods(['setUp'])]
     #[Revs(5)]
     public function bench_load_10k() : void
     {

--- a/src/adapter/etl-adapter-parquet/tests/Flow/ETL/Adapter/Parquet/Tests/Benchmark/ParquetExtractorBench.php
+++ b/src/adapter/etl-adapter-parquet/tests/Flow/ETL/Adapter/Parquet/Tests/Benchmark/ParquetExtractorBench.php
@@ -5,7 +5,6 @@ namespace Flow\ETL\Adapter\Parquet\Tests\Benchmark;
 use Flow\ETL\Config;
 use Flow\ETL\DSL\Parquet;
 use Flow\ETL\FlowContext;
-use PhpBench\Attributes\BeforeMethods;
 use PhpBench\Attributes\Groups;
 use PhpBench\Attributes\Iterations;
 use PhpBench\Attributes\Revs;
@@ -14,14 +13,13 @@ use PhpBench\Attributes\Revs;
 #[Groups(['extractor'])]
 final class ParquetExtractorBench
 {
-    private ?FlowContext $context = null;
+    private FlowContext $context;
 
-    public function setUp() : void
+    public function __construct()
     {
         $this->context = new FlowContext(Config::default());
     }
 
-    #[BeforeMethods(['setUp'])]
     #[Revs(5)]
     public function bench_extract_10k() : void
     {

--- a/src/adapter/etl-adapter-parquet/tests/Flow/ETL/Adapter/Parquet/Tests/Benchmark/ParquetExtractorBench.php
+++ b/src/adapter/etl-adapter-parquet/tests/Flow/ETL/Adapter/Parquet/Tests/Benchmark/ParquetExtractorBench.php
@@ -5,6 +5,7 @@ namespace Flow\ETL\Adapter\Parquet\Tests\Benchmark;
 use Flow\ETL\Config;
 use Flow\ETL\DSL\Parquet;
 use Flow\ETL\FlowContext;
+use PhpBench\Attributes\BeforeMethods;
 use PhpBench\Attributes\Groups;
 use PhpBench\Attributes\Iterations;
 use PhpBench\Attributes\Revs;
@@ -13,10 +14,18 @@ use PhpBench\Attributes\Revs;
 #[Groups(['extractor'])]
 final class ParquetExtractorBench
 {
+    private ?FlowContext $context = null;
+
+    public function setUp() : void
+    {
+        $this->context = new FlowContext(Config::default());
+    }
+
+    #[BeforeMethods(['setUp'])]
     #[Revs(5)]
     public function bench_extract_10k() : void
     {
-        foreach (Parquet::from(__DIR__ . '/../Fixtures/orders_flow.parquet')->extract(new FlowContext(Config::default())) as $rows) {
+        foreach (Parquet::from(__DIR__ . '/../Fixtures/orders_flow.parquet')->extract($this->context) as $rows) {
         }
     }
 }

--- a/src/adapter/etl-adapter-parquet/tests/Flow/ETL/Adapter/Parquet/Tests/Benchmark/ParquetLoaderBench.php
+++ b/src/adapter/etl-adapter-parquet/tests/Flow/ETL/Adapter/Parquet/Tests/Benchmark/ParquetLoaderBench.php
@@ -6,7 +6,6 @@ use Flow\ETL\Config;
 use Flow\ETL\DSL\Parquet;
 use Flow\ETL\FlowContext;
 use Flow\ETL\Rows;
-use PhpBench\Attributes\BeforeMethods;
 use PhpBench\Attributes\Groups;
 use PhpBench\Attributes\Iterations;
 use PhpBench\Attributes\Revs;
@@ -15,11 +14,11 @@ use PhpBench\Attributes\Revs;
 #[Groups(['loader'])]
 final class ParquetLoaderBench
 {
-    private ?FlowContext $context = null;
+    private FlowContext $context;
 
-    private ?Rows $rows = null;
+    private Rows $rows;
 
-    public function setUp() : void
+    public function __construct()
     {
         $this->context = new FlowContext(Config::default());
 
@@ -30,7 +29,6 @@ final class ParquetLoaderBench
         }
     }
 
-    #[BeforeMethods(['setUp'])]
     #[Revs(5)]
     public function bench_load_10k() : void
     {

--- a/src/adapter/etl-adapter-text/tests/Flow/ETL/Adapter/Text/Tests/Benchmark/TextExtractorBench.php
+++ b/src/adapter/etl-adapter-text/tests/Flow/ETL/Adapter/Text/Tests/Benchmark/TextExtractorBench.php
@@ -5,6 +5,7 @@ namespace Flow\ETL\Adapter\Text\Tests\Benchmark;
 use Flow\ETL\Config;
 use Flow\ETL\DSL\Text;
 use Flow\ETL\FlowContext;
+use PhpBench\Attributes\BeforeMethods;
 use PhpBench\Attributes\Groups;
 use PhpBench\Attributes\Iterations;
 use PhpBench\Attributes\Revs;
@@ -13,10 +14,18 @@ use PhpBench\Attributes\Revs;
 #[Groups(['extractor'])]
 final class TextExtractorBench
 {
+    private ?FlowContext $context = null;
+
+    public function setUp() : void
+    {
+        $this->context = new FlowContext(Config::default());
+    }
+
+    #[BeforeMethods(['setUp'])]
     #[Revs(5)]
     public function bench_extract_10k() : void
     {
-        foreach (Text::from(__DIR__ . '/../Fixtures/orders_flow.csv')->extract(new FlowContext(Config::default())) as $rows) {
+        foreach (Text::from(__DIR__ . '/../Fixtures/orders_flow.csv')->extract($this->context) as $rows) {
         }
     }
 }

--- a/src/adapter/etl-adapter-text/tests/Flow/ETL/Adapter/Text/Tests/Benchmark/TextExtractorBench.php
+++ b/src/adapter/etl-adapter-text/tests/Flow/ETL/Adapter/Text/Tests/Benchmark/TextExtractorBench.php
@@ -5,7 +5,6 @@ namespace Flow\ETL\Adapter\Text\Tests\Benchmark;
 use Flow\ETL\Config;
 use Flow\ETL\DSL\Text;
 use Flow\ETL\FlowContext;
-use PhpBench\Attributes\BeforeMethods;
 use PhpBench\Attributes\Groups;
 use PhpBench\Attributes\Iterations;
 use PhpBench\Attributes\Revs;
@@ -14,14 +13,13 @@ use PhpBench\Attributes\Revs;
 #[Groups(['extractor'])]
 final class TextExtractorBench
 {
-    private ?FlowContext $context = null;
+    private FlowContext $context;
 
-    public function setUp() : void
+    public function __construct()
     {
         $this->context = new FlowContext(Config::default());
     }
 
-    #[BeforeMethods(['setUp'])]
     #[Revs(5)]
     public function bench_extract_10k() : void
     {

--- a/src/adapter/etl-adapter-text/tests/Flow/ETL/Adapter/Text/Tests/Benchmark/TextLoaderBench.php
+++ b/src/adapter/etl-adapter-text/tests/Flow/ETL/Adapter/Text/Tests/Benchmark/TextLoaderBench.php
@@ -6,7 +6,6 @@ use Flow\ETL\Config;
 use Flow\ETL\DSL\Text;
 use Flow\ETL\FlowContext;
 use Flow\ETL\Rows;
-use PhpBench\Attributes\BeforeMethods;
 use PhpBench\Attributes\Groups;
 use PhpBench\Attributes\Iterations;
 use PhpBench\Attributes\Revs;
@@ -15,14 +14,13 @@ use PhpBench\Attributes\Revs;
 #[Groups(['loader'])]
 final class TextLoaderBench
 {
-    private ?FlowContext $context = null;
+    private FlowContext $context;
 
-    private ?Rows $rows = null;
+    private Rows $rows;
 
-    public function setUp() : void
+    public function __construct()
     {
         $this->context = new FlowContext(Config::default());
-
         $this->rows = new Rows();
 
         foreach (Text::from(__DIR__ . '/../Fixtures/orders_flow.csv', rows_in_batch: 1)->extract($this->context) as $rows) {
@@ -30,7 +28,6 @@ final class TextLoaderBench
         }
     }
 
-    #[BeforeMethods(['setUp'])]
     #[Revs(5)]
     public function bench_load_10k() : void
     {

--- a/src/adapter/etl-adapter-xml/tests/Flow/ETL/Adapter/XML/Tests/Benchmark/XmlExtractorBench.php
+++ b/src/adapter/etl-adapter-xml/tests/Flow/ETL/Adapter/XML/Tests/Benchmark/XmlExtractorBench.php
@@ -5,6 +5,7 @@ namespace Flow\ETL\Adapter\XML\Tests\Benchmark;
 use Flow\ETL\Config;
 use Flow\ETL\DSL\XML;
 use Flow\ETL\FlowContext;
+use PhpBench\Attributes\BeforeMethods;
 use PhpBench\Attributes\Groups;
 use PhpBench\Attributes\Iterations;
 use PhpBench\Attributes\Revs;
@@ -13,10 +14,18 @@ use PhpBench\Attributes\Revs;
 #[Groups(['extractor'])]
 final class XmlExtractorBench
 {
+    private ?FlowContext $context = null;
+
+    public function setUp() : void
+    {
+        $this->context = new FlowContext(Config::default());
+    }
+
+    #[BeforeMethods(['setUp'])]
     #[Revs(5)]
     public function bench_extract_10k() : void
     {
-        foreach (XML::from(__DIR__ . '/../Fixtures/flow_orders.xml', xml_node_path: 'root/row')->extract(new FlowContext(Config::default())) as $rows) {
+        foreach (XML::from(__DIR__ . '/../Fixtures/flow_orders.xml', xml_node_path: 'root/row')->extract($this->context) as $rows) {
         }
     }
 }

--- a/src/adapter/etl-adapter-xml/tests/Flow/ETL/Adapter/XML/Tests/Benchmark/XmlExtractorBench.php
+++ b/src/adapter/etl-adapter-xml/tests/Flow/ETL/Adapter/XML/Tests/Benchmark/XmlExtractorBench.php
@@ -5,7 +5,6 @@ namespace Flow\ETL\Adapter\XML\Tests\Benchmark;
 use Flow\ETL\Config;
 use Flow\ETL\DSL\XML;
 use Flow\ETL\FlowContext;
-use PhpBench\Attributes\BeforeMethods;
 use PhpBench\Attributes\Groups;
 use PhpBench\Attributes\Iterations;
 use PhpBench\Attributes\Revs;
@@ -14,14 +13,13 @@ use PhpBench\Attributes\Revs;
 #[Groups(['extractor'])]
 final class XmlExtractorBench
 {
-    private ?FlowContext $context = null;
+    private FlowContext $context;
 
-    public function setUp() : void
+    public function __construct()
     {
         $this->context = new FlowContext(Config::default());
     }
 
-    #[BeforeMethods(['setUp'])]
     #[Revs(5)]
     public function bench_extract_10k() : void
     {

--- a/src/core/etl/tests/Flow/ETL/Tests/Benchmark/Transformer/RenameEntryTransformerBench.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Benchmark/Transformer/RenameEntryTransformerBench.php
@@ -6,7 +6,6 @@ use Flow\ETL\Config;
 use Flow\ETL\FlowContext;
 use Flow\ETL\Rows;
 use Flow\ETL\Transformer\RenameEntryTransformer;
-use PhpBench\Attributes\BeforeMethods;
 use PhpBench\Attributes\Groups;
 use PhpBench\Attributes\Iterations;
 use PhpBench\Attributes\Revs;
@@ -15,11 +14,11 @@ use PhpBench\Attributes\Revs;
 #[Groups(['transformer'])]
 final class RenameEntryTransformerBench
 {
-    private ?FlowContext $context = null;
+    private FlowContext $context;
 
-    private ?Rows $rows = null;
+    private Rows $rows;
 
-    public function setUp() : void
+    public function __construct()
     {
         $this->rows = Rows::fromArray(
             \array_merge(...\array_map(static function () : array {
@@ -35,7 +34,6 @@ final class RenameEntryTransformerBench
         $this->context = new FlowContext(Config::default());
     }
 
-    #[BeforeMethods(['setUp'])]
     #[Revs(5)]
     public function bench_transform_10k_rows() : void
     {


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Rework benchmarks to set up test data in constructors</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

To unify with other benchmarks, context is created once.
