### PR TITLE
Improve performance for a few `Rows` methods

### DIFF
--- a/.github/workflows/test-benchmark.yml
+++ b/.github/workflows/test-benchmark.yml
@@ -60,16 +60,12 @@ jobs:
       - name: "Install locked dependencies"
         run: "composer install --no-interaction --no-progress"
 
-      - name: "Restore PHPBench cache"
-        uses: "actions/cache@v3"
+      - name: "Download phpbench benchmarks artifact"
+        uses: dawidd6/action-download-artifact@v2
         with:
-          path: "var/phpbench"
-          key: "php-${{ matrix.php-version }}-1.x-phpbench-"
-          restore-keys: |
-            php-${{ matrix.php-version }}-1.x-phpbench-
-
-      - name: "Clean previous summary"
-        run: rm -rf ./var/phpbench/summary.txt
+          workflow: benchmark-baseline.yml
+          name: phpbench-baseline
+          path: ./var/phpbench/
 
       - name: "Execute benchmarks"
         id: init_comment

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/RowsTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/RowsTest.php
@@ -158,7 +158,7 @@ final class RowsTest extends TestCase
     public function test_array_access_unset() : void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('In order to add new rows use Rows::remove(int $offset) : self');
+        $this->expectExceptionMessage('In order to remove rows use Rows::remove(int $offset) : self');
         $rows = new Rows(Row::create(new IntegerEntry('id', 1)));
         unset($rows[0]);
     }


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Improve performance for a few `Rows` methods</li>
    <li>Rework benchmark GH action to use artifact for baseline</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

Covered: `find`, `findOne`, `first`, `partitionBy`, `take`, `takeRight`.

Comparing local benchmarks:
```console
composer run-script test:benchmark:building_blocks
> tools/phpbench/vendor/bin/phpbench run --report=flow-report --group=building_blocks --ref=1.x
PHPBench (1.2.14) running benchmarks... #standwithukraine
with configuration file: /Users/stloyd/Documents/flow/phpbench.json
with PHP version 8.1.25, xdebug ❌, opcache ❌
comparing [actual vs. 1.x]

.......................... 

Subjects: 26, Assertions: 0, Failures: 0, Errors: 0
+-------------------------+----------------------------+------+-----+-----------------+------------------+
| benchmark               | subject                    | revs | its | mem_peak        | mode             |
+-------------------------+----------------------------+------+-----+-----------------+------------------+
| RowsBench               | bench_chunk_10_on_10k      | 5    | 5   | 60.962mb -0.00% | 2.571ms -1.38%   |
| RowsBench               | bench_diff_left_1k_on_10k  | 5    | 5   | 80.754mb -0.00% | 234.289ms +2.53% |
| RowsBench               | bench_diff_right_1k_on_10k | 5    | 5   | 59.279mb -0.00% | 23.252ms +6.90%  |
| RowsBench               | bench_drop_1k_on_10k       | 5    | 5   | 60.101mb -0.00% | 2.374ms -9.14%   |
| RowsBench               | bench_drop_right_1k_on_10k | 5    | 5   | 62.203mb -0.00% | 2.452ms +1.86%   |
| RowsBench               | bench_entries_on_10k       | 5    | 5   | 59.315mb -0.00% | 3.931ms -2.71%   |
| RowsBench               | bench_filter_on_10k        | 5    | 5   | 59.843mb -0.00% | 21.557ms -8.90%  |
| RowsBench               | bench_find_on_10k          | 5    | 5   | 59.843mb -0.00% | 23.355ms +8.62%  |
| RowsBench               | bench_find_one_on_10k      | 5    | 5   | 58.267mb -0.61% | 5.000μs -99.98%  |
| RowsBench               | bench_first_on_10k         | 5    | 5   | 57.914mb -0.00% | 2.000μs 0.00%    |
| RowsBench               | bench_flat_map_on_1k       | 5    | 5   | 66.148mb -0.00% | 12.537ms +2.71%  |
| RowsBench               | bench_map_on_10k           | 5    | 5   | 91.668mb -0.00% | 58.519ms +3.87%  |
| RowsBench               | bench_merge_1k_on_10k      | 5    | 5   | 60.364mb -0.00% | 2.820ms -11.90%  |
| RowsBench               | bench_partition_by_on_10k  | 5    | 5   | 64.735mb -3.25% | 49.046ms -9.22%  |
| RowsBench               | bench_remove_on_10k        | 5    | 5   | 62.465mb -0.00% | 6.297ms +1.23%   |
| RowsBench               | bench_sort_asc_on_1k       | 5    | 5   | 57.914mb -0.00% | 62.019ms -4.12%  |
| RowsBench               | bench_sort_by_on_1k        | 5    | 5   | 57.914mb -0.00% | 60.592ms -1.10%  |
| RowsBench               | bench_sort_desc_on_1k      | 5    | 5   | 57.914mb -0.00% | 63.074ms +0.75%  |
| RowsBench               | bench_sort_entries_on_1k   | 5    | 5   | 60.189mb -0.00% | 9.063ms -3.89%   |
| RowsBench               | bench_sort_on_1k           | 5    | 5   | 57.914mb -0.00% | 44.019ms -1.26%  |
| RowsBench               | bench_take_1k_on_10k       | 5    | 5   | 59.389mb -2.48% | 17.290μs -99.98% |
| RowsBench               | bench_take_right_1k_on_10k | 5    | 5   | 59.389mb -2.48% | 28.598μs -96.75% |
| RowsBench               | bench_unique_on_1k         | 5    | 5   | 80.754mb -0.00% | 229.792ms -7.76% |
| NativeEntryFactoryBench | bench_10k_rows             | 5    | 5   | 84.172mb -0.01% | 132.170ms +1.31% |
| NativeEntryFactoryBench | bench_1k_rows              | 5    | 5   | 45.704mb +0.00% | 13.150ms -2.29%  |
| NativeEntryFactoryBench | bench_5k_rows              | 5    | 5   | 62.977mb -0.00% | 64.536ms -0.95%  |
+-------------------------+----------------------------+------+-----+-----------------+------------------+

