### PR TITLE
Reduce amount of runs for benchmark testing

### DIFF
--- a/.github/workflows/test-benchmark.yml
+++ b/.github/workflows/test-benchmark.yml
@@ -3,12 +3,12 @@ name: Benchmark Suite
 on:
   pull_request:
     paths:
-      - '.github/workflows/**'
+      - '.github/workflows/benchmark-baseline.yml'
+      - '.github/workflows/test-benchmark.yml'
       - 'src/adapter/**'
       - 'src/core/**'
       - 'src/lib/**'
-      - 'tools/**'
-      - 'composer.json'
+      - 'tools/phpbench/composer.lock'
       - 'composer.lock'
 
 # See https://stackoverflow.com/a/72408109


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Reduce amount of runs for benchmark testing</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

Similar to https://github.com/flow-php/flow/pull/674, we don't need benchmark being run when unrelated changes are applied.
