### PR TITLE
Add GPG Signature to "flow-php.phar" artifact

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -54,6 +54,21 @@ jobs:
           ./build/flow-php.phar --version
           ./build/flow-php.phar examples/topics/transformations/array_expand.php
 
+      - name: "Import GPG Key"
+        uses: crazy-max/ghaction-import-gpg@72b6676b71ab476b77e676928516f6982eef7a41
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+
+      - name: "Sign PHAR"
+        run: >
+          gpg
+          --local-user ${{ env.GPG_USER_EMAIL }}
+          --passphrase ${{ secrets.GPG_PASSPHRASE }}
+          --detach-sign
+          --output ./build/flow-php.phar.asc
+          ./build/flow-php.phar
+
       - name: "Prepare artifact name"
         run: |
           BUILD_TAG=${{ github.ref_name }}
@@ -64,5 +79,6 @@ jobs:
         uses: softprops/action-gh-release@v1
         if: ${{startsWith(github.ref, 'refs/tags/') }}
         with:
-          files: build/flow-php.phar
-
+          files: |
+            build/flow-php.phar
+            build/flow-php.phar.asc


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <li>Add GPG Signature to "flow-php.phar" artifact</li>
  </ul> 
</div>
<hr/>

<h2>Description</h2>

This PR adds two new steps to [build-release](.github/workflows/build-release.yml) workflow:
1. **Import GPG Key:** this step imports a GPG Key (`GPG_PRIVATE_KEY`, a GH secret) - it's a good practice to secure such key with a passphrase (`GPG_PASSPHRASE`, also a GH secret);
2. **Sign PHAR:** this step performs the actual signature, it requires the local user that owns the GPG Key to be set to the env var `GPG_USER_EMAIL` (format: `user@host.tld`).

It also includes the new `flow-php.phar.asc` artifact to **"Upload binaries to release"** step.

Closes #512