### PR TITLE
Improve adapters benchmark stability

### DIFF
--- a/phpbench.json
+++ b/phpbench.json
@@ -10,7 +10,8 @@
         "revs": null,
         "its": null,
         "mem_peak": null,
-        "mode": null
+        "mode": null,
+        "rstdev": null
       }
     }
   },
@@ -25,5 +26,6 @@
   ],
   "runner.php_config": { "memory_limit": "1G" },
   "runner.iterations": 3,
+  "runner.retry_threshold": 5,
   "storage.xml_storage_path": "var/phpbench"
 }

--- a/src/adapter/etl-adapter-avro/tests/Flow/ETL/Adapter/Avro/Tests/Benchmark/AvroExtractorBench.php
+++ b/src/adapter/etl-adapter-avro/tests/Flow/ETL/Adapter/Avro/Tests/Benchmark/AvroExtractorBench.php
@@ -6,21 +6,17 @@ use Flow\ETL\Config;
 use Flow\ETL\DSL\Avro;
 use Flow\ETL\FlowContext;
 use PhpBench\Attributes\Groups;
-use PhpBench\Attributes\Iterations;
-use PhpBench\Attributes\Revs;
 
-#[Iterations(3)]
 #[Groups(['extractor'])]
 final class AvroExtractorBench
 {
-    private FlowContext $context;
+    private readonly FlowContext $context;
 
     public function __construct()
     {
         $this->context = new FlowContext(Config::default());
     }
 
-    #[Revs(5)]
     public function bench_extract_10k() : void
     {
         foreach (Avro::from(__DIR__ . '/../Fixtures/orders_flow.avro')->extract($this->context) as $rows) {

--- a/src/adapter/etl-adapter-avro/tests/Flow/ETL/Adapter/Avro/Tests/Benchmark/AvroLoaderBench.php
+++ b/src/adapter/etl-adapter-avro/tests/Flow/ETL/Adapter/Avro/Tests/Benchmark/AvroLoaderBench.php
@@ -7,20 +7,20 @@ use Flow\ETL\DSL\Avro;
 use Flow\ETL\FlowContext;
 use Flow\ETL\Rows;
 use PhpBench\Attributes\Groups;
-use PhpBench\Attributes\Iterations;
-use PhpBench\Attributes\Revs;
 
-#[Iterations(3)]
 #[Groups(['loader'])]
 final class AvroLoaderBench
 {
-    private FlowContext $context;
+    private readonly FlowContext $context;
+
+    private readonly string $outputPath;
 
     private Rows $rows;
 
     public function __construct()
     {
         $this->context = new FlowContext(Config::default());
+        $this->outputPath = \tempnam(\sys_get_temp_dir(), 'etl_avro_loader_bench') . '.avro';
         $this->rows = new Rows();
 
         foreach (Avro::from(__DIR__ . '/../Fixtures/orders_flow.avro')->extract($this->context) as $rows) {
@@ -28,14 +28,17 @@ final class AvroLoaderBench
         }
     }
 
-    #[Revs(5)]
+    public function __destruct()
+    {
+        if (!\file_exists($this->outputPath)) {
+            throw new \RuntimeException("Benchmark failed, \"{$this->outputPath}\" doesn't exist");
+        }
+
+        \unlink($this->outputPath);
+    }
+
     public function bench_load_10k() : void
     {
-        Avro::to($outputPath = \tempnam(\sys_get_temp_dir(), 'etl_avro_loader_bench') . '.avro')->load($this->rows, $this->context);
-
-        if (!\file_exists($outputPath)) {
-            throw new \RuntimeException("Benchmark failed, \"{$outputPath}\" doesn't exist");
-        }
-        \unlink($outputPath);
+        Avro::to($this->outputPath)->load($this->rows, $this->context);
     }
 }

--- a/src/adapter/etl-adapter-csv/tests/Flow/ETL/Adapter/CSV/Tests/Benchmark/CSVExtractorBench.php
+++ b/src/adapter/etl-adapter-csv/tests/Flow/ETL/Adapter/CSV/Tests/Benchmark/CSVExtractorBench.php
@@ -6,21 +6,17 @@ use Flow\ETL\Config;
 use Flow\ETL\DSL\CSV;
 use Flow\ETL\FlowContext;
 use PhpBench\Attributes\Groups;
-use PhpBench\Attributes\Iterations;
-use PhpBench\Attributes\Revs;
 
-#[Iterations(3)]
 #[Groups(['extractor'])]
 final class CSVExtractorBench
 {
-    private FlowContext $context;
+    private readonly FlowContext $context;
 
     public function __construct()
     {
         $this->context = new FlowContext(Config::default());
     }
 
-    #[Revs(5)]
     public function bench_extract_10k() : void
     {
         foreach (CSV::from(__DIR__ . '/../Fixtures/orders_flow.csv')->extract($this->context) as $rows) {

--- a/src/adapter/etl-adapter-csv/tests/Flow/ETL/Adapter/CSV/Tests/Benchmark/CSVLoaderBench.php
+++ b/src/adapter/etl-adapter-csv/tests/Flow/ETL/Adapter/CSV/Tests/Benchmark/CSVLoaderBench.php
@@ -7,20 +7,20 @@ use Flow\ETL\DSL\CSV;
 use Flow\ETL\FlowContext;
 use Flow\ETL\Rows;
 use PhpBench\Attributes\Groups;
-use PhpBench\Attributes\Iterations;
-use PhpBench\Attributes\Revs;
 
-#[Iterations(3)]
 #[Groups(['loader'])]
 final class CSVLoaderBench
 {
-    private FlowContext $context;
+    private readonly FlowContext $context;
+
+    private readonly string $outputPath;
 
     private Rows $rows;
 
     public function __construct()
     {
         $this->context = new FlowContext(Config::default());
+        $this->outputPath = \tempnam(\sys_get_temp_dir(), 'etl_csv_loader_bench') . '.csv';
         $this->rows = new Rows();
 
         foreach (CSV::from(__DIR__ . '/../Fixtures/orders_flow.csv')->extract($this->context) as $rows) {
@@ -28,14 +28,17 @@ final class CSVLoaderBench
         }
     }
 
-    #[Revs(5)]
+    public function __destruct()
+    {
+        if (!\file_exists($this->outputPath)) {
+            throw new \RuntimeException("Benchmark failed, \"{$this->outputPath}\" doesn't exist");
+        }
+
+        \unlink($this->outputPath);
+    }
+
     public function bench_load_10k() : void
     {
-        CSV::to($outputPath = \tempnam(\sys_get_temp_dir(), 'etl_csv_loader_bench') . '.csv')->load($this->rows, $this->context);
-
-        if (!\file_exists($outputPath)) {
-            throw new \RuntimeException("Benchmark failed, \"{$outputPath}\" doesn't exist");
-        }
-        \unlink($outputPath);
+        CSV::to($this->outputPath)->load($this->rows, $this->context);
     }
 }

--- a/src/adapter/etl-adapter-json/tests/Flow/ETL/Adapter/JSON/Tests/Benchmark/JsonExtractorBench.php
+++ b/src/adapter/etl-adapter-json/tests/Flow/ETL/Adapter/JSON/Tests/Benchmark/JsonExtractorBench.php
@@ -6,21 +6,17 @@ use Flow\ETL\Config;
 use Flow\ETL\DSL\Json;
 use Flow\ETL\FlowContext;
 use PhpBench\Attributes\Groups;
-use PhpBench\Attributes\Iterations;
-use PhpBench\Attributes\Revs;
 
-#[Iterations(3)]
 #[Groups(['extractor'])]
 final class JsonExtractorBench
 {
-    private FlowContext $context;
+    private readonly FlowContext $context;
 
     public function __construct()
     {
         $this->context = new FlowContext(Config::default());
     }
 
-    #[Revs(5)]
     public function bench_extract_10k() : void
     {
         foreach (Json::from(__DIR__ . '/../Fixtures/orders_flow.json')->extract($this->context) as $rows) {

--- a/src/adapter/etl-adapter-json/tests/Flow/ETL/Adapter/JSON/Tests/Benchmark/JsonLoaderBench.php
+++ b/src/adapter/etl-adapter-json/tests/Flow/ETL/Adapter/JSON/Tests/Benchmark/JsonLoaderBench.php
@@ -7,20 +7,20 @@ use Flow\ETL\DSL\Json;
 use Flow\ETL\FlowContext;
 use Flow\ETL\Rows;
 use PhpBench\Attributes\Groups;
-use PhpBench\Attributes\Iterations;
-use PhpBench\Attributes\Revs;
 
-#[Iterations(3)]
 #[Groups(['loader'])]
 final class JsonLoaderBench
 {
-    private FlowContext $context;
+    private readonly FlowContext $context;
+
+    private readonly string $outputPath;
 
     private Rows $rows;
 
     public function __construct()
     {
         $this->context = new FlowContext(Config::default());
+        $this->outputPath = \tempnam(\sys_get_temp_dir(), 'etl_json_loader_bench') . '.json';
         $this->rows = new Rows();
 
         foreach (Json::from(__DIR__ . '/../Fixtures/orders_flow.json')->extract($this->context) as $rows) {
@@ -28,14 +28,17 @@ final class JsonLoaderBench
         }
     }
 
-    #[Revs(5)]
+    public function __destruct()
+    {
+        if (!\file_exists($this->outputPath)) {
+            throw new \RuntimeException("Benchmark failed, \"{$this->outputPath}\" doesn't exist");
+        }
+
+        \unlink($this->outputPath);
+    }
+
     public function bench_load_10k() : void
     {
-        Json::to($outputPath = \tempnam(\sys_get_temp_dir(), 'etl_json_loader_bench') . '.json')->load($this->rows, $this->context);
-
-        if (!\file_exists($outputPath)) {
-            throw new \RuntimeException("Benchmark failed, \"{$outputPath}\" doesn't exist");
-        }
-        \unlink($outputPath);
+        Json::to($this->outputPath)->load($this->rows, $this->context);
     }
 }

--- a/src/adapter/etl-adapter-parquet/tests/Flow/ETL/Adapter/Parquet/Tests/Benchmark/ParquetExtractorBench.php
+++ b/src/adapter/etl-adapter-parquet/tests/Flow/ETL/Adapter/Parquet/Tests/Benchmark/ParquetExtractorBench.php
@@ -6,21 +6,17 @@ use Flow\ETL\Config;
 use Flow\ETL\DSL\Parquet;
 use Flow\ETL\FlowContext;
 use PhpBench\Attributes\Groups;
-use PhpBench\Attributes\Iterations;
-use PhpBench\Attributes\Revs;
 
-#[Iterations(3)]
 #[Groups(['extractor'])]
 final class ParquetExtractorBench
 {
-    private FlowContext $context;
+    private readonly FlowContext $context;
 
     public function __construct()
     {
         $this->context = new FlowContext(Config::default());
     }
 
-    #[Revs(5)]
     public function bench_extract_10k() : void
     {
         foreach (Parquet::from(__DIR__ . '/../Fixtures/orders_flow.parquet')->extract($this->context) as $rows) {

--- a/src/adapter/etl-adapter-parquet/tests/Flow/ETL/Adapter/Parquet/Tests/Benchmark/ParquetLoaderBench.php
+++ b/src/adapter/etl-adapter-parquet/tests/Flow/ETL/Adapter/Parquet/Tests/Benchmark/ParquetLoaderBench.php
@@ -7,21 +7,20 @@ use Flow\ETL\DSL\Parquet;
 use Flow\ETL\FlowContext;
 use Flow\ETL\Rows;
 use PhpBench\Attributes\Groups;
-use PhpBench\Attributes\Iterations;
-use PhpBench\Attributes\Revs;
 
-#[Iterations(3)]
 #[Groups(['loader'])]
 final class ParquetLoaderBench
 {
-    private FlowContext $context;
+    private readonly FlowContext $context;
+
+    private readonly string $outputPath;
 
     private Rows $rows;
 
     public function __construct()
     {
         $this->context = new FlowContext(Config::default());
-
+        $this->outputPath = \tempnam(\sys_get_temp_dir(), 'etl_parquet_loader_bench') . '.parquet';
         $this->rows = new Rows();
 
         foreach (Parquet::from(__DIR__ . '/../Fixtures/orders_flow.parquet')->extract($this->context) as $rows) {
@@ -29,14 +28,17 @@ final class ParquetLoaderBench
         }
     }
 
-    #[Revs(5)]
+    public function __destruct()
+    {
+        if (!\file_exists($this->outputPath)) {
+            throw new \RuntimeException("Benchmark failed, \"{$this->outputPath}\" doesn't exist");
+        }
+
+        \unlink($this->outputPath);
+    }
+
     public function bench_load_10k() : void
     {
-        Parquet::to($outputPath = \tempnam(\sys_get_temp_dir(), 'etl_parquet_loader_bench') . '.parquet')->load($this->rows, $this->context);
-
-        if (!\file_exists($outputPath)) {
-            throw new \RuntimeException("Benchmark failed, \"{$outputPath}\" doesn't exist");
-        }
-        \unlink($outputPath);
+        Parquet::to($this->outputPath)->load($this->rows, $this->context);
     }
 }

--- a/src/adapter/etl-adapter-text/tests/Flow/ETL/Adapter/Text/Tests/Benchmark/TextExtractorBench.php
+++ b/src/adapter/etl-adapter-text/tests/Flow/ETL/Adapter/Text/Tests/Benchmark/TextExtractorBench.php
@@ -6,21 +6,17 @@ use Flow\ETL\Config;
 use Flow\ETL\DSL\Text;
 use Flow\ETL\FlowContext;
 use PhpBench\Attributes\Groups;
-use PhpBench\Attributes\Iterations;
-use PhpBench\Attributes\Revs;
 
-#[Iterations(3)]
 #[Groups(['extractor'])]
 final class TextExtractorBench
 {
-    private FlowContext $context;
+    private readonly FlowContext $context;
 
     public function __construct()
     {
         $this->context = new FlowContext(Config::default());
     }
 
-    #[Revs(5)]
     public function bench_extract_10k() : void
     {
         foreach (Text::from(__DIR__ . '/../Fixtures/orders_flow.csv')->extract($this->context) as $rows) {

--- a/src/adapter/etl-adapter-text/tests/Flow/ETL/Adapter/Text/Tests/Benchmark/TextLoaderBench.php
+++ b/src/adapter/etl-adapter-text/tests/Flow/ETL/Adapter/Text/Tests/Benchmark/TextLoaderBench.php
@@ -7,20 +7,20 @@ use Flow\ETL\DSL\Text;
 use Flow\ETL\FlowContext;
 use Flow\ETL\Rows;
 use PhpBench\Attributes\Groups;
-use PhpBench\Attributes\Iterations;
-use PhpBench\Attributes\Revs;
 
-#[Iterations(3)]
 #[Groups(['loader'])]
 final class TextLoaderBench
 {
-    private FlowContext $context;
+    private readonly FlowContext $context;
+
+    private readonly string $outputPath;
 
     private Rows $rows;
 
     public function __construct()
     {
         $this->context = new FlowContext(Config::default());
+        $this->outputPath = \tempnam(\sys_get_temp_dir(), 'etl_txt_loader_bench') . '.txt';
         $this->rows = new Rows();
 
         foreach (Text::from(__DIR__ . '/../Fixtures/orders_flow.csv', rows_in_batch: 1)->extract($this->context) as $rows) {
@@ -28,14 +28,17 @@ final class TextLoaderBench
         }
     }
 
-    #[Revs(5)]
+    public function __destruct()
+    {
+        if (!\file_exists($this->outputPath)) {
+            throw new \RuntimeException("Benchmark failed, \"{$this->outputPath}\" doesn't exist");
+        }
+
+        \unlink($this->outputPath);
+    }
+
     public function bench_load_10k() : void
     {
-        Text::to($outputPath = \tempnam(\sys_get_temp_dir(), 'etl_txt_loader_bench') . '.txt')->load($this->rows, $this->context);
-
-        if (!\file_exists($outputPath)) {
-            throw new \RuntimeException("Benchmark failed, \"{$outputPath}\" doesn't exist");
-        }
-        \unlink($outputPath);
+        Text::to($this->outputPath)->load($this->rows, $this->context);
     }
 }

--- a/src/adapter/etl-adapter-xml/tests/Flow/ETL/Adapter/XML/Tests/Benchmark/XmlExtractorBench.php
+++ b/src/adapter/etl-adapter-xml/tests/Flow/ETL/Adapter/XML/Tests/Benchmark/XmlExtractorBench.php
@@ -6,21 +6,17 @@ use Flow\ETL\Config;
 use Flow\ETL\DSL\XML;
 use Flow\ETL\FlowContext;
 use PhpBench\Attributes\Groups;
-use PhpBench\Attributes\Iterations;
-use PhpBench\Attributes\Revs;
 
-#[Iterations(3)]
 #[Groups(['extractor'])]
 final class XmlExtractorBench
 {
-    private FlowContext $context;
+    private readonly FlowContext $context;
 
     public function __construct()
     {
         $this->context = new FlowContext(Config::default());
     }
 
-    #[Revs(5)]
     public function bench_extract_10k() : void
     {
         foreach (XML::from(__DIR__ . '/../Fixtures/flow_orders.xml', xml_node_path: 'root/row')->extract($this->context) as $rows) {


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Improve adapters benchmark stability</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

Added retry-threshold back to settings, which allows getting better `rstdev` values as it re-tries benchmark if the value is over the given value.

Moved the setup of files out of benchmark methods, which should make those more reliable.
