### PR TITLE
Boolean encoding and RLEBitPackedHybrid

### DIFF
--- a/src/lib/parquet/src/Flow/Parquet/ParquetFile/Data/RLEBitPackedHybrid.php
+++ b/src/lib/parquet/src/Flow/Parquet/ParquetFile/Data/RLEBitPackedHybrid.php
@@ -174,7 +174,7 @@ final class RLEBitPackedHybrid
                 continue;
             }
 
-            if (\count($bitPackedBuffer) % 8 === 0) {
+            if (\count($bitPackedBuffer) && \count($bitPackedBuffer) % 8 === 0) {
                 $this->encodeBitPacked($writer, $bitWidth, $bitPackedBuffer);
                 $bitPackedBuffer = [];
             }

--- a/src/lib/parquet/src/Flow/Parquet/ParquetFile/Page/Header/DataPageHeader.php
+++ b/src/lib/parquet/src/Flow/Parquet/ParquetFile/Page/Header/DataPageHeader.php
@@ -12,6 +12,8 @@ final class DataPageHeader
 {
     public function __construct(
         private readonly Encodings $encoding,
+        private readonly Encodings $repetitionLevelEncoding,
+        private readonly Encodings $definitionLevelEncoding,
         private readonly int $valuesCount,
     ) {
     }
@@ -20,8 +22,15 @@ final class DataPageHeader
     {
         return new self(
             Encodings::from($thrift->encoding),
+            Encodings::from($thrift->repetition_level_encoding),
+            Encodings::from($thrift->definition_level_encoding),
             $thrift->num_values
         );
+    }
+
+    public function definitionLevelEncoding() : Encodings
+    {
+        return $this->definitionLevelEncoding;
     }
 
     public function encoding() : Encodings
@@ -29,13 +38,18 @@ final class DataPageHeader
         return $this->encoding;
     }
 
+    public function repetitionLevelEncoding() : Encodings
+    {
+        return $this->repetitionLevelEncoding;
+    }
+
     public function toThrift() : \Flow\Parquet\Thrift\DataPageHeader
     {
         return new \Flow\Parquet\Thrift\DataPageHeader([
             'num_values' => $this->valuesCount,
             'encoding' => $this->encoding->value,
-            'definition_level_encoding' => Encodings::RLE->value,
-            'repetition_level_encoding' => Encodings::RLE->value,
+            'definition_level_encoding' => $this->definitionLevelEncoding->value,
+            'repetition_level_encoding' => $this->repetitionLevelEncoding->value,
         ]);
     }
 

--- a/src/lib/parquet/src/Flow/Parquet/ParquetFile/RowGroupBuilder/PageBuilder/DataPageBuilder.php
+++ b/src/lib/parquet/src/Flow/Parquet/ParquetFile/RowGroupBuilder/PageBuilder/DataPageBuilder.php
@@ -57,8 +57,10 @@ final class DataPageBuilder
             \strlen($compressedBuffer),
             \strlen($pageBuffer),
             dataPageHeader: new DataPageHeader(
-                $dictionary && $indices ? Encodings::RLE_DICTIONARY : Encodings::PLAIN,
-                \count($shredded->definitions)
+                encoding: (\is_array($dictionary) && \is_array($indices)) ? Encodings::RLE_DICTIONARY : Encodings::PLAIN,
+                repetitionLevelEncoding: Encodings::RLE,
+                definitionLevelEncoding: Encodings::RLE,
+                valuesCount: \count($shredded->definitions)
             ),
             dataPageHeaderV2: null,
             dictionaryPageHeader: null,

--- a/src/lib/parquet/src/Flow/Parquet/ParquetFile/RowGroupBuilder/PageBuilder/DictionaryPageBuilder.php
+++ b/src/lib/parquet/src/Flow/Parquet/ParquetFile/RowGroupBuilder/PageBuilder/DictionaryPageBuilder.php
@@ -42,7 +42,7 @@ final class DictionaryPageBuilder
             dataPageHeader: null,
             dataPageHeaderV2: null,
             dictionaryPageHeader: new DictionaryPageHeader(
-                Encodings::PLAIN,
+                Encodings::PLAIN_DICTIONARY,
                 \count($dictionary->dictionary)
             ),
         );

--- a/src/lib/parquet/src/Flow/Parquet/ParquetFile/Schema/ConvertedType.php
+++ b/src/lib/parquet/src/Flow/Parquet/ParquetFile/Schema/ConvertedType.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types=1);
+
+namespace Flow\Parquet\ParquetFile\Schema;
+
+enum ConvertedType : int
+{
+    case BSON = 20;
+    case DATE = 6;
+    case DECIMAL = 5;
+    case ENUM = 4;
+    case INT_16 = 16;
+    case INT_32 = 17;
+    case INT_64 = 18;
+    case INT_8 = 15;
+    case INTERVAL = 21;
+    case JSON = 19;
+    case LIST = 3;
+    case MAP = 1;
+    case MAP_KEY_VALUE = 2;
+    case TIME_MICROS = 8;
+    case TIME_MILLIS = 7;
+    case TIMESTAMP_MICROS = 10;
+    case TIMESTAMP_MILLIS = 9;
+    case UINT_16 = 12;
+    case UINT_32 = 13;
+    case UINT_64 = 14;
+    case UINT_8 = 11;
+    case UTF8 = 0;
+}

--- a/src/lib/parquet/src/Flow/Parquet/ParquetFile/Schema/NestedColumn.php
+++ b/src/lib/parquet/src/Flow/Parquet/ParquetFile/Schema/NestedColumn.php
@@ -18,6 +18,7 @@ final class NestedColumn implements Column
         private readonly string $name,
         private readonly ?Repetition $repetition,
         private readonly array $children,
+        private readonly ?ConvertedType $convertedType = null,
         private readonly ?LogicalType $logicalType = null,
         public readonly bool $schemaRoot = false
     ) {
@@ -46,6 +47,7 @@ final class NestedColumn implements Column
             $schemaElement->name,
             $schemaElement->repetition_type ? Repetition::from($schemaElement->repetition_type) : null,
             $children,
+            $schemaElement->converted_type ? ConvertedType::from($schemaElement->converted_type) : null,
             /** @phpstan-ignore-next-line */
             $schemaElement->logicalType ? LogicalType::fromThrift($schemaElement->logicalType) : null
         );
@@ -63,6 +65,7 @@ final class NestedColumn implements Column
                     [$element->element]
                 ),
             ],
+            ConvertedType::LIST,
             new LogicalType(LogicalType::LIST)
         );
     }
@@ -82,6 +85,7 @@ final class NestedColumn implements Column
                     ],
                 ),
             ],
+            ConvertedType::MAP,
             new LogicalType(LogicalType::MAP)
         );
     }
@@ -91,7 +95,7 @@ final class NestedColumn implements Column
      */
     public static function schemaRoot(string $name, array $children) : self
     {
-        return new self($name, Repetition::REQUIRED, $children, null, true);
+        return new self($name, Repetition::REQUIRED, $children, null, null, true);
     }
 
     /**
@@ -395,7 +399,7 @@ final class NestedColumn implements Column
             new SchemaElement([
                 'name' => $this->name(),
                 'num_children' => \count($this->children),
-                'converted_type' => null,
+                'converted_type' => $this->convertedType?->value,
                 'repetition_type' => $this->repetition()?->value,
                 'logicalType' => $this->logicalType()?->toThrift(),
             ]),

--- a/src/lib/parquet/tests/Flow/Parquet/Tests/Integration/ParquetFile/Data/RLEBitPackedHybridTest.php
+++ b/src/lib/parquet/tests/Flow/Parquet/Tests/Integration/ParquetFile/Data/RLEBitPackedHybridTest.php
@@ -129,6 +129,23 @@ final class RLEBitPackedHybridTest extends TestCase
         );
     }
 
+    public function test_plain_long_rle() : void
+    {
+        $values = \array_fill(0, 100, 1);
+
+        $buffer = '';
+        (new RLEBitPackedHybrid())->encodeHybrid(new BinaryBufferWriter($buffer), $values);
+
+        $this->assertSame(
+            $values,
+            (new RLEBitPackedHybrid())->decodeHybrid(
+                new BinaryBufferReader($buffer),
+                BitWidth::fromArray($values),
+                \count($values)
+            )
+        );
+    }
+
     public function test_plain_rle_with_two_sequences() : void
     {
         $values = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1];

--- a/src/lib/parquet/tests/Flow/Parquet/Tests/Integration/ParquetFile/RowGroupBuilder/PagesBuilderTest.php
+++ b/src/lib/parquet/tests/Flow/Parquet/Tests/Integration/ParquetFile/RowGroupBuilder/PagesBuilderTest.php
@@ -43,6 +43,8 @@ final class PagesBuilderTest extends TestCase
                 \strlen($pages->dataPageContainers()[0]->pageBuffer),
                 new DataPageHeader(
                     Encodings::PLAIN,
+                    Encodings::RLE,
+                    Encodings::RLE,
                     256,
                 ),
                 null,
@@ -79,7 +81,7 @@ final class PagesBuilderTest extends TestCase
                 null,
                 null,
                 new DictionaryPageHeader(
-                    Encodings::PLAIN,
+                    Encodings::PLAIN_DICTIONARY,
                     \count($enum),
                 )
             ),
@@ -92,6 +94,8 @@ final class PagesBuilderTest extends TestCase
                 \strlen($pages->dataPageContainers()[0]->pageBuffer),
                 new DataPageHeader(
                     Encodings::RLE_DICTIONARY,
+                    Encodings::RLE,
+                    Encodings::RLE,
                     \count($values),
                 ),
                 null,
@@ -124,6 +128,8 @@ final class PagesBuilderTest extends TestCase
                 \strlen($pages->dataPageContainers()[0]->pageBuffer),
                 new DataPageHeader(
                     Encodings::PLAIN,
+                    Encodings::RLE,
+                    Encodings::RLE,
                     \count($values),
                 ),
                 null,
@@ -156,6 +162,8 @@ final class PagesBuilderTest extends TestCase
                 \strlen($pages->dataPageContainers()[0]->pageBuffer),
                 new DataPageHeader(
                     Encodings::PLAIN,
+                    Encodings::RLE,
+                    Encodings::RLE,
                     \count($values),
                 ),
                 null,
@@ -188,7 +196,7 @@ final class PagesBuilderTest extends TestCase
                 null,
                 null,
                 new DictionaryPageHeader(
-                    Encodings::PLAIN,
+                    Encodings::PLAIN_DICTIONARY,
                     1, // string is constant, so we only have one value in dictionary
                 )
             ),
@@ -201,6 +209,8 @@ final class PagesBuilderTest extends TestCase
                 \strlen($pages->dataPageContainers()[0]->pageBuffer),
                 new DataPageHeader(
                     Encodings::RLE_DICTIONARY,
+                    Encodings::RLE,
+                    Encodings::RLE,
                     100,
                 ),
                 null,
@@ -232,6 +242,8 @@ final class PagesBuilderTest extends TestCase
                 \strlen($pages->dataPageContainers()[0]->pageBuffer),
                 new DataPageHeader(
                     Encodings::PLAIN,
+                    Encodings::RLE,
+                    Encodings::RLE,
                     \count($values),
                 ),
                 null,


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <li>ConvertedType to column definitions in parquet for compatibility with other readers</li>
    <li>Repetitions/Definitions levels encodings in DataPage</li>
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>Bug in RLEBitPackHybrid algorithm that was always bitpacking values</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Boolean columns can't be anymore dictionary packed for compatibility with spark</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

Closes: #695 

<h2>Description</h2>

<!-- Please provide a short description of changes in this section, feel free to use markdown syntax -->
