### PR TITLE
Adjusted time related columns to be compatibile with other parquet libraries

### DIFF
--- a/src/lib/parquet/src/Flow/Parquet/Data/Converter/Int64DateTimeConverter.php
+++ b/src/lib/parquet/src/Flow/Parquet/Data/Converter/Int64DateTimeConverter.php
@@ -35,12 +35,12 @@ final class Int64DateTimeConverter implements Converter
      */
     private function dateTimeToMicroseconds(\DateTimeInterface $dateTime) : int
     {
-        return (int) \bcadd(\bcmul($dateTime->format('U'), '1000000000'), $dateTime->format('u'));
+        return (int) \bcadd(\bcmul($dateTime->format('U'), '1000000'), $dateTime->format('u'));
     }
 
     private function microsecondsToDateTimeImmutable(int $microseconds) : \DateTimeImmutable
     {
-        $seconds = (int) ($microseconds / 1000000000);
+        $seconds = (int) ($microseconds / 1000000);
         $fraction = \str_pad((string) ($microseconds % 1000000), 6, '0', STR_PAD_LEFT);
 
         $dateTime = \DateTimeImmutable::createFromFormat('U.u', \sprintf('%d.%s', $seconds, $fraction));

--- a/src/lib/parquet/src/Flow/Parquet/Data/Converter/TimeConverter.php
+++ b/src/lib/parquet/src/Flow/Parquet/Data/Converter/TimeConverter.php
@@ -35,8 +35,8 @@ final class TimeConverter implements Converter
      */
     private function toDateInterval(int $microseconds) : \DateInterval
     {
-        $seconds = (int) \floor($microseconds / 100000000);
-        $remainingMicroseconds = $microseconds % 100000000;
+        $seconds = (int) \floor($microseconds / 1000000);
+        $remainingMicroseconds = $microseconds % 1000000;
 
         $minutes = (int) \floor($seconds / 60);
         $remainingSeconds = $seconds % 60;
@@ -44,14 +44,7 @@ final class TimeConverter implements Converter
         $hours = (int) \floor($minutes / 60);
         $remainingMinutes = $minutes % 60;
 
-        $days = (int) \floor($hours / 24);
         $remainingHours = $hours % 24;
-
-        $months = (int) \floor($days / 30); // Approximation
-
-        if ($months !== 0) {
-            throw new InvalidArgumentException('The DateInterval object contains months, cannot convert to microseconds to represent time.');
-        }
 
         $intervalSpec = \sprintf(
             'PT%dH%dM%dS',
@@ -64,7 +57,7 @@ final class TimeConverter implements Converter
         $interval->y = 0;
         $interval->m = 0;
         $interval->d = 0;
-        $interval->f = ($remainingMicroseconds / 100000000);
+        $interval->f = ($remainingMicroseconds / 1000000);
 
         return $interval;
     }
@@ -81,13 +74,13 @@ final class TimeConverter implements Converter
 
         $microseconds = 0;
 
-        $microseconds += $interval->y * 365 * 24 * 60 * 60 * 100000000; // years to microseconds
-        $microseconds += $interval->m * 30 * 24 * 60 * 60 * 100000000; // months to microseconds (approx)
-        $microseconds += $interval->d * 24 * 60 * 60 * 100000000; // days to microseconds
-        $microseconds += $interval->h * 60 * 60 * 100000000; // hours to microseconds
-        $microseconds += $interval->i * 60 * 100000000; // minutes to microseconds
-        $microseconds += $interval->s * 100000000; // seconds to microseconds
-        $microseconds += (int) (($interval->f) * 100000000); // microseconds
+        $microseconds += $interval->y * 365 * 24 * 60 * 60 * 1000000; // years to microseconds
+        $microseconds += $interval->m * 30 * 24 * 60 * 60 * 1000000; // months to microseconds (approx)
+        $microseconds += $interval->d * 24 * 60 * 60 * 1000000; // days to microseconds
+        $microseconds += $interval->h * 60 * 60 * 1000000; // hours to microseconds
+        $microseconds += $interval->i * 60 * 1000000; // minutes to microseconds
+        $microseconds += $interval->s * 1000000; // seconds to microseconds
+        $microseconds += (int) (($interval->f) * 1000000); // microseconds
 
         return $microseconds;
     }

--- a/src/lib/parquet/src/Flow/Parquet/ParquetFile/Schema/FlatColumn.php
+++ b/src/lib/parquet/src/Flow/Parquet/ParquetFile/Schema/FlatColumn.php
@@ -4,7 +4,6 @@ namespace Flow\Parquet\ParquetFile\Schema;
 
 use Flow\Parquet\Consts;
 use Flow\Parquet\Exception\InvalidArgumentException;
-use Flow\Parquet\ParquetFile\Schema\LogicalType\Timestamp;
 use Flow\Parquet\Thrift\SchemaElement;
 
 /**
@@ -37,20 +36,16 @@ final class FlatColumn implements Column
 
     public static function date(string $name) : self
     {
-        return new self($name, PhysicalType::INT32, ConvertedType::DATE, new LogicalType(LogicalType::DATE), Repetition::OPTIONAL);
+        return new self($name, PhysicalType::INT32, ConvertedType::DATE, LogicalType::date(), Repetition::OPTIONAL);
     }
 
-    public static function dateTime(string $name, TimeUnit $timeUnit = TimeUnit::MICROSECONDS) : self
+    public static function dateTime(string $name) : self
     {
         if (PHP_INT_MAX !== Consts::PHP_INT64_MAX) {
             throw new InvalidArgumentException('PHP_INT_MAX must be equal to ' . Consts::PHP_INT64_MAX . ' to support 64-bit timestamps.');
         }
 
-        $timestamp = match ($timeUnit) {
-            TimeUnit::MICROSECONDS => new Timestamp(false, false, true, false),
-        };
-
-        return new self($name, PhysicalType::INT64, ConvertedType::TIMESTAMP_MICROS, new LogicalType(LogicalType::TIMESTAMP, $timestamp), Repetition::OPTIONAL);
+        return new self($name, PhysicalType::INT64, ConvertedType::TIMESTAMP_MICROS, LogicalType::timestamp(), Repetition::OPTIONAL);
     }
 
     public static function decimal(string $name, int $precision = 10, int $scale = 2) : self
@@ -85,7 +80,7 @@ final class FlatColumn implements Column
 
     public static function enum(string $string) : self
     {
-        return new self($string, PhysicalType::BYTE_ARRAY, ConvertedType::ENUM, new LogicalType(LogicalType::STRING), Repetition::OPTIONAL);
+        return new self($string, PhysicalType::BYTE_ARRAY, ConvertedType::ENUM, LogicalType::string(), Repetition::OPTIONAL);
     }
 
     public static function float(string $name) : self
@@ -123,22 +118,26 @@ final class FlatColumn implements Column
 
     public static function json(string $string) : self
     {
-        return new self($string, PhysicalType::BYTE_ARRAY, ConvertedType::JSON, new LogicalType(LogicalType::STRING), Repetition::OPTIONAL);
+        return new self($string, PhysicalType::BYTE_ARRAY, ConvertedType::JSON, LogicalType::string(), Repetition::OPTIONAL);
     }
 
     public static function string(string $name) : self
     {
-        return new self($name, PhysicalType::BYTE_ARRAY, ConvertedType::UTF8, new LogicalType(LogicalType::STRING), Repetition::OPTIONAL);
+        return new self($name, PhysicalType::BYTE_ARRAY, ConvertedType::UTF8, LogicalType::string(), Repetition::OPTIONAL);
     }
 
     public static function time(string $name) : self
     {
-        return new self($name, PhysicalType::INT64, ConvertedType::TIME_MICROS, new LogicalType(LogicalType::TIME), Repetition::OPTIONAL);
+        if (PHP_INT_MAX !== Consts::PHP_INT64_MAX) {
+            throw new InvalidArgumentException('PHP_INT_MAX must be equal to ' . Consts::PHP_INT64_MAX . ' to support 64-bit timestamps.');
+        }
+
+        return new self($name, PhysicalType::INT64, ConvertedType::TIME_MICROS, LogicalType::time(), Repetition::OPTIONAL);
     }
 
     public static function uuid(string $string) : self
     {
-        return new self($string, PhysicalType::BYTE_ARRAY, null, new LogicalType(LogicalType::STRING), Repetition::OPTIONAL);
+        return new self($string, PhysicalType::BYTE_ARRAY, null, LogicalType::string(), Repetition::OPTIONAL);
     }
 
     public function __debugInfo() : ?array

--- a/src/lib/parquet/src/Flow/Parquet/ParquetFile/Schema/ListElement.php
+++ b/src/lib/parquet/src/Flow/Parquet/ParquetFile/Schema/ListElement.php
@@ -18,9 +18,9 @@ final class ListElement
         return new self(FlatColumn::date('element'));
     }
 
-    public static function datetime(TimeUnit $timeUnit = TimeUnit::MICROSECONDS) : self
+    public static function datetime() : self
     {
-        return new self(FlatColumn::dateTime('element', $timeUnit));
+        return new self(FlatColumn::dateTime('element'));
     }
 
     public static function decimal(int $precision, int $scale) : self

--- a/src/lib/parquet/src/Flow/Parquet/ParquetFile/Schema/LogicalType/Time.php
+++ b/src/lib/parquet/src/Flow/Parquet/ParquetFile/Schema/LogicalType/Time.php
@@ -1,0 +1,49 @@
+<?php declare(strict_types=1);
+
+namespace Flow\Parquet\ParquetFile\Schema\LogicalType;
+
+use Flow\Parquet\Thrift\TimeType;
+
+/**
+ * @psalm-suppress RedundantConditionGivenDocblockType
+ */
+final class Time
+{
+    public function __construct(
+        private readonly bool $isAdjustedToUTC,
+        private readonly bool $millis,
+        private readonly bool $micros,
+        private readonly bool $nanos
+    ) {
+    }
+
+    public static function fromThrift(TimeType $timestamp) : self
+    {
+        return new self(
+            $timestamp->isAdjustedToUTC,
+            $timestamp->unit->MILLIS !== null,
+            $timestamp->unit->MICROS !== null,
+            $timestamp->unit->NANOS !== null
+        );
+    }
+
+    public function isAdjustedToUTC() : bool
+    {
+        return $this->isAdjustedToUTC;
+    }
+
+    public function micros() : bool
+    {
+        return $this->micros;
+    }
+
+    public function millis() : bool
+    {
+        return $this->millis;
+    }
+
+    public function nanos() : bool
+    {
+        return $this->nanos;
+    }
+}

--- a/src/lib/parquet/src/Flow/Parquet/ParquetFile/Schema/MapKey.php
+++ b/src/lib/parquet/src/Flow/Parquet/ParquetFile/Schema/MapKey.php
@@ -18,9 +18,9 @@ final class MapKey
         return new self(FlatColumn::date('key')->makeRequired());
     }
 
-    public static function datetime(TimeUnit $timeUnit = TimeUnit::MICROSECONDS) : self
+    public static function datetime() : self
     {
-        return new self(FlatColumn::dateTime('key', $timeUnit)->makeRequired());
+        return new self(FlatColumn::dateTime('key')->makeRequired());
     }
 
     public static function decimal(int $precision, int $scale) : self

--- a/src/lib/parquet/src/Flow/Parquet/ParquetFile/Schema/MapValue.php
+++ b/src/lib/parquet/src/Flow/Parquet/ParquetFile/Schema/MapValue.php
@@ -18,9 +18,9 @@ final class MapValue
         return new self(FlatColumn::date('value'));
     }
 
-    public static function datetime(TimeUnit $timeUnit = TimeUnit::MICROSECONDS) : self
+    public static function datetime() : self
     {
-        return new self(FlatColumn::dateTime('value', $timeUnit));
+        return new self(FlatColumn::dateTime('value'));
     }
 
     public static function decimal(int $precision, int $scale) : self


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Adjusted time related columns to be compatibile with other parquet libraries</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

For now, I had to hardcode the time precision for all time-based columns to MICROSECONDS, which is the most precise way of calculating time in PHP. 
Depends on demand we can later implement also MILLISECONDS precision but I'm not even sure if there will be any real use cases for it. 
