### PR TITLE
DataFrame - batch size

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -26,6 +26,10 @@ Which does exactly the same thing as BufferLoader did, but in a more generic way
 Pipeline Closure was reduced to be only Loader Closure and it was moved to \Flow\ETL\Loader namespace. 
 Additionally, \Closure::close method no longer requires Rows to be passed as an argument.
 
+### 5) Parallelize 
+
+DataFrame::parallelize() method is deprecated, and it will be removed, instead use DataFrame::batchSize(int $size) method. 
+
 ---
 
 ## Upgrading from 0.3.x to 0.4.x

--- a/src/adapter/etl-adapter-avro/tests/Flow/ETL/Adapter/Avro/Tests/Integration/AvroTest.php
+++ b/src/adapter/etl-adapter-avro/tests/Flow/ETL/Adapter/Avro/Tests/Integration/AvroTest.php
@@ -130,7 +130,7 @@ final class AvroTest extends TestCase
                     }, \range(1, 100))
                 )
             ))
-            ->parallelize(10)
+            ->batchSize(10)
             ->write(Avro::to($path))
             ->run();
 

--- a/src/core/etl/tests/Flow/ETL/Tests/Integration/Pipeline/BatchingPipelineTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Integration/Pipeline/BatchingPipelineTest.php
@@ -1,0 +1,132 @@
+<?php declare(strict_types=1);
+
+namespace Flow\ETL\Tests\Integration\Pipeline;
+
+use Flow\ETL\Config;
+use Flow\ETL\DSL\From;
+use Flow\ETL\FlowContext;
+use Flow\ETL\Pipeline\BatchingPipeline;
+use Flow\ETL\Pipeline\SynchronousPipeline;
+use Flow\ETL\Rows;
+use PHPUnit\Framework\TestCase;
+
+final class BatchingPipelineTest extends TestCase
+{
+    public function test_batching_rows() : void
+    {
+        $pipeline = new BatchingPipeline(new SynchronousPipeline(), size: 10);
+        $pipeline->source(From::chain(
+            From::array([
+                ['id' => 1],
+                ['id' => 2],
+                ['id' => 3],
+                ['id' => 4],
+                ['id' => 5],
+            ]),
+            From::array([
+                ['id' => 6],
+                ['id' => 7],
+                ['id' => 8],
+                ['id' => 9],
+                ['id' => 10],
+            ])
+        ));
+
+        $this->assertCount(
+            1,
+            \iterator_to_array($pipeline->process(new FlowContext(Config::default())))
+        );
+    }
+
+    public function test_that_rows_are_not_lost() : void
+    {
+        $pipeline = new BatchingPipeline(new SynchronousPipeline(), $batchSize = 7);
+        $pipeline->source(From::chain(
+            From::array([
+                ['id' => 1],
+                ['id' => 2],
+                ['id' => 3],
+                ['id' => 4],
+                ['id' => 5],
+                ['id' => 6],
+                ['id' => 7],
+                ['id' => 8],
+                ['id' => 9],
+                ['id' => 10],
+            ])
+        ));
+
+        $this->assertEquals(
+            [
+                [
+                    ['id' => 1],
+                    ['id' => 2],
+                    ['id' => 3],
+                    ['id' => 4],
+                    ['id' => 5],
+                    ['id' => 6],
+                    ['id' => 7],
+                ],
+                [
+                    ['id' => 8],
+                    ['id' => 9],
+                    ['id' => 10],
+                ],
+            ],
+            \array_map(
+                static fn (Rows $r) => $r->toArray(),
+                \iterator_to_array($pipeline->process(new FlowContext(Config::default())))
+            )
+        );
+    }
+
+    public function test_using_bigger_batch_size_than_total_number_of_rows() : void
+    {
+        $pipeline = new BatchingPipeline(new SynchronousPipeline(), size: 11);
+        $pipeline->source(From::chain(
+            From::array([
+                ['id' => 1],
+                ['id' => 2],
+                ['id' => 3],
+                ['id' => 4],
+                ['id' => 5],
+            ]),
+            From::array([
+                ['id' => 6],
+                ['id' => 7],
+                ['id' => 8],
+                ['id' => 9],
+                ['id' => 10],
+            ])
+        ));
+
+        $this->assertCount(
+            1,
+            \iterator_to_array($pipeline->process(new FlowContext(Config::default())))
+        );
+    }
+
+    public function test_using_smaller_batch_size_than_total_number_of_rows() : void
+    {
+        $pipeline = new BatchingPipeline(new SynchronousPipeline(), size: 5);
+        $pipeline->source(From::chain(
+            From::array([
+                ['id' => 1],
+                ['id' => 2],
+                ['id' => 3],
+                ['id' => 4],
+                ['id' => 5],
+                ['id' => 6],
+                ['id' => 7],
+                ['id' => 8],
+                ['id' => 9],
+                ['id' => 10],
+            ])
+        ));
+
+        $this->assertCount(
+            2,
+            \iterator_to_array($pipeline->process(new FlowContext(Config::default())))
+        );
+    }
+}

--- a/src/core/etl/tests/Flow/ETL/Tests/Integration/Pipeline/CollectingPipelineTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Integration/Pipeline/CollectingPipelineTest.php
@@ -11,59 +11,7 @@ use PHPUnit\Framework\TestCase;
 
 final class CollectingPipelineTest extends TestCase
 {
-    public function test_collecting_with_batch_size() : void
-    {
-        $pipeline = new CollectingPipeline(new SynchronousPipeline(), 3);
-        $pipeline->source(From::chain(
-            From::array([
-                ['id' => 1],
-                ['id' => 2],
-                ['id' => 3],
-                ['id' => 4],
-                ['id' => 5],
-            ]),
-            From::array([
-                ['id' => 6],
-                ['id' => 7],
-                ['id' => 8],
-                ['id' => 9],
-                ['id' => 10],
-            ])
-        ));
-
-        $this->assertCount(
-            4,
-            \iterator_to_array($pipeline->process(new FlowContext(Config::default())))
-        );
-    }
-
-    public function test_collecting_with_batch_size_smaller_bigger_than_total_number_of_rows() : void
-    {
-        $pipeline = new CollectingPipeline(new SynchronousPipeline(), 20);
-        $pipeline->source(From::chain(
-            From::array([
-                ['id' => 1],
-                ['id' => 2],
-                ['id' => 3],
-                ['id' => 4],
-                ['id' => 5],
-            ]),
-            From::array([
-                ['id' => 6],
-                ['id' => 7],
-                ['id' => 8],
-                ['id' => 9],
-                ['id' => 10],
-            ])
-        ));
-
-        $this->assertCount(
-            1,
-            \iterator_to_array($pipeline->process(new FlowContext(Config::default())))
-        );
-    }
-
-    public function test_collecting_without_batch_size() : void
+    public function test_collecting() : void
     {
         $pipeline = new CollectingPipeline(new SynchronousPipeline());
         $pipeline->source(From::chain(
@@ -80,6 +28,11 @@ final class CollectingPipelineTest extends TestCase
                 ['id' => 8],
                 ['id' => 9],
                 ['id' => 10],
+            ]),
+            From::array([
+                ['id' => 11],
+                ['id' => 12],
+                ['id' => 13],
             ])
         ));
 


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <li>DataFrame::batchSize(int $size) method</li>
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <li>DataFrame::parallelize()</li>
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

Instead of using DataFrame::parallelize which was only splitting rows, from now DataFrame::batchSize should be used that is more generic and can not only split but also merge rows together when smaller batches are yielded from Extractors. 