### PR TITLE
`GoogleSheetExtractor::$rowsInBatch` renamed to `$endRow`

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -30,6 +30,10 @@ Additionally, \Closure::close method no longer requires Rows to be passed as an 
 
 DataFrame::parallelize() method is deprecated, and it will be removed, instead use DataFrame::batchSize(int $size) method. 
 
+### 6) `GoogleSheetExtractor::$rowsInBatch` renamed
+
+`GoogleSheetExtractor::$rowsInBatch` was renamed to a more adequate `$endRow`, the same as the one used in the underlying code of the `SheetRange` class. Related code was adjusted to new naming. Additionally,  the `SheetRange::nextRows()` method was removed.
+
 ---
 
 ## Upgrading from 0.3.x to 0.4.x

--- a/src/adapter/etl-adapter-google-sheet/src/Flow/ETL/Adapter/GoogleSheet/GoogleSheetExtractor.php
+++ b/src/adapter/etl-adapter-google-sheet/src/Flow/ETL/Adapter/GoogleSheet/GoogleSheetExtractor.php
@@ -22,20 +22,19 @@ final class GoogleSheetExtractor implements Extractor
         private readonly string $spreadsheetId,
         private readonly Columns $columnRange,
         private readonly bool $withHeader,
-        private readonly int $rowsInBatch,
+        private readonly int $endRow,
         private readonly array $options = [],
     ) {
-        if ($this->rowsInBatch < 1) {
-            throw new InvalidArgumentException('Rows in batch must be greater than 0');
+        if ($this->endRow < 1) {
+            throw new InvalidArgumentException('End row must be greater than 0');
         }
     }
 
     public function extract(FlowContext $context) : \Generator
     {
-        $cellsRange = new SheetRange($this->columnRange, 1, $this->rowsInBatch);
+        $cellsRange = new SheetRange($this->columnRange, 1, $this->endRow);
         $headers = [];
 
-        $totalRows = 0;
         /** @var Sheets\ValueRange $response */
         $response = $this->service->spreadsheets_values->get($this->spreadsheetId, $cellsRange->toString(), $this->options);
         /**
@@ -51,56 +50,40 @@ final class GoogleSheetExtractor implements Extractor
             /** @var string[] $headers */
             $headers = $values[0];
             unset($values[0]);
-            $totalRows = 1;
         }
 
         $shouldPutInputIntoRows = $context->config->shouldPutInputIntoRows();
 
-        while ([] !== $values) {
-            yield array_to_rows(
-                \array_map(
-                    function (array $rowData) use ($headers, $shouldPutInputIntoRows, &$totalRows) {
-                        if (\count($headers) > \count($rowData)) {
-                            \array_push(
-                                $rowData,
-                                ...\array_map(
-                                    static fn (int $i) => null,
-                                    \range(1, \count($headers) - \count($rowData))
-                                )
-                            );
-                        }
+        yield array_to_rows(
+            \array_map(
+                function (array $rowData) use ($headers, $shouldPutInputIntoRows) {
+                    if (\count($headers) > \count($rowData)) {
+                        \array_push(
+                            $rowData,
+                            ...\array_map(
+                                static fn (int $i) => null,
+                                \range(1, \count($headers) - \count($rowData))
+                            )
+                        );
+                    }
 
-                        if (\count($rowData) > \count($headers)) {
-                            /** @phpstan-ignore-next-line */
-                            $rowData = \array_chunk($rowData, \count($headers));
-                        }
+                    if (\count($rowData) > \count($headers)) {
+                        /** @phpstan-ignore-next-line */
+                        $rowData = \array_chunk($rowData, \count($headers));
+                    }
 
-                        /** @var int $totalRows */
-                        $totalRows++;
+                    $row = \array_combine($headers, $rowData);
 
-                        $row = \array_combine($headers, $rowData);
+                    if ($shouldPutInputIntoRows) {
+                        $row['_spread_sheet_id'] = $this->spreadsheetId;
+                        $row['_sheet_name'] = $this->columnRange->sheetName;
+                    }
 
-                        if ($shouldPutInputIntoRows) {
-                            $row['_spread_sheet_id'] = $this->spreadsheetId;
-                            $row['_sheet_name'] = $this->columnRange->sheetName;
-                        }
-
-                        return $row;
-                    },
-                    $values
-                ),
-                $context->entryFactory()
-            );
-
-            if ($totalRows < $cellsRange->endRow) {
-                return;
-            }
-
-            $cellsRange = $cellsRange->nextRows($this->rowsInBatch);
-            /** @var Sheets\ValueRange $response */
-            $response = $this->service->spreadsheets_values->get($this->spreadsheetId, $cellsRange->toString(), $this->options);
-            /** @var array[] $values */
-            $values = $response->getValues();
-        }
+                    return $row;
+                },
+                $values
+            ),
+            $context->entryFactory()
+        );
     }
 }

--- a/src/adapter/etl-adapter-google-sheet/src/Flow/ETL/Adapter/GoogleSheet/SheetRange.php
+++ b/src/adapter/etl-adapter-google-sheet/src/Flow/ETL/Adapter/GoogleSheet/SheetRange.php
@@ -26,19 +26,6 @@ final class SheetRange
         }
     }
 
-    public function nextRows(int $count) : self
-    {
-        if ($count < 1) {
-            throw new InvalidArgumentException(\sprintf('Count "%d" must be greater than 0', $count));
-        }
-
-        return new self(
-            $this->columnRange,
-            $this->endRow + 1,
-            $this->endRow + $count,
-        );
-    }
-
     public function toString() : string
     {
         return \sprintf(

--- a/src/adapter/etl-adapter-google-sheet/src/Flow/ETL/DSL/GoogleSheet.php
+++ b/src/adapter/etl-adapter-google-sheet/src/Flow/ETL/DSL/GoogleSheet.php
@@ -14,7 +14,7 @@ class GoogleSheet
 {
     /**
      * @param array{type: string, project_id: string, private_key_id: string, private_key: string, client_email: string, client_id: string, auth_uri: string, token_uri: string, auth_provider_x509_cert_url: string, client_x509_cert_url: string}|Sheets $auth_config
-     * @param int $rows_in_batch
+     * @param int $end_row
      * @param bool $with_header
      * @param array{dateTimeRenderOption?: string, majorDimension?: string, valueRenderOption?: string} $options
      *
@@ -25,7 +25,7 @@ class GoogleSheet
         string $spreadsheet_id,
         string $sheet_name,
         bool $with_header = true,
-        int $rows_in_batch = 1000,
+        int $end_row = 1000,
         array $options = [],
     ) : Extractor {
         if ($auth_config instanceof Sheets) {
@@ -42,14 +42,14 @@ class GoogleSheet
             $spreadsheet_id,
             new Columns($sheet_name, 'A', 'Z'),
             $with_header,
-            $rows_in_batch,
+            $end_row,
             $options,
         );
     }
 
     /**
      * @param array{type: string, project_id: string, private_key_id: string, private_key: string, client_email: string, client_id: string, auth_uri: string, token_uri: string, auth_provider_x509_cert_url: string, client_x509_cert_url: string}|Sheets $auth_config
-     * @param int $rows_in_batch
+     * @param int $end_row
      * @param bool $with_header
      * @param array{dateTimeRenderOption?: string, majorDimension?: string, valueRenderOption?: string} $options
      *
@@ -62,7 +62,7 @@ class GoogleSheet
         string $start_range_column,
         string $end_range_column,
         bool $with_header = true,
-        int $rows_in_batch = 1000,
+        int $end_row = 1000,
         array $options = [],
     ) : Extractor {
         if ($auth_config instanceof Sheets) {
@@ -79,7 +79,7 @@ class GoogleSheet
             $spreadsheet_id,
             new Columns($sheet_name, $start_range_column, $end_range_column),
             $with_header,
-            $rows_in_batch,
+            $end_row,
             $options,
         );
     }

--- a/src/adapter/etl-adapter-google-sheet/tests/Flow/ETL/Adapter/GoogleSheet/Tests/Unit/GoogleSheetExtractorTest.php
+++ b/src/adapter/etl-adapter-google-sheet/tests/Flow/ETL/Adapter/GoogleSheet/Tests/Unit/GoogleSheetExtractorTest.php
@@ -4,14 +4,9 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Adapter\GoogleSheet\Tests\Unit;
 
-use Flow\ETL\ConfigBuilder;
-use Flow\ETL\DSL\Entry;
+use Flow\ETL\Config;
 use Flow\ETL\DSL\GoogleSheet;
-use Flow\ETL\Exception\InvalidArgumentException;
 use Flow\ETL\FlowContext;
-use Flow\ETL\Row;
-use Flow\ETL\Row\Entry\StringEntry;
-use Flow\ETL\Rows;
 use Google\Service\Sheets;
 use Google\Service\Sheets\Resource\SpreadsheetsValues;
 use PHPUnit\Framework\TestCase;
@@ -22,52 +17,34 @@ final class GoogleSheetExtractorTest extends TestCase
     {
         $extractor = GoogleSheet::from_columns(
             $service = $this->createMock(Sheets::class),
-            $spreadSheetId = 'spread-id',
-            $sheetName = 'sheet',
-            'A',
-            'B',
-            true,
-            2,
-        );
-        $spreadSheetIdEntry = new StringEntry('_spread_sheet_id', $spreadSheetId);
-        $sheetNameEntry = new StringEntry('_sheet_name', $sheetName);
-        $firstValueRangeMock = $this->createMock(Sheets\ValueRange::class);
-        $firstValueRangeMock->method('getValues')->willReturn([
-            ['header'],
-            ['row1'],
-        ]);
-        $secondValueRangeMock = $this->createMock(Sheets\ValueRange::class);
-        $secondValueRangeMock->method('getValues')->willReturn([
-            ['row2'],
-        ]);
-        $service->spreadsheets_values = ($spreadsheetsValues = $this->createMock(SpreadsheetsValues::class));
-
-        $spreadsheetsValues->expects($this->exactly(2))
-            ->method('get')
-            ->willReturnOnConsecutiveCalls($firstValueRangeMock, $secondValueRangeMock);
-
-        /** @var array<Rows> $rowsArray */
-        $rowsArray = \iterator_to_array($extractor->extract(new FlowContext((new ConfigBuilder())->putInputIntoRows()->build())));
-        $this->assertCount(2, $rowsArray);
-        $this->assertSame(1, $rowsArray[0]->count());
-        $this->assertEquals(Row::create($sheetNameEntry, $spreadSheetIdEntry, Entry::string('header', 'row1')), $rowsArray[0]->first());
-        $this->assertSame(1, $rowsArray[1]->count());
-        $this->assertEquals(Row::create($sheetNameEntry, $spreadSheetIdEntry, Entry::string('header', 'row2')), $rowsArray[1]->first());
-    }
-
-    public function test_rows_in_batch_must_be_positive_integer() : void
-    {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Rows in batch must be greater than 0');
-
-        GoogleSheet::from_columns(
-            $this->createMock(Sheets::class),
             'spread-id',
             'sheet',
             'A',
             'B',
-            true,
-            0
+        );
+
+        $valueRangeMock = $this->createMock(Sheets\ValueRange::class);
+        $valueRangeMock->method('getValues')->willReturn([
+            ['header'],
+            ['row1'],
+            ['row2'],
+        ]);
+        $service->spreadsheets_values = ($spreadsheetsValues = $this->createMock(SpreadsheetsValues::class));
+
+        $spreadsheetsValues->expects($this->once())
+            ->method('get')
+            ->willReturn($valueRangeMock);
+
+        $this->assertSame(
+            [
+                [
+                    'header' => 'row1',
+                ],
+                [
+                    'header' => 'row2',
+                ],
+            ],
+            \iterator_to_array($extractor->extract(new FlowContext(Config::default())))[0]->toArray()
         );
     }
 
@@ -87,8 +64,8 @@ final class GoogleSheetExtractorTest extends TestCase
 
         $service->spreadsheets_values = ($spreadsheetsValues = $this->createMock(SpreadsheetsValues::class));
         $spreadsheetsValues->method('get')->willReturn($ValueRangeMock);
-        /** @var array<Rows> $rowsArray */
-        $rowsArray = \iterator_to_array($extractor->extract(new FlowContext((new ConfigBuilder())->build())));
+
+        $rowsArray = \iterator_to_array($extractor->extract(new FlowContext(Config::default())))[0]->toArray();
         $this->assertCount(0, $rowsArray);
     }
 }

--- a/src/adapter/etl-adapter-google-sheet/tests/Flow/ETL/Adapter/GoogleSheet/Tests/Unit/SheetRangeTest.php
+++ b/src/adapter/etl-adapter-google-sheet/tests/Flow/ETL/Adapter/GoogleSheet/Tests/Unit/SheetRangeTest.php
@@ -56,13 +56,6 @@ final class SheetRangeTest extends TestCase
         new SheetRange(new Columns('Sheet2', 'A', 'B'), $startRow, $endRow);
     }
 
-    public function test_next_rows_range() : void
-    {
-        $range = new SheetRange(new Columns('Sheet2', 'A', 'B'), 1, 10);
-        $this->assertSame('Sheet2!A11:B20', $range->nextRows(10)->toString());
-        $this->assertSame('Sheet2!A21:B40', $range->nextRows(10)->nextRows(20)->toString());
-    }
-
     /**
      * @dataProvider example_string_ranges
      */


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>`GoogleSheetExtractor::$rowsInBatch` renamed to `$endRow`</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <li>`SheetRange::nextRows()`</li>
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

Related to https://github.com/flow-php/flow/issues/719, but `GoogleSheetExtractor::$rowsInBatch` had an internal additional meaning of limiting the whole read spreadsheet to a given value.
