### PR TITLE
Add way to limit `GoogleSheetExtractor` to particular limit of rows

### DIFF
--- a/src/adapter/etl-adapter-google-sheet/src/Flow/ETL/Adapter/GoogleSheet/SheetRange.php
+++ b/src/adapter/etl-adapter-google-sheet/src/Flow/ETL/Adapter/GoogleSheet/SheetRange.php
@@ -34,7 +34,7 @@ final class SheetRange
 
         return new self(
             $this->columnRange,
-            $this->endRow + 1,
+            $count,
             $this->endRow + $count,
         );
     }

--- a/src/adapter/etl-adapter-google-sheet/src/Flow/ETL/DSL/GoogleSheet.php
+++ b/src/adapter/etl-adapter-google-sheet/src/Flow/ETL/DSL/GoogleSheet.php
@@ -14,8 +14,6 @@ class GoogleSheet
 {
     /**
      * @param array{type: string, project_id: string, private_key_id: string, private_key: string, client_email: string, client_id: string, auth_uri: string, token_uri: string, auth_provider_x509_cert_url: string, client_x509_cert_url: string}|Sheets $auth_config
-     * @param int $rows_in_batch
-     * @param bool $with_header
      * @param array{dateTimeRenderOption?: string, majorDimension?: string, valueRenderOption?: string} $options
      *
      * @return Extractor
@@ -25,7 +23,7 @@ class GoogleSheet
         string $spreadsheet_id,
         string $sheet_name,
         bool $with_header = true,
-        int $rows_in_batch = 1000,
+        int $last_row = 1000,
         array $options = [],
     ) : Extractor {
         if ($auth_config instanceof Sheets) {
@@ -42,15 +40,13 @@ class GoogleSheet
             $spreadsheet_id,
             new Columns($sheet_name, 'A', 'Z'),
             $with_header,
-            $rows_in_batch,
+            $last_row,
             $options,
         );
     }
 
     /**
      * @param array{type: string, project_id: string, private_key_id: string, private_key: string, client_email: string, client_id: string, auth_uri: string, token_uri: string, auth_provider_x509_cert_url: string, client_x509_cert_url: string}|Sheets $auth_config
-     * @param int $rows_in_batch
-     * @param bool $with_header
      * @param array{dateTimeRenderOption?: string, majorDimension?: string, valueRenderOption?: string} $options
      *
      * @return Extractor
@@ -62,7 +58,7 @@ class GoogleSheet
         string $start_range_column,
         string $end_range_column,
         bool $with_header = true,
-        int $rows_in_batch = 1000,
+        int $last_row = 1000,
         array $options = [],
     ) : Extractor {
         if ($auth_config instanceof Sheets) {
@@ -79,7 +75,7 @@ class GoogleSheet
             $spreadsheet_id,
             new Columns($sheet_name, $start_range_column, $end_range_column),
             $with_header,
-            $rows_in_batch,
+            $last_row,
             $options,
         );
     }

--- a/src/adapter/etl-adapter-google-sheet/tests/Flow/ETL/Adapter/GoogleSheet/Tests/Unit/GoogleSheetExtractorTest.php
+++ b/src/adapter/etl-adapter-google-sheet/tests/Flow/ETL/Adapter/GoogleSheet/Tests/Unit/GoogleSheetExtractorTest.php
@@ -4,13 +4,12 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Adapter\GoogleSheet\Tests\Unit;
 
-use Flow\ETL\ConfigBuilder;
+use Flow\ETL\Config;
 use Flow\ETL\DSL\Entry;
 use Flow\ETL\DSL\GoogleSheet;
 use Flow\ETL\Exception\InvalidArgumentException;
 use Flow\ETL\FlowContext;
 use Flow\ETL\Row;
-use Flow\ETL\Row\Entry\StringEntry;
 use Flow\ETL\Rows;
 use Google\Service\Sheets;
 use Google\Service\Sheets\Resource\SpreadsheetsValues;
@@ -18,47 +17,10 @@ use PHPUnit\Framework\TestCase;
 
 final class GoogleSheetExtractorTest extends TestCase
 {
-    public function test_its_stop_fetching_data_if_processed_row_count_is_less_then_last_range_end_row() : void
-    {
-        $extractor = GoogleSheet::from_columns(
-            $service = $this->createMock(Sheets::class),
-            $spreadSheetId = 'spread-id',
-            $sheetName = 'sheet',
-            'A',
-            'B',
-            true,
-            2,
-        );
-        $spreadSheetIdEntry = new StringEntry('_spread_sheet_id', $spreadSheetId);
-        $sheetNameEntry = new StringEntry('_sheet_name', $sheetName);
-        $firstValueRangeMock = $this->createMock(Sheets\ValueRange::class);
-        $firstValueRangeMock->method('getValues')->willReturn([
-            ['header'],
-            ['row1'],
-        ]);
-        $secondValueRangeMock = $this->createMock(Sheets\ValueRange::class);
-        $secondValueRangeMock->method('getValues')->willReturn([
-            ['row2'],
-        ]);
-        $service->spreadsheets_values = ($spreadsheetsValues = $this->createMock(SpreadsheetsValues::class));
-
-        $spreadsheetsValues->expects($this->exactly(2))
-            ->method('get')
-            ->willReturnOnConsecutiveCalls($firstValueRangeMock, $secondValueRangeMock);
-
-        /** @var array<Rows> $rowsArray */
-        $rowsArray = \iterator_to_array($extractor->extract(new FlowContext((new ConfigBuilder())->putInputIntoRows()->build())));
-        $this->assertCount(2, $rowsArray);
-        $this->assertSame(1, $rowsArray[0]->count());
-        $this->assertEquals(Row::create($sheetNameEntry, $spreadSheetIdEntry, Entry::string('header', 'row1')), $rowsArray[0]->first());
-        $this->assertSame(1, $rowsArray[1]->count());
-        $this->assertEquals(Row::create($sheetNameEntry, $spreadSheetIdEntry, Entry::string('header', 'row2')), $rowsArray[1]->first());
-    }
-
     public function test_rows_in_batch_must_be_positive_integer() : void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Rows in batch must be greater than 0');
+        $this->expectExceptionMessage('Last row must be greater than 0');
 
         GoogleSheet::from_columns(
             $this->createMock(Sheets::class),
@@ -69,6 +31,77 @@ final class GoogleSheetExtractorTest extends TestCase
             true,
             0
         );
+    }
+
+    public function test_stop_fetching_data_when_no_more_data_is_returned() : void
+    {
+        $extractor = GoogleSheet::from_columns(
+            $service = $this->createMock(Sheets::class),
+            'spread-id',
+            'sheet',
+            'A',
+            'B',
+            true,
+            150,
+        );
+
+        $firstValueRangeMock = $this->createMock(Sheets\ValueRange::class);
+        $firstValueRangeMock->method('getValues')->willReturn([
+            ['header'],
+            ['row1'],
+            ...\array_fill(2, 49, ['row']),
+        ]);
+        $secondValueRangeMock = $this->createMock(Sheets\ValueRange::class);
+        $secondValueRangeMock->method('getValues')->willReturn([]);
+        $service->spreadsheets_values = ($spreadsheetsValues = $this->createMock(SpreadsheetsValues::class));
+
+        $spreadsheetsValues->expects($this->exactly(2))
+            ->method('get')
+            ->willReturnOnConsecutiveCalls($firstValueRangeMock, $secondValueRangeMock);
+
+        /** @var array<Rows> $rowsArray */
+        $rowsArray = \iterator_to_array($extractor->extract(new FlowContext(Config::default())));
+        $this->assertCount(1, $rowsArray);
+        $this->assertSame(50, $rowsArray[0]->count());
+        $this->assertEquals(Row::create(Entry::string('header', 'row1')), $rowsArray[0]->first());
+    }
+
+    public function test_stop_fetching_data_when_processed_row_count_is_less_then_last_range_end_row() : void
+    {
+        $extractor = GoogleSheet::from_columns(
+            $service = $this->createMock(Sheets::class),
+            'spread-id',
+            'sheet',
+            'A',
+            'B',
+            true,
+            150,
+        );
+
+        $firstValueRangeMock = $this->createMock(Sheets\ValueRange::class);
+        $firstValueRangeMock->method('getValues')->willReturn([
+            ['header'],
+            ['row1'],
+            ...\array_fill(2, 99, ['row']),
+        ]);
+        $secondValueRangeMock = $this->createMock(Sheets\ValueRange::class);
+        $secondValueRangeMock->method('getValues')->willReturn([
+            ['row2'],
+            ...\array_fill(2, 49, ['row']),
+        ]);
+        $service->spreadsheets_values = ($spreadsheetsValues = $this->createMock(SpreadsheetsValues::class));
+
+        $spreadsheetsValues->expects($this->exactly(2))
+            ->method('get')
+            ->willReturnOnConsecutiveCalls($firstValueRangeMock, $secondValueRangeMock);
+
+        /** @var array<Rows> $rowsArray */
+        $rowsArray = \iterator_to_array($extractor->extract(new FlowContext(Config::default())));
+        $this->assertCount(2, $rowsArray);
+        $this->assertSame(100, $rowsArray[0]->count());
+        $this->assertEquals(Row::create(Entry::string('header', 'row1')), $rowsArray[0]->first());
+        $this->assertSame(50, $rowsArray[1]->count());
+        $this->assertEquals(Row::create(Entry::string('header', 'row2')), $rowsArray[1]->first());
     }
 
     public function test_works_for_no_data() : void
@@ -82,13 +115,14 @@ final class GoogleSheetExtractorTest extends TestCase
             true,
             20
         );
-        $ValueRangeMock = $this->createMock(Sheets\ValueRange::class);
-        $ValueRangeMock->method('getValues')->willReturn(null);
+        $valueRangeMock = $this->createMock(Sheets\ValueRange::class);
+        $valueRangeMock->method('getValues')->willReturn(null);
 
         $service->spreadsheets_values = ($spreadsheetsValues = $this->createMock(SpreadsheetsValues::class));
-        $spreadsheetsValues->method('get')->willReturn($ValueRangeMock);
+        $spreadsheetsValues->method('get')->willReturn($valueRangeMock);
+
         /** @var array<Rows> $rowsArray */
-        $rowsArray = \iterator_to_array($extractor->extract(new FlowContext((new ConfigBuilder())->build())));
+        $rowsArray = \iterator_to_array($extractor->extract(new FlowContext(Config::default())));
         $this->assertCount(0, $rowsArray);
     }
 }

--- a/src/adapter/etl-adapter-google-sheet/tests/Flow/ETL/Adapter/GoogleSheet/Tests/Unit/SheetRangeTest.php
+++ b/src/adapter/etl-adapter-google-sheet/tests/Flow/ETL/Adapter/GoogleSheet/Tests/Unit/SheetRangeTest.php
@@ -59,8 +59,8 @@ final class SheetRangeTest extends TestCase
     public function test_next_rows_range() : void
     {
         $range = new SheetRange(new Columns('Sheet2', 'A', 'B'), 1, 10);
-        $this->assertSame('Sheet2!A11:B20', $range->nextRows(10)->toString());
-        $this->assertSame('Sheet2!A21:B40', $range->nextRows(10)->nextRows(20)->toString());
+        $this->assertSame('Sheet2!A10:B20', $range->nextRows(10)->toString());
+        $this->assertSame('Sheet2!A20:B40', $range->nextRows(10)->nextRows(20)->toString());
     }
 
     /**


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <li>Add way to limit `GoogleSheetExtractor` to a particular limit of rows</li>
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

Right now there is no real way to limit `GoogleSheetExtractor`, it will iterate till the end of a given spreadsheet, with given changes it will stop if receives the given amount of rows or less than.
