### PR TITLE
Prevent PHP notices when working with `BinaryReader` & `SnappyCompressor`

### DIFF
--- a/src/lib/parquet/src/Flow/Parquet/BinaryReader/Bytes.php
+++ b/src/lib/parquet/src/Flow/Parquet/BinaryReader/Bytes.php
@@ -47,7 +47,7 @@ final class Bytes implements \ArrayAccess, \Countable, \IteratorAggregate
 
     public function offsetGet($offset) : mixed
     {
-        return $this->bytes[$offset];
+        return $this->bytes[$offset] ?? null;
     }
 
     public function offsetSet($offset, $value) : void

--- a/src/lib/snappy/src/Flow/Snappy/SnappyCompressor.php
+++ b/src/lib/snappy/src/Flow/Snappy/SnappyCompressor.php
@@ -218,7 +218,7 @@ final class SnappyCompressor
 
     private function load32(array $array, int $pos) : int
     {
-        return $array[$pos] + ($array[$pos + 1] << 8) + ($array[$pos + 2] << 16) + ($array[$pos + 3] << 24);
+        return $array[$pos] + ($array[$pos + 1] << 8) + ($array[$pos + 2] << 16) + ($array[$pos + 3] ?? 0 << 24);
     }
 
     private function putVarInt(int $value, array &$output, int $op) : int


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>Prevent PHP notices when working with `BinaryReader` & `SnappyCompressor`</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

Closes #722
