### PR TITLE
Convert PHP warnings to test failures

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -170,6 +170,9 @@
         "test": [
             "tools/phpunit/vendor/bin/phpunit"
         ],
+        "test:no-coverage": [
+            "tools/phpunit/vendor/bin/phpunit --no-coverage"
+        ],
         "test:benchmark": [
             "@test:benchmark:building_blocks",
             "@test:benchmark:extractor",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -7,6 +7,8 @@
         cacheResultFile="./var/phpunit/phpunit.cache"
         displayDetailsOnTestsThatTriggerWarnings="true"
         displayDetailsOnTestsThatTriggerErrors="true"
+        failOnNotice="true"
+        failOnWarning="true"
         executionOrder="random"
 >
   <coverage cacheDirectory="./var/phpunit/">


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Convert PHP warnings to test failures</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

Related to #722 
