### PR TITLE
Fixed bitpacking zero values

### DIFF
--- a/src/lib/parquet/src/Flow/Parquet/ParquetFile/Data/RLEBitPackedHybrid.php
+++ b/src/lib/parquet/src/Flow/Parquet/ParquetFile/Data/RLEBitPackedHybrid.php
@@ -23,6 +23,12 @@ final class RLEBitPackedHybrid
             return;
         }
 
+        if ($bitWidth === 0) {
+            $output = \array_merge($output, \array_fill(0, \min($numGroups * 8, $maxItems), 0));
+
+            return;
+        }
+
         $count = $numGroups * 8;
         $totalByteCount = (int) (($bitWidth * $count) / 8);
 

--- a/src/lib/parquet/tests/Flow/Parquet/Tests/Integration/ParquetFile/Data/RLEBitPackedHybridTest.php
+++ b/src/lib/parquet/tests/Flow/Parquet/Tests/Integration/ParquetFile/Data/RLEBitPackedHybridTest.php
@@ -63,6 +63,23 @@ final class RLEBitPackedHybridTest extends TestCase
         );
     }
 
+    public function test_bit_packing_zeroes() : void
+    {
+        $values = [0, 0, 0, 0];
+
+        $buffer = '';
+        (new RLEBitPackedHybrid())->encodeHybrid(new BinaryBufferWriter($buffer), $values);
+
+        $this->assertSame(
+            $values,
+            (new RLEBitPackedHybrid())->decodeHybrid(
+                new BinaryBufferReader($buffer),
+                BitWidth::fromArray($values),
+                \count($values)
+            )
+        );
+    }
+
     public function test_bit_rle_reading_with_extra_bytes_in_the_buffer() : void
     {
         $values = [3, 3, 3, 3, 3, 3, 3, 3, 3, 3];


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>bitpacking zero values</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

Closes: #727 

Here is how it can be reproduced: 

```php
$dateTime = new \DateTimeImmutable('2023-01-01 00:00:00 UTC');

(new Flow())
    ->read(From::array([
        ['date_time' => $dateTime],
        ['date_time' => $dateTime],
        ['date_time' => $dateTime],
        ['date_time' => $dateTime],
        ['date_time' => $dateTime],
        ['date_time' => $dateTime],
        ['date_time' => $dateTime],
        ['date_time' => $dateTime],
    ]))
    ->mode(SaveMode::Overwrite)
    ->write(Parquet::to(__DIR__ . '/bytes_offset.parquet'))
    ->run();

(new Flow())
    ->read(Parquet::from(__DIR__ . '/bytes_offset.parquet'))
    ->batchSize(10)
    ->write(To::output())
    ->run();
```

So what happens here, is that date_time column has very low cardinality ratio (all values are exactly the same) so dictionary encoding is being applied. 
The problem starts when we are writing indices to the buffer, in this case we are going to get a dictionary with a single value and index position 0. So we are going to write following index: 

```
[0, 0, 0, 0, 0, 0, 0] // each value points to the first element of the dictionary
```

Because of that, while bit packing our bitWidth (determines the maximum size of bits needed to pack each element of given array) is 0, and because of that, the algorithm is getting confused about the total number of bytes to read, that's why its reading 0 bytes and that's why Bytes are actually empty. 

I double-checked that with python, it seems it's using the same approach as it's reading our parquet files without any warnings. 