### PR TITLE
Renamed threadSafe into appendSafe

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -70,6 +70,12 @@ Affected extractors:
 Argument `$rows_in_batch` was renamed to `$rows_per_page` which no longer determines the size of the batch, but the size of the page that will be fetched from Google API. 
 Rows are yielded one by one. 
 
+### 8) DataFrame::threadSafe() method was replaced by DataFrame::appendSafe()
+
+`DataFrame::appendSafe()` is doing exactly the same thing as the old method, it's just more 
+descriptive and self-explanatory. 
+It's no longer mandatory to set this flat to true when using SaveMode::APPEND, it's now set automatically. 
+
 ---
 
 ## Upgrading from 0.3.x to 0.4.x

--- a/src/adapter/etl-adapter-avro/src/Flow/ETL/Adapter/Avro/FlixTech/AvroLoader.php
+++ b/src/adapter/etl-adapter-avro/src/Flow/ETL/Adapter/Avro/FlixTech/AvroLoader.php
@@ -155,7 +155,7 @@ final class AvroLoader implements Closure, Loader, Loader\FileLoader
                     $this->path,
                     'avro',
                     Mode::WRITE_BINARY,
-                    $context->threadSafe()
+                    $context->appendSafe()
                 )->resource()
             ),
             new \AvroIODatumWriter($schema),

--- a/src/adapter/etl-adapter-avro/tests/Flow/ETL/Adapter/Avro/Tests/Integration/AvroTest.php
+++ b/src/adapter/etl-adapter-avro/tests/Flow/ETL/Adapter/Avro/Tests/Integration/AvroTest.php
@@ -92,7 +92,7 @@ final class AvroTest extends TestCase
                     }, \range(1, 100))
                 )
             ))
-            ->threadSafe()
+            ->appendSafe()
             ->write(Avro::to($path))
             ->run();
 

--- a/src/adapter/etl-adapter-csv/src/Flow/ETL/Adapter/CSV/CSVLoader.php
+++ b/src/adapter/etl-adapter-csv/src/Flow/ETL/Adapter/CSV/CSVLoader.php
@@ -97,14 +97,14 @@ final class CSVLoader implements Closure, Loader, Loader\FileLoader
         if ($this->header && !$context->streams()->exists($this->path, $partitions)) {
             $this->writeCSV(
                 $headers,
-                $context->streams()->open($this->path, 'csv', Mode::WRITE, $context->threadSafe(), $partitions)
+                $context->streams()->open($this->path, 'csv', Mode::WRITE, $context->appendSafe(), $partitions)
             );
         }
 
         foreach ($nextRows as $row) {
             $this->writeCSV(
                 $row->toArray(),
-                $context->streams()->open($this->path, 'csv', Mode::WRITE, $context->threadSafe(), $partitions)
+                $context->streams()->open($this->path, 'csv', Mode::WRITE, $context->appendSafe(), $partitions)
             );
         }
     }

--- a/src/adapter/etl-adapter-csv/tests/Flow/ETL/Adapter/CSV/Tests/Integration/CSVLoaderTest.php
+++ b/src/adapter/etl-adapter-csv/tests/Flow/ETL/Adapter/CSV/Tests/Integration/CSVLoaderTest.php
@@ -16,39 +16,6 @@ use PHPUnit\Framework\TestCase;
 
 final class CSVLoaderTest extends TestCase
 {
-    public function test_appending_to_csv_in_non_thread_safe() : void
-    {
-        $path = \rtrim(\sys_get_temp_dir(), '/') . '/' . \uniqid('flow_php_etl_csv_loader', true) . '.csv';
-        $this->expectExceptionMessage("Appending to destination \"file:/{$path}\" in non thread safe mode is not supported.");
-
-        (new Flow())
-            ->process(
-                new Rows(
-                    Row::create(Entry::integer('id', 1), Entry::string('name', 'Norbert')),
-                    Row::create(Entry::integer('id', 2), Entry::string('name', 'Tomek')),
-                    Row::create(Entry::integer('id', 3), Entry::string('name', 'Dawid')),
-                )
-            )
-            ->load(CSV::to($path))
-            ->run();
-
-        (new Flow())
-            ->process(
-                new Rows(
-                    Row::create(Entry::integer('id', 1), Entry::string('name', 'Norbert')),
-                    Row::create(Entry::integer('id', 2), Entry::string('name', 'Tomek')),
-                    Row::create(Entry::integer('id', 3), Entry::string('name', 'Dawid')),
-                )
-            )
-            ->mode(SaveMode::Append)
-            ->load(CSV::to($path))
-            ->run();
-
-        if (\file_exists($path)) {
-            \unlink($path);
-        }
-    }
-
     public function test_loading_array_entry() : void
     {
         $path = \sys_get_temp_dir() . '/' . \uniqid('flow_php_etl_csv_loader', true) . '.csv';
@@ -69,7 +36,7 @@ final class CSVLoaderTest extends TestCase
         }
     }
 
-    public function test_loading_csv_files_with_threadsafe() : void
+    public function test_loading_csv_files_with_append_safe() : void
     {
         $path = \sys_get_temp_dir() . '/' . \uniqid('flow_php_etl_csv_loader', true) . '.csv';
 
@@ -81,7 +48,7 @@ final class CSVLoaderTest extends TestCase
                     Row::create(new Row\Entry\IntegerEntry('id', 3), new Row\Entry\StringEntry('name', 'Dawid')),
                 )
             )
-            ->threadSafe()
+            ->appendSafe()
             ->load(CSV::to($path))
             ->run();
 

--- a/src/adapter/etl-adapter-json/src/Flow/ETL/Adapter/JSON/JsonLoader.php
+++ b/src/adapter/etl-adapter-json/src/Flow/ETL/Adapter/JSON/JsonLoader.php
@@ -79,11 +79,11 @@ final class JsonLoader implements Closure, Loader, Loader\FileLoader
         $streams = $context->streams();
 
         if (!$streams->isOpen($this->path, $partitions)) {
-            $stream = $streams->open($this->path, 'json', $mode, $context->threadSafe(), $partitions);
+            $stream = $streams->open($this->path, 'json', $mode, $context->appendSafe(), $partitions);
 
             $this->init($stream);
         } else {
-            $stream = $streams->open($this->path, 'json', $mode, $context->threadSafe(), $partitions);
+            $stream = $streams->open($this->path, 'json', $mode, $context->appendSafe(), $partitions);
         }
 
         $this->writeJSON($nextRows, $stream);

--- a/src/adapter/etl-adapter-parquet/src/Flow/ETL/Adapter/Parquet/ParquetLoader.php
+++ b/src/adapter/etl-adapter-parquet/src/Flow/ETL/Adapter/Parquet/ParquetLoader.php
@@ -82,7 +82,7 @@ final class ParquetLoader implements Closure, Loader, Loader\FileLoader
         if ($context->partitionEntries()->count()) {
             foreach ($rows->partitionBy(...$context->partitionEntries()->all()) as $partitions) {
 
-                $stream = $streams->open($this->path, 'parquet', Mode::WRITE_BINARY, $context->threadSafe(), $partitions->partitions);
+                $stream = $streams->open($this->path, 'parquet', Mode::WRITE_BINARY, $context->appendSafe(), $partitions->partitions);
 
                 if (!\array_key_exists($stream->path()->uri(), $this->writers)) {
                     $this->writers[$stream->path()->uri()] = new Writer(
@@ -98,7 +98,7 @@ final class ParquetLoader implements Closure, Loader, Loader\FileLoader
                 }
             }
         } else {
-            $stream = $streams->open($this->path, 'parquet', Mode::WRITE_BINARY, $context->threadSafe());
+            $stream = $streams->open($this->path, 'parquet', Mode::WRITE_BINARY, $context->appendSafe());
 
             if (!\array_key_exists($stream->path()->uri(), $this->writers)) {
                 $this->writers[$stream->path()->uri()] = new Writer(

--- a/src/adapter/etl-adapter-text/src/Flow/ETL/Adapter/Text/TextLoader.php
+++ b/src/adapter/etl-adapter-text/src/Flow/ETL/Adapter/Text/TextLoader.php
@@ -63,7 +63,7 @@ final class TextLoader implements Closure, Loader, Loader\FileLoader
                     }
 
                     \fwrite(
-                        $context->streams()->open($this->path, 'text', Mode::WRITE, $context->threadSafe(), $partition->partitions)->resource(),
+                        $context->streams()->open($this->path, 'text', Mode::WRITE, $context->appendSafe(), $partition->partitions)->resource(),
                         $row->entries()->all()[0]->toString() . $this->newLineSeparator
                     );
                 }
@@ -75,7 +75,7 @@ final class TextLoader implements Closure, Loader, Loader\FileLoader
                 }
 
                 \fwrite(
-                    $context->streams()->open($this->path, 'text', Mode::WRITE, $context->threadSafe(), [])->resource(),
+                    $context->streams()->open($this->path, 'text', Mode::WRITE, $context->appendSafe(), [])->resource(),
                     $row->entries()->all()[0]->toString() . $this->newLineSeparator
                 );
             }

--- a/src/adapter/etl-adapter-text/tests/Flow/ETL/Adapter/Text/Tests/Integration/TextLoaderTest.php
+++ b/src/adapter/etl-adapter-text/tests/Flow/ETL/Adapter/Text/Tests/Integration/TextLoaderTest.php
@@ -14,7 +14,7 @@ use PHPUnit\Framework\TestCase;
 
 final class TextLoaderTest extends TestCase
 {
-    public function test_loading_text_files_with_thread_safe() : void
+    public function test_loading_text_files_with_append_safe() : void
     {
         $path = \sys_get_temp_dir() . '/' . \uniqid('flow_php_etl_csv_loader', true) . '.csv';
 
@@ -27,7 +27,7 @@ final class TextLoaderTest extends TestCase
                 )
             )
             ->load(Text::to($path))
-            ->threadSafe()
+            ->appendSafe()
             ->run();
 
         $files = \array_values(\array_diff(\scandir($path), ['..', '.']));

--- a/src/core/etl/src/Flow/ETL/Async/Socket/Worker/Processor.php
+++ b/src/core/etl/src/Flow/ETL/Async/Socket/Worker/Processor.php
@@ -56,7 +56,7 @@ final class Processor
              * each worker would remove all files created by other workers.
              */
             ->mode(SaveMode::Append)
-            ->threadSafe();
+            ->appendSafe();
 
         if ([] !== $this->partitionEntries) {
             $dataFrame = $dataFrame->partitionBy(...$this->partitionEntries);

--- a/src/core/etl/src/Flow/ETL/DataFrame.php
+++ b/src/core/etl/src/Flow/ETL/DataFrame.php
@@ -70,6 +70,19 @@ final class DataFrame
     }
 
     /**
+     * @lazy
+     * When set to true, files are never written under the origin name but instead initial path is turned
+     * into a folder in which each process writes to a new file.
+     * This is also mandatory for SaveMode::Append
+     */
+    public function appendSafe(bool $appendSafe = true) : self
+    {
+        $this->context->setAppendSafe($appendSafe);
+
+        return $this;
+    }
+
+    /**
      * Merge/Split Rows yielded by Extractor into batches of given size.
      * For example, when Extractor is yielding one row at time, this method will merge them into batches of given size
      * before passing them to the next pipeline element.
@@ -439,6 +452,10 @@ final class DataFrame
     {
         $this->context->setMode($mode);
 
+        if ($mode === SaveMode::Append) {
+            $this->appendSafe();
+        }
+
         return $this;
     }
 
@@ -653,16 +670,13 @@ final class DataFrame
     }
 
     /**
+     * @deprecated please use DataFrame::appendSafe() instead
+     *
      * @lazy
-     * When set to true, files are never written under the origin name but instead initial path is turned
-     * into a folder in which each process writes to a new file.
-     * Otherwise parallel processing would not be possible due to a single file bottleneck.
-     * In a single process pipelines there is not much added value from this setting unless
-     * there is a chance that the same pipeline execution might overlap.
      */
-    public function threadSafe(bool $threadSafe = true) : self
+    public function threadSafe(bool $appendSafe = true) : self
     {
-        $this->context->setThreadSafe($threadSafe);
+        $this->appendSafe($appendSafe);
 
         return $this;
     }

--- a/src/core/etl/src/Flow/ETL/FlowContext.php
+++ b/src/core/etl/src/Flow/ETL/FlowContext.php
@@ -20,6 +20,8 @@ use Flow\Serializer\Serializer;
  */
 final class FlowContext
 {
+    private bool $appendSafe = false;
+
     private ErrorHandler $errorHandler;
 
     private SaveMode $mode = SaveMode::ExceptionIfExists;
@@ -28,13 +30,16 @@ final class FlowContext
 
     private References $partitions;
 
-    private bool $threadSafe = false;
-
     public function __construct(public readonly Config $config)
     {
         $this->partitionFilter = new NoopFilter();
         $this->errorHandler = new ThrowError();
         $this->partitions = new References();
+    }
+
+    public function appendSafe() : bool
+    {
+        return $this->appendSafe;
     }
 
     public function cache() : Cache
@@ -86,6 +91,13 @@ final class FlowContext
         return $this->config->serializer();
     }
 
+    public function setAppendSafe(bool $appendSafe = true) : self
+    {
+        $this->appendSafe = $appendSafe;
+
+        return $this;
+    }
+
     public function setErrorHandler(ErrorHandler $handler) : self
     {
         $this->errorHandler = $handler;
@@ -100,20 +112,8 @@ final class FlowContext
         return $this;
     }
 
-    public function setThreadSafe(bool $threadSafe = true) : self
-    {
-        $this->threadSafe = $threadSafe;
-
-        return $this;
-    }
-
     public function streams() : FilesystemStreams
     {
         return $this->config->filesystemStreams();
-    }
-
-    public function threadSafe() : bool
-    {
-        return $this->threadSafe;
     }
 }

--- a/src/core/etl/src/Flow/ETL/Pipeline/Execution/Processor/FilesystemProcessor.php
+++ b/src/core/etl/src/Flow/ETL/Pipeline/Execution/Processor/FilesystemProcessor.php
@@ -50,8 +50,8 @@ final class FilesystemProcessor implements Processor
             }
 
             if ($context->mode() === SaveMode::Append) {
-                if (!$context->threadSafe()) {
-                    throw new RuntimeException('Appending to destination "' . $loader->destination()->uri() . '" in non thread safe mode is not supported.');
+                if (!$context->appendSafe()) {
+                    throw new RuntimeException('Appending to destination "' . $loader->destination()->uri() . '" in non append safe mode is not supported.');
                 }
 
                 if ($context->streams()->fs()->fileExists($loader->destination())) {

--- a/src/core/etl/src/Flow/ETL/Pipeline/LocalSocketPipeline.php
+++ b/src/core/etl/src/Flow/ETL/Pipeline/LocalSocketPipeline.php
@@ -72,7 +72,7 @@ final class LocalSocketPipeline implements Pipeline
 
     public function process(FlowContext $context) : \Generator
     {
-        $threadSafeContext = $context->setThreadSafe();
+        $threadSafeContext = $context->setAppendSafe();
 
         $plan = $threadSafeContext
             ->config

--- a/src/core/etl/tests/Flow/ETL/Tests/Integration/Filesystem/FilesystemStreamsTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Integration/Filesystem/FilesystemStreamsTest.php
@@ -13,7 +13,7 @@ use PHPUnit\Framework\TestCase;
 
 class FilesystemStreamsTest extends TestCase
 {
-    public function test_closing_stream_with_non_thread_safe_base_path() : void
+    public function test_closing_stream_with_non_append_safe_base_path() : void
     {
         $streams = (new FilesystemStreams(new FlysystemFS()));
 

--- a/src/core/etl/tests/Flow/ETL/Tests/Integration/Pipeline/Execution/Processor/FilesystemProcessorTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Integration/Pipeline/Execution/Processor/FilesystemProcessorTest.php
@@ -41,36 +41,8 @@ final class FilesystemProcessorTest extends TestCase
                 new Pipes([CSV::to($path)])
             ),
             (new FlowContext(Config::default()))
-                ->setThreadSafe()
+                ->setAppendSafe()
                 ->setMode(SaveMode::Append)
-        );
-    }
-
-    public function test_append_mode_without_thread_safe() : void
-    {
-        $path = \sys_get_temp_dir() . '/flow-etl-filesystem-processor-test-overwrite-mode.csv';
-
-        if (\file_exists($path)) {
-            \unlink($path);
-        }
-
-        (new Flow())
-            ->read(From::array([['id' => 1], ['id' => 2]]))
-            ->write(CSV::to($path))
-            ->run();
-
-        $processor = new FilesystemProcessor();
-        $extractor = CSV::from($path);
-
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage("Appending to destination \"file:/{$path}\" in non thread safe mode is not supported");
-
-        $processor->process(
-            new ExecutionPlan(
-                $extractor,
-                new Pipes([CSV::to($path)])
-            ),
-            (new FlowContext(Config::default()))->setMode(SaveMode::Append)
         );
     }
 


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Renamed threadSafe into appendSafe</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <li>DataFrame::threadSafe()</li>
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

<!-- Please provide a short description of changes in this section, feel free to use markdown syntax -->

Additionally, DataFrame will automatically turn on appendSafe when SaveMode::APPEND is used. 