### PR TITLE
Remove batchsize from loaders

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -76,6 +76,11 @@ Rows are yielded one by one.
 descriptive and self-explanatory. 
 It's no longer mandatory to set this flat to true when using SaveMode::APPEND, it's now set automatically. 
 
+### 9) Loaders - chunk size
+
+Loaders are no longer accepting chunk_size parameter, from now in order to control 
+the number of rows saved at once use `DataFrame::batchSize(int $size)` method.
+
 ---
 
 ## Upgrading from 0.3.x to 0.4.x

--- a/src/adapter/etl-adapter-amphp/README.md
+++ b/src/adapter/etl-adapter-amphp/README.md
@@ -65,7 +65,7 @@ $logger->pushHandler(new StreamHandler("php://stderr", LogLevel::ERROR, false));
     ->withEntry('id', ref('id')->cast('int'))
     ->withEntry('name', concat(ref('name'), lit(' '), ref('last name')))
     ->drop('last_name')
-    ->load(new DbalLoader($tableName, $chunkSize = 1000, $dbConnectionParams))
+    ->load(new DbalLoader($tableName, $dbConnectionParams))
     ->run();
 ```
 

--- a/src/adapter/etl-adapter-doctrine/README.md
+++ b/src/adapter/etl-adapter-doctrine/README.md
@@ -36,9 +36,9 @@ ETL::extract(
 
 All supported types of `DbalBulkLoader` loading: 
 
-- `::insert(Connection $connection, int $bulkChunkSize, string $table, QueryFactory $queryFactory = null) : self`
-- `::insertOrSkipOnConflict(Connection $connection, int $bulkChunkSize, string $table, QueryFactory $queryFactory = null) : self`
-- `::insertOrUpdateOnConstraintConflict(Connection $connection, int $bulkChunkSize, string $table, string $constraint, QueryFactory $queryFactory = null) : self`
+- `::insert(Connection $connection, string $table, QueryFactory $queryFactory = null) : self`
+- `::insertOrSkipOnConflict(Connection $connection, string $table, QueryFactory $queryFactory = null) : self`
+- `::insertOrUpdateOnConstraintConflict(Connection $connection, string $table, string $constraint, QueryFactory $queryFactory = null) : self`
 
 The `bulkSize` means how many rows you want to push to a database in a single `INSERT` query. Each extracted rows set
 is going to be split before inserting data into the database.

--- a/src/adapter/etl-adapter-doctrine/src/Flow/ETL/Adapter/Doctrine/DbalLoader.php
+++ b/src/adapter/etl-adapter-doctrine/src/Flow/ETL/Adapter/Doctrine/DbalLoader.php
@@ -16,7 +16,6 @@ use Flow\ETL\Rows;
 /**
  * @implements Loader<array{
  *  table_name: string,
- *  chunk_size: int<1, max>,
  *  connection_params: array<string, mixed>,
  *  operation: string,
  *  operation_options: array{
@@ -35,7 +34,6 @@ final class DbalLoader implements Loader
     private string $operation;
 
     /**
-     * @param int<1, max> $chunkSize
      * @param array<string, mixed> $connectionParams
      * @param array{
      *  skip_conflicts?: boolean,
@@ -49,7 +47,6 @@ final class DbalLoader implements Loader
      */
     public function __construct(
         private string $tableName,
-        private int $chunkSize,
         private array $connectionParams,
         private array $operationOptions = [],
         string $operation = 'insert'
@@ -64,7 +61,6 @@ final class DbalLoader implements Loader
      * Since Connection::getParams() is marked as an internal method, please
      * use this constructor with caution.
      *
-     * @param int<1, max> $chunkSize
      * @param array{
      *  skip_conflicts?: boolean,
      *  constraint?: string,
@@ -78,12 +74,11 @@ final class DbalLoader implements Loader
     public static function fromConnection(
         Connection $connection,
         string $tableName,
-        int $chunkSize,
         array $operationOptions = [],
         string $operation = 'insert'
     ) : self {
         /** @psalm-suppress InternalMethod */
-        $loader = new self($tableName, $chunkSize, $connection->getParams(), $operationOptions, $operation);
+        $loader = new self($tableName, $connection->getParams(), $operationOptions, $operation);
         $loader->connection = $connection;
 
         return $loader;
@@ -93,7 +88,6 @@ final class DbalLoader implements Loader
     {
         return [
             'table_name' => $this->tableName,
-            'chunk_size' => $this->chunkSize,
             'connection_params' => $this->connectionParams,
             'operation' => $this->operation,
             'operation_options' => $this->operationOptions,
@@ -103,7 +97,6 @@ final class DbalLoader implements Loader
     public function __unserialize(array $data) : void
     {
         $this->tableName = $data['table_name'];
-        $this->chunkSize = $data['chunk_size'];
         $this->connectionParams = $data['connection_params'];
         $this->operation = $data['operation'];
         $this->operationOptions = $data['operation_options'];
@@ -111,14 +104,12 @@ final class DbalLoader implements Loader
 
     public function load(Rows $rows, FlowContext $context) : void
     {
-        foreach ($rows->chunks($this->chunkSize) as $chunk) {
-            Bulk::create()->{$this->operation}(
-                $this->connection(),
-                $this->tableName,
-                new BulkData($chunk->sortEntries()->toArray()),
-                $this->operationOptions
-            );
-        }
+        Bulk::create()->{$this->operation}(
+            $this->connection(),
+            $this->tableName,
+            new BulkData($rows->sortEntries()->toArray()),
+            $this->operationOptions
+        );
     }
 
     private function connection() : Connection

--- a/src/adapter/etl-adapter-doctrine/src/Flow/ETL/DSL/Dbal.php
+++ b/src/adapter/etl-adapter-doctrine/src/Flow/ETL/DSL/Dbal.php
@@ -132,8 +132,9 @@ class Dbal
     }
 
     /**
+     * In order to control the size of the single insert, use DataFrame::chunkSize() method just before calling DataFrame::load().
+     *
      * @param array<string, mixed>|Connection $connection
-     * @param int<1, max> $chunk_size
      * @param array{
      *  skip_conflicts?: boolean,
      *  constraint?: string,
@@ -147,17 +148,17 @@ class Dbal
     final public static function to_table_insert(
         array|Connection $connection,
         string $table,
-        int $chunk_size = 1000,
         array $options = [],
     ) : Loader {
         return \is_array($connection)
-            ? new DbalLoader($table, $chunk_size, $connection, $options, 'insert')
-            : DbalLoader::fromConnection($connection, $table, $chunk_size, $options, 'insert');
+            ? new DbalLoader($table, $connection, $options, 'insert')
+            : DbalLoader::fromConnection($connection, $table, $options, 'insert');
     }
 
     /**
+     *  In order to control the size of the single request, use DataFrame::chunkSize() method just before calling DataFrame::load().
+     *
      * @param array<string, mixed>|Connection $connection
-     * @param int<1, max> $chunk_size
      * @param array{
      *  skip_conflicts?: boolean,
      *  constraint?: string,
@@ -173,11 +174,10 @@ class Dbal
     final public static function to_table_update(
         array|Connection $connection,
         string $table,
-        int $chunk_size = 1000,
         array $options = [],
     ) : Loader {
         return \is_array($connection)
-            ? new DbalLoader($table, $chunk_size, $connection, $options, 'update')
-            : DbalLoader::fromConnection($connection, $table, $chunk_size, $options, 'update');
+            ? new DbalLoader($table, $connection, $options, 'update')
+            : DbalLoader::fromConnection($connection, $table, $options, 'update');
     }
 }

--- a/src/adapter/etl-adapter-doctrine/tests/Flow/ETL/Adapter/Doctrine/Tests/Integration/DbalQueryExtractorTest.php
+++ b/src/adapter/etl-adapter-doctrine/tests/Flow/ETL/Adapter/Doctrine/Tests/Integration/DbalQueryExtractorTest.php
@@ -36,7 +36,7 @@ final class DbalQueryExtractorTest extends IntegrationTestCase
                 ['id' => 3, 'name' => 'Name Three', 'description' => 'Description Three'],
             ])
         )->load(
-            DbalLoader::fromConnection($this->pgsqlDatabaseContext->connection(), $table, chunkSize: 10)
+            DbalLoader::fromConnection($this->pgsqlDatabaseContext->connection(), $table)
         )->run();
 
         $rows = (new Flow())->extract(
@@ -83,7 +83,7 @@ final class DbalQueryExtractorTest extends IntegrationTestCase
                     ['id' => 10, 'name' => 'Name', 'description' => 'Description'],
                 ])
             )
-            ->load(DbalLoader::fromConnection($this->pgsqlDatabaseContext->connection(), $table, chunkSize: 10))
+            ->load(DbalLoader::fromConnection($this->pgsqlDatabaseContext->connection(), $table))
             ->run();
 
         $rows = (new Flow())->extract(

--- a/src/adapter/etl-adapter-elasticsearch/src/Flow/ETL/DSL/Elasticsearch.php
+++ b/src/adapter/etl-adapter-elasticsearch/src/Flow/ETL/DSL/Elasticsearch.php
@@ -18,6 +18,8 @@ class Elasticsearch
     /**
      * https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-bulk.html.
      *
+     * In order to control the size of the single request, use DataFrame::chunkSize() method just before calling DataFrame::load().
+     *
      * @param array{
      *  hosts?: array<string>,
      *  connectionParams?: array<mixed>,
@@ -29,7 +31,6 @@ class Elasticsearch
      *  elasticMetaHeader?: boolean,
      *  includePortInHostHeader?: boolean
      * } $config
-     * @param int<1, max> $chunk_size
      * @param string $index
      * @param IdFactory $id_factory
      * @param array<mixed> $parameters - https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-bulk.html
@@ -38,16 +39,17 @@ class Elasticsearch
      */
     final public static function bulk_index(
         array $config,
-        int $chunk_size,
         string $index,
         IdFactory $id_factory,
         array $parameters = []
     ) : Loader {
-        return new ElasticsearchLoader($config, $chunk_size, $index, $id_factory, $parameters);
+        return new ElasticsearchLoader($config, $index, $id_factory, $parameters);
     }
 
     /**
      *  https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-bulk.html.
+     *
+     * In order to control the size of the single request, use DataFrame::chunkSize() method just before calling DataFrame::load().
      *
      * @param array{
      *  hosts?: array<string>,
@@ -60,7 +62,6 @@ class Elasticsearch
      *  elasticMetaHeader?: boolean,
      *  includePortInHostHeader?: boolean
      * } $config
-     * @param int<1, max> $chunk_size
      * @param string $index
      * @param IdFactory $id_factory
      * @param array<mixed> $parameters - https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-bulk.html
@@ -69,12 +70,11 @@ class Elasticsearch
      */
     final public static function bulk_update(
         array $config,
-        int $chunk_size,
         string $index,
         IdFactory $id_factory,
         array $parameters = []
     ) : Loader {
-        return ElasticsearchLoader::update($config, $chunk_size, $index, $id_factory, $parameters);
+        return ElasticsearchLoader::update($config, $index, $id_factory, $parameters);
     }
 
     /**

--- a/src/adapter/etl-adapter-elasticsearch/tests/Flow/ETL/Adapter/Elasticsearch/Tests/Context/Elasticsearch7Context.php
+++ b/src/adapter/etl-adapter-elasticsearch/tests/Flow/ETL/Adapter/Elasticsearch/Tests/Context/Elasticsearch7Context.php
@@ -71,7 +71,6 @@ final class Elasticsearch7Context implements ElasticsearchContext
     {
         Elasticsearch::bulk_index(
             $this->clientConfig(),
-            100,
             $index,
             $idFactory,
             ['refresh' => true]

--- a/src/adapter/etl-adapter-elasticsearch/tests/Flow/ETL/Adapter/Elasticsearch/Tests/Context/Elasticsearch8Context.php
+++ b/src/adapter/etl-adapter-elasticsearch/tests/Flow/ETL/Adapter/Elasticsearch/Tests/Context/Elasticsearch8Context.php
@@ -70,7 +70,6 @@ final class Elasticsearch8Context implements ElasticsearchContext
     {
         Elasticsearch::bulk_index(
             $this->clientConfig(),
-            100,
             $index,
             $idFactory,
             ['refresh' => true]

--- a/src/adapter/etl-adapter-elasticsearch/tests/Flow/ETL/Adapter/Elasticsearch/Tests/Integration/ElasticsearchPHP/ElasticsearchExtractorTest.php
+++ b/src/adapter/etl-adapter-elasticsearch/tests/Flow/ETL/Adapter/Elasticsearch/Tests/Integration/ElasticsearchPHP/ElasticsearchExtractorTest.php
@@ -35,7 +35,7 @@ final class ElasticsearchExtractorTest extends TestCase
 
     public function test_empty_extraction() : void
     {
-        $loader = Elasticsearch::bulk_index($this->elasticsearchContext->clientConfig(), 100, self::INDEX_NAME, new EntryIdFactory('id'), ['refresh' => true]);
+        $loader = Elasticsearch::bulk_index($this->elasticsearchContext->clientConfig(), self::INDEX_NAME, new EntryIdFactory('id'), ['refresh' => true]);
 
         $loader->load(new Rows(
             ...\array_map(
@@ -75,7 +75,7 @@ final class ElasticsearchExtractorTest extends TestCase
 
     public function test_extraction_index_with_from_and_size() : void
     {
-        $loader = Elasticsearch::bulk_index($this->elasticsearchContext->clientConfig(), 100, self::INDEX_NAME, new EntryIdFactory('id'), ['refresh' => true]);
+        $loader = Elasticsearch::bulk_index($this->elasticsearchContext->clientConfig(), self::INDEX_NAME, new EntryIdFactory('id'), ['refresh' => true]);
 
         $loader->load(new Rows(
             ...\array_map(
@@ -118,7 +118,7 @@ final class ElasticsearchExtractorTest extends TestCase
 
     public function test_extraction_index_with_search_after() : void
     {
-        $loader = Elasticsearch::bulk_index($this->elasticsearchContext->clientConfig(), 100, self::INDEX_NAME, new EntryIdFactory('id'), ['refresh' => true]);
+        $loader = Elasticsearch::bulk_index($this->elasticsearchContext->clientConfig(), self::INDEX_NAME, new EntryIdFactory('id'), ['refresh' => true]);
 
         $loader->load(new Rows(
             ...\array_map(
@@ -154,7 +154,7 @@ final class ElasticsearchExtractorTest extends TestCase
 
     public function test_extraction_index_with_search_after_with_point_in_time() : void
     {
-        $loader = Elasticsearch::bulk_index($this->elasticsearchContext->clientConfig(), 100, self::INDEX_NAME, new EntryIdFactory('id'), ['refresh' => true]);
+        $loader = Elasticsearch::bulk_index($this->elasticsearchContext->clientConfig(), self::INDEX_NAME, new EntryIdFactory('id'), ['refresh' => true]);
 
         $loader->load(new Rows(
             ...\array_map(
@@ -195,7 +195,7 @@ final class ElasticsearchExtractorTest extends TestCase
 
     public function test_extraction_whole_index_with_point_in_time() : void
     {
-        $loader = Elasticsearch::bulk_index($this->elasticsearchContext->clientConfig(), 100, self::INDEX_NAME, new EntryIdFactory('id'), ['refresh' => true]);
+        $loader = Elasticsearch::bulk_index($this->elasticsearchContext->clientConfig(), self::INDEX_NAME, new EntryIdFactory('id'), ['refresh' => true]);
 
         $loader->load(new Rows(
             ...\array_map(

--- a/src/adapter/etl-adapter-elasticsearch/tests/Flow/ETL/Adapter/Elasticsearch/Tests/Integration/ElasticsearchPHP/ElasticsearchLoaderTest.php
+++ b/src/adapter/etl-adapter-elasticsearch/tests/Flow/ETL/Adapter/Elasticsearch/Tests/Integration/ElasticsearchPHP/ElasticsearchLoaderTest.php
@@ -34,7 +34,7 @@ final class ElasticsearchLoaderTest extends TestCase
 
     public function test_empty_rows() : void
     {
-        $loader = Elasticsearch::bulk_index($this->elasticsearchContext->clientConfig(), 2, self::INDEX_NAME, new EntryIdFactory('id'), ['refresh' => true]);
+        $loader = Elasticsearch::bulk_index($this->elasticsearchContext->clientConfig(), self::INDEX_NAME, new EntryIdFactory('id'), ['refresh' => true]);
 
         $loader->load(new Rows(), new FlowContext(Config::default()));
 
@@ -54,7 +54,7 @@ final class ElasticsearchLoaderTest extends TestCase
 
     public function test_integration_with_entry_factory() : void
     {
-        $loader = Elasticsearch::bulk_index($this->elasticsearchContext->clientConfig(), 2, self::INDEX_NAME, new EntryIdFactory('id'), ['refresh' => true]);
+        $loader = Elasticsearch::bulk_index($this->elasticsearchContext->clientConfig(), self::INDEX_NAME, new EntryIdFactory('id'), ['refresh' => true]);
 
         $loader->load(new Rows(
             Row::create(
@@ -96,7 +96,7 @@ final class ElasticsearchLoaderTest extends TestCase
 
     public function test_integration_with_json_entry() : void
     {
-        $loader = Elasticsearch::bulk_index($this->elasticsearchContext->clientConfig(), 2, self::INDEX_NAME, new HashIdFactory('id'), ['refresh' => true]);
+        $loader = Elasticsearch::bulk_index($this->elasticsearchContext->clientConfig(), self::INDEX_NAME, new HashIdFactory('id'), ['refresh' => true]);
 
         $loader->load(new Rows(
             Row::create(
@@ -125,7 +125,7 @@ final class ElasticsearchLoaderTest extends TestCase
 
     public function test_integration_with_partial_update_id_factory() : void
     {
-        $insertLoader = Elasticsearch::bulk_index($this->elasticsearchContext->clientConfig(), 2, self::INDEX_NAME, new HashIdFactory('id'), ['refresh' => true]);
+        $insertLoader = Elasticsearch::bulk_index($this->elasticsearchContext->clientConfig(), self::INDEX_NAME, new HashIdFactory('id'), ['refresh' => true]);
 
         $insertLoader->load(new Rows(
             Row::create(
@@ -136,7 +136,7 @@ final class ElasticsearchLoaderTest extends TestCase
             ),
         ), new FlowContext(Config::default()));
 
-        $updateLoader = Elasticsearch::bulk_update($this->elasticsearchContext->clientConfig(), 2, self::INDEX_NAME, new HashIdFactory('id'), ['refresh' => true]);
+        $updateLoader = Elasticsearch::bulk_update($this->elasticsearchContext->clientConfig(), self::INDEX_NAME, new HashIdFactory('id'), ['refresh' => true]);
 
         $updateLoader->load(new Rows(
             Row::create(
@@ -182,7 +182,7 @@ final class ElasticsearchLoaderTest extends TestCase
         $serializer = new CompressingSerializer();
 
         $loaderSerialized = $serializer->serialize(
-            Elasticsearch::bulk_index($this->elasticsearchContext->clientConfig(), 2, self::INDEX_NAME, new HashIdFactory('id'), ['refresh' => true])
+            Elasticsearch::bulk_index($this->elasticsearchContext->clientConfig(), self::INDEX_NAME, new HashIdFactory('id'), ['refresh' => true])
         );
 
         $serializer->unserialize($loaderSerialized)->load(new Rows(
@@ -212,7 +212,7 @@ final class ElasticsearchLoaderTest extends TestCase
 
     public function test_integration_with_sha1_id_factory() : void
     {
-        $loader = Elasticsearch::bulk_index($this->elasticsearchContext->clientConfig(), 2, self::INDEX_NAME, new HashIdFactory('id'), ['refresh' => true]);
+        $loader = Elasticsearch::bulk_index($this->elasticsearchContext->clientConfig(), self::INDEX_NAME, new HashIdFactory('id'), ['refresh' => true]);
 
         $loader->load(new Rows(
             Row::create(

--- a/src/adapter/etl-adapter-elasticsearch/tests/Flow/ETL/Adapter/Elasticsearch/Tests/Integration/ElasticsearchPHP/IntegrationTest.php
+++ b/src/adapter/etl-adapter-elasticsearch/tests/Flow/ETL/Adapter/Elasticsearch/Tests/Integration/ElasticsearchPHP/IntegrationTest.php
@@ -73,7 +73,6 @@ final class IntegrationTest extends TestCase
             ->load(
                 Elasticsearch::bulk_index(
                     $this->elasticsearchContext->clientConfig(),
-                    chunk_size: 100,
                     index: self::DESTINATION_INDEX,
                     id_factory: new EntryIdFactory('id')
                 )

--- a/src/adapter/etl-adapter-reactphp/README.md
+++ b/src/adapter/etl-adapter-reactphp/README.md
@@ -79,7 +79,7 @@ $memory = new Consumption();
     ->withEntry('id', ref('id')->cast('int'))
     ->withEntry('name', concat(ref('name'), lit(' '), ref('last name')))
     ->drop('last_name')
-    ->load(new DbalLoader($tableName, $chunkSize = 1000, $dbConnectionParams))
+    ->load(new DbalLoader($tableName, $dbConnectionParams))
     ->run();
 ```
 


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <li>Loaders are no longer allowing for setting chunk size</li>
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

Closes: #717 
<h2>Description</h2>

<!-- Please provide a short description of changes in this section, feel free to use markdown syntax -->

Just like with Extractors, chunk size should now be controller through DataFrame::chunkSize(int $size) method. 