### PR TITLE
Prevent uninitialized string check in `NativeEntryFactory`

### DIFF
--- a/src/core/etl/src/Flow/ETL/Row/Factory/NativeEntryFactory.php
+++ b/src/core/etl/src/Flow/ETL/Row/Factory/NativeEntryFactory.php
@@ -39,9 +39,9 @@ final class NativeEntryFactory implements EntryFactory
         }
 
         if (\is_string($value)) {
-            if ('' !== $value) {
-                $trimmedValue = \trim($value);
+            $trimmedValue = \trim($value);
 
+            if ('' !== $trimmedValue) {
                 if ($this->isJson($trimmedValue)) {
                     return Row\Entry\JsonEntry::fromJsonString($entryName, $value);
                 }

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Factory/NativeEntryFactoryTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Factory/NativeEntryFactoryTest.php
@@ -11,10 +11,38 @@ use Flow\ETL\PHP\Type\ScalarType;
 use Flow\ETL\Row\Factory\NativeEntryFactory;
 use Flow\ETL\Row\Schema;
 use Flow\ETL\Tests\Fixtures\Enum\BackedIntEnum;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class NativeEntryFactoryTest extends TestCase
 {
+    public static function provide_unrecognized_data() : \Generator
+    {
+        yield 'json alike' => [
+            '{"id":1',
+        ];
+
+        yield 'uuid alike' => [
+            '00000000-0000-0000-0000-00000',
+        ];
+
+        yield 'xml alike' => [
+            '<root',
+        ];
+
+        yield 'space' => [
+            ' ',
+        ];
+
+        yield 'new line' => [
+            "\n",
+        ];
+
+        yield 'invisible' => [
+            '‎ ',
+        ];
+    }
+
     public function test_array() : void
     {
         $this->assertEquals(
@@ -138,30 +166,6 @@ final class NativeEntryFactoryTest extends TestCase
         $this->assertEquals(
             Entry::integer('e', 1),
             (new NativeEntryFactory())->create('e', 1, new Schema(Schema\Definition::integer('e')))
-        );
-    }
-
-    public function test_invalid_json() : void
-    {
-        $this->assertEquals(
-            Entry::string('e', $invalid = '{"id":1'),
-            (new NativeEntryFactory())->create('e', $invalid)
-        );
-    }
-
-    public function test_invalid_uuid() : void
-    {
-        $this->assertEquals(
-            Entry::string('e', $invalid = '00000000-0000-0000-0000-00000'),
-            (new NativeEntryFactory())->create('e', $invalid)
-        );
-    }
-
-    public function test_invalid_xml() : void
-    {
-        $this->assertEquals(
-            Entry::string('e', $invalid = '<root'),
-            (new NativeEntryFactory())->create('e', $invalid)
         );
     }
 
@@ -341,6 +345,15 @@ final class NativeEntryFactoryTest extends TestCase
                 Entry::string('zip', '31-021')
             ),
             (new NativeEntryFactory())->create('address', ['city' => 'Krakow', 'street' => 'Floriańska', 'zip' => '31-021'])
+        );
+    }
+
+    #[DataProvider('provide_unrecognized_data')]
+    public function test_unrecognized_data_set_same_as_provided(string $input) : void
+    {
+        $this->assertEquals(
+            Entry::string('e', $input),
+            (new NativeEntryFactory())->create('e', $input)
         );
     }
 


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>Prevent uninitialized string check in `NativeEntryFactory`</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

Closes #742 
