### PR TITLE
Implement new `MapEntry`

### DIFF
--- a/src/core/etl/src/Flow/ETL/Row/Entry/MapEntry.php
+++ b/src/core/etl/src/Flow/ETL/Row/Entry/MapEntry.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Row\Entry;
+
+use Flow\ArrayComparison\ArrayComparison;
+use Flow\ETL\Exception\InvalidArgumentException;
+use Flow\ETL\PHP\Type\Logical\Map\MapKey;
+use Flow\ETL\PHP\Type\Logical\Map\MapValue;
+use Flow\ETL\PHP\Type\Logical\MapType;
+use Flow\ETL\PHP\Type\Type;
+use Flow\ETL\Row\Entry;
+use Flow\ETL\Row\Reference;
+use Flow\ETL\Row\Schema\Definition;
+use Flow\ETL\Row\Schema\FlowMetadata;
+use Flow\ETL\Row\Schema\Metadata;
+
+/**
+ * @template T
+ *
+ * @implements Entry<array<T>, array{name: string, type: MapType, value: array<T>}>
+ */
+final class MapEntry implements Entry, TypedCollection
+{
+    use EntryRef;
+
+    private readonly MapType $type;
+
+    /**
+     * @param array<T> $value
+     *
+     * @throws InvalidArgumentException
+     */
+    public function __construct(
+        private readonly string $name,
+        MapKey $mapKey,
+        MapValue $mapValue,
+        private readonly array $value
+    ) {
+        if ('' === $name) {
+            throw InvalidArgumentException::because('Entry name cannot be empty');
+        }
+
+        $this->type = new MapType($mapKey, $mapValue);
+
+        if (!$this->type->isValid($value)) {
+            throw InvalidArgumentException::because('Expected map of ' . $mapKey->toString() . ' with value of ' . $mapValue->toString() . ' got different types.');
+        }
+    }
+
+    public function __serialize() : array
+    {
+        return ['name' => $this->name, 'type' => $this->type, 'value' => $this->value];
+    }
+
+    public function __toString() : string
+    {
+        return $this->toString();
+    }
+
+    public function __unserialize(array $data) : void
+    {
+        $this->name = $data['name'];
+        $this->type = $data['type'];
+        $this->value = $data['value'];
+    }
+
+    public function definition() : Definition
+    {
+        return Definition::map(
+            $this->name,
+            $this->type->key(),
+            $this->type->value(),
+            metadata: Metadata::with(FlowMetadata::METADATA_MAP_ENTRY_TYPE, $this->type())
+        );
+    }
+
+    public function is(string|Reference $name) : bool
+    {
+        if ($name instanceof Reference) {
+            return $this->name === $name->name();
+        }
+
+        return $this->name === $name;
+    }
+
+    public function isEqual(Entry $entry) : bool
+    {
+        return $this->is($entry->name())
+            && $entry instanceof self
+            && (new ArrayComparison())->equals($this->value, $entry->value())
+            && $this->type->isEqual($entry->type);
+    }
+
+    public function map(callable $mapper) : Entry
+    {
+        return new self($this->name, $this->type->key(), $this->type->value(), $mapper($this->value));
+    }
+
+    public function name() : string
+    {
+        return $this->name;
+    }
+
+    public function rename(string $name) : Entry
+    {
+        return new self($name, $this->type->key(), $this->type->value(), $this->value);
+    }
+
+    public function toString() : string
+    {
+        return \json_encode($this->value(), JSON_THROW_ON_ERROR);
+    }
+
+    public function type() : Type
+    {
+        return $this->type;
+    }
+
+    public function value() : array
+    {
+        return $this->value;
+    }
+}

--- a/src/core/etl/src/Flow/ETL/Row/Schema/Definition.php
+++ b/src/core/etl/src/Flow/ETL/Row/Schema/Definition.php
@@ -6,6 +6,9 @@ namespace Flow\ETL\Row\Schema;
 
 use Flow\ETL\Exception\InvalidArgumentException;
 use Flow\ETL\PHP\Type\Logical\List\ListElement;
+use Flow\ETL\PHP\Type\Logical\Map\MapKey;
+use Flow\ETL\PHP\Type\Logical\Map\MapValue;
+use Flow\ETL\PHP\Type\Logical\MapType;
 use Flow\ETL\Row\Entry;
 use Flow\ETL\Row\Entry\ArrayEntry;
 use Flow\ETL\Row\Entry\BooleanEntry;
@@ -124,6 +127,18 @@ final class Definition implements Serializable
             $constraint,
             ($metadata ?? Metadata::empty())->merge(
                 Metadata::empty()->add(FlowMetadata::METADATA_LIST_ENTRY_TYPE, $type)
+            )
+        );
+    }
+
+    public static function map(string|EntryReference $entry, MapKey $mapKey, MapValue $mapValue, bool $nullable = false, ?Constraint $constraint = null, ?Metadata $metadata = null) : self
+    {
+        return new self(
+            $entry,
+            ($nullable) ? [Entry\MapEntry::class, NullEntry::class] : [Entry\MapEntry::class],
+            $constraint,
+            ($metadata ?? Metadata::empty())->merge(
+                Metadata::empty()->add(FlowMetadata::METADATA_MAP_ENTRY_TYPE, new MapType($mapKey, $mapValue))
             )
         );
     }

--- a/src/core/etl/src/Flow/ETL/Row/Schema/FlowMetadata.php
+++ b/src/core/etl/src/Flow/ETL/Row/Schema/FlowMetadata.php
@@ -12,5 +12,7 @@ final class FlowMetadata
 
     public const METADATA_LIST_ENTRY_TYPE = 'flow_list_entry_type';
 
+    public const METADATA_MAP_ENTRY_TYPE = 'flow_map_entry_type';
+
     public const METADATA_STRUCTURE_DEFINITIONS = 'flow_structure_definitions';
 }

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Entry/MapEntryTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Entry/MapEntryTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Tests\Unit\Row\Entry;
+
+use Flow\ETL\Exception\InvalidArgumentException;
+use Flow\ETL\PHP\Type\Logical\Map\MapKey;
+use Flow\ETL\PHP\Type\Logical\Map\MapValue;
+use Flow\ETL\PHP\Type\Logical\MapType;
+use Flow\ETL\Row\Entry\MapEntry;
+use Flow\ETL\Row\Schema\Definition;
+use PHPUnit\Framework\TestCase;
+
+final class MapEntryTest extends TestCase
+{
+    public function test_create_with_empty_name() : void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Entry name cannot be empty');
+
+        new MapEntry('', MapKey::integer(), MapValue::string(), ['one', 'two', 'three']);
+    }
+
+    public function test_creating_boolean_map_from_wrong_value_types() : void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Expected map of integer with value of boolean got different types');
+
+        new MapEntry('map', MapKey::integer(), MapValue::boolean(), ['string', false]);
+    }
+
+    public function test_creating_datetime_map_from_wrong_value_types() : void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Expected map of integer with value of object<DateTimeInterface> got different types.');
+
+        new MapEntry('map', MapKey::integer(), MapValue::object(\DateTimeInterface::class), ['string', new \DateTimeImmutable()]);
+    }
+
+    public function test_creating_float_map_from_wrong_value_types() : void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Expected map of integer with value of float got different types');
+
+        new MapEntry('map', MapKey::integer(), MapValue::float(), ['string', 1.3]);
+    }
+
+    public function test_creating_integer_map_from_wrong_value_types() : void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Expected map of integer with value of integer got different types');
+
+        new MapEntry('map', MapKey::integer(), MapValue::integer(), ['string', 1]);
+    }
+
+    public function test_creating_map_from_not_map_array() : void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Expected map of integer with value of integer got different types');
+
+        new MapEntry('map', MapKey::integer(), MapValue::integer(), ['a' => 1, 'b' => 2]);
+    }
+
+    public function test_creating_string_map_from_wrong_value_types() : void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Expected map of integer with value of string got different types');
+
+        new MapEntry('map', MapKey::integer(), MapValue::string(), ['string', 1]);
+    }
+
+    public function test_definition() : void
+    {
+        $this->assertEquals(
+            Definition::map('strings', MapKey::integer(), MapValue::string()),
+            (new MapEntry('strings', MapKey::integer(), MapValue::string(), ['one', 'two', 'three']))->definition()
+        );
+    }
+
+    public function test_is_equal() : void
+    {
+        $this->assertTrue(
+            (new MapEntry('strings', MapKey::integer(), MapValue::string(), ['one', 'two', 'three']))
+                ->isEqual((new MapEntry('strings', MapKey::integer(), MapValue::string(), ['one', 'two', 'three'])))
+        );
+        $this->assertFalse(
+            (new MapEntry('strings', MapKey::integer(), MapValue::string(), ['one', 'two', 'three']))
+                ->isEqual(new MapEntry('strings', MapKey::integer(), MapValue::integer(), [1, 2, 3]))
+        );
+        $this->assertTrue(
+            (new MapEntry('strings', MapKey::integer(), MapValue::string(), ['one', 'two', 'three']))
+                ->isEqual((new MapEntry('strings', MapKey::integer(), MapValue::string(), ['one', 'two', 'three'])))
+        );
+    }
+
+    public function test_map() : void
+    {
+        $this->assertEquals(
+            (new MapEntry('strings', MapKey::integer(), MapValue::string(), ['one, two, three'])),
+            (new MapEntry('strings', MapKey::integer(), MapValue::string(), ['one', 'two', 'three']))->map(fn (array $value) => [\implode(', ', $value)])
+        );
+    }
+
+    public function test_rename() : void
+    {
+        $this->assertEquals(
+            (new MapEntry('new_name', MapKey::integer(), MapValue::string(), ['one', 'two', 'three'])),
+            (new MapEntry('strings', MapKey::integer(), MapValue::string(), ['one', 'two', 'three']))->rename('new_name')
+        );
+    }
+
+    public function test_to_string() : void
+    {
+        $this->assertSame(
+            '["one","two","three"]',
+            (new MapEntry('strings', MapKey::integer(), MapValue::string(), ['one', 'two', 'three']))->toString()
+        );
+    }
+
+    public function test_type() : void
+    {
+        $this->assertEquals(
+            new MapType(MapKey::integer(), MapValue::string()),
+            (new MapEntry('strings', MapKey::integer(), MapValue::string(), ['one', 'two', 'three']))->type()
+        );
+    }
+
+    public function test_value() : void
+    {
+        $this->assertSame(
+            ['one', 'two', 'three'],
+            (new MapEntry('strings', MapKey::integer(), MapValue::string(), ['one', 'two', 'three']))->value()
+        );
+        $this->assertSame(
+            ['one' => 'two'],
+            (new MapEntry('strings', MapKey::string(), MapValue::string(), ['one' => 'two']))->value()
+        );
+    }
+}


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <li>Implement new `MapEntry`</li>
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

Refs #684 

As per PHP documentation, the map key accepts only strings & integers, cause all other types are cast to those.
