### PR TITLE
Fixed Dremel to properly shred/assemble nested structures with nullable elements

### DIFF
--- a/src/lib/dremel/src/Flow/Dremel/Dremel.php
+++ b/src/lib/dremel/src/Flow/Dremel/Dremel.php
@@ -101,7 +101,7 @@ final class Dremel
 
     private function buildDefinitions(array $data, array &$definitions, int $maxDefinitionLevel, int $level = 1) : void
     {
-        $previousElement = null;
+        $previousElementType = null;
 
         foreach ($data as $key => $value) {
             if (\is_array($value)) {
@@ -112,7 +112,7 @@ final class Dremel
                 }
             } else {
                 if ($value === null) {
-                    if ($level === 1 || $previousElement === 'array') {
+                    if ($level === 1 || $previousElementType === 'array') {
                         $definitions[] = 0;
                     } else {
                         $definitions[] = $level;
@@ -122,7 +122,7 @@ final class Dremel
                 }
             }
 
-            $previousElement = \is_array($value) ? 'array' : 'scalar';
+            $previousElementType = \gettype($value);
         }
     }
 

--- a/src/lib/dremel/src/Flow/Dremel/Dremel.php
+++ b/src/lib/dremel/src/Flow/Dremel/Dremel.php
@@ -4,7 +4,6 @@ namespace Flow\Dremel;
 
 use function Flow\Parquet\array_flatten;
 use Flow\Dremel\Exception\InvalidArgumentException;
-use Flow\Dremel\Exception\RuntimeException;
 
 final class Dremel
 {
@@ -19,26 +18,27 @@ final class Dremel
      *
      * @psalm-suppress UndefinedInterfaceMethod
      */
-    public function assemble(array $repetitions, array $definitions, array $values) : \Generator
+    public function assemble(array $repetitions, array $definitions, array $values) : array
     {
         $this->assertInput($repetitions, $definitions);
 
         $maxDefinitionLevel = \count($definitions) ? \max($definitions) : 0;
         $maxRepetitionLevel = \count($repetitions) ? \max($repetitions) : 0;
 
+        $output = [];
         $valueIndex = 0;
 
         if ($maxRepetitionLevel === 0) {
             foreach ($definitions as $definition) {
                 if ($definition === 0) {
-                    yield null;
+                    $output[] = null;
                 } elseif ($definition === $maxDefinitionLevel) {
-                    yield $values[$valueIndex];
+                    $output[] = $values[$valueIndex];
                     $valueIndex++;
                 }
             }
 
-            return;
+            return $output;
         }
 
         $stack = new Stack();
@@ -46,40 +46,26 @@ final class Dremel
         foreach ($definitions as $definitionIndex => $definition) {
             $repetition = $repetitions[$definitionIndex];
 
-            if ($repetition === 0) {
-                if ($stack->size()) {
-                    yield $stack->dropFlat();
-                    $stack->clear();
-                    $stack->push(new ListNode($maxRepetitionLevel));
-                } else {
-                    $stack->push(new ListNode($maxRepetitionLevel));
-                }
+            if ($repetition === 0 && $definition !== 0) {
+                $stack->push(new ListNode($maxRepetitionLevel));
             }
 
             if ($repetition === 0 && $definition === 0) {
-                yield null;
-                $stack->clear();
-            } else {
-                if ($repetition <= $maxRepetitionLevel && $repetition > 0) {
-                    /** @phpstan-ignore-next-line  */
-                    $stack->last()->push(
-                        $this->value($definition, $maxDefinitionLevel, $values, $valueIndex),
-                        $repetition
-                    );
-                } elseif ($repetition === 0) {
-                    /** @phpstan-ignore-next-line  */
-                    $stack->last()->push(
-                        $this->value($definition, $maxDefinitionLevel, $values, $valueIndex),
-                        $maxRepetitionLevel
-                    );
-                }
+                $stack->push(new NullNode());
+
+                continue;
+            }
+
+            if ($definition + 1 >= $maxDefinitionLevel) {
+                /** @phpstan-ignore-next-line  */
+                $stack->last()->push(
+                    $this->value($definition, $maxDefinitionLevel, $values, $valueIndex),
+                    $repetition === 0 ? $maxRepetitionLevel : $repetition
+                );
             }
         }
 
-        if ($stack->size()) {
-            yield $stack->dropFlat();
-            $stack->clear();
-        }
+        return $stack->dropFlat();
     }
 
     /**
@@ -89,9 +75,10 @@ final class Dremel
     {
         $definitions = [];
         $this->buildDefinitions($data, $definitions, $maxDefinitionLevel);
+        $repetitions = $this->buildRepetitions($data);
 
         return new DataShredded(
-            $this->buildRepetitions($data),
+            $repetitions,
             $definitions,
             \array_values(\array_filter(array_flatten($data), static fn ($item) => $item !== null))
         );
@@ -112,55 +99,50 @@ final class Dremel
         }
     }
 
-    private function buildDefinitions(array $data, array &$definitions, int $maxDefinitionLevel) : void
+    private function buildDefinitions(array $data, array &$definitions, int $maxDefinitionLevel, int $level = 1) : void
     {
+        $previousElement = null;
+
         foreach ($data as $key => $value) {
             if (\is_array($value)) {
-                // Recursively call the function if the value is an array
-                $this->buildDefinitions($value, $definitions, $maxDefinitionLevel);
+                if (!\count($value)) {
+                    $definitions[] = $level;
+                } else {
+                    $this->buildDefinitions($value, $definitions, $maxDefinitionLevel, $level + 1);
+                }
             } else {
                 if ($value === null) {
-                    $definitions[] = 0;
+                    if ($level === 1 || $previousElement === 'array') {
+                        $definitions[] = 0;
+                    } else {
+                        $definitions[] = $level;
+                    }
                 } else {
                     $definitions[] = $maxDefinitionLevel;
                 }
             }
+
+            $previousElement = \is_array($value) ? 'array' : 'scalar';
         }
     }
 
-    private function buildRepetitions(array $data, int $currentLevel = 0, bool $newRow = true) : array
+    private function buildRepetitions(array $data, int $currentLevel = 0, int $topIndex = 0) : array
     {
         $output = [];
 
-        foreach ($data as $item) {
+        foreach ($data as $index => $item) {
             if (\is_array($item)) {
-                $currentLevel++;
 
-                $valueTypes = [];
+                if (!\count($item)) {
+                    $output[] = 0;
 
-                foreach ($item as $subItem) {
-                    $valueTypes[] = \gettype($subItem);
+                    continue;
                 }
 
-                if (\count(\array_unique($valueTypes)) !== 1) {
-                    throw new RuntimeException('Invalid data structure, each row must be an array of arrays or scalars, got both, arrays and scalars. ' . \json_encode($item, \JSON_THROW_ON_ERROR));
-                }
-
-                $newRow = true;
-
-                foreach ($item as $subItem) {
-                    if (\is_array($subItem)) {
-                        $output = \array_merge($output, $this->buildRepetitions($subItem, $currentLevel + 1, $newRow));
-                    } else {
-                        $output[] = $newRow ? 0 : $currentLevel;
-                    }
-
-                    $newRow = false;
-                }
-                $currentLevel--;
+                $output = \array_merge($output, $this->buildRepetitions($item, $currentLevel + 1, $index));
             } else {
                 if (!\count($output)) {
-                    $output[] = $newRow ? 0 : $currentLevel - 1;
+                    $output[] = $topIndex === 0 ? 0 : $currentLevel - 1;
                 } else {
                     $output[] = $currentLevel;
                 }

--- a/src/lib/dremel/src/Flow/Dremel/NullNode.php
+++ b/src/lib/dremel/src/Flow/Dremel/NullNode.php
@@ -4,13 +4,8 @@ namespace Flow\Dremel;
 
 final class NullNode implements Node
 {
-    public function __construct(private readonly int $level)
+    public function __construct()
     {
-    }
-
-    public function repetition() : int
-    {
-        return $this->level;
     }
 
     public function value() : array|null

--- a/src/lib/dremel/src/Flow/Dremel/Stack.php
+++ b/src/lib/dremel/src/Flow/Dremel/Stack.php
@@ -31,13 +31,13 @@ final class Stack
         $this->nodes = [];
     }
 
-    public function dropFlat() : ?array
+    public function dropFlat() : array
     {
-        $output = [];
-
-        if (\count($this->nodes) === 1) {
-            return $this->nodes[0]->value();
+        if (!\count($this->nodes)) {
+            return [];
         }
+
+        $output = [];
 
         foreach ($this->nodes as $node) {
             $output[] = $node->value();

--- a/src/lib/dremel/tests/Flow/Dremel/Tests/Integration/DremelTest.php
+++ b/src/lib/dremel/tests/Flow/Dremel/Tests/Integration/DremelTest.php
@@ -7,10 +7,33 @@ use PHPUnit\Framework\TestCase;
 
 final class DremelTest extends TestCase
 {
+    public function test_deeply_nested_lists() : void
+    {
+        $values = [
+            [
+                [0, 1, 2],
+            ],
+            [
+                [3, 4, 5],
+                [3, 4, 5],
+            ],
+            [
+                [6, 7, 8],
+            ],
+        ];
+
+        $shredded = (new Dremel())->shred($values, 5);
+
+        $this->assertSame(
+            $values,
+            (new Dremel())->assemble($shredded->repetitions, $shredded->definitions, $shredded->values)
+        );
+    }
+
     public function test_dremel_shredding_and_assembling() : void
     {
         $repetitions = [0, 1, 0, 1, 1, 0, 1, 1, 0, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 0, 1, 1, 0, 1, 1, 1, 1];
-        $definitions = [3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3];
+        $definitions = [2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2];
         $values = [['Suscipit officiis dolorum ea omnis est id magnam.', 'Ea rerum saepe a minima non iusto.'], ['Id dolor et et repellendus.', 'Cumque facilis aut quos et.', 'Sit illum ipsam dolor voluptatem est.'], ['Commodi dicta rerum quas omnis sunt dolor.', 'Architecto sint corrupti nihil soluta nesciunt.', 'Accusamus libero aliquam rerum.'], ['Eum molestias reiciendis cumque ad animi.', 'Sunt ad magnam quas dolores possimus sint aut.', 'Quidem cupiditate doloremque aut esse non.', 'Consequatur nobis delectus aut.', 'Quo fuga fugiat nulla dolor non fugit dolorum.', 'Voluptate ex culpa deleniti est eum qui.', 'Quia sunt quia ut consequatur et optio et.'], ['Aut soluta corrupti laborum qui.', 'Officia maiores natus voluptatem provident aut.', 'Voluptatem modi sequi molestiae aut molestiae.', 'Cumque qui voluptas quia.', 'Quis esse ut odio commodi quae.', 'Voluptatem est accusantium est et eum.', 'Ratione et ut fuga qui atque sed et.', 'Et aut ut quidem provident excepturi placeat.'], ['Rerum molestiae dicta libero dolorem.', 'Expedita fuga sequi a maiores quasi.', 'Nesciunt qui similique et.', 'Architecto perferendis qui sequi sint qui nemo.', 'Sequi in atque tenetur.', 'Voluptatem quod et placeat cupiditate.', 'Qui qui laborum consequatur quos cum totam.', 'Saepe sit quae eos accusamus.', 'Qui illum dolor vel consequuntur nihil.'], ['Vel tenetur velit quas.', 'Natus autem ab beatae nihil recusandae.', 'Ut quasi voluptatum qui dolore ut.', 'Ducimus et minima voluptatem cum sint non.', 'Rerum tenetur sunt quidem est et modi et.', 'Vitae sit eum eius rerum possimus.', 'Eos ipsa est a aliquid impedit doloremque nisi.', 'Aut illum quam sit asperiores.'], ['Repellat dolore sit ad amet sed repudiandae.', 'Quam nemo cum quo culpa.', 'Omnis sed minima vero.', 'Esse qui quo cumque earum eius nulla.', 'Sed in adipisci quas fuga.', 'Dolor est aliquid tempora.', 'Ut expedita id suscipit ut voluptatem.'], ['Sint ipsa et autem ut id vitae.', 'Sapiente ut ab qui.', 'Ullam sit numquam qui perferendis aut.'], ['Qui illum id nam quia quibusdam vero.', 'Quas laboriosam perferendis temporibus vero.', 'Numquam quas deserunt est et eius.', 'Voluptas debitis incidunt ea minus.', 'Pariatur ipsa ipsa sequi ut est dolor adipisci.']];
 
         $dremel = new Dremel();
@@ -19,9 +42,45 @@ final class DremelTest extends TestCase
         $this->assertSame($repetitions, $shredded->repetitions);
         $this->assertSame($definitions, $shredded->definitions);
 
-        $assembledValues = \iterator_to_array($dremel->assemble($shredded->repetitions, $shredded->definitions, $shredded->values));
+        $assembledValues = $dremel->assemble($shredded->repetitions, $shredded->definitions, $shredded->values);
 
         $this->assertSame($values, $assembledValues);
+    }
+
+    public function test_dremel_shredding_and_assembling_list_with_empty_elements() : void
+    {
+        $repetitions = [0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1];
+        $definitions = [3, 3, 3, 1, 3, 3, 3, 0, 2, 2, 2];
+        $values = [[1, 2, 3], [], [4, 5, 6], null, [null, null, null]];
+
+        $dremel = new Dremel();
+        $shredded = $dremel->shred($values, 3);
+
+        $this->assertSame($repetitions, $shredded->repetitions);
+        $this->assertSame($definitions, $shredded->definitions);
+
+        $this->assertSame(
+            $values,
+            $dremel->assemble($shredded->repetitions, $shredded->definitions, $shredded->values)
+        );
+    }
+
+    public function test_dremel_shredding_and_assembling_list_with_nulls_in_list() : void
+    {
+        $repetitions = [0, 1, 1, 0, 1, 0, 1, 1];
+        $definitions = [3, 3, 3, 2, 2, 3, 3, 3];
+        $values = [[1, 2, 3], [null, null], [4, 5, 6]];
+
+        $dremel = new Dremel();
+        $shredded = $dremel->shred($values, 3);
+
+        $this->assertSame($repetitions, $shredded->repetitions);
+        $this->assertSame($definitions, $shredded->definitions);
+
+        $this->assertSame(
+            $values,
+            $dremel->assemble($shredded->repetitions, $shredded->definitions, $shredded->values)
+        );
     }
 
     public function test_dremel_shredding_and_assembling_nullable_nested_values() : void
@@ -38,8 +97,9 @@ final class DremelTest extends TestCase
         $this->assertSame($definitions, $shredded->definitions);
         $this->assertSame($flatValues, $shredded->values);
 
-        $assembledValues = \iterator_to_array($dremel->assemble($shredded->repetitions, $shredded->definitions, $flatValues));
-
-        $this->assertSame($values, $assembledValues);
+        $this->assertSame(
+            $values,
+            $dremel->assemble($shredded->repetitions, $shredded->definitions, $shredded->values)
+        );
     }
 }

--- a/src/lib/dremel/tests/Flow/Dremel/Tests/Unit/DremelAssembleTest.php
+++ b/src/lib/dremel/tests/Flow/Dremel/Tests/Unit/DremelAssembleTest.php
@@ -8,6 +8,18 @@ use PHPUnit\Framework\TestCase;
 
 final class DremelAssembleTest extends TestCase
 {
+    public function test_assembly_shred_on_nested_nullable_lists() : void
+    {
+        $repetitions = [0, 2, 2, 0, 2, 0, 2, 2];
+        $definitions = [2, 2, 2, 1, 1, 2, 2, 2];
+        $values = [0, 1, 2, 4, 5, 6];
+
+        $this->assertSame(
+            [[[0, 1, 2]], [[null, null]], [[4, 5, 6]]],
+            (new Dremel())->assemble($repetitions, $definitions, $values)
+        );
+    }
+
     public function test_decode_column_of_integer_list() : void
     {
         $repetitions = [0, 1, 1, 0, 1, 1, 0, 1, 1, 0, 1, 1, 0, 1, 1, 0, 1, 1, 0, 1, 1, 0, 1, 1, 0, 1, 1, 0, 1, 1];
@@ -16,7 +28,7 @@ final class DremelAssembleTest extends TestCase
 
         $this->assertSame(
             [[3, 7, 5], [4, 4, 7], [10, 6, 4], [10, 3, 2], [10, 4, 4], [5, 3, 2], [1, 4, 3], [4, 3, 9], [10, 3, 4], [5, 7, 4]],
-            \iterator_to_array((new Dremel())->assemble($repetitions, $definitions, $values))
+            (new Dremel())->assemble($repetitions, $definitions, $values)
         );
     }
 
@@ -28,7 +40,7 @@ final class DremelAssembleTest extends TestCase
 
         $this->assertSame(
             [0, null, 2, null, 4, null, 6, null, 8, null],
-            \iterator_to_array((new Dremel())->assemble($repetitions, $definitions, $values))
+            (new Dremel())->assemble($repetitions, $definitions, $values)
         );
     }
 
@@ -40,7 +52,7 @@ final class DremelAssembleTest extends TestCase
 
         $this->assertSame(
             [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
-            \iterator_to_array((new Dremel())->assemble($repetitions, $definitions, $values))
+            (new Dremel())->assemble($repetitions, $definitions, $values)
         );
     }
 
@@ -52,7 +64,7 @@ final class DremelAssembleTest extends TestCase
 
         $this->assertSame(
             [[10], [7, null, null], [9], [8, null], [9], [4, null, null, null, null], [6], [3, null, null], [10, null, null], [8, null]],
-            \iterator_to_array((new Dremel())->assemble($repetitions, $definitions, $values))
+            (new Dremel())->assemble($repetitions, $definitions, $values)
         );
     }
 
@@ -164,7 +176,7 @@ final class DremelAssembleTest extends TestCase
                 [[[8, 4, 4], [10]], [[3, 1, 7], [7], [1, 1]], [[2], [1]]],
                 [[[6, 5], [7, 3], [9]], [[5, 6, 1]], [[4, 8], [7]]],
             ],
-            \iterator_to_array((new Dremel())->assemble($repetitions, $definitions, $values))
+            (new Dremel())->assemble($repetitions, $definitions, $values)
         );
     }
 
@@ -176,7 +188,7 @@ final class DremelAssembleTest extends TestCase
 
         $this->assertSame(
             [[5, 9, 2], null, [3, 2, 9], null, [5, 2, 3], null, [7, 2, 3], null, [2, 6, 6], null],
-            \iterator_to_array((new Dremel())->assemble($repetitions, $definitions, $values))
+            (new Dremel())->assemble($repetitions, $definitions, $values)
         );
     }
 
@@ -220,7 +232,7 @@ final class DremelAssembleTest extends TestCase
                 [[null, 5], [1, null]],
                 [[2, null, null], [null, 2, 3], [null, null, 9]],
             ],
-            \iterator_to_array((new Dremel())->assemble($repetitions, $definitions, $values))
+            (new Dremel())->assemble($repetitions, $definitions, $values)
         );
     }
 
@@ -252,7 +264,7 @@ final class DremelAssembleTest extends TestCase
                 [[[2, 7, 6], [10, 2, null], [null, null, null]], [[5, 7, 5], [null, null, 3], [9, 10, 1]], [[null, 5, 7], [null, null, 6], [7, 4, 4]]],
                 [[[6, 7, 7, 6], [3, 6, 1, 8]], [[2, 8, 3, null], [7, 9, 3, 5]], [[8, 5, null, 2], [null, 2, 5, null]]],
             ],
-            \iterator_to_array((new Dremel())->assemble($repetitions, $definitions, $values))
+            (new Dremel())->assemble($repetitions, $definitions, $values)
         );
     }
 
@@ -333,7 +345,7 @@ final class DremelAssembleTest extends TestCase
                     ],
                 ],
             ],
-            \iterator_to_array((new Dremel())->assemble($repetitions, $definitions, $values))
+            (new Dremel())->assemble($repetitions, $definitions, $values)
         );
     }
 
@@ -346,6 +358,6 @@ final class DremelAssembleTest extends TestCase
         $definitions = [4, 4, 4, 4, 4, 4];
         $values = ['value', 'value', 'value', 'value', 'value', 'value'];
 
-        \iterator_to_array((new Dremel())->assemble($repetitions, $definitions, $values));
+        (new Dremel())->assemble($repetitions, $definitions, $values);
     }
 }

--- a/src/lib/parquet/src/Flow/Parquet/ParquetFile/RowGroupBuilder/ColumnChunkStatistics.php
+++ b/src/lib/parquet/src/Flow/Parquet/ParquetFile/RowGroupBuilder/ColumnChunkStatistics.php
@@ -2,6 +2,7 @@
 
 namespace Flow\Parquet\ParquetFile\RowGroupBuilder;
 
+use function Flow\Parquet\array_flatten;
 use Flow\Parquet\Data\ObjectToString;
 use Flow\Parquet\Exception\RuntimeException;
 use Flow\Parquet\ParquetFile\RowGroupBuilder\Statistics\Comparator;
@@ -40,6 +41,10 @@ final class ColumnChunkStatistics
 
     public function add(string|int|float|null|array|bool|object $value) : void
     {
+        if (\is_array($value)) {
+            $value = array_flatten($value);
+        }
+
         if (\is_array($value)) {
             $this->valuesCount += \count($value);
         } else {

--- a/src/lib/parquet/src/Flow/Parquet/ParquetFile/RowGroupBuilder/PageBuilder/DataPageV2Statistics.php
+++ b/src/lib/parquet/src/Flow/Parquet/ParquetFile/RowGroupBuilder/PageBuilder/DataPageV2Statistics.php
@@ -2,6 +2,7 @@
 
 namespace Flow\Parquet\ParquetFile\RowGroupBuilder\PageBuilder;
 
+use function Flow\Parquet\array_flatten;
 use Flow\Parquet\Data\ObjectToString;
 use Flow\Parquet\ParquetFile\RowGroupBuilder\Statistics\Comparator;
 
@@ -30,6 +31,10 @@ final class DataPageV2Statistics
 
     public function add(string|int|float|null|array|bool|object $value) : void
     {
+        if (\is_array($value)) {
+            $value = array_flatten($value);
+        }
+
         if (\is_array($value)) {
             $this->valuesCount += \count($value);
         } else {

--- a/src/lib/parquet/src/Flow/Parquet/ParquetFile/RowGroupBuilder/PageBuilder/RLEBitPackedPacker.php
+++ b/src/lib/parquet/src/Flow/Parquet/ParquetFile/RowGroupBuilder/PageBuilder/RLEBitPackedPacker.php
@@ -48,7 +48,7 @@ final class RLEBitPackedPacker
         $this->bitPackedHybrid->encodeHybrid(new BinaryBufferWriter($dataBuffer), $values);
         $outputBuffer = '';
         $outputWriter = new BinaryBufferWriter($outputBuffer);
-        $outputWriter->writeInts32([\strlen($dataBuffer)]);
+        $outputWriter->writeInts32([$length = \strlen($dataBuffer)]);
         $outputWriter->append($dataBuffer);
 
         return $outputBuffer;

--- a/src/lib/parquet/tests/Flow/Parquet/Tests/Integration/IO/ListsWritingTest.php
+++ b/src/lib/parquet/tests/Flow/Parquet/Tests/Integration/IO/ListsWritingTest.php
@@ -61,6 +61,58 @@ final class ListsWritingTest extends TestCase
         );
     }
 
+    public function test_writing_list_with_nullable_elements() : void
+    {
+        $path = \sys_get_temp_dir() . '/test-writer' . \uniqid('parquet-test-', true) . '.parquet';
+
+        $writer = new Writer();
+        $schema = Schema::with(NestedColumn::list('list_of_ints', ListElement::int32()));
+
+        $faker = Factory::create();
+        $inputData = \array_merge(...\array_map(static function (int $i) use ($faker) : array {
+            return [
+                [
+                    'list_of_ints' => $i % 2 === 0
+                        ? \array_map(static fn ($a) => $faker->numberBetween(0, Consts::PHP_INT32_MAX), \range(1, \random_int(2, 10)))
+                        : null,
+                ],
+            ];
+        }, \range(1, 100)));
+
+        $writer->write($path, $schema, $inputData);
+
+        $this->assertSame(
+            $inputData,
+            \iterator_to_array((new Reader())->read($path)->values())
+        );
+    }
+
+    public function test_writing_list_with_nullable_list_values() : void
+    {
+        $path = \sys_get_temp_dir() . '/test-writer' . \uniqid('parquet-test-', true) . '.parquet';
+
+        $writer = new Writer();
+        $schema = Schema::with(NestedColumn::list('list_of_ints', ListElement::int32()));
+
+        $faker = Factory::create();
+        $inputData = \array_merge(...\array_map(static function (int $i) use ($faker) : array {
+            return [
+                [
+                    'list_of_ints' => $i % 2 === 0
+                        ? \array_map(static fn ($a) => $faker->numberBetween(0, Consts::PHP_INT32_MAX), \range(1, \random_int(2, 2)))
+                        : [null, null],
+                ],
+            ];
+        }, \range(1, 10)));
+
+        $writer->write($path, $schema, $inputData);
+
+        $this->assertSame(
+            $inputData,
+            \iterator_to_array((new Reader())->read($path)->values())
+        );
+    }
+
     public function test_writing_nullable_list_of_ints() : void
     {
         $path = \sys_get_temp_dir() . '/test-writer' . \uniqid('parquet-test-', true) . '.parquet';

--- a/src/lib/parquet/tests/Flow/Parquet/Tests/Integration/ParquetFile/Data/RLEBitPackedHybridTest.php
+++ b/src/lib/parquet/tests/Flow/Parquet/Tests/Integration/ParquetFile/Data/RLEBitPackedHybridTest.php
@@ -10,6 +10,36 @@ use PHPUnit\Framework\TestCase;
 
 final class RLEBitPackedHybridTest extends TestCase
 {
+    public function test_() : void
+    {
+        $values = [0, 1, 1, 1, 1, 1, 1, 1, 1, 1];
+        $buffer = '';
+        (new RLEBitPackedHybrid())->encodeHybrid($writer = new BinaryBufferWriter($buffer), $values);
+        $this->assertSame(
+            $values,
+            (new RLEBitPackedHybrid())->decodeHybrid(
+                new BinaryBufferReader($buffer),
+                BitWidth::fromArray($values),
+                \count($values)
+            )
+        );
+    }
+
+    public function test_1() : void
+    {
+        $values = [5, 5, 5, 5, 5, 5, 4, 4, 4, 4];
+        $buffer = '';
+        (new RLEBitPackedHybrid())->encodeHybrid($writer = new BinaryBufferWriter($buffer), $values);
+        $this->assertSame(
+            $values,
+            (new RLEBitPackedHybrid())->decodeHybrid(
+                new BinaryBufferReader($buffer),
+                BitWidth::fromArray($values),
+                \count($values)
+            )
+        );
+    }
+
     public function test_bit_packing_reading_with_extra_bytes_in_the_buffer() : void
     {
         $values = [3, 3, 3, 3];

--- a/src/lib/parquet/tests/Flow/Parquet/Tests/Integration/ParquetFile/RowGroupBuilder/PageBuilder/RLEBitPackedTest.php
+++ b/src/lib/parquet/tests/Flow/Parquet/Tests/Integration/ParquetFile/RowGroupBuilder/PageBuilder/RLEBitPackedTest.php
@@ -1,0 +1,42 @@
+<?php declare(strict_types=1);
+
+namespace Flow\Parquet\Tests\Integration\ParquetFile\RowGroupBuilder\PageBuilder;
+
+use Flow\Parquet\BinaryReader\BinaryBufferReader;
+use Flow\Parquet\ParquetFile\Data\BitWidth;
+use Flow\Parquet\ParquetFile\Data\RLEBitPackedHybrid;
+use Flow\Parquet\ParquetFile\RowGroupBuilder\PageBuilder\RLEBitPackedPacker;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class RLEBitPackedTest extends TestCase
+{
+    public static function values_provider() : \Generator
+    {
+        yield [
+            [0, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+            4,
+        ];
+
+        yield [
+            [5, 5, 5, 5, 5, 5, 4, 4, 4, 4],
+            8,
+        ];
+    }
+
+    #[DataProvider('values_provider')]
+    public function test_packing_and_unpacking_with_length(array $values, int $length) : void
+    {
+        $packer = new RLEBitPackedPacker($rleBitPackedHybrid = new RLEBitPackedHybrid());
+
+        $buffer = $packer->packWithLength($values);
+        $reader = new BinaryBufferReader($buffer);
+        $this->assertSame($length, $reader->readInts32(1)[0]);
+        $unpacked = $rleBitPackedHybrid->decodeHybrid($reader, BitWidth::fromArray($values), \count($values));
+
+        $this->assertSame(
+            $values,
+            $unpacked
+        );
+    }
+}


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <li>Dremel to properly shred/assemble nested structures with nullable elements</li>
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Dremel algorithms are no longer working as Generators</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

While working on Dremel algorithms implementation I was mostly focused on non nullable nested structures, that's how this bug was missed in the first implementation. 
After this fix, it will not only properly handle maps/lists with nulls but also empty maps/lists. 
Dremel is no longer working as a generator because all data needs to sit in the memory anyway and since we are operating at small integers, this was bringing very little value compared to complexity of debugging it. 
