### PR TITLE
Removed DSL functions: `datetime_string()`, `json_string()`

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -81,6 +81,12 @@ It's no longer mandatory to set this flat to true when using SaveMode::APPEND, i
 Loaders are no longer accepting chunk_size parameter, from now in order to control 
 the number of rows saved at once use `DataFrame::batchSize(int $size)` method.
 
+### 10) Removed DSL functions: `datetime_string()`, `json_string()`
+
+Those functions were removed in favor of accepting string values in related DSL functions:
+- `datetime_string()` => `datetime()`,
+- `json_string()` => `json()` & `json_object()`
+
 ---
 
 ## Upgrading from 0.3.x to 0.4.x

--- a/src/core/etl/src/Flow/ETL/DSL/Entry.php
+++ b/src/core/etl/src/Flow/ETL/DSL/Entry.php
@@ -58,19 +58,9 @@ class Entry
      *
      * @return RowEntry\DateTimeEntry
      */
-    final public static function datetime(string $name, \DateTimeInterface $value) : RowEntry
+    final public static function datetime(string $name, \DateTimeInterface|string $value) : RowEntry
     {
         return new RowEntry\DateTimeEntry($name, $value);
-    }
-
-    /**
-     * @throws InvalidArgumentException
-     *
-     * @return RowEntry\DateTimeEntry
-     */
-    final public static function datetime_string(string $name, string $value) : RowEntry
-    {
-        return new RowEntry\DateTimeEntry($name, new \DateTimeImmutable($value));
     }
 
     /**
@@ -117,18 +107,14 @@ class Entry
     }
 
     /**
-     * @param array<mixed> $data
-     *
      * @return RowEntry\JsonEntry
      */
-    final public static function json(string $name, array $data) : RowEntry
+    final public static function json(string $name, array|string $data) : RowEntry
     {
         return new RowEntry\JsonEntry($name, $data);
     }
 
     /**
-     * @param array<mixed> $data
-     *
      * @throws InvalidArgumentException
      *
      * @return RowEntry\JsonEntry
@@ -136,16 +122,6 @@ class Entry
     final public static function json_object(string $name, array $data) : RowEntry
     {
         return RowEntry\JsonEntry::object($name, $data);
-    }
-
-    /**
-     * @param string $data
-     *
-     * @return RowEntry\JsonEntry
-     */
-    final public static function json_string(string $name, string $data) : RowEntry
-    {
-        return RowEntry\JsonEntry::fromJsonString($name, $data);
     }
 
     /**

--- a/src/core/etl/src/Flow/ETL/Row/Entry/DateTimeEntry.php
+++ b/src/core/etl/src/Flow/ETL/Row/Entry/DateTimeEntry.php
@@ -16,13 +16,25 @@ final class DateTimeEntry implements \Stringable, Entry
 {
     use EntryRef;
 
+    private readonly \DateTimeInterface $value;
+
     /**
      * @throws InvalidArgumentException
      */
-    public function __construct(private readonly string $name, private readonly \DateTimeInterface $value)
+    public function __construct(private readonly string $name, \DateTimeInterface|string $value)
     {
         if ($name === '') {
             throw InvalidArgumentException::because('Entry name cannot be empty');
+        }
+
+        if (\is_string($value)) {
+            try {
+                $this->value = new \DateTimeImmutable($value);
+            } catch (\Exception $e) {
+                throw new InvalidArgumentException("Invalid value given: '{$value}', reason: " . $e->getMessage(), previous: $e);
+            }
+        } else {
+            $this->value = $value;
         }
     }
 
@@ -44,7 +56,7 @@ final class DateTimeEntry implements \Stringable, Entry
 
     public function definition() : Definition
     {
-        return Definition::dateTime($this->name, false);
+        return Definition::dateTime($this->name);
     }
 
     public function is(string|Reference $name) : bool

--- a/src/core/etl/src/Flow/ETL/Row/Factory/NativeEntryFactory.php
+++ b/src/core/etl/src/Flow/ETL/Row/Factory/NativeEntryFactory.php
@@ -42,7 +42,7 @@ final class NativeEntryFactory implements EntryFactory
 
             if ('' !== $trimmedValue) {
                 if ($this->isJson($trimmedValue)) {
-                    return Row\Entry\JsonEntry::fromJsonString($entryName, $value);
+                    return new Row\Entry\JsonEntry($entryName, $value);
                 }
 
                 if ($this->isUuid($trimmedValue)) {
@@ -196,7 +196,7 @@ final class NativeEntryFactory implements EntryFactory
             }
 
             if ($type === Entry\JsonEntry::class && \is_string($value)) {
-                return EntryDSL::json_string($definition->entry()->name(), $value);
+                return EntryDSL::json($definition->entry()->name(), $value);
             }
 
             if ($type === Entry\JsonEntry::class && \is_array($value)) {

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Entry/DateTimeEntryTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Entry/DateTimeEntryTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Tests\Unit\Row\Entry;
 
+use Flow\ETL\Exception\InvalidArgumentException;
 use Flow\ETL\Row\Entry\DateTimeEntry;
 use PHPUnit\Framework\TestCase;
 
@@ -26,6 +27,14 @@ final class DateTimeEntryTest extends TestCase
         $this->assertSame('0', (new DateTimeEntry('0', new \DateTimeImmutable('2020-07-13 12:00')))->name());
     }
 
+    public function test_invalid_date() : void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("Invalid value given: 'random string', reason: Failed to parse time string (random string) at position 0 (r): The timezone could not be found in the database");
+
+        new DateTimeEntry('a', 'random string');
+    }
+
     /**
      * @dataProvider is_equal_data_provider
      */
@@ -46,6 +55,7 @@ final class DateTimeEntryTest extends TestCase
 
     public function test_prevents_from_creating_entry_with_empty_entry_name() : void
     {
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Entry name cannot be empty');
 
         new DateTimeEntry('', new \DateTimeImmutable('2020-07-13 12:00'));
@@ -75,6 +85,6 @@ final class DateTimeEntryTest extends TestCase
     {
         $entry = new DateTimeEntry('entry-name', new \DateTimeImmutable('2020-07-13 12:00'));
 
-        $this->assertEquals(new \DateTimeImmutable('2020-07-13 12:00'), new \DateTimeImmutable('2020-07-13 12:00'));
+        $this->assertEquals($entry->value(), new \DateTimeImmutable('2020-07-13 12:00'));
     }
 }

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Entry/JsonEntryTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Entry/JsonEntryTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Tests\Unit\Row\Entry;
 
+use Flow\ETL\Exception\InvalidArgumentException;
 use Flow\ETL\Row\Entry\IntegerEntry;
 use Flow\ETL\Row\Entry\JsonEntry;
 use Flow\Serializer\NativePHPSerializer;
@@ -94,6 +95,14 @@ final class JsonEntryTest extends TestCase
         $this->assertSame('0', (new JsonEntry('0', [1]))->name());
     }
 
+    public function test_invalid_json() : void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("Invalid value given: 'random string', reason: Syntax error");
+
+        new JsonEntry('a', 'random string');
+    }
+
     /**
      * @dataProvider is_equal_data_provider
      */
@@ -135,6 +144,7 @@ final class JsonEntryTest extends TestCase
 
     public function test_prevent_from_creating_object_with_integers_as_keys_in_entry() : void
     {
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('All keys for JsonEntry object must be strings');
 
         JsonEntry::object('entry-name', [1 => 'one', 'id' => 1, 'name' => 'one']);
@@ -142,6 +152,7 @@ final class JsonEntryTest extends TestCase
 
     public function test_prevents_from_creating_entry_with_empty_entry_name() : void
     {
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Entry name cannot be empty');
 
         new JsonEntry('', [1, 2, 3]);

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Factory/NativeEntryFactoryTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Factory/NativeEntryFactoryTest.php
@@ -95,7 +95,7 @@ final class NativeEntryFactoryTest extends TestCase
     public function test_datetime_string_with_schema() : void
     {
         $this->assertEquals(
-            Entry::datetime_string('e', '2022-01-01 00:00:00 UTC'),
+            Entry::datetime('e', '2022-01-01 00:00:00 UTC'),
             (new NativeEntryFactory())
                 ->create('e', '2022-01-01 00:00:00 UTC', new Schema(Schema\Definition::dateTime('e')))
         );
@@ -176,14 +176,6 @@ final class NativeEntryFactoryTest extends TestCase
         );
     }
 
-    public function test_json_array_with_schema() : void
-    {
-        $this->assertEquals(
-            Entry::json('e', [['id' => 1]]),
-            (new NativeEntryFactory())->create('e', [['id' => 1]], new Schema(Schema\Definition::json('e')))
-        );
-    }
-
     public function test_json_object_array_with_schema() : void
     {
         $this->assertEquals(
@@ -192,11 +184,27 @@ final class NativeEntryFactoryTest extends TestCase
         );
     }
 
+    public function test_json_string() : void
+    {
+        $this->assertEquals(
+            Entry::json('e', '{"id": 1}'),
+            (new NativeEntryFactory())->create('e', '{"id": 1}')
+        );
+    }
+
     public function test_json_string_with_schema() : void
     {
         $this->assertEquals(
-            Entry::json_string('e', '{"id": 1}'),
+            Entry::json('e', '{"id": 1}'),
             (new NativeEntryFactory())->create('e', '{"id": 1}', new Schema(Schema\Definition::json('e')))
+        );
+    }
+
+    public function test_json_with_schema() : void
+    {
+        $this->assertEquals(
+            Entry::json('e', [['id' => 1]]),
+            (new NativeEntryFactory())->create('e', [['id' => 1]], new Schema(Schema\Definition::json('e')))
         );
     }
 

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Reference/Expression/BinaryComparisonsTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Reference/Expression/BinaryComparisonsTest.php
@@ -33,7 +33,7 @@ final class BinaryComparisonsTest extends TestCase
 {
     public function test_equals() : void
     {
-        $row = Row::create(Entry::integer('a', 100), Entry::integer('b', 100), Entry::integer('c', 10), Entry::datetime_string('d', '2023-01-01 00:00:00 UTC'), Entry::datetime_string('e', '2023-01-01 00:00:00 UTC'));
+        $row = Row::create(Entry::integer('a', 100), Entry::integer('b', 100), Entry::integer('c', 10), Entry::datetime('d', '2023-01-01 00:00:00 UTC'), Entry::datetime('e', '2023-01-01 00:00:00 UTC'));
 
         $this->assertTrue(
             (new Equals(ref('a'), ref('b')))->eval($row)
@@ -52,8 +52,8 @@ final class BinaryComparisonsTest extends TestCase
             Entry::integer('a', 100),
             Entry::integer('b', 100),
             Entry::integer('c', 10),
-            Entry::datetime_string('d', '2023-01-01 00:00:00 UTC'),
-            Entry::datetime_string('e', '2023-01-02 00:00:00 UTC'),
+            Entry::datetime('d', '2023-01-01 00:00:00 UTC'),
+            Entry::datetime('e', '2023-01-02 00:00:00 UTC'),
         );
 
         $this->assertTrue((new GreaterThan(ref('a'), ref('c')))->eval($row));
@@ -177,7 +177,7 @@ final class BinaryComparisonsTest extends TestCase
 
     public function test_same() : void
     {
-        $row = Row::create(Entry::integer('a', 100), Entry::integer('b', 100), Entry::integer('c', 10), Entry::datetime_string('d', '2023-01-01 00:00:00 UTC'), Entry::datetime_string('e', '2023-01-01 00:00:00 UTC'));
+        $row = Row::create(Entry::integer('a', 100), Entry::integer('b', 100), Entry::integer('c', 10), Entry::datetime('d', '2023-01-01 00:00:00 UTC'), Entry::datetime('e', '2023-01-01 00:00:00 UTC'));
 
         $this->assertTrue(
             (new Same(ref('a'), ref('b')))->eval($row)

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Reference/Expression/CallMethodTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Reference/Expression/CallMethodTest.php
@@ -13,7 +13,7 @@ final class CallMethodTest extends TestCase
     public function test_call_method() : void
     {
         $row = Row::create(
-            Entry::datetime_string('object', '2023-01-01 00:00:00 UTC'),
+            Entry::datetime('object', '2023-01-01 00:00:00 UTC'),
             Entry::str('method', 'format'),
             Entry::str('method_param', 'H:i:s Y-m-d'),
         );
@@ -31,8 +31,8 @@ final class CallMethodTest extends TestCase
     public function test_method_not_string() : void
     {
         $row = Row::create(
-            Entry::datetime_string('object', '2023-01-01 00:00:00 UTC'),
-            Entry::datetime_string('method', '2023-01-01 00:00:00 UTC'),
+            Entry::datetime('object', '2023-01-01 00:00:00 UTC'),
+            Entry::datetime('method', '2023-01-01 00:00:00 UTC'),
         );
 
         $this->assertNull(
@@ -46,7 +46,7 @@ final class CallMethodTest extends TestCase
     public function test_not_existing_method() : void
     {
         $row = Row::create(
-            Entry::datetime_string('object', '2023-01-01 00:00:00 UTC'),
+            Entry::datetime('object', '2023-01-01 00:00:00 UTC'),
             Entry::str('method', 'method_that_not_exists'),
         );
 
@@ -61,7 +61,7 @@ final class CallMethodTest extends TestCase
     public function test_null_method() : void
     {
         $row = Row::create(
-            Entry::datetime_string('object', '2023-01-01 00:00:00 UTC'),
+            Entry::datetime('object', '2023-01-01 00:00:00 UTC'),
             Entry::null('method'),
         );
 


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <li>Removed DSL functions: `datetime_string()`, `json_string()`</li>
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

Those functions were removed in favor of accepting string values in related DSL functions:
- `datetime_string()` => `datetime()`,
- `json_string()` => `json()` & `json_object()`
