### PR TITLE
Fix hardcoded entry name for enum entry with schema

### DIFF
--- a/src/core/etl/src/Flow/ETL/Row/Factory/NativeEntryFactory.php
+++ b/src/core/etl/src/Flow/ETL/Row/Factory/NativeEntryFactory.php
@@ -243,7 +243,7 @@ final class NativeEntryFactory implements EntryFactory
                     }
                 }
 
-                throw new InvalidArgumentException("Value \"not_valid\" can't be converted to " . $enumClass . ' enum');
+                throw new InvalidArgumentException("Value \"{$value}\" can't be converted to " . $enumClass . ' enum');
             }
 
             if ($type === Entry\ListEntry::class && \is_array($value) && \array_is_list($value)) {

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Factory/NativeEntryFactoryTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Factory/NativeEntryFactoryTest.php
@@ -113,10 +113,10 @@ final class NativeEntryFactoryTest extends TestCase
     public function test_enum_invalid_value_with_schema() : void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage("Value \"not_valid\" can't be converted to " . BackedIntEnum::class . ' enum');
+        $this->expectExceptionMessage("Value \"invalid\" can't be converted to " . BackedIntEnum::class . ' enum');
 
         (new NativeEntryFactory())
-            ->create('e', 'not_valid', new Schema(Schema\Definition::enum('e', BackedIntEnum::class)));
+            ->create('e', 'invalid', new Schema(Schema\Definition::enum('e', BackedIntEnum::class)));
     }
 
     public function test_enum_with_schema() : void


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>Fix hardcoded entry name for enum entry with schema</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

<!-- Please provide a short description of changes in this section, feel free to use markdown syntax -->
