### PR TITLE
Use createSchemaManger instead of deprecated getSchemaManager

### DIFF
--- a/src/lib/doctrine-dbal-bulk/src/Flow/Doctrine/Bulk/Bulk.php
+++ b/src/lib/doctrine-dbal-bulk/src/Flow/Doctrine/Bulk/Bulk.php
@@ -35,8 +35,6 @@ final class Bulk
      * } $insertOptions $insertOptions
      *
      * @throws Exception|RuntimeException
-     *
-     * @psalm-suppress DeprecatedMethod
      */
     public function insert(Connection $connection, string $table, BulkData $bulkData, array $insertOptions = []) : void
     {
@@ -59,8 +57,6 @@ final class Bulk
      * } $updateOptions $updateOptions
      *
      * @throws Exception|RuntimeException
-     *
-     * @psalm-suppress DeprecatedMethod
      */
     public function update(Connection $connection, string $table, BulkData $bulkData, array $updateOptions = []) : void
     {

--- a/src/lib/doctrine-dbal-bulk/src/Flow/Doctrine/Bulk/Bulk.php
+++ b/src/lib/doctrine-dbal-bulk/src/Flow/Doctrine/Bulk/Bulk.php
@@ -40,7 +40,7 @@ final class Bulk
      */
     public function insert(Connection $connection, string $table, BulkData $bulkData, array $insertOptions = []) : void
     {
-        $tableDefinition = new TableDefinition($table, ...\array_values($connection->getSchemaManager()->listTableColumns($table)));
+        $tableDefinition = new TableDefinition($table, ...\array_values($connection->createSchemaManager()->listTableColumns($table)));
 
         $connection->executeStatement(
             $this->queryFactory->insert($connection->getDatabasePlatform(), $tableDefinition, $bulkData, $insertOptions),
@@ -64,7 +64,7 @@ final class Bulk
      */
     public function update(Connection $connection, string $table, BulkData $bulkData, array $updateOptions = []) : void
     {
-        $tableDefinition = new TableDefinition($table, ...\array_values($connection->getSchemaManager()->listTableColumns($table)));
+        $tableDefinition = new TableDefinition($table, ...\array_values($connection->createSchemaManager()->listTableColumns($table)));
 
         $connection->executeQuery(
             $this->queryFactory->update($connection->getDatabasePlatform(), $tableDefinition, $bulkData, $updateOptions),


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
<li>Deprecated notice for using Connection::getSchemaManager()</li> 
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

`Connection::getSchemaManager()` is deprecated, `Connection::createSchemaManager()` should be used instead.

https://github.com/doctrine/dbal/blob/3.7.x/src/Connection.php#L1695 

<img width="770" alt="image" src="https://github.com/flow-php/flow/assets/7013293/48e25b5c-0cfe-4c8c-b620-af8a2fb61921">
