### PR TITLE
Remove `from*` methods from scalar entry classes

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -93,12 +93,16 @@ More details can be found in [this issue](https://github.com/flow-php/flow/issue
 
 - Removed etl-adapter-amphp
 - Removed etl-adapter-reactphp
-- Removed LocalSocketPipeline
+- Removed `LocalSocketPipeline`
 - Removed `DataFrame::pipeline()` 
 
 ### 12) `CollectionEntry` removal
 
 After adding native & logical types into the Flow, we remove the `CollectionEntry` as obsolete. New types that cover it better are: `ListType`, `MapType` & `StructureType` along with related new entry types.
+
+### 13) Removed `from*()` methods from scalar entries
+
+Removed `BooleanEntry::from()`, `FloatEntry::from()`, `IntegerEntry::from()`, `StringEntry::fromDateTime()` methods in favor of using DSL functions.
 
 ---
 

--- a/src/core/etl/src/Flow/ETL/Row/Entry/BooleanEntry.php
+++ b/src/core/etl/src/Flow/ETL/Row/Entry/BooleanEntry.php
@@ -32,29 +32,6 @@ final class BooleanEntry implements \Stringable, Entry
         $this->type = ScalarType::boolean();
     }
 
-    public static function from(string $name, bool|int|string $value) : self
-    {
-        if (\is_bool($value)) {
-            return new self($name, $value);
-        }
-
-        $value = \mb_strtolower(\trim((string) $value));
-
-        if (!\in_array($value, ['1', '0', 'true', 'false', 'yes', 'no'], true)) {
-            throw InvalidArgumentException::because('Value "%s" can\'t be casted to boolean.', $value);
-        }
-
-        if ($value === 'true' || $value === 'yes') {
-            return new self($name, true);
-        }
-
-        if ($value === 'false' || $value === 'no') {
-            return new self($name, false);
-        }
-
-        return new self($name, (bool) $value);
-    }
-
     public function __serialize() : array
     {
         return ['name' => $this->name, 'value' => $this->value, 'type' => $this->type];

--- a/src/core/etl/src/Flow/ETL/Row/Entry/FloatEntry.php
+++ b/src/core/etl/src/Flow/ETL/Row/Entry/FloatEntry.php
@@ -32,15 +32,6 @@ final class FloatEntry implements \Stringable, Entry
         $this->type = ScalarType::float();
     }
 
-    public static function from(string $name, float|int|string $value) : self
-    {
-        if (!\is_numeric($value) || $value != (int) $value) {
-            throw InvalidArgumentException::because(\sprintf('Value "%s" can\'t be casted to integer.', $value));
-        }
-
-        return new self($name, (float) $value);
-    }
-
     public function __serialize() : array
     {
         return ['name' => $this->name, 'value' => $this->value, 'precision' => $this->precision, 'type' => $this->type];

--- a/src/core/etl/src/Flow/ETL/Row/Entry/IntegerEntry.php
+++ b/src/core/etl/src/Flow/ETL/Row/Entry/IntegerEntry.php
@@ -32,15 +32,6 @@ final class IntegerEntry implements \Stringable, Entry
         $this->type = ScalarType::integer();
     }
 
-    public static function from(string $name, float|int|string $value) : self
-    {
-        if (!\is_numeric($value) || $value != (int) $value) {
-            throw InvalidArgumentException::because(\sprintf('Value "%s" can\'t be casted to integer.', $value));
-        }
-
-        return new self($name, (int) $value);
-    }
-
     public function __serialize() : array
     {
         return ['name' => $this->name, 'value' => $this->value, 'type' => $this->type];

--- a/src/core/etl/src/Flow/ETL/Row/Entry/StringEntry.php
+++ b/src/core/etl/src/Flow/ETL/Row/Entry/StringEntry.php
@@ -35,14 +35,6 @@ final class StringEntry implements \Stringable, Entry
     /**
      * @throws InvalidArgumentException
      */
-    public static function fromDateTime(string $name, \DateTimeInterface $dateTime, string $format = \DateTimeInterface::ATOM) : self
-    {
-        return new self($name, $dateTime->format($format));
-    }
-
-    /**
-     * @throws InvalidArgumentException
-     */
     public static function lowercase(string $name, string $value) : self
     {
         return new self($name, \mb_strtolower($value));

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Entry/BooleanEntryTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Entry/BooleanEntryTest.php
@@ -17,44 +17,6 @@ final class BooleanEntryTest extends TestCase
         yield 'different names characters and equal values' => [false, new BooleanEntry('NAME', true), new BooleanEntry('name', true)];
     }
 
-    public static function valid_false_entries() : \Generator
-    {
-        yield [false];
-        yield [0];
-        yield ['0'];
-        yield ['false'];
-        yield ['no'];
-    }
-
-    public static function valid_true_entries() : \Generator
-    {
-        yield [true];
-        yield [1];
-        yield ['1'];
-        yield ['true'];
-        yield ['yes'];
-    }
-
-    /**
-     * @dataProvider valid_false_entries
-     */
-    public function test_creates_false_entry_from_not_boolean_values($value) : void
-    {
-        $entry = BooleanEntry::from('entry-name', $value);
-
-        $this->assertFalse($entry->value());
-    }
-
-    /**
-     * @dataProvider valid_true_entries
-     */
-    public function test_creates_true_entry_from_not_boolean_values($value) : void
-    {
-        $entry = BooleanEntry::from('entry-name', $value);
-
-        $this->assertTrue($entry->value());
-    }
-
     public function test_entry_name_can_be_zero() : void
     {
         $this->assertSame('0', (new BooleanEntry('0', true))->name());
@@ -76,13 +38,6 @@ final class BooleanEntryTest extends TestCase
             $entry,
             $entry->map(fn (bool $value) => $value)
         );
-    }
-
-    public function test_prevents_from_creating_entry_from_random_value() : void
-    {
-        $this->expectExceptionMessage('Value "random-value" can\'t be casted to boolean');
-
-        BooleanEntry::from('entry-name', 'random-value');
     }
 
     public function test_prevents_from_creating_entry_with_empty_entry_name() : void

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Entry/FloatEntryTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Entry/FloatEntryTest.php
@@ -9,11 +9,6 @@ use PHPUnit\Framework\TestCase;
 
 final class FloatEntryTest extends TestCase
 {
-    public static function invalid_entries() : \Generator
-    {
-        yield ['random_value'];
-    }
-
     public static function is_equal_data_provider() : \Generator
     {
         yield 'equal names and values' => [true, new FloatEntry('name', 1.0), new FloatEntry('name', 1.0)];
@@ -22,24 +17,6 @@ final class FloatEntryTest extends TestCase
         yield 'different names characters and equal values' => [false, new FloatEntry('NAME', 1.1), new FloatEntry('name', 1.1)];
         yield 'different names characters and equal values with high precision' => [false, new FloatEntry('NAME', 1.00001), new FloatEntry('name', 1.00001)];
         yield 'different names characters and different values with high precision' => [false, new FloatEntry('NAME', 1.205502), new FloatEntry('name', 1.205501)];
-    }
-
-    public static function valid_float_entries() : \Generator
-    {
-        yield [100];
-        yield [100.00];
-        yield ['100'];
-        yield ['100.00'];
-    }
-
-    /**
-     * @dataProvider valid_float_entries
-     */
-    public function test_creates_true_entry_from_not_boolean_values($value) : void
-    {
-        $entry = FloatEntry::from('entry-name', $value);
-
-        $this->assertEquals((int) $value, $entry->value());
     }
 
     public function test_entry_name_can_be_zero() : void
@@ -63,16 +40,6 @@ final class FloatEntryTest extends TestCase
             $entry,
             $entry->map(fn (float $float) => $float)
         );
-    }
-
-    /**
-     * @dataProvider invalid_entries
-     */
-    public function test_prevents_from_creating_entry_from_invalid_entry_values($value) : void
-    {
-        $this->expectExceptionMessage(\sprintf('Value "%s" can\'t be casted to integer', $value));
-
-        FloatEntry::from('entry-name', $value);
     }
 
     public function test_prevents_from_creating_entry_with_empty_entry_name() : void

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Entry/IntegerEntryTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Entry/IntegerEntryTest.php
@@ -9,37 +9,12 @@ use PHPUnit\Framework\TestCase;
 
 final class IntegerEntryTest extends TestCase
 {
-    public static function invalid_entries() : \Generator
-    {
-        yield ['random_value'];
-        yield [100.50];
-        yield ['100.5'];
-    }
-
     public static function is_equal_data_provider() : \Generator
     {
         yield 'equal names and values' => [true, new IntegerEntry('name', 1), new IntegerEntry('name', 1)];
         yield 'different names and values' => [false, new IntegerEntry('name', 1), new IntegerEntry('different_name', 1)];
         yield 'equal names and different values' => [false, new IntegerEntry('name', 1), new IntegerEntry('name', 2)];
         yield 'different names characters and equal values' => [false, new IntegerEntry('NAME', 1), new IntegerEntry('name', 1)];
-    }
-
-    public static function valid_integer_entries() : \Generator
-    {
-        yield [100];
-        yield [100.00];
-        yield ['100'];
-        yield ['100.00'];
-    }
-
-    /**
-     * @dataProvider valid_integer_entries
-     */
-    public function test_creates_true_entry_from_not_boolean_values($value) : void
-    {
-        $entry = IntegerEntry::from('entry-name', $value);
-
-        $this->assertEquals((int) $value, $entry->value());
     }
 
     public function test_entry_name_can_be_zero() : void
@@ -63,16 +38,6 @@ final class IntegerEntryTest extends TestCase
             $entry,
             $entry->map(fn (int $int) => $int)
         );
-    }
-
-    /**
-     * @dataProvider invalid_entries
-     */
-    public function test_prevents_from_creating_entry_from_invalid_entry_values($value) : void
-    {
-        $this->expectExceptionMessage(\sprintf('Value "%s" can\'t be casted to integer', $value));
-
-        IntegerEntry::from('entry-name', $value);
     }
 
     public function test_prevents_from_creating_entry_with_empty_entry_name() : void

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Entry/StringEntryTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Entry/StringEntryTest.php
@@ -18,13 +18,6 @@ final class StringEntryTest extends TestCase
         yield 'different names characters and equal values' => [false, new StringEntry('NAME', 'value'), new StringEntry('name', 'value')];
     }
 
-    public function test_creates_datetime_value() : void
-    {
-        $entry = StringEntry::fromDateTime('datetime', new \DateTimeImmutable('2021-06-01 00:00:00 UTC'));
-
-        $this->assertEquals('2021-06-01T00:00:00+00:00', $entry->value());
-    }
-
     public function test_creates_lowercase_value() : void
     {
         $entry = StringEntry::lowercase('lowercase', 'It Should Be Lowercase');


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <li>Remove `from*` methods from scalar entry classes</li>
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

Those methods were used only in tests, while we provide more proper usage for creating those entries using DSL functions.
