### PR TITLE
Added DataFrame::until method

### DIFF
--- a/src/core/etl/src/Flow/ETL/DataFrame.php
+++ b/src/core/etl/src/Flow/ETL/DataFrame.php
@@ -10,6 +10,7 @@ use Flow\ETL\Exception\InvalidArgumentException;
 use Flow\ETL\Filesystem\SaveMode;
 use Flow\ETL\Formatter\AsciiTableFormatter;
 use Flow\ETL\Function\AggregatingFunction;
+use Flow\ETL\Function\ScalarFunction;
 use Flow\ETL\Function\WindowFunction;
 use Flow\ETL\Join\Expression;
 use Flow\ETL\Join\Join;
@@ -36,6 +37,7 @@ use Flow\ETL\Transformer\RemoveEntriesTransformer;
 use Flow\ETL\Transformer\ScalarFunctionFilterTransformer;
 use Flow\ETL\Transformer\ScalarFunctionTransformer;
 use Flow\ETL\Transformer\StyleConverter\StringStyles;
+use Flow\ETL\Transformer\UntilTransformer;
 use Flow\ETL\Transformer\WindowFunctionTransformer;
 
 final class DataFrame
@@ -248,9 +250,9 @@ final class DataFrame
     /**
      * @lazy
      */
-    public function filter(Function\ScalarFunction $callback) : self
+    public function filter(ScalarFunction $function) : self
     {
-        $this->pipeline->add(new ScalarFunctionFilterTransformer($callback));
+        $this->pipeline->add(new ScalarFunctionFilterTransformer($function));
 
         return $this;
     }
@@ -675,6 +677,19 @@ final class DataFrame
         }
 
         return $transformer->transform($this);
+    }
+
+    /**
+     * The difference between filter and until is that filter will keep filtering rows until extractors finish yielding rows.
+     * Until will send a STOP signal to the Extractor when the condition is not met.
+     *
+     * @lazy
+     */
+    public function until(ScalarFunction $function) : self
+    {
+        $this->pipeline->add(new UntilTransformer($function));
+
+        return $this;
     }
 
     /**

--- a/src/core/etl/src/Flow/ETL/Transformer/UntilTransformer.php
+++ b/src/core/etl/src/Flow/ETL/Transformer/UntilTransformer.php
@@ -1,0 +1,52 @@
+<?php declare(strict_types=1);
+
+namespace Flow\ETL\Transformer;
+
+use Flow\ETL\Exception\LimitReachedException;
+use Flow\ETL\FlowContext;
+use Flow\ETL\Function\ScalarFunction;
+use Flow\ETL\Rows;
+use Flow\ETL\Transformer;
+
+/**
+ * @implements Transformer<array{function: ScalarFunction}>
+ */
+final class UntilTransformer implements Transformer
+{
+    private bool $limitReached = false;
+
+    public function __construct(private readonly ScalarFunction $function)
+    {
+    }
+
+    public function __serialize() : array
+    {
+        return [
+            'function' => $this->function,
+        ];
+    }
+
+    public function __unserialize(array $data) : void
+    {
+        $this->function = $data['function'];
+    }
+
+    public function transform(Rows $rows, FlowContext $context) : Rows
+    {
+        if ($this->limitReached) {
+            throw new LimitReachedException(0);
+        }
+
+        $nextRows = [];
+
+        foreach ($rows as $row) {
+            if (!$this->function->eval($row)) {
+                $this->limitReached = true;
+            } else {
+                $nextRows[] = $row;
+            }
+        }
+
+        return new Rows(...$nextRows);
+    }
+}

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/DataFrameTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/DataFrameTest.php
@@ -1730,6 +1730,39 @@ ASCII,
         );
     }
 
+    public function test_until() : void
+    {
+        $rows = (new Flow())
+            ->read(From::chain(
+                From::array([
+                    ['id' => 1],
+                    ['id' => 2],
+                    ['id' => 3],
+                    ['id' => 4],
+                    ['id' => 5],
+                ]),
+                From::array([
+                    ['id' => 6],
+                    ['id' => 7],
+                    ['id' => 8],
+                    ['id' => 9],
+                    ['id' => 10],
+                ])
+            ))
+            ->until(ref('id')->lessThanEqual(lit(3)))
+            ->fetch();
+
+        $this->assertCount(3, $rows);
+        $this->assertSame(
+            [
+                ['id' => 1],
+                ['id' => 2],
+                ['id' => 3],
+            ],
+            $rows->toArray()
+        );
+    }
+
     public function test_void() : void
     {
         $rows = (new Flow())->process(
@@ -1785,7 +1818,6 @@ ASCII,
             (new Flow)
                 ->read(From::chain(From::memory($memoryPage1), From::memory($memoryPage2)))
                 ->withEntry('avg_salary', average(ref('salary'))->over(window()->partitionBy(ref('department'))))
-//                ->withEntry('avg_salary', _Window::partitionBy(ref('department'))->orderBy(ref('salary')->desc())->avg(ref('salary')))
                 ->select('department', 'avg_salary')
                 ->dropDuplicates(ref('department'), ref('avg_salary'))
                 ->withEntry('avg_salary', ref('avg_salary')->round(lit(0)))
@@ -1833,7 +1865,6 @@ ASCII,
                 ->read(From::all(From::memory($memoryPage1), From::memory($memoryPage2)))
                 ->dropDuplicates(ref('employee_name'), ref('department'))
                 ->withEntry('rank', rank()->over(window()->partitionBy(ref('department'))->orderBy(ref('salary')->desc())))
-//                ->withEntry('rank', _Window::partitionBy(ref('department'))->orderBy(ref('salary')->desc())->rank())
                 ->filter(ref('rank')->equals(lit(1)))
                 ->fetch()
                 ->toArray()


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <li>Added DataFrame::until</li>
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

The difference between DataFrame::filter and DataFrame::until is that the filter will be executed at all extracted Rows, until on the other hand will send an STOP signal to extractor when a condition is not satisfied. 

This is helpful when iterating over sorted datasets without possibility to filter them upfront to avoid reading all rows. 
