### PR TITLE
Improve performance of `TypeDetector`

### DIFF
--- a/src/core/etl/src/Flow/ETL/PHP/Type/Logical/List/ListElement.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Logical/List/ListElement.php
@@ -52,11 +52,6 @@ final class ListElement
         return new self(ObjectType::of($class, $nullable));
     }
 
-    public static function scalar(string $value, bool $nullable = false) : self
-    {
-        return new self(ScalarType::fromString($value, $nullable));
-    }
-
     public static function string() : self
     {
         return new self(ScalarType::string());

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Logical/Map/MapValue.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Logical/Map/MapValue.php
@@ -52,11 +52,6 @@ final class MapValue
         return new self(ObjectType::of($class, $optional));
     }
 
-    public static function scalar(string $value, bool $optional = false) : self
-    {
-        return new self(ScalarType::fromString($value, $optional));
-    }
-
     public static function string() : self
     {
         return new self(ScalarType::string());

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Native/ScalarType.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Native/ScalarType.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Flow\ETL\PHP\Type\Native;
 
-use Flow\ETL\Exception\InvalidArgumentException;
 use Flow\ETL\PHP\Type\Type;
 
 /**
@@ -20,17 +19,8 @@ final class ScalarType implements NativeType
 
     public const STRING = 'string';
 
-    private readonly string $value;
-
-    private function __construct(string $value, private readonly bool $nullable)
+    private function __construct(private readonly string $value, private readonly bool $nullable)
     {
-        $this->value = match (\strtolower($value)) {
-            'integer' => self::INTEGER,
-            'float', 'double' => self::FLOAT,
-            'string' => self::STRING,
-            'boolean' => self::BOOLEAN,
-            default => throw new InvalidArgumentException("Unsupported scalar type: {$value}")
-        };
     }
 
     public static function boolean(bool $nullable = false) : self
@@ -41,11 +31,6 @@ final class ScalarType implements NativeType
     public static function float(bool $nullable = false) : self
     {
         return new self(self::FLOAT, $nullable);
-    }
-
-    public static function fromString(string $value, bool $nullable = false) : self
-    {
-        return new self($value, $nullable);
     }
 
     public static function integer(bool $nullable = false) : self

--- a/src/core/etl/src/Flow/ETL/PHP/Type/TypeDetector.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/TypeDetector.php
@@ -23,16 +23,20 @@ final class TypeDetector
             return new NullType();
         }
 
-        if (\is_scalar($value)) {
-            return ScalarType::fromString(\gettype($value));
+        if (\is_string($value)) {
+            return ScalarType::string();
         }
 
-        if (\is_object($value)) {
-            if ($value instanceof \UnitEnum) {
-                return EnumType::of($value::class);
-            }
+        if (\is_int($value)) {
+            return ScalarType::integer();
+        }
 
-            return ObjectType::fromObject($value);
+        if (\is_bool($value)) {
+            return ScalarType::boolean();
+        }
+
+        if (\is_float($value)) {
+            return ScalarType::float();
         }
 
         if (\is_array($value)) {
@@ -62,6 +66,14 @@ final class TypeDetector
             }
 
             return new ArrayType([] === \array_filter($value, fn ($value) : bool => null !== $value));
+        }
+
+        if ($value instanceof \UnitEnum) {
+            return EnumType::of($value::class);
+        }
+
+        if (\is_object($value)) {
+            return ObjectType::fromObject($value);
         }
 
         throw InvalidArgumentException::because('Unsupported type given: ' . \gettype($value));


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Improve performance of `TypeDetector`</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

Result based on script:

<details>

```php
<?php

declare(strict_types=1);

include __DIR__ . '/../vendor/autoload.php';
include __DIR__ . '/../tools/blackfire/vendor/autoload.php';

$blackfire = new \Blackfire\Client();
$probe = $blackfire->createProbe(null, false);

// Disable profiling for the irrelevant parts of the code
$probe->disable();

$callback = static fn (int $i) : array => [
    'order_id' => '2d76fb83-c1a7-4b6e-9d68-46258af783b4',
    'created_at' => (new \DateTimeImmutable('-10 day ago'))->format(\DateTimeInterface::RFC3339),
    'updated_at' => (new \DateTimeImmutable('+1 week'))->format(\DateTimeInterface::RFC3339),
    'active' => true,
    'total_price' => 123.45,
    'discount' => 5.5,
    'customer' => [
        'name' => 'firstName',
        'last_name' => 'lastName',
        'email' => 'foo@bar.test',
    ],
    'address' => [
        'street' => 'streetAddress',
        'city' => 'city',
        'zip' => '12-345',
        'country' => 'country',
        'location' => [
            'lat' => 66.6,
            'lng' => 33.3,
        ],
    ],
    'notes' => "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.",
];

$data = \array_map($callback, \range(1, 5000));

// Actual profiling starts here
$probe->enable();

(new \Flow\ETL\PHP\Type\TypeDetector())->detectType($data);

// Profiling ends here
$profile = $blackfire->endProbe($probe);
var_dump($profile->getUrl());
```

</details>

<img width="1370" alt="Zrzut ekranu 2023-11-21 o 14 35 20" src="https://github.com/flow-php/flow/assets/67402/03a49569-a350-4207-9c72-09088b757165">
