### PR TITLE
Fix wrong return type on entry reference DSL functions

### DIFF
--- a/src/core/etl/src/Flow/ETL/DSL/functions.php
+++ b/src/core/etl/src/Flow/ETL/DSL/functions.php
@@ -69,22 +69,19 @@ use Flow\ETL\Row\Reference;
 use Flow\ETL\Rows;
 use Flow\ETL\Window;
 
-function col(string $entry) : Reference
+function col(string $entry) : EntryReference
 {
     return new EntryReference($entry);
 }
 
-function entry(string $entry) : Reference
+function entry(string $entry) : EntryReference
 {
     return new EntryReference($entry);
 }
 
-/**
- * Alias for entry function.
- */
-function ref(string $entry) : Reference
+function ref(string $entry) : EntryReference
 {
-    return entry($entry);
+    return new EntryReference($entry);
 }
 
 function optional(ScalarFunction $function) : ScalarFunction


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>Fix wrong return type on entry reference DSL functions</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

Before:
<img width="977" alt="Zrzut ekranu 2023-11-21 o 17 14 44" src="https://github.com/flow-php/flow/assets/67402/91ca0e2e-3ba9-41bb-aa4c-eabb4f1c8c36">
After:
<img width="587" alt="Zrzut ekranu 2023-11-21 o 17 15 50" src="https://github.com/flow-php/flow/assets/67402/eedc7781-ca74-4936-bce7-ccd67506224e">
