### PR TITLE
Simplify PHPUnit configuration

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -26,39 +26,18 @@
   </php>
   <testsuites>
     <testsuite name="unit">
-      <directory>src/adapter/etl-adapter-avro/tests/Flow/ETL/Adapter/Avro/Tests/Unit</directory>
-      <directory>src/adapter/etl-adapter-chartjs/tests/Flow/ETL/Adapter/ChartJS/Tests/Unit</directory>
-      <directory>src/adapter/etl-adapter-doctrine/tests/Flow/ETL/Adapter/Doctrine/Tests/Unit</directory>
-      <directory>src/adapter/etl-adapter-google-sheet/tests/Flow/ETL/Adapter/GoogleSheet/Tests/Unit</directory>
-      <directory>src/adapter/etl-adapter-http/tests/Flow/ETL/Adapter/HTTP/Tests/Unit</directory>
-      <directory>src/adapter/etl-adapter-logger/tests/Flow/ETL/Adapter/Logger/Tests/Unit</directory>
-      <directory>src/adapter/etl-adapter-parquet/tests/Flow/ETL/Adapter/Parquet/Tests/Unit</directory>
+      <directory>src/adapter/**/**/**/**/**/**/Tests/Unit</directory>
       <directory>src/core/etl/tests/Flow/ETL/Tests/Unit</directory>
-      <directory>src/lib/array-dot/tests/Flow/ArrayDot/Tests/Unit</directory>
+      <directory>src/lib/**/**/**/**/Tests/Unit</directory>
       <directory>src/lib/doctrine-dbal-bulk/tests/Flow/Doctrine/Bulk/Tests/Unit</directory>
-      <directory>src/lib/dremel/tests/Flow/Dremel/Tests/Unit</directory>
-      <directory>src/lib/parquet/tests/Flow/Parquet/Tests/Unit</directory>
     </testsuite>
     <testsuite name="integration-io">
-      <directory>src/adapter/etl-adapter-avro/tests/Flow/ETL/Adapter/Avro/Tests/Integration</directory>
-      <directory>src/adapter/etl-adapter-chartjs/tests/Flow/ETL/Adapter/ChartJS/Tests/Integration</directory>
-      <directory>src/adapter/etl-adapter-csv/tests/Flow/ETL/Adapter/CSV/Tests/Integration</directory>
-      <directory>src/adapter/etl-adapter-filesystem/tests/Flow/ETL/Adapter/Filesystem/Tests/Integration</directory>
-      <directory>src/adapter/etl-adapter-http/tests/Flow/ETL/Adapter/HTTP/Tests/Integration</directory>
-      <directory>src/adapter/etl-adapter-json/tests/Flow/ETL/Adapter/JSON/Tests/Integration</directory>
-      <directory>src/adapter/etl-adapter-parquet/tests/Flow/ETL/Adapter/Parquet/Tests/Integration</directory>
-      <directory>src/adapter/etl-adapter-text/tests/Flow/ETL/Adapter/Text/Tests/Integration</directory>
-      <directory>src/adapter/etl-adapter-xml/tests/Flow/ETL/Adapter/XML/Tests/Integration</directory>
+      <directory>src/adapter/**/**/**/**/**/**/Tests/Integration</directory>
       <directory>src/core/etl/tests/Flow/ETL/Tests/Integration</directory>
-      <directory>src/lib/parquet/tests/Flow/Parquet/Tests/Integration</directory>
-      <directory>src/lib/parquet-viewer/tests/Flow/ParquetViewer/Tests/Integration</directory>
-      <directory>src/lib/dremel/tests/Flow/Dremel/Tests/Integration</directory>
-      <directory>src/lib/snappy/tests/Flow/Snappy/Tests/Integration</directory>
+      <directory>src/lib/**/**/**/**/Tests/Integration</directory>
     </testsuite>
     <testsuite name="integration-services">
-      <directory>src/adapter/etl-adapter-doctrine/tests/Flow/ETL/Adapter/Doctrine/Tests/Integration</directory>
-      <directory>src/adapter/etl-adapter-elasticsearch/tests/Flow/ETL/Adapter/Elasticsearch/Tests/Integration</directory>
-      <directory>src/adapter/etl-adapter-meilisearch/tests/Flow/ETL/Adapter/Meilisearch/Tests/Integration</directory>
+      <directory>src/adapter/**/**/**/**/**/**/Tests/Integration</directory>
       <directory>src/lib/doctrine-dbal-bulk/tests/Flow/Doctrine/Bulk/Tests/Integration</directory>
     </testsuite>
   </testsuites>


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Simplify PHPUnit configuration</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

Declaring every adapter or library in the PHPUnit configuration increases maintenance costs for maintainers while introducing potential issues with missing some tests. While we reworked the test structure to be the same between adapters (excluding Doctrine) we can use glob patterns in the configuration of PHPUnit.

Seems like we missed over 100 tests ([1677](https://github.com/flow-php/flow/actions/runs/6948688618/job/18905198758) vs 1798):
```console
composer run-script test
> tools/phpunit/vendor/bin/phpunit
PHPUnit 10.4.2 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.1.25 with PCOV 1.0.11
Configuration: /Users/stloyd/Documents/flow/phpunit.xml
Random Seed:   1700652801

.............................................................   61 / 1798 (  3%)
.............................................................  122 / 1798 (  6%)
.............................................................  183 / 1798 ( 10%)
.............................................................  244 / 1798 ( 13%)
.............................................................  305 / 1798 ( 16%)
.............................................................  366 / 1798 ( 20%)
.............................................................  427 / 1798 ( 23%)
.............................................................  488 / 1798 ( 27%)
.............................................................  549 / 1798 ( 30%)
.............................................................  610 / 1798 ( 33%)
.............................................................  671 / 1798 ( 37%)
.............................................................  732 / 1798 ( 40%)
.............................................................  793 / 1798 ( 44%)
.............................................................  854 / 1798 ( 47%)
.............................................................  915 / 1798 ( 50%)
.............................................................  976 / 1798 ( 54%)
............................................................. 1037 / 1798 ( 57%)
............................................................. 1098 / 1798 ( 61%)
............................................................. 1159 / 1798 ( 64%)
............................................................. 1220 / 1798 ( 67%)
............................................................. 1281 / 1798 ( 71%)
............................................................. 1342 / 1798 ( 74%)
............................................................. 1403 / 1798 ( 78%)
............................................................. 1464 / 1798 ( 81%)
............................................................. 1525 / 1798 ( 84%)
............................................................. 1586 / 1798 ( 88%)
............................................................. 1647 / 1798 ( 91%)
............................................................. 1708 / 1798 ( 94%)
............................................................. 1769 / 1798 ( 98%)
.............................                                 1798 / 1798 (100%)

Time: 00:43.928, Memory: 214.50 MB

OK (1798 tests, 283983 assertions)
```
