### PR TITLE
Use references instead of array of strings in Charts

### DIFF
--- a/src/adapter/etl-adapter-chartjs/src/Flow/ETL/Adapter/ChartJS/Chart/BarChart.php
+++ b/src/adapter/etl-adapter-chartjs/src/Flow/ETL/Adapter/ChartJS/Chart/BarChart.php
@@ -7,6 +7,7 @@ namespace Flow\ETL\Adapter\ChartJS\Chart;
 use Flow\ETL\Adapter\ChartJS\Chart;
 use Flow\ETL\Exception\InvalidArgumentException;
 use Flow\ETL\Row\Reference;
+use Flow\ETL\Row\References;
 use Flow\ETL\Rows;
 
 final class BarChart implements Chart
@@ -28,13 +29,12 @@ final class BarChart implements Chart
 
     /**
      * @param Reference $label
-     * @param array<Reference> $datasets
      *
      * @throws InvalidArgumentException
      */
     public function __construct(
         private readonly Reference $label,
-        private readonly array $datasets,
+        private readonly References $datasets,
     ) {
         if (!\count($this->datasets)) {
             throw new InvalidArgumentException('Bar chart must have at least one dataset, please provide at least one entry reference');

--- a/src/adapter/etl-adapter-chartjs/src/Flow/ETL/Adapter/ChartJS/Chart/LineChart.php
+++ b/src/adapter/etl-adapter-chartjs/src/Flow/ETL/Adapter/ChartJS/Chart/LineChart.php
@@ -7,6 +7,7 @@ namespace Flow\ETL\Adapter\ChartJS\Chart;
 use Flow\ETL\Adapter\ChartJS\Chart;
 use Flow\ETL\Exception\InvalidArgumentException;
 use Flow\ETL\Row\Reference;
+use Flow\ETL\Row\References;
 use Flow\ETL\Rows;
 
 final class LineChart implements Chart
@@ -28,13 +29,12 @@ final class LineChart implements Chart
 
     /**
      * @param Reference $label
-     * @param array<Reference> $datasets
      *
      * @throws InvalidArgumentException
      */
     public function __construct(
         private readonly Reference $label,
-        private readonly array $datasets,
+        private readonly References $datasets,
     ) {
         if (!\count($this->datasets)) {
             throw new InvalidArgumentException('Bar chart must have at least one dataset, please provide at least one entry reference');

--- a/src/adapter/etl-adapter-chartjs/src/Flow/ETL/Adapter/ChartJS/Chart/PieChart.php
+++ b/src/adapter/etl-adapter-chartjs/src/Flow/ETL/Adapter/ChartJS/Chart/PieChart.php
@@ -31,13 +31,11 @@ final class PieChart implements Chart
     private array $options = [];
 
     /**
-     * @param array<Reference> $datasets
-     *
      * @throws InvalidArgumentException
      */
     public function __construct(
         private readonly Reference $label,
-        private readonly array|References $datasets,
+        private readonly References $datasets,
     ) {
         if (!\count($this->datasets)) {
             throw new InvalidArgumentException('Bar chart must have at least one dataset, please provide at least one entry reference');

--- a/src/adapter/etl-adapter-chartjs/src/Flow/ETL/DSL/ChartJS.php
+++ b/src/adapter/etl-adapter-chartjs/src/Flow/ETL/DSL/ChartJS.php
@@ -10,15 +10,14 @@ use Flow\ETL\Exception\InvalidArgumentException;
 use Flow\ETL\Filesystem\Path;
 use Flow\ETL\Loader;
 use Flow\ETL\Row\EntryReference;
+use Flow\ETL\Row\References;
 
 class ChartJS
 {
     /**
-     * @param array<EntryReference> $datasets
-     *
      * @throws InvalidArgumentException
      */
-    final public static function bar(EntryReference $label, array $datasets) : Chart
+    final public static function bar(EntryReference $label, References $datasets) : Chart
     {
         return new Chart\BarChart($label, $datasets);
     }
@@ -41,21 +40,17 @@ class ChartJS
     }
 
     /**
-     * @param array<EntryReference> $datasets
-     *
      * @throws InvalidArgumentException
      */
-    final public static function line(EntryReference $label, array $datasets) : Chart
+    final public static function line(EntryReference $label, References $datasets) : Chart
     {
         return new Chart\LineChart($label, $datasets);
     }
 
     /**
-     * @param array<EntryReference> $datasets
-     *
      * @throws InvalidArgumentException
      */
-    final public static function pie(EntryReference $label, array $datasets) : Chart
+    final public static function pie(EntryReference $label, References $datasets) : Chart
     {
         return new Chart\PieChart($label, $datasets);
     }

--- a/src/adapter/etl-adapter-chartjs/tests/Flow/ETL/Adapter/ChartJS/Tests/Integration/ChartJSLoaderTest.php
+++ b/src/adapter/etl-adapter-chartjs/tests/Flow/ETL/Adapter/ChartJS/Tests/Integration/ChartJSLoaderTest.php
@@ -7,6 +7,7 @@ namespace Flow\ETL\Adapter\ChartJS\Tests\Integration;
 use function Flow\ETL\DSL\first;
 use function Flow\ETL\DSL\lit;
 use function Flow\ETL\DSL\ref;
+use function Flow\ETL\DSL\refs;
 use function Flow\ETL\DSL\sum;
 use Flow\ETL\DSL\ChartJS;
 use Flow\ETL\DSL\From;
@@ -34,14 +35,14 @@ final class ChartJSLoaderTest extends TestCase
                 ChartJS::chart(
                     $chart = ChartJS::bar(
                         ref('Date'),
-                        [
+                        refs(
                             ref('Revenue'),
                             ref('CM'),
                             ref('Ads Spends'),
                             ref('Storage Costs'),
                             ref('Shipping Costs'),
                             ref('Profit'),
-                        ]
+                        )
                     ),
                     $output = __DIR__ . '/Output/bar_chart.html'
                 )
@@ -104,14 +105,14 @@ final class ChartJSLoaderTest extends TestCase
                 ChartJS::chart(
                     $chart = ChartJS::line(
                         ref('Date'),
-                        [
+                        refs(
                             ref('Revenue'),
                             ref('CM'),
                             ref('Ads Spends'),
                             ref('Storage Costs'),
                             ref('Shipping Costs'),
                             ref('Profit'),
-                        ]
+                        )
                     ),
                     $output = __DIR__ . '/Output/line_chart.html'
                 )
@@ -169,14 +170,14 @@ final class ChartJSLoaderTest extends TestCase
 
         $chart = ChartJS::pie(
             ref('Date'),
-            [
+            refs(
                 ref('Revenue'),
                 ref('CM'),
                 ref('Ads Spends'),
                 ref('Storage Costs'),
                 ref('Shipping Costs'),
                 ref('Profit'),
-            ]
+            )
         )
             ->setOptions(['label' => 'PnL']);
 

--- a/src/adapter/etl-adapter-chartjs/tests/Flow/ETL/Adapter/ChartJS/Tests/Unit/Chart/BarChartTest.php
+++ b/src/adapter/etl-adapter-chartjs/tests/Flow/ETL/Adapter/ChartJS/Tests/Unit/Chart/BarChartTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Flow\ETL\Adapter\ChartJS\Tests\Unit\Chart;
 
 use function Flow\ETL\DSL\ref;
+use function Flow\ETL\DSL\refs;
 use Flow\ETL\Adapter\ChartJS\Chart\BarChart;
 use Flow\ETL\DSL\From;
 use Flow\ETL\Exception\InvalidArgumentException;
@@ -29,7 +30,7 @@ final class BarChartTest extends TestCase
             ->read(From::memory(new ArrayMemory($data)))
             ->fetch();
 
-        $chart = new BarChart(ref('Date'), [ref('Revenue'), ref('CM'), ref('Ads Spends'), ref('Storage Costs'), ref('Shipping Costs')]);
+        $chart = new BarChart(ref('Date'), refs(ref('Revenue'), ref('CM'), ref('Ads Spends'), ref('Storage Costs'), ref('Shipping Costs')));
 
         $chart->setDatasetOptions(ref('Revenue'), ['backgroundColor' => 'green']);
 
@@ -74,7 +75,7 @@ final class BarChartTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Dataset "CM" does not exist');
 
-        $chart = new BarChart(ref('Date'), [ref('Revenue'), ref('Ads Spends'), ref('Storage Costs'), ref('Shipping Costs')]);
+        $chart = new BarChart(ref('Date'), refs(ref('Revenue'), ref('Ads Spends'), ref('Storage Costs'), ref('Shipping Costs')));
 
         $chart->setDatasetOptions(ref('CM'), ['label' => 'CM']);
     }


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Use references instead of array of strings in Charts</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

<!-- Please provide a short description of changes in this section, feel free to use markdown syntax -->
