### PR TITLE
Fix `Definition::isEqual()` with random class order

### DIFF
--- a/src/core/etl/src/Flow/ETL/Row/Schema/Definition.php
+++ b/src/core/etl/src/Flow/ETL/Row/Schema/Definition.php
@@ -231,7 +231,7 @@ final class Definition implements Serializable
         \sort($classes);
         \sort($otherClasses);
 
-        if ($this->classes !== $otherClasses) {
+        if ($classes !== $otherClasses) {
             return false;
         }
 

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Schema/DefinitionTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Schema/DefinitionTest.php
@@ -33,17 +33,23 @@ final class DefinitionTest extends TestCase
 
     public function test_equals() : void
     {
-        $def = Definition::union('test', [IntegerEntry::class, StringEntry::class]);
+        $def = Definition::union('test', [IntegerEntry::class, StringEntry::class, NullEntry::class]);
 
         $this->assertTrue(
             $def->isEqual(
-                Definition::union('test', [StringEntry::class, IntegerEntry::class])
+                Definition::union('test', [StringEntry::class, IntegerEntry::class, NullEntry::class])
+            )
+        );
+
+        $this->assertTrue(
+            $def->isEqual(
+                Definition::union('test', [NullEntry::class, StringEntry::class, IntegerEntry::class])
             )
         );
 
         $this->assertFalse(
             $def->isEqual(
-                Definition::boolean('test', false)
+                Definition::boolean('test')
             )
         );
     }


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>Fix `Definition::isEqual()` with random class order</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

<!-- Please provide a short description of changes in this section, feel free to use markdown syntax -->
