### PR TITLE
Use platform for column escaping in bulk insert

### DIFF
--- a/src/lib/doctrine-dbal-bulk/src/Flow/Doctrine/Bulk/BulkData.php
+++ b/src/lib/doctrine-dbal-bulk/src/Flow/Doctrine/Bulk/BulkData.php
@@ -23,7 +23,7 @@ final class BulkData
      */
     public function __construct(array $rows)
     {
-        if (empty($rows)) {
+        if (0 === \count($rows)) {
             throw new RuntimeException('Bulk data cannot be empty');
         }
 

--- a/src/lib/doctrine-dbal-bulk/src/Flow/Doctrine/Bulk/Columns.php
+++ b/src/lib/doctrine-dbal-bulk/src/Flow/Doctrine/Bulk/Columns.php
@@ -34,11 +34,6 @@ final class Columns
         return $this->columns;
     }
 
-    public function concat(string $separator) : string
-    {
-        return \implode($separator, $this->columns);
-    }
-
     /**
      * @param string ...$columnNames
      *

--- a/src/lib/doctrine-dbal-bulk/src/Flow/Doctrine/Bulk/DbalPlatform.php
+++ b/src/lib/doctrine-dbal-bulk/src/Flow/Doctrine/Bulk/DbalPlatform.php
@@ -29,11 +29,11 @@ final class DbalPlatform
         }
 
         if ($this->isMySQL() || $this->isMariaDB()) {
-            return new MySQLDialect();
+            return new MySQLDialect($this->platform);
         }
 
         if ($this->isSqlite()) {
-            return new SqliteDialect();
+            return new SqliteDialect($this->platform);
         }
 
         throw new RuntimeException(\sprintf(

--- a/src/lib/doctrine-dbal-bulk/tests/Flow/Doctrine/Bulk/Tests/Unit/ColumnsTest.php
+++ b/src/lib/doctrine-dbal-bulk/tests/Flow/Doctrine/Bulk/Tests/Unit/ColumnsTest.php
@@ -66,14 +66,4 @@ final class ColumnsTest extends TestCase
             $columns->prefix(':')
         );
     }
-
-    public function test_transforms_columns_to_string_using_comma_as_a_separator() : void
-    {
-        $columns = new Columns('date', 'title', 'description', 'quantity');
-
-        $this->assertEquals(
-            'date,title,description,quantity',
-            $columns->concat(',')
-        );
-    }
 }


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>Use platform for column escaping in bulk insert</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

Ensure that column names in generated queries are escaped to match the default behavior done in Doctrine.
