### PR TITLE
Fix spelling mistake in documentation

### DIFF
--- a/docs/components/core/display.md
+++ b/docs/components/core/display.md
@@ -42,7 +42,7 @@ Alternatively you can use `DataFrame::write` function to display data frame:
 $output = data_frame()
     ->read(from_())
     ->withEntry('...', ref()->doSomething())
-    ->write(to_otuput(truncate: false))
+    ->write(to_output(truncate: false))
     ->run();
 ```
 `


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>Spelling mistake in documentation</li>
  </ul>
</div>
<hr/>
