### PR TITLE
Building pipelines from JSON

### DIFF
--- a/box.json
+++ b/box.json
@@ -9,7 +9,6 @@
     "tools",
     "var",
     "fakerphp",
-    "fig",
     "mock-client",
     "dotenv",
     "var-exporter"

--- a/examples/topics/dataframe/from_json.php
+++ b/examples/topics/dataframe/from_json.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+use Flow\ETL\DataFrame;
+
+require __DIR__ . '/../../bootstrap.php';
+
+$df = DataFrame::fromJson(\file_get_contents(__DIR__ . '/json/pipeline.json'));
+
+if ($_ENV['FLOW_PHAR_APP'] ?? false) {
+    return $df;
+}
+
+print "Reading XML dataset...\n";
+
+$df->run();

--- a/examples/topics/dataframe/json/pipeline.json
+++ b/examples/topics/dataframe/json/pipeline.json
@@ -1,0 +1,32 @@
+[
+  {
+    "function" : "data_frame",
+    "call": {
+      "method": "read",
+      "args": [
+        {
+          "function": "from_array",
+          "args": [
+            [{"id": 1, "name": "user_01"},{"id": 2, "name": "user_02"},{"id": 3, "name": "user_03"}]
+          ]
+        }
+      ],
+      "call": {
+        "method": "collect",
+        "call": {
+          "method": "withEntry",
+          "args": ["active", {"function": "lit", "args":  [true]}],
+          "call": {
+            "method": "write",
+            "args": [
+              {
+                "function": "to_output",
+                "args": [false]
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
+]

--- a/src/adapter/etl-adapter-json/tests/Flow/ETL/Adapter/JSON/Tests/Integration/JsonLoaderTest.php
+++ b/src/adapter/etl-adapter-json/tests/Flow/ETL/Adapter/JSON/Tests/Integration/JsonLoaderTest.php
@@ -188,6 +188,7 @@ JSON,
             ],
             df()
                 ->read(from_json($path))
+                ->sortBy(ref('id'))
                 ->fetch()
                 ->toArray()
         );

--- a/src/adapter/etl-adapter-json/tests/Flow/ETL/Adapter/JSON/Tests/Integration/JsonLoaderTest.php
+++ b/src/adapter/etl-adapter-json/tests/Flow/ETL/Adapter/JSON/Tests/Integration/JsonLoaderTest.php
@@ -37,6 +37,7 @@ final class JsonLoaderTest extends TestCase
                     )
                 )
             )
+            ->sortBy(ref('id')->asc())
             ->write(to_json($stream))
             ->run();
 
@@ -235,6 +236,7 @@ JSON,
             ],
             (new Flow())
                 ->read(from_json($path))
+                ->sortBy(ref('id')->asc())
                 ->fetch()
                 ->toArray()
         );
@@ -311,6 +313,7 @@ JSON,
             ],
             (new Flow)
                 ->read(from_json($path))
+                ->sortBy(ref('id')->asc())
                 ->fetch()
                 ->toArray()
         );

--- a/src/core/etl/src/Flow/ETL/DSL/functions.php
+++ b/src/core/etl/src/Flow/ETL/DSL/functions.php
@@ -963,3 +963,13 @@ function execution_context(?Config $config = null) : FlowContext
 {
     return new FlowContext($config ?? Config::default());
 }
+
+function config() : Config
+{
+    return Config::default();
+}
+
+function config_builder() : ConfigBuilder
+{
+    return new ConfigBuilder();
+}

--- a/src/core/etl/src/Flow/ETL/DataFrame.php
+++ b/src/core/etl/src/Flow/ETL/DataFrame.php
@@ -6,6 +6,7 @@ namespace Flow\ETL;
 
 use function Flow\ETL\DSL\to_output;
 use Flow\ETL\Exception\InvalidArgumentException;
+use Flow\ETL\Exception\InvalidFileFormatException;
 use Flow\ETL\Exception\RuntimeException;
 use Flow\ETL\Filesystem\SaveMode;
 use Flow\ETL\Formatter\AsciiTableFormatter;
@@ -86,8 +87,12 @@ final class DataFrame
         try {
             $builder = new Builder(new Finder($namespaces, new AllowList(['data_frame', 'df'])));
 
-            $results = (new Executor())
-                ->execute($builder->parse(\json_decode($json, true, 512, JSON_THROW_ON_ERROR)));
+            try {
+                $results = (new Executor())
+                    ->execute($builder->parse(\json_decode($json, true, 512, JSON_THROW_ON_ERROR)));
+            } catch (\JsonException $exception) {
+                throw new InvalidFileFormatException('json', 'unknown');
+            }
 
             if (\count($results) !== 1) {
                 throw new InvalidArgumentException('Invalid JSON, please make sure that there is only one data_frame function');

--- a/src/core/etl/src/Flow/ETL/DataFrame.php
+++ b/src/core/etl/src/Flow/ETL/DataFrame.php
@@ -44,6 +44,13 @@ use Flow\ETL\Transformer\ScalarFunctionTransformer;
 use Flow\ETL\Transformer\StyleConverter\StringStyles;
 use Flow\ETL\Transformer\UntilTransformer;
 use Flow\ETL\Transformer\WindowFunctionTransformer;
+use Flow\RDSL\AccessControl\AllowAll;
+use Flow\RDSL\AccessControl\AllowList;
+use Flow\RDSL\AccessControl\DenyAll;
+use Flow\RDSL\Builder;
+use Flow\RDSL\DSLNamespace;
+use Flow\RDSL\Executor;
+use Flow\RDSL\Finder;
 
 final class DataFrame
 {
@@ -52,6 +59,48 @@ final class DataFrame
     public function __construct(private Pipeline $pipeline, Config $configuration)
     {
         $this->context = new FlowContext($configuration);
+    }
+
+    /**
+     * @throws \JsonException
+     * @throws RuntimeException
+     */
+    public static function fromJson(string $json) : self
+    {
+        $namespaces = [
+            DSLNamespace::global(new DenyAll()),
+            new DSLNamespace('\Flow\ETL\DSL\Adapter\Avro', new AllowAll()),
+            new DSLNamespace('\Flow\ETL\Adapter\ChartJS', new AllowAll()),
+            new DSLNamespace('\Flow\ETL\Adapter\CSV', new AllowAll()),
+            new DSLNamespace('\Flow\ETL\Adapter\Doctrine', new AllowAll()),
+            new DSLNamespace('\Flow\ETL\Adapter\Elasticsearch', new AllowAll()),
+            new DSLNamespace('\Flow\ETL\Adapter\GoogleSheet', new AllowAll()),
+            new DSLNamespace('\Flow\ETL\Adapter\JSON', new AllowAll()),
+            new DSLNamespace('\Flow\ETL\Adapter\Meilisearch', new AllowAll()),
+            new DSLNamespace('\Flow\ETL\Adapter\Parquet', new AllowAll()),
+            new DSLNamespace('\Flow\ETL\Adapter\Text', new AllowAll()),
+            new DSLNamespace('\Flow\ETL\Adapter\XML', new AllowAll()),
+            new DSLNamespace('\Flow\ETL\DSL', new AllowAll()),
+        ];
+
+        try {
+            $builder = new Builder(new Finder($namespaces, new AllowList(['data_frame', 'df'])));
+
+            $results = (new Executor())
+                ->execute($builder->parse(\json_decode($json, true, 512, JSON_THROW_ON_ERROR)));
+
+            if (\count($results) !== 1) {
+                throw new InvalidArgumentException('Invalid JSON, please make sure that there is only one data_frame function');
+            }
+
+            if (!$results[0] instanceof self) {
+                throw new InvalidArgumentException('Invalid JSON, expected DataFrame instance but got ' . \get_class($results[0]));
+            }
+
+            return $results[0];
+        } catch (\Flow\RDSL\Exception\InvalidArgumentException $e) {
+            throw new InvalidArgumentException($e->getMessage(), $e->getCode(), $e);
+        }
     }
 
     /**

--- a/src/core/etl/src/Flow/ETL/Exception/InvalidFileFormatException.php
+++ b/src/core/etl/src/Flow/ETL/Exception/InvalidFileFormatException.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Flow\ETL\Exception;
+
+final class InvalidFileFormatException extends \RuntimeException
+{
+    public function __construct(public readonly string $expected, public readonly string $given, ?\Throwable $previous = null)
+    {
+        parent::__construct(\sprintf('Expected "%s" file format, "%s" given.', $expected, $given), 0, $previous);
+    }
+}

--- a/src/core/etl/src/Flow/ETL/PipelineFactory.php
+++ b/src/core/etl/src/Flow/ETL/PipelineFactory.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Flow\ETL;
 
 use Flow\ETL\Exception\InvalidArgumentException;
+use Flow\ETL\Exception\InvalidFileFormatException;
 
 final class PipelineFactory
 {
@@ -20,7 +21,7 @@ final class PipelineFactory
         }
 
         if (!\str_ends_with($this->filename, '.php')) {
-            throw InvalidArgumentException::because('Input file must be a PHP one!');
+            throw new InvalidFileFormatException('php', \pathinfo($this->filename, \PATHINFO_EXTENSION));
         }
 
         $resource = \fopen($this->filename, 'rb');

--- a/src/core/etl/tests/Flow/ETL/Tests/Integration/DataFrame/DataFrameJsonTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Integration/DataFrame/DataFrameJsonTest.php
@@ -1,0 +1,103 @@
+<?php declare(strict_types=1);
+
+namespace Flow\ETL\Tests\Integration\DataFrame;
+
+use Flow\ETL\DataFrame;
+use Flow\ETL\Exception\InvalidArgumentException;
+use Flow\ETL\Tests\Integration\IntegrationTestCase;
+
+final class DataFrameJsonTest extends IntegrationTestCase
+{
+    public function test_building_data_frame_from_json() : void
+    {
+        $df = DataFrame::fromJson(
+            <<<'JSON'
+[
+  {
+    "function" : "data_frame",
+    "call": {
+      "method": "read",
+      "args": [
+        {
+          "function": "from_array",
+          "args": [
+            [{"id": 1, "name": "Norbert"},{"id": 2, "name": "Michal"}]
+          ]
+        }
+      ],
+      "call": {
+        "method": "withEntry",
+        "args": ["active", {"function": "lit", "args":  [true]}]
+      }
+    }
+  }
+]
+JSON
+        );
+
+        $this->assertSame(
+            [
+                ['id' => 1, 'name' => 'Norbert', 'active' => true],
+                ['id' => 2, 'name' => 'Michal', 'active' => true],
+            ],
+            $df->fetch()->toArray()
+        );
+    }
+
+    public function test_building_dataframe_with_two_entry_points() : void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid JSON, please make sure that there is only one data_frame function');
+
+        DataFrame::fromJson(
+            <<<'JSON'
+[
+  {
+    "function" : "data_frame",
+    "call": {
+      "method": "read",
+      "args": [
+        {
+          "function": "from_array",
+          "args": [
+            [{"id": 1, "name": "Norbert"},{"id": 2, "name": "Michal"}]
+          ]
+        }
+      ],
+      "call": {
+        "method": "withEntry",
+        "args": ["active", {"function": "lit", "args":  [true]}]
+      }
+    }
+  },
+  {
+    "function" : "data_frame",
+    "call": {
+      "method": "read",
+      "args": [
+        {
+          "function": "from_array",
+          "args": [
+            [{"id": 1, "name": "Norbert"},{"id": 2, "name": "Michal"}]
+          ]
+        }
+      ],
+      "call": {
+        "method": "withEntry",
+        "args": ["active", {"function": "lit", "args":  [false]}]
+      }
+    }
+  }
+]
+JSON
+        );
+    }
+
+    public function test_building_dataframe_with_zero_entry_points() : void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Definition must have at least one function: [{"function":"name","args":[]}]');
+
+        DataFrame::fromJson('[]');
+    }
+}

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Extractor/ArrayExtractorTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Extractor/ArrayExtractorTest.php
@@ -2,6 +2,8 @@
 
 namespace Flow\ETL\Tests\Unit\Extractor;
 
+use function Flow\ETL\DSL\config;
+use function Flow\ETL\DSL\config_builder;
 use function Flow\ETL\DSL\execution_context;
 use function Flow\ETL\DSL\from_array;
 use PHPUnit\Framework\TestCase;
@@ -15,7 +17,7 @@ final class ArrayExtractorTest extends TestCase
             ['id' => 2, 'name' => 'Michal'],
         ]);
 
-        $rows = \iterator_to_array($extractor->extract(execution_context()));
+        $rows = \iterator_to_array($extractor->extract(execution_context(config_builder()->build())));
 
         $this->assertCount(2, $rows);
         $this->assertSame(['id' => 1, 'name' => 'Norbert'], $rows[0]->first()->toArray());
@@ -31,7 +33,7 @@ final class ArrayExtractorTest extends TestCase
 
         $extractor = from_array($generator());
 
-        $rows = \iterator_to_array($extractor->extract(execution_context()));
+        $rows = \iterator_to_array($extractor->extract(execution_context(config())));
 
         $this->assertCount(2, $rows);
         $this->assertSame(['id' => 1, 'name' => 'Norbert'], $rows[0]->first()->toArray());

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/PipelineFactoryTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/PipelineFactoryTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Flow\ETL\Tests\Unit;
 
 use Flow\ETL\Exception\InvalidArgumentException;
+use Flow\ETL\Exception\InvalidFileFormatException;
 use Flow\ETL\PipelineFactory;
 use PHPUnit\Framework\TestCase;
 
@@ -30,8 +31,8 @@ final class PipelineFactoryTest extends TestCase
 
     public function test_non_php_file() : void
     {
-        $this->expectExceptionMessage('Input file must be a PHP one!');
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Expected "php" file format, "txt" given.');
+        $this->expectException(InvalidFileFormatException::class);
 
         $factory = new PipelineFactory(__DIR__ . '/../Fixtures/empty.txt');
         $factory->run();

--- a/src/lib/rdsl/src/Flow/RDSL/Builder.php
+++ b/src/lib/rdsl/src/Flow/RDSL/Builder.php
@@ -44,7 +44,7 @@ final class Builder
             throw new InvalidArgumentException('Method are allowed only in calls, if you want to pass a method as argument, use a function instead');
         }
 
-        return $this->parseArg($definition);
+        return $definition;
     }
 
     public function parseArgs(array $definition) : Arguments
@@ -85,7 +85,7 @@ final class Builder
         if ($callDefinition === null) {
             return new DSLFunction(
                 $functionReflection->name,
-                new Arguments($args)
+                $this->parseArgs($args)
             );
         }
 
@@ -135,7 +135,7 @@ final class Builder
             throw new InvalidArgumentException(\sprintf('Method "%s::%s" must have return type', $objectClass->getName(), $methodReflection->name));
         }
 
-        return (new Method($methodReflection->name, new Arguments($args)))
+        return (new Method($methodReflection->name, $this->parseArgs($args)))
             ->addMethodCall($this->parseMethod($returnType, $callDefinition));
     }
 }


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <li>DataFrame::fromJson()</li>
    <li>support for running dataframes from json through flow CLI</li>
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>phar file</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

<!-- Please provide a short description of changes in this section, feel free to use markdown syntax -->

Pipelines can now be defined in JSON: 

```
build/flow.phar run pipeline.json
bin/flow.php run pipeline.json
```

```json
[
  {
    "function" : "data_frame",
    "call": {
      "method": "read",
      "args": [
        {
          "function": "from_array",
          "args": [
            [{"id": 1, "name": "user_01"},{"id": 2, "name": "user_02"},{"id": 3, "name": "user_03"}]
          ]
        }
      ],
      "call": {
        "method": "collect",
        "call": {
          "method": "withEntry",
          "args": ["active", {"function": "lit", "args":  [true]}],
          "call": {
            "method": "write",
            "args": [
              {
                "function": "to_output",
                "args": [false]
              }
            ]
          }
        }
      }
    }
  }
]
```

or from the code:

```php
DataFrame::fromJson(file_get_contents('pipeline.json'))->run();
```
