### PR TITLE
Display partitions

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -5,6 +5,24 @@ Please follow the instructions for your specific version to ensure a smooth upgr
 
 ---
 
+## Upgrading from 0.5.x to 0.6.x
+
+### 1) Rows::merge() accepts single instance of Rows
+
+Before: 
+
+```php
+Rows::merge(Rows ...$rows) : Rows
+```
+
+After:
+
+```php
+Rows::merge(Rows $rows) : Rows
+```
+
+---
+
 ## Upgrading from 0.4.x to 0.5.x
 
 ### 1) Entry factory moved from extractors to `FlowContext`

--- a/src/adapter/etl-adapter-avro/tests/Flow/ETL/Adapter/Avro/Tests/Integration/AvroTest.php
+++ b/src/adapter/etl-adapter-avro/tests/Flow/ETL/Adapter/Avro/Tests/Integration/AvroTest.php
@@ -12,6 +12,7 @@ use function Flow\ETL\DSL\df;
 use function Flow\ETL\DSL\float_entry;
 use function Flow\ETL\DSL\from_array;
 use function Flow\ETL\DSL\from_rows;
+use function Flow\ETL\DSL\ignore;
 use function Flow\ETL\DSL\int_entry;
 use function Flow\ETL\DSL\json_entry;
 use function Flow\ETL\DSL\json_object_entry;
@@ -331,7 +332,7 @@ final class AvroTest extends TestCase
                     }, \range(1, 100))
                 )
             ))
-            ->mode(SaveMode::Ignore)
+            ->saveMode(ignore())
             ->write(to_avro($path))
             ->run();
 

--- a/src/adapter/etl-adapter-csv/src/Flow/ETL/Adapter/CSV/CSVLoader.php
+++ b/src/adapter/etl-adapter-csv/src/Flow/ETL/Adapter/CSV/CSVLoader.php
@@ -81,7 +81,7 @@ final class CSVLoader implements Closure, Loader, Loader\FileLoader
 
         if ($context->partitionEntries()->count()) {
             foreach ($rows->partitionBy(...$context->partitionEntries()->all()) as $partitionedRows) {
-                $this->write($partitionedRows, $headers, $context, $partitionedRows->partitions());
+                $this->write($partitionedRows, $headers, $context, $partitionedRows->partitions()->toArray());
             }
         } else {
             $this->write($rows, $headers, $context, []);

--- a/src/adapter/etl-adapter-csv/tests/Flow/ETL/Adapter/CSV/Tests/Integration/CSVExtractorTest.php
+++ b/src/adapter/etl-adapter-csv/tests/Flow/ETL/Adapter/CSV/Tests/Integration/CSVExtractorTest.php
@@ -6,6 +6,7 @@ namespace Flow\ETL\Adapter\CSV\Tests\Integration;
 
 use function Flow\ETL\Adapter\CSV\from_csv;
 use function Flow\ETL\Adapter\CSV\to_csv;
+use function Flow\ETL\DSL\df;
 use function Flow\ETL\DSL\from_array;
 use function Flow\ETL\DSL\ref;
 use Flow\ETL\Adapter\CSV\CSVExtractor;
@@ -115,7 +116,7 @@ final class CSVExtractorTest extends TestCase
     {
         $path = __DIR__ . '/../Fixtures/annual-enterprise-survey-2019-financial-year-provisional-csv.csv';
 
-        $rows = (new Flow())
+        $rows = df()
             ->read(from_csv($path))
             ->fetch();
 
@@ -166,7 +167,7 @@ final class CSVExtractorTest extends TestCase
 
     public function test_extracting_csv_with_corrupted_row() : void
     {
-        $rows = (new Flow())
+        $rows = df()
             ->extract(from_csv(__DIR__ . '/../Fixtures/corrupted_row.csv'))
             ->fetch();
 
@@ -221,7 +222,7 @@ final class CSVExtractorTest extends TestCase
     {
         $this->assertCount(
             2,
-            (new Flow())
+            df()
                 ->read(from_csv(__DIR__ . '/../Fixtures/more_than_1000_characters_per_line.csv'))
                 ->fetch()
                 ->toArray(),
@@ -233,7 +234,7 @@ final class CSVExtractorTest extends TestCase
     {
         $this->assertCount(
             1,
-            (new Flow())
+            df()
                 ->read(from_csv(__DIR__ . '/../Fixtures/more_than_1000_characters_per_line.csv', characters_read_in_line: 2000))
                 ->fetch()
                 ->toArray(),
@@ -249,7 +250,7 @@ final class CSVExtractorTest extends TestCase
             \unlink($path);
         }
 
-        (new Flow())->read(from_array([['id' => 1], ['id' => 2], ['id' => 3], ['id' => 4], ['id' => 5]]))
+        df()->read(from_array([['id' => 1], ['id' => 2], ['id' => 3], ['id' => 4], ['id' => 5]]))
             ->write(to_csv($path))
             ->run();
 
@@ -275,7 +276,7 @@ final class CSVExtractorTest extends TestCase
                 ['group' => '2', 'id' => 7, 'value' => 'g'],
                 ['group' => '2', 'id' => 8, 'value' => 'h'],
             ],
-            (new Flow())
+            df()
                 ->read(from_csv(__DIR__ . '/../Fixtures/partitioned/group=*/*.csv'))
                 ->withEntry('id', ref('id')->cast('int'))
                 ->sortBy(ref('id'))
@@ -314,7 +315,7 @@ final class CSVExtractorTest extends TestCase
             \unlink($path);
         }
 
-        (new Flow())->read(from_array([['id' => 1], ['id' => 2], ['id' => 3], ['id' => 4], ['id' => 5]]))
+        df()->read(from_array([['id' => 1], ['id' => 2], ['id' => 3], ['id' => 4], ['id' => 5]]))
             ->write(to_csv($path))
             ->run();
 

--- a/src/adapter/etl-adapter-csv/tests/Flow/ETL/Adapter/CSV/Tests/Integration/CSVLoaderTest.php
+++ b/src/adapter/etl-adapter-csv/tests/Flow/ETL/Adapter/CSV/Tests/Integration/CSVLoaderTest.php
@@ -7,9 +7,9 @@ namespace Flow\ETL\Adapter\CSV\Tests\Integration;
 use function Flow\ETL\Adapter\CSV\to_csv;
 use function Flow\ETL\DSL\array_entry;
 use function Flow\ETL\DSL\int_entry;
+use function Flow\ETL\DSL\overwrite;
 use function Flow\ETL\DSL\str_entry;
 use Flow\ETL\Filesystem\Path;
-use Flow\ETL\Filesystem\SaveMode;
 use Flow\ETL\Flow;
 use Flow\ETL\Row;
 use Flow\ETL\Rows;
@@ -207,7 +207,7 @@ CSV,
                     Row::create(int_entry('id', 3), str_entry('name', 'Dawid')),
                 )
             )
-            ->mode(SaveMode::Overwrite)
+            ->saveMode(overwrite())
             ->load(to_csv($path))
             ->run();
 

--- a/src/adapter/etl-adapter-json/src/Flow/ETL/Adapter/JSON/JsonLoader.php
+++ b/src/adapter/etl-adapter-json/src/Flow/ETL/Adapter/JSON/JsonLoader.php
@@ -62,7 +62,7 @@ final class JsonLoader implements Closure, Loader, Loader\FileLoader
     {
         if ($context->partitionEntries()->count()) {
             foreach ($rows->partitionBy(...$context->partitionEntries()->all()) as $partitionedRows) {
-                $this->write($partitionedRows, $partitionedRows->partitions(), $context);
+                $this->write($partitionedRows, $partitionedRows->partitions()->toArray(), $context);
             }
         } else {
             $this->write($rows, [], $context);

--- a/src/adapter/etl-adapter-json/tests/Flow/ETL/Adapter/JSON/Tests/Integration/JsonLoaderTest.php
+++ b/src/adapter/etl-adapter-json/tests/Flow/ETL/Adapter/JSON/Tests/Integration/JsonLoaderTest.php
@@ -7,7 +7,9 @@ namespace Flow\ETL\Adapter\JSON\Tests\Integration;
 use function Flow\ETL\Adapter\Json\from_json;
 use function Flow\ETL\Adapter\Json\to_json;
 use function Flow\ETL\DSL\df;
+use function Flow\ETL\DSL\exception_if_exists;
 use function Flow\ETL\DSL\from_array;
+use function Flow\ETL\DSL\ignore;
 use function Flow\ETL\DSL\ref;
 use Flow\ETL\Adapter\JSON\JsonLoader;
 use Flow\ETL\Config;
@@ -259,7 +261,7 @@ JSON,
                 ['id' => 5, 'partition' => 'b'],
             ]))
             ->partitionBy(ref('partition'))
-            ->mode(SaveMode::ExceptionIfExists)
+            ->saveMode(exception_if_exists())
             ->write(to_json($path))
             ->run();
 
@@ -291,7 +293,7 @@ JSON,
                 ['id' => 2],
                 ['id' => 3],
             ]))
-            ->mode(SaveMode::Ignore)
+            ->saveMode(ignore())
             ->write(to_json($path))
             ->run();
 

--- a/src/adapter/etl-adapter-parquet/src/Flow/ETL/Adapter/Parquet/ParquetLoader.php
+++ b/src/adapter/etl-adapter-parquet/src/Flow/ETL/Adapter/Parquet/ParquetLoader.php
@@ -81,7 +81,7 @@ final class ParquetLoader implements Closure, Loader, Loader\FileLoader
         if ($context->partitionEntries()->count()) {
             foreach ($rows->partitionBy(...$context->partitionEntries()->all()) as $partitionedRows) {
 
-                $stream = $streams->open($this->path, 'parquet', $context->appendSafe(), $partitionedRows->partitions());
+                $stream = $streams->open($this->path, 'parquet', $context->appendSafe(), $partitionedRows->partitions()->toArray());
 
                 if (!\array_key_exists($stream->path()->uri(), $this->writers)) {
                     $this->writers[$stream->path()->uri()] = new Writer(

--- a/src/adapter/etl-adapter-text/src/Flow/ETL/Adapter/Text/TextLoader.php
+++ b/src/adapter/etl-adapter-text/src/Flow/ETL/Adapter/Text/TextLoader.php
@@ -62,7 +62,7 @@ final class TextLoader implements Closure, Loader, Loader\FileLoader
                     }
 
                     \fwrite(
-                        $context->streams()->open($this->path, 'text', $context->appendSafe(), $partitionedRows->partitions())->resource(),
+                        $context->streams()->open($this->path, 'text', $context->appendSafe(), $partitionedRows->partitions()->toArray())->resource(),
                         $row->entries()->all()[0]->toString() . $this->newLineSeparator
                     );
                 }

--- a/src/core/etl/src/Flow/ETL/DSL/functions.php
+++ b/src/core/etl/src/Flow/ETL/DSL/functions.php
@@ -11,6 +11,7 @@ use Flow\ETL\ErrorHandler\IgnoreError;
 use Flow\ETL\ErrorHandler\SkipRows;
 use Flow\ETL\ErrorHandler\ThrowError;
 use Flow\ETL\Extractor;
+use Flow\ETL\Filesystem\SaveMode;
 use Flow\ETL\Filesystem\Stream\Mode;
 use Flow\ETL\Flow;
 use Flow\ETL\FlowContext;
@@ -987,4 +988,24 @@ function config() : Config
 function config_builder() : ConfigBuilder
 {
     return new ConfigBuilder();
+}
+
+function overwrite() : SaveMode
+{
+    return SaveMode::Overwrite;
+}
+
+function ignore() : SaveMode
+{
+    return SaveMode::Ignore;
+}
+
+function exception_if_exists() : SaveMode
+{
+    return SaveMode::ExceptionIfExists;
+}
+
+function append() : SaveMode
+{
+    return SaveMode::Append;
 }

--- a/src/core/etl/src/Flow/ETL/DSL/functions.php
+++ b/src/core/etl/src/Flow/ETL/DSL/functions.php
@@ -431,6 +431,21 @@ function rows(Row ...$row) : Rows
     return new Rows(...$row);
 }
 
+function partition(string $name, string $value) : Partition
+{
+    return new Partition($name, $value);
+}
+
+function partitions(Partition ...$partition) : \Flow\ETL\Partitions
+{
+    return new \Flow\ETL\Partitions(...$partition);
+}
+
+function rows_partitioned(array $rows, array $partitions) : Rows
+{
+    return Rows::partitioned($rows, new \Flow\ETL\Partitions(...$partitions));
+}
+
 function col(string $entry) : EntryReference
 {
     return new EntryReference($entry);

--- a/src/core/etl/src/Flow/ETL/DataFrame.php
+++ b/src/core/etl/src/Flow/ETL/DataFrame.php
@@ -745,6 +745,16 @@ final class DataFrame
     }
 
     /**
+     * Alias for DataFrame::mode.
+     *
+     * @lazy
+     */
+    public function saveMode(SaveMode $mode) : self
+    {
+        return $this->mode($mode);
+    }
+
+    /**
      * @lazy
      * Keep only given entries.
      */

--- a/src/core/etl/src/Flow/ETL/DataFrame.php
+++ b/src/core/etl/src/Flow/ETL/DataFrame.php
@@ -259,7 +259,16 @@ final class DataFrame
     #[DSLMethod(exclude: true)]
     public function display(int $limit = 20, int|bool $truncate = 20, Formatter $formatter = new AsciiTableFormatter()) : string
     {
-        return $formatter->format($this->fetch($limit), $truncate);
+        $clone = clone $this;
+        $clone->limit($limit);
+
+        $output = '';
+
+        foreach ($clone->pipeline->process($clone->context) as $rows) {
+            $output .= $formatter->format($rows, $truncate);
+        }
+
+        return $output;
     }
 
     /**
@@ -305,35 +314,30 @@ final class DataFrame
     public function fetch(?int $limit = null) : Rows
     {
         $clone = clone $this;
-        $clone->collect();
 
         if ($limit !== null) {
             $clone->limit($limit);
         }
 
         if ($clone->context->partitionEntries()->count()) {
-            $rows = (new Rows())->merge(
-                ...\iterator_to_array($clone->pipeline->process($clone->context))
-            );
+            $rows = new Rows();
 
-            $fetchedRows = (new Rows());
-
-            foreach ($rows->partitionBy(...$clone->context->partitionEntries()->all()) as $partitionedRows) {
-                if ($clone->context->partitionFilter()->keep(...$partitionedRows->partitions())) {
-                    $fetchedRows = $fetchedRows->merge($partitionedRows);
+            foreach ($clone->pipeline->process($clone->context) as $nextRows) {
+                if ($clone->context->partitionFilter()->keep(...$nextRows->partitions()->toArray())) {
+                    $rows = $rows->merge($nextRows);
                 }
             }
 
-            return $fetchedRows;
+            return $rows;
         }
 
-        $rows = \iterator_to_array($clone->pipeline->process($clone->context));
+        $rows = new Rows();
 
-        if (!\count($rows)) {
-            return new Rows();
+        foreach ($clone->pipeline->process($clone->context) as $nextRows) {
+            $rows = $rows->merge($nextRows);
         }
 
-        return $rows[0];
+        return $rows;
     }
 
     /**

--- a/src/core/etl/src/Flow/ETL/Formatter/ASCII/ASCIIBody.php
+++ b/src/core/etl/src/Flow/ETL/Formatter/ASCII/ASCIIBody.php
@@ -46,6 +46,15 @@ final class ASCIIBody
             $buffer .= '-' . \str_repeat('-', $length) . '-+';
         }
 
+        if (\count($this->body->partitions())) {
+            $buffer .= PHP_EOL;
+            $buffer .= 'Partitions:';
+
+            foreach ($this->body->partitions() as $partition) {
+                $buffer .= PHP_EOL . ' - ' . $partition->name . '=' . $partition->value;
+            }
+        }
+
         return $buffer;
     }
 }

--- a/src/core/etl/src/Flow/ETL/Formatter/ASCII/Body.php
+++ b/src/core/etl/src/Flow/ETL/Formatter/ASCII/Body.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Flow\ETL\Formatter\ASCII;
 
 use Flow\ETL\Exception\InvalidArgumentException;
+use Flow\ETL\Partition;
 use Flow\ETL\Row;
 use Flow\ETL\Rows;
 
@@ -30,6 +31,14 @@ final class Body
         }
 
         return $max;
+    }
+
+    /**
+     * @return Partition[]
+     */
+    public function partitions() : array
+    {
+        return $this->rows->partitions()->toArray();
     }
 
     /**

--- a/src/core/etl/src/Flow/ETL/Partitions.php
+++ b/src/core/etl/src/Flow/ETL/Partitions.php
@@ -1,0 +1,84 @@
+<?php declare(strict_types=1);
+
+namespace Flow\ETL;
+
+use Flow\ETL\Exception\RuntimeException;
+use Flow\Serializer\Serializable;
+
+/**
+ * @implements \ArrayAccess<int, Partition>
+ * @implements \IteratorAggregate<int, Partition>
+ * @implements Serializable<array{partitions: array<Partition>}>
+ */
+final class Partitions implements \ArrayAccess, \Countable, \IteratorAggregate, Serializable
+{
+    private readonly array $partitions;
+
+    public function __construct(Partition ...$partitions)
+    {
+        \uasort($partitions, static fn (Partition $a, Partition $b) => $a->name <=> $b->name);
+
+        $this->partitions = $partitions;
+    }
+
+    public function __serialize() : array
+    {
+        return [
+            'partitions' => $this->partitions,
+        ];
+    }
+
+    public function __unserialize(array $data) : void
+    {
+        $this->partitions = $data['partitions'];
+    }
+
+    public function count() : int
+    {
+        return \count($this->partitions);
+    }
+
+    public function getIterator() : \Traversable
+    {
+        return new \ArrayIterator($this->partitions);
+    }
+
+    public function id() : string
+    {
+        $id = '|';
+
+        foreach ($this->partitions as $partition) {
+            $id .= $partition->name . '_' . $partition->value . '|';
+        }
+
+        return \hash('xxh128', $id);
+    }
+
+    public function offsetExists(mixed $offset) : bool
+    {
+        return \array_key_exists($offset, $this->partitions);
+    }
+
+    public function offsetGet(mixed $offset) : mixed
+    {
+        return $this->partitions[$offset];
+    }
+
+    public function offsetSet(mixed $offset, mixed $value) : void
+    {
+        throw new RuntimeException('Partitions are immutable');
+    }
+
+    public function offsetUnset(mixed $offset) : void
+    {
+        throw new RuntimeException('Partitions are immutable');
+    }
+
+    /**
+     * @return array<Partition>
+     */
+    public function toArray() : array
+    {
+        return $this->partitions;
+    }
+}

--- a/src/core/etl/src/Flow/ETL/Pipeline/CollectingPipeline.php
+++ b/src/core/etl/src/Flow/ETL/Pipeline/CollectingPipeline.php
@@ -74,9 +74,13 @@ final class CollectingPipeline implements OverridingPipeline, Pipeline
 
     public function process(FlowContext $context) : \Generator
     {
-        $this->nextPipeline->setSource(from_rows(
-            (new Rows())->merge(...\iterator_to_array($this->pipeline->process($context)))
-        ));
+        $rows = new Rows();
+
+        foreach ($this->pipeline->process($context) as $nextRows) {
+            $rows = $rows->merge($nextRows);
+        }
+
+        $this->nextPipeline->setSource(from_rows($rows));
 
         return $this->nextPipeline->process($context);
     }

--- a/src/core/etl/src/Flow/ETL/Pipeline/PartitioningPipeline.php
+++ b/src/core/etl/src/Flow/ETL/Pipeline/PartitioningPipeline.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Pipeline;
 
+use function Flow\ETL\DSL\from_all;
+use function Flow\ETL\DSL\from_cache;
 use Flow\ETL\Extractor;
-use Flow\ETL\Extractor\CacheExtractor;
-use Flow\ETL\Extractor\ChainExtractor;
 use Flow\ETL\Extractor\CollectingExtractor;
 use Flow\ETL\FlowContext;
 use Flow\ETL\Loader;
@@ -86,7 +86,7 @@ final class PartitioningPipeline implements OverridingPipeline, Pipeline
 
                 $partitionId = \hash('xxh128', $context->config->id() . '_' . \implode('_', \array_map(
                     static fn (Partition $partition) : string => $partition->id(),
-                    $partitionedRows->partitions()
+                    $partitionedRows->partitions()->toArray()
                 )));
 
                 $partitionIds[] = $partitionId;
@@ -94,8 +94,8 @@ final class PartitioningPipeline implements OverridingPipeline, Pipeline
             }
         }
 
-        $this->nextPipeline->setSource(new ChainExtractor(...\array_map(
-            static fn (string $id) : Extractor => new CollectingExtractor(new CacheExtractor($id, null, true)),
+        $this->nextPipeline->setSource(from_all(...\array_map(
+            static fn (string $id) : Extractor => new CollectingExtractor(from_cache($id, null, true)),
             \array_unique($partitionIds)
         )));
 

--- a/src/core/etl/tests/Flow/ETL/Tests/Integration/DataFrame/LimitTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Integration/DataFrame/LimitTest.php
@@ -188,7 +188,7 @@ final class LimitTest extends IntegrationTestCase
                  */
                 public function extract(FlowContext $context) : \Generator
                 {
-                    for ($i = 0; $i < 1000; $i++) {
+                    for ($i = 0; $i < 100; $i++) {
                         yield new Rows(
                             Row::create(new IntegerEntry('id', $i + 1)),
                             Row::create(new IntegerEntry('id', $i + 2)),

--- a/src/core/etl/tests/Flow/ETL/Tests/Integration/DataFrame/PartitioningTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Integration/DataFrame/PartitioningTest.php
@@ -6,10 +6,12 @@ use function Flow\ETL\DSL\df;
 use function Flow\ETL\DSL\from_rows;
 use function Flow\ETL\DSL\int_entry;
 use function Flow\ETL\DSL\lit;
+use function Flow\ETL\DSL\partition;
 use function Flow\ETL\DSL\ref;
+use function Flow\ETL\DSL\row;
+use function Flow\ETL\DSL\rows;
+use function Flow\ETL\DSL\rows_partitioned;
 use function Flow\ETL\DSL\str_entry;
-use Flow\ETL\Row;
-use Flow\ETL\Rows;
 use Flow\ETL\Tests\Integration\IntegrationTestCase;
 
 final class PartitioningTest extends IntegrationTestCase
@@ -18,15 +20,15 @@ final class PartitioningTest extends IntegrationTestCase
     {
         $partitionedRows = df()
             ->read(from_rows(
-                new Rows(
-                    Row::create(int_entry('id', 1), str_entry('country', 'PL'), int_entry('age', 20)),
-                    Row::create(int_entry('id', 2), str_entry('country', 'PL'), int_entry('age', 20)),
-                    Row::create(int_entry('id', 3), str_entry('country', 'PL'), int_entry('age', 25)),
-                    Row::create(int_entry('id', 4), str_entry('country', 'PL'), int_entry('age', 30)),
-                    Row::create(int_entry('id', 5), str_entry('country', 'US'), int_entry('age', 40)),
-                    Row::create(int_entry('id', 6), str_entry('country', 'US'), int_entry('age', 40)),
-                    Row::create(int_entry('id', 7), str_entry('country', 'US'), int_entry('age', 45)),
-                    Row::create(int_entry('id', 9), str_entry('country', 'US'), int_entry('age', 50)),
+                rows(
+                    row(int_entry('id', 1), str_entry('country', 'PL'), int_entry('age', 20)),
+                    row(int_entry('id', 2), str_entry('country', 'PL'), int_entry('age', 20)),
+                    row(int_entry('id', 3), str_entry('country', 'PL'), int_entry('age', 25)),
+                    row(int_entry('id', 4), str_entry('country', 'PL'), int_entry('age', 30)),
+                    row(int_entry('id', 5), str_entry('country', 'US'), int_entry('age', 40)),
+                    row(int_entry('id', 6), str_entry('country', 'US'), int_entry('age', 40)),
+                    row(int_entry('id', 7), str_entry('country', 'US'), int_entry('age', 45)),
+                    row(int_entry('id', 9), str_entry('country', 'US'), int_entry('age', 50)),
                 )
             ))
             ->partitionBy('country')
@@ -34,11 +36,16 @@ final class PartitioningTest extends IntegrationTestCase
             ->fetch();
 
         $this->assertEquals(
-            new Rows(
-                Row::create(int_entry('id', 5), str_entry('country', 'US'), int_entry('age', 40)),
-                Row::create(int_entry('id', 6), str_entry('country', 'US'), int_entry('age', 40)),
-                Row::create(int_entry('id', 7), str_entry('country', 'US'), int_entry('age', 45)),
-                Row::create(int_entry('id', 9), str_entry('country', 'US'), int_entry('age', 50)),
+            rows_partitioned(
+                [
+                    row(int_entry('id', 5), str_entry('country', 'US'), int_entry('age', 40)),
+                    row(int_entry('id', 6), str_entry('country', 'US'), int_entry('age', 40)),
+                    row(int_entry('id', 7), str_entry('country', 'US'), int_entry('age', 45)),
+                    row(int_entry('id', 9), str_entry('country', 'US'), int_entry('age', 50)),
+                ],
+                [
+                    partition('country', 'US'),
+                ]
             ),
             $partitionedRows
         );
@@ -48,15 +55,15 @@ final class PartitioningTest extends IntegrationTestCase
     {
         $rows = df()
             ->read(from_rows(
-                new Rows(
-                    Row::create(int_entry('id', 1), str_entry('country', 'PL'), int_entry('age', 20)),
-                    Row::create(int_entry('id', 2), str_entry('country', 'PL'), int_entry('age', 20)),
-                    Row::create(int_entry('id', 3), str_entry('country', 'PL'), int_entry('age', 25)),
-                    Row::create(int_entry('id', 4), str_entry('country', 'PL'), int_entry('age', 30)),
-                    Row::create(int_entry('id', 5), str_entry('country', 'US'), int_entry('age', 40)),
-                    Row::create(int_entry('id', 6), str_entry('country', 'US'), int_entry('age', 40)),
-                    Row::create(int_entry('id', 7), str_entry('country', 'US'), int_entry('age', 45)),
-                    Row::create(int_entry('id', 9), str_entry('country', 'US'), int_entry('age', 50)),
+                rows(
+                    row(int_entry('id', 1), str_entry('country', 'PL'), int_entry('age', 20)),
+                    row(int_entry('id', 2), str_entry('country', 'PL'), int_entry('age', 20)),
+                    row(int_entry('id', 3), str_entry('country', 'PL'), int_entry('age', 25)),
+                    row(int_entry('id', 4), str_entry('country', 'PL'), int_entry('age', 30)),
+                    row(int_entry('id', 5), str_entry('country', 'US'), int_entry('age', 40)),
+                    row(int_entry('id', 6), str_entry('country', 'US'), int_entry('age', 40)),
+                    row(int_entry('id', 7), str_entry('country', 'US'), int_entry('age', 45)),
+                    row(int_entry('id', 9), str_entry('country', 'US'), int_entry('age', 50)),
                 )
             ))
             ->partitionBy(ref('country'))
@@ -65,21 +72,41 @@ final class PartitioningTest extends IntegrationTestCase
 
         $this->assertEquals(
             [
-                new Rows(
-                    Row::create(int_entry('id', 1), str_entry('country', 'PL'), int_entry('age', 20)),
-                    Row::create(int_entry('id', 2), str_entry('country', 'PL'), int_entry('age', 20))
+                rows_partitioned(
+                    [
+                        row(int_entry('id', 1), str_entry('country', 'PL'), int_entry('age', 20)),
+                        row(int_entry('id', 2), str_entry('country', 'PL'), int_entry('age', 20)),
+                    ],
+                    [
+                        partition('country', 'PL'),
+                    ]
                 ),
-                new Rows(
-                    Row::create(int_entry('id', 3), str_entry('country', 'PL'), int_entry('age', 25)),
-                    Row::create(int_entry('id', 4), str_entry('country', 'PL'), int_entry('age', 30)),
+                rows_partitioned(
+                    [
+                        row(int_entry('id', 3), str_entry('country', 'PL'), int_entry('age', 25)),
+                        row(int_entry('id', 4), str_entry('country', 'PL'), int_entry('age', 30)),
+                    ],
+                    [
+                        partition('country', 'PL'),
+                    ]
                 ),
-                new Rows(
-                    Row::create(int_entry('id', 5), str_entry('country', 'US'), int_entry('age', 40)),
-                    Row::create(int_entry('id', 6), str_entry('country', 'US'), int_entry('age', 40))
+                rows_partitioned(
+                    [
+                        row(int_entry('id', 5), str_entry('country', 'US'), int_entry('age', 40)),
+                        row(int_entry('id', 6), str_entry('country', 'US'), int_entry('age', 40)),
+                    ],
+                    [
+                        partition('country', 'US'),
+                    ]
                 ),
-                new Rows(
-                    Row::create(int_entry('id', 7), str_entry('country', 'US'), int_entry('age', 45)),
-                    Row::create(int_entry('id', 9), str_entry('country', 'US'), int_entry('age', 50)),
+                rows_partitioned(
+                    [
+                        row(int_entry('id', 7), str_entry('country', 'US'), int_entry('age', 45)),
+                        row(int_entry('id', 9), str_entry('country', 'US'), int_entry('age', 50)),
+                    ],
+                    [
+                        partition('country', 'US'),
+                    ]
                 ),
             ],
             \iterator_to_array($rows)

--- a/src/core/etl/tests/Flow/ETL/Tests/Integration/Filesystem/FilesystemStreamsTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Integration/Filesystem/FilesystemStreamsTest.php
@@ -51,7 +51,7 @@ class FilesystemStreamsTest extends IntegrationTestCase
 
         $stream = (new FilesystemStreams(new LocalFilesystem()))
             ->setSaveMode(SaveMode::Overwrite)
-            ->open(Path::realpath($dir = \rtrim(\sys_get_temp_dir(), '/')), 'csv', false, $rows->partitions())
+            ->open(Path::realpath($dir = \rtrim(\sys_get_temp_dir(), '/')), 'csv', false, $rows->partitions()->toArray())
             ->path();
         $this->assertStringStartsWith(
             $dir . '/group=a/',
@@ -236,14 +236,14 @@ class FilesystemStreamsTest extends IntegrationTestCase
         $streams->setSaveMode(SaveMode::Overwrite);
 
         $groupAStream = $streams
-            ->open(Path::realpath($dir = \rtrim(\sys_get_temp_dir(), '/')), 'csv', false, $partitionedRows[0]->partitions())
+            ->open(Path::realpath($dir = \rtrim(\sys_get_temp_dir(), '/')), 'csv', false, $partitionedRows[0]->partitions()->toArray())
             ->path();
         $this->assertStringStartsWith(
             $dir . '/group=a/',
             $groupAStream->path()
         );
         $groupBStream = $streams
-            ->open(Path::realpath($dir), 'csv', false, $partitionedRows[1]->partitions())
+            ->open(Path::realpath($dir), 'csv', false, $partitionedRows[1]->partitions()->toArray())
             ->path();
         $this->assertStringStartsWith(
             $dir . '/group=b/',
@@ -257,7 +257,7 @@ class FilesystemStreamsTest extends IntegrationTestCase
 
         // Open stream again, but just touched partition
         $groupAStream = $streams
-            ->open(Path::realpath($dir), 'csv', false, $partitionedRows[0]->partitions())
+            ->open(Path::realpath($dir), 'csv', false, $partitionedRows[0]->partitions()->toArray())
             ->path();
 
         $this->assertEquals('', \file_get_contents($groupAStream->path()));

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Formatter/ASCII/ASCIIBodyTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Formatter/ASCII/ASCIIBodyTest.php
@@ -6,20 +6,22 @@ namespace Flow\ETL\Tests\Unit\Formatter\ASCII;
 
 use function Flow\ETL\DSL\float_entry;
 use function Flow\ETL\DSL\int_entry;
+use function Flow\ETL\DSL\ref;
+use function Flow\ETL\DSL\row;
+use function Flow\ETL\DSL\rows;
+use function Flow\ETL\DSL\string_entry;
 use Flow\ETL\Formatter\ASCII\ASCIIBody;
 use Flow\ETL\Formatter\ASCII\Body;
 use Flow\ETL\Formatter\ASCII\Headers;
-use Flow\ETL\Row;
-use Flow\ETL\Rows;
 use PHPUnit\Framework\TestCase;
 
 final class ASCIIBodyTest extends TestCase
 {
     public function test_printing_ascii_body() : void
     {
-        $rows = new Rows(
-            Row::create(int_entry('id', 1), float_entry('value', 1.4)),
-            Row::create(int_entry('id', 2), float_entry('value', 3.4))
+        $rows = rows(
+            row(int_entry('id', 1), float_entry('value', 1.4)),
+            row(int_entry('id', 2), float_entry('value', 3.4))
         );
 
         $headers = new ASCIIBody(
@@ -32,6 +34,30 @@ final class ASCIIBodyTest extends TestCase
 |  1 |   1.4 |
 |  2 |   3.4 |
 +----+-------+
+TABLE,
+            $headers->print(false)
+        );
+    }
+
+    public function test_printing_ascii_body_with_partitioned_rows() : void
+    {
+        $rows = rows(
+            row(int_entry('id', 1), float_entry('value', 1.4), string_entry('group', 'a')),
+            row(int_entry('id', 2), float_entry('value', 3.4), string_entry('group', 'a'))
+        )->partitionBy(ref('group'));
+
+        $headers = new ASCIIBody(
+            new Headers($rows[0]),
+            new Body($rows[0])
+        );
+
+        $this->assertStringContainsString(
+            <<<'TABLE'
+|  1 |   1.4 |     a |
+|  2 |   3.4 |     a |
++----+-------+-------+
+Partitions:
+ - group=a
 TABLE,
             $headers->print(false)
         );

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Loader/StreamLoaderTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Loader/StreamLoaderTest.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace Flow\ETL\Tests\Unit\Loader;
 
 use function Flow\ETL\DSL\int_entry;
+use function Flow\ETL\DSL\ref;
+use function Flow\ETL\DSL\row;
+use function Flow\ETL\DSL\rows;
 use function Flow\ETL\DSL\str_entry;
 use function Flow\ETL\DSL\to_output;
 use function Flow\ETL\DSL\to_stream;
@@ -13,13 +16,11 @@ use Flow\ETL\Exception\RuntimeException;
 use Flow\ETL\Filesystem\Stream\Mode;
 use Flow\ETL\FlowContext;
 use Flow\ETL\Loader\StreamLoader;
-use Flow\ETL\Row;
-use Flow\ETL\Rows;
 use PHPUnit\Framework\TestCase;
 
 final class StreamLoaderTest extends TestCase
 {
-    public function test_loading_data_int_invalid_stream() : void
+    public function test_loading_data_into_invalid_stream() : void
     {
         $this->expectExceptionMessage("Can't open stream for url: php://qweqweqw in mode: w");
         $this->expectException(RuntimeException::class);
@@ -27,12 +28,46 @@ final class StreamLoaderTest extends TestCase
         $loader = to_stream('php://qweqweqw', 0);
 
         $loader->load(
-            new Rows(
-                Row::create(int_entry('id', 1), str_entry('name', 'id_1')),
-                Row::create(int_entry('id', 2), str_entry('name', 'id_2')),
-                Row::create(int_entry('id', 3), str_entry('name', 'id_3'))
+            rows(
+                row(int_entry('id', 1), str_entry('name', 'id_1')),
+                row(int_entry('id', 2), str_entry('name', 'id_2')),
+                row(int_entry('id', 3), str_entry('name', 'id_3'))
             ),
             new FlowContext(Config::default())
+        );
+    }
+
+    public function test_loading_partitioned_rows_into_php_memory_stream() : void
+    {
+        $loader = new StreamLoader('php://output', Mode::WRITE, 0);
+
+        \ob_start();
+
+        $loader->load(
+            rows(
+                row(int_entry('id', 1), str_entry('name', 'id_1'), str_entry('group', 'a')),
+                row(int_entry('id', 2), str_entry('name', 'id_2'), str_entry('group', 'a')),
+                row(int_entry('id', 3), str_entry('name', 'id_3'), str_entry('group', 'a'))
+            )->partitionBy(ref('group'))[0],
+            new FlowContext(Config::default())
+        );
+        $output = \ob_get_contents();
+        \ob_end_clean();
+
+        $this->assertStringContainsString(
+            <<<'TABLE'
++----+------+-------+
+| id | name | group |
++----+------+-------+
+|  1 | id_1 |     a |
+|  2 | id_2 |     a |
+|  3 | id_3 |     a |
++----+------+-------+
+Partitions:
+ - group=a
+3 rows
+TABLE,
+            $output
         );
     }
 
@@ -43,10 +78,10 @@ final class StreamLoaderTest extends TestCase
         \ob_start();
 
         $loader->load(
-            new Rows(
-                Row::create(int_entry('id', 1), str_entry('name', 'id_1')),
-                Row::create(int_entry('id', 2), str_entry('name', 'id_2')),
-                Row::create(int_entry('id', 3), str_entry('name', 'id_3'))
+            rows(
+                row(int_entry('id', 1), str_entry('name', 'id_1')),
+                row(int_entry('id', 2), str_entry('name', 'id_2')),
+                row(int_entry('id', 3), str_entry('name', 'id_3'))
             ),
             new FlowContext(Config::default())
         );
@@ -80,10 +115,10 @@ ASCII,
         \ob_start();
 
         $loader->load(
-            new Rows(
-                Row::create(int_entry('id', 1), str_entry('name', 'id_1')),
-                Row::create(int_entry('id', 2), str_entry('name', 'id_2')),
-                Row::create(int_entry('id', 3), str_entry('name', 'id_3'))
+            rows(
+                row(int_entry('id', 1), str_entry('name', 'id_1')),
+                row(int_entry('id', 2), str_entry('name', 'id_2')),
+                row(int_entry('id', 3), str_entry('name', 'id_3'))
             ),
             new FlowContext(Config::default())
         );
@@ -112,10 +147,10 @@ TABLE,
         \ob_start();
 
         $loader->load(
-            new Rows(
-                Row::create(int_entry('id', 1), str_entry('name', 'id_1')),
-                Row::create(int_entry('id', 2), str_entry('name', 'id_2')),
-                Row::create(int_entry('id', 3), str_entry('name', 'id_3'))
+            rows(
+                row(int_entry('id', 1), str_entry('name', 'id_1')),
+                row(int_entry('id', 2), str_entry('name', 'id_2')),
+                row(int_entry('id', 3), str_entry('name', 'id_3'))
             ),
             new FlowContext(Config::default())
         );

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/RowTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/RowTest.php
@@ -207,6 +207,19 @@ final class RowTest extends TestCase
         );
     }
 
+    public function test_merge_row_with_another_row_using_prefix() : void
+    {
+        $this->assertSame(
+            [
+                'id' => 1,
+                '_id' => 2,
+            ],
+            Row::create(new IntegerEntry('id', 1))
+                ->merge(Row::create(new IntegerEntry('id', 2)), $prefix = '_')
+                ->toArray()
+        );
+    }
+
     public function test_remove() : void
     {
         $row = new Row(new Entries(

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/RowsTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/RowsTest.php
@@ -5,22 +5,29 @@ declare(strict_types=1);
 namespace Flow\ETL\Tests\Unit;
 
 use function Flow\ETL\DSL\array_entry;
+use function Flow\ETL\DSL\array_to_rows;
 use function Flow\ETL\DSL\bool_entry;
 use function Flow\ETL\DSL\int_entry;
 use function Flow\ETL\DSL\list_entry;
 use function Flow\ETL\DSL\null_entry;
+use function Flow\ETL\DSL\partition;
 use function Flow\ETL\DSL\ref;
+use function Flow\ETL\DSL\row;
+use function Flow\ETL\DSL\rows;
+use function Flow\ETL\DSL\rows_partitioned;
 use function Flow\ETL\DSL\str_entry;
 use function Flow\ETL\DSL\type_int;
 use function Flow\ETL\DSL\type_list;
 use function Flow\ETL\DSL\type_string;
 use Flow\ETL\Exception\InvalidArgumentException;
 use Flow\ETL\Exception\RuntimeException;
-use Flow\ETL\Partition;
+use Flow\ETL\Partitions;
 use Flow\ETL\PHP\Type\Logical\List\ListElement;
 use Flow\ETL\PHP\Type\Logical\ListType;
 use Flow\ETL\Row;
+use Flow\ETL\Row\Comparator;
 use Flow\ETL\Row\Comparator\NativeComparator;
+use Flow\ETL\Row\Comparator\WeakObjectComparator;
 use Flow\ETL\Row\Entry\BooleanEntry;
 use Flow\ETL\Row\Entry\DateTimeEntry;
 use Flow\ETL\Row\Entry\IntegerEntry;
@@ -37,105 +44,105 @@ final class RowsTest extends TestCase
     public static function rows_diff_left_provider() : \Generator
     {
         yield 'one entry identical row' => [
-            $expected = new Rows(),
-            $left = new Rows(Row::create(new IntegerEntry('number', 1))),
-            $right = new Rows(Row::create(new IntegerEntry('number', 1))),
+            $expected = rows(),
+            $left = rows(row(int_entry('number', 1))),
+            $right = rows(row(int_entry('number', 1))),
         ];
 
         yield 'one entry right different - missing entry' => [
-            $expected = new Rows(Row::create(new IntegerEntry('number', 1))),
-            $left = new Rows(Row::create(new IntegerEntry('number', 1))),
-            $right = new Rows(),
+            $expected = rows(row(int_entry('number', 1))),
+            $left = rows(row(int_entry('number', 1))),
+            $right = rows(),
         ];
 
         yield 'one entry left different - missing entry' => [
-            $expected = new Rows(),
-            $left = new Rows(),
-            $right = new Rows(Row::create(new IntegerEntry('number', 1))),
+            $expected = rows(),
+            $left = rows(),
+            $right = rows(row(int_entry('number', 1))),
         ];
 
         yield 'one entry right different - different entry' => [
-            $expected = new Rows(Row::create(new IntegerEntry('number', 1))),
-            $left = new Rows(Row::create(new IntegerEntry('number', 1))),
-            $right = new Rows(Row::create(new IntegerEntry('number', 2))),
+            $expected = rows(row(int_entry('number', 1))),
+            $left = rows(row(int_entry('number', 1))),
+            $right = rows(row(int_entry('number', 2))),
         ];
 
         yield 'one entry left different - different entry' => [
-            $expected = new Rows(Row::create(new IntegerEntry('number', 2))),
-            $left = new Rows(Row::create(new IntegerEntry('number', 2))),
-            $right = new Rows(Row::create(new IntegerEntry('number', 1))),
+            $expected = rows(row(int_entry('number', 2))),
+            $left = rows(row(int_entry('number', 2))),
+            $right = rows(row(int_entry('number', 1))),
         ];
     }
 
     public static function rows_diff_right_provider() : \Generator
     {
         yield 'one entry identical row' => [
-            $expected = new Rows(),
-            $left = new Rows(Row::create(new IntegerEntry('number', 1))),
-            $right = new Rows(Row::create(new IntegerEntry('number', 1))),
+            $expected = rows(),
+            $left = rows(row(int_entry('number', 1))),
+            $right = rows(row(int_entry('number', 1))),
         ];
 
         yield 'one entry right different - missing entry' => [
-            $expected = new Rows(),
-            $left = new Rows(Row::create(new IntegerEntry('number', 1))),
-            $right = new Rows(),
+            $expected = rows(),
+            $left = rows(row(int_entry('number', 1))),
+            $right = rows(),
         ];
 
         yield 'one entry left different - missing entry' => [
-            $expected = new Rows(Row::create(new IntegerEntry('number', 1))),
-            $left = new Rows(),
-            $right = new Rows(Row::create(new IntegerEntry('number', 1))),
+            $expected = rows(row(int_entry('number', 1))),
+            $left = rows(),
+            $right = rows(row(int_entry('number', 1))),
         ];
 
         yield 'one entry right different - different entry' => [
-            $expected = new Rows(Row::create(new IntegerEntry('number', 2))),
-            $left = new Rows(Row::create(new IntegerEntry('number', 1))),
-            $right = new Rows(Row::create(new IntegerEntry('number', 2))),
+            $expected = rows(row(int_entry('number', 2))),
+            $left = rows(row(int_entry('number', 1))),
+            $right = rows(row(int_entry('number', 2))),
         ];
 
         yield 'one entry left different - different entry' => [
-            $expected = new Rows(Row::create(new IntegerEntry('number', 1))),
-            $left = new Rows(Row::create(new IntegerEntry('number', 2))),
-            $right = new Rows(Row::create(new IntegerEntry('number', 1))),
+            $expected = rows(row(int_entry('number', 1))),
+            $left = rows(row(int_entry('number', 2))),
+            $right = rows(row(int_entry('number', 1))),
         ];
     }
 
     public static function unique_rows_provider() : \Generator
     {
         yield 'simple identical rows' => [
-            $expected = new Rows(Row::create(new IntegerEntry('number', 1))),
-            $notUnique = new Rows(
-                Row::create(new IntegerEntry('number', 1)),
-                Row::create(new IntegerEntry('number', 1))
+            $expected = rows(row(int_entry('number', 1))),
+            $notUnique = rows(
+                row(int_entry('number', 1)),
+                row(int_entry('number', 1))
             ),
             $comparator = new NativeComparator(),
         ];
 
         yield 'simple identical rows with objects' => [
-            $expected = new Rows(Row::create(new ObjectEntry('object', new \stdClass()))),
-            $notUnique = new Rows(
-                Row::create(new ObjectEntry('object', $object = new \stdClass())),
-                Row::create(new ObjectEntry('object', $object = new \stdClass()))
+            $expected = rows(row(new ObjectEntry('object', new \stdClass()))),
+            $notUnique = rows(
+                row(new ObjectEntry('object', $object = new \stdClass())),
+                row(new ObjectEntry('object', $object = new \stdClass()))
             ),
-            $comparator = new Row\Comparator\WeakObjectComparator(),
+            $comparator = new WeakObjectComparator(),
         ];
     }
 
     public function test_adding_multiple_rows() : void
     {
-        $one = Row::create(new IntegerEntry('number', 1), new StringEntry('name', 'one'));
-        $two = Row::create(new IntegerEntry('number', 2), new StringEntry('name', 'two'));
-        $rows = (new Rows())->add($one, $two);
+        $one = row(int_entry('number', 1), new StringEntry('name', 'one'));
+        $two = row(int_entry('number', 2), new StringEntry('name', 'two'));
+        $rows = (rows())->add($one, $two);
 
-        $this->assertEquals(new Rows($one, $two), $rows);
+        $this->assertEquals(rows($one, $two), $rows);
     }
 
     public function test_array_access_exists() : void
     {
-        $rows = new Rows(
-            Row::create(new IntegerEntry('id', 1)),
-            Row::create(new IntegerEntry('id', 2)),
-            Row::create(new IntegerEntry('id', 3)),
+        $rows = rows(
+            row(int_entry('id', 1)),
+            row(int_entry('id', 2)),
+            row(int_entry('id', 3)),
         );
 
         $this->assertTrue(isset($rows[0]));
@@ -144,10 +151,10 @@ final class RowsTest extends TestCase
 
     public function test_array_access_get() : void
     {
-        $rows = new Rows(
-            Row::create(new IntegerEntry('id', 1)),
-            Row::create(new IntegerEntry('id', 2)),
-            Row::create(new IntegerEntry('id', 3)),
+        $rows = rows(
+            row(int_entry('id', 1)),
+            row(int_entry('id', 2)),
+            row(int_entry('id', 3)),
         );
 
         $this->assertSame(1, $rows[0]->valueOf('id'));
@@ -159,21 +166,21 @@ final class RowsTest extends TestCase
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('In order to add new rows use Rows::add(Row $row) : self');
-        $rows = new Rows();
-        $rows[0] = Row::create(new IntegerEntry('id', 1));
+        $rows = rows();
+        $rows[0] = row(int_entry('id', 1));
     }
 
     public function test_array_access_unset() : void
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('In order to remove rows use Rows::remove(int $offset) : self');
-        $rows = new Rows(Row::create(new IntegerEntry('id', 1)));
+        $rows = rows(row(int_entry('id', 1)));
         unset($rows[0]);
     }
 
     public function test_building_rows_from_array() : void
     {
-        $rows = Rows::fromArray(
+        $rows = array_to_rows(
             [
                 ['id' => 1234, 'deleted' => false, 'phase' => null],
                 ['id' => 4321, 'deleted' => true, 'phase' => 'launch'],
@@ -181,13 +188,13 @@ final class RowsTest extends TestCase
         );
 
         $this->assertEquals(
-            new Rows(
-                Row::create(
+            rows(
+                row(
                     int_entry('id', 1234),
                     bool_entry('deleted', false),
                     null_entry('phase'),
                 ),
-                Row::create(
+                row(
                     int_entry('id', 4321),
                     bool_entry('deleted', true),
                     str_entry('phase', 'launch'),
@@ -199,14 +206,14 @@ final class RowsTest extends TestCase
 
     public function test_chunks_with_less() : void
     {
-        $rows = new Rows(
-            Row::create(new IntegerEntry('id', 1)),
-            Row::create(new IntegerEntry('id', 2)),
-            Row::create(new IntegerEntry('id', 3)),
-            Row::create(new IntegerEntry('id', 4)),
-            Row::create(new IntegerEntry('id', 5)),
-            Row::create(new IntegerEntry('id', 6)),
-            Row::create(new IntegerEntry('id', 7)),
+        $rows = rows(
+            row(int_entry('id', 1)),
+            row(int_entry('id', 2)),
+            row(int_entry('id', 3)),
+            row(int_entry('id', 4)),
+            row(int_entry('id', 5)),
+            row(int_entry('id', 6)),
+            row(int_entry('id', 7)),
         );
 
         $chunk = \iterator_to_array($rows->chunks(10));
@@ -217,17 +224,17 @@ final class RowsTest extends TestCase
 
     public function test_chunks_with_more_than_expected_in_chunk_rows() : void
     {
-        $rows = new Rows(
-            Row::create(new IntegerEntry('id', 1)),
-            Row::create(new IntegerEntry('id', 2)),
-            Row::create(new IntegerEntry('id', 3)),
-            Row::create(new IntegerEntry('id', 4)),
-            Row::create(new IntegerEntry('id', 5)),
-            Row::create(new IntegerEntry('id', 6)),
-            Row::create(new IntegerEntry('id', 7)),
-            Row::create(new IntegerEntry('id', 8)),
-            Row::create(new IntegerEntry('id', 9)),
-            Row::create(new IntegerEntry('id', 10)),
+        $rows = rows(
+            row(int_entry('id', 1)),
+            row(int_entry('id', 2)),
+            row(int_entry('id', 3)),
+            row(int_entry('id', 4)),
+            row(int_entry('id', 5)),
+            row(int_entry('id', 6)),
+            row(int_entry('id', 7)),
+            row(int_entry('id', 8)),
+            row(int_entry('id', 9)),
+            row(int_entry('id', 10)),
         );
 
         $chunk = \iterator_to_array($rows->chunks(5));
@@ -239,10 +246,10 @@ final class RowsTest extends TestCase
 
     public function test_drop() : void
     {
-        $rows = new Rows(
-            Row::create(new IntegerEntry('id', 1)),
-            Row::create(new IntegerEntry('id', 2)),
-            Row::create(new IntegerEntry('id', 3)),
+        $rows = rows(
+            row(int_entry('id', 1)),
+            row(int_entry('id', 2)),
+            row(int_entry('id', 3)),
         );
 
         $rows = $rows->drop(1);
@@ -254,10 +261,10 @@ final class RowsTest extends TestCase
 
     public function test_drop_all() : void
     {
-        $rows = new Rows(
-            Row::create(new IntegerEntry('id', 1)),
-            Row::create(new IntegerEntry('id', 2)),
-            Row::create(new IntegerEntry('id', 3)),
+        $rows = rows(
+            row(int_entry('id', 1)),
+            row(int_entry('id', 2)),
+            row(int_entry('id', 3)),
         );
 
         $rows = $rows->drop(3);
@@ -267,10 +274,10 @@ final class RowsTest extends TestCase
 
     public function test_drop_more_than_exists() : void
     {
-        $rows = new Rows(
-            Row::create(new IntegerEntry('id', 1)),
-            Row::create(new IntegerEntry('id', 2)),
-            Row::create(new IntegerEntry('id', 3)),
+        $rows = rows(
+            row(int_entry('id', 1)),
+            row(int_entry('id', 2)),
+            row(int_entry('id', 3)),
         );
 
         $rows = $rows->drop(4);
@@ -280,10 +287,10 @@ final class RowsTest extends TestCase
 
     public function test_drop_right() : void
     {
-        $rows = new Rows(
-            Row::create(new IntegerEntry('id', 1)),
-            Row::create(new IntegerEntry('id', 2)),
-            Row::create(new IntegerEntry('id', 3)),
+        $rows = rows(
+            row(int_entry('id', 1)),
+            row(int_entry('id', 2)),
+            row(int_entry('id', 3)),
         );
 
         $rows = $rows->dropRight(1);
@@ -295,10 +302,10 @@ final class RowsTest extends TestCase
 
     public function test_drop_right_all() : void
     {
-        $rows = new Rows(
-            Row::create(new IntegerEntry('id', 1)),
-            Row::create(new IntegerEntry('id', 2)),
-            Row::create(new IntegerEntry('id', 3)),
+        $rows = rows(
+            row(int_entry('id', 1)),
+            row(int_entry('id', 2)),
+            row(int_entry('id', 3)),
         );
 
         $rows = $rows->dropRight(3);
@@ -308,10 +315,10 @@ final class RowsTest extends TestCase
 
     public function test_drop_right_more_than_available() : void
     {
-        $rows = new Rows(
-            Row::create(new IntegerEntry('id', 1)),
-            Row::create(new IntegerEntry('id', 2)),
-            Row::create(new IntegerEntry('id', 3)),
+        $rows = rows(
+            row(int_entry('id', 1)),
+            row(int_entry('id', 2)),
+            row(int_entry('id', 3)),
         );
 
         $rows = $rows->dropRight(5);
@@ -321,10 +328,10 @@ final class RowsTest extends TestCase
 
     public function test_drop_right_more_than_exists() : void
     {
-        $rows = new Rows(
-            Row::create(new IntegerEntry('id', 1)),
-            Row::create(new IntegerEntry('id', 2)),
-            Row::create(new IntegerEntry('id', 3)),
+        $rows = rows(
+            row(int_entry('id', 1)),
+            row(int_entry('id', 2)),
+            row(int_entry('id', 3)),
         );
 
         $rows = $rows->dropRight(4);
@@ -334,39 +341,39 @@ final class RowsTest extends TestCase
 
     public function test_empty_rows() : void
     {
-        $this->assertTrue((new Rows())->empty());
-        $this->assertFalse((new Rows(Row::create(int_entry('id', 1))))->empty());
+        $this->assertTrue((rows())->empty());
+        $this->assertFalse((rows(row(int_entry('id', 1))))->empty());
     }
 
     public function test_filters_out_rows() : void
     {
-        $rows = new Rows(
-            $one = Row::create(new IntegerEntry('number', 1), new StringEntry('name', 'one')),
-            $two = Row::create(new IntegerEntry('number', 2), new StringEntry('name', 'two')),
-            $three = Row::create(new IntegerEntry('number', 3), new StringEntry('name', 'three')),
-            $four = Row::create(new IntegerEntry('number', 4), new StringEntry('name', 'four')),
-            $five = Row::create(new IntegerEntry('number', 5), new StringEntry('name', 'five'))
+        $rows = rows(
+            $one = row(int_entry('number', 1), new StringEntry('name', 'one')),
+            $two = row(int_entry('number', 2), new StringEntry('name', 'two')),
+            $three = row(int_entry('number', 3), new StringEntry('name', 'three')),
+            $four = row(int_entry('number', 4), new StringEntry('name', 'four')),
+            $five = row(int_entry('number', 5), new StringEntry('name', 'five'))
         );
 
         $evenRows = fn (Row $row) : bool => $row->get('number')->value() % 2 === 0;
         $oddRows = fn (Row $row) : bool => $row->get('number')->value() % 2 === 1;
 
-        $this->assertEquals(new Rows($two, $four), $rows->filter($evenRows));
-        $this->assertEquals(new Rows($one, $three, $five), $rows->filter($oddRows));
+        $this->assertEquals(rows($two, $four), $rows->filter($evenRows));
+        $this->assertEquals(rows($one, $three, $five), $rows->filter($oddRows));
     }
 
     public function test_find() : void
     {
-        $rows = new Rows(
-            $one = Row::create(new IntegerEntry('number', 1), new StringEntry('name', 'one')),
-            $two = Row::create(new IntegerEntry('number', 2), new StringEntry('name', 'two')),
-            $three = Row::create(new IntegerEntry('number', 3), new StringEntry('name', 'one')),
-            $four = Row::create(new IntegerEntry('number', 4), new StringEntry('name', 'four')),
-            $three1 = Row::create(new IntegerEntry('number', 3), new StringEntry('name', 'three')),
+        $rows = rows(
+            $one = row(int_entry('number', 1), new StringEntry('name', 'one')),
+            $two = row(int_entry('number', 2), new StringEntry('name', 'two')),
+            $three = row(int_entry('number', 3), new StringEntry('name', 'one')),
+            $four = row(int_entry('number', 4), new StringEntry('name', 'four')),
+            $three1 = row(int_entry('number', 3), new StringEntry('name', 'three')),
         );
 
         $this->assertEquals(
-            new Rows(
+            rows(
                 $one,
                 $three
             ),
@@ -376,17 +383,17 @@ final class RowsTest extends TestCase
 
     public function test_find_on_empty_rows() : void
     {
-        $this->assertEquals(new Rows(), (new Rows())->find(fn (Row $row) => false));
+        $this->assertEquals(rows(), (rows())->find(fn (Row $row) => false));
     }
 
     public function test_find_one() : void
     {
-        $rows = new Rows(
-            $one = Row::create(new IntegerEntry('number', 1), new StringEntry('name', 'one')),
-            $two = Row::create(new IntegerEntry('number', 2), new StringEntry('name', 'two')),
-            $three = Row::create(new IntegerEntry('number', 3), new StringEntry('name', 'three')),
-            $four = Row::create(new IntegerEntry('number', 4), new StringEntry('name', 'four')),
-            $three1 = Row::create(new IntegerEntry('number', 3), new StringEntry('name', 'three')),
+        $rows = rows(
+            $one = row(int_entry('number', 1), new StringEntry('name', 'one')),
+            $two = row(int_entry('number', 2), new StringEntry('name', 'two')),
+            $three = row(int_entry('number', 3), new StringEntry('name', 'three')),
+            $four = row(int_entry('number', 4), new StringEntry('name', 'four')),
+            $three1 = row(int_entry('number', 3), new StringEntry('name', 'three')),
         );
 
         $this->assertSame($three, $rows->findOne(fn (Row $row) : bool => $row->valueOf('number') === 3));
@@ -395,17 +402,17 @@ final class RowsTest extends TestCase
 
     public function test_find_one_on_empty_rows() : void
     {
-        $this->assertNull((new Rows())->findOne(fn (Row $row) => false));
+        $this->assertNull((rows())->findOne(fn (Row $row) => false));
     }
 
     public function test_find_without_results() : void
     {
-        $rows = new Rows(
-            $one = Row::create(new IntegerEntry('number', 1), new StringEntry('name', 'one')),
-            $two = Row::create(new IntegerEntry('number', 2), new StringEntry('name', 'two')),
-            $three = Row::create(new IntegerEntry('number', 3), new StringEntry('name', 'three')),
-            $four = Row::create(new IntegerEntry('number', 4), new StringEntry('name', 'four')),
-            $three1 = Row::create(new IntegerEntry('number', 3), new StringEntry('name', 'three')),
+        $rows = rows(
+            $one = row(int_entry('number', 1), new StringEntry('name', 'one')),
+            $two = row(int_entry('number', 2), new StringEntry('name', 'two')),
+            $three = row(int_entry('number', 3), new StringEntry('name', 'three')),
+            $four = row(int_entry('number', 4), new StringEntry('name', 'four')),
+            $three1 = row(int_entry('number', 3), new StringEntry('name', 'three')),
         );
 
         $this->assertNull($rows->findOne(fn (Row $row) : bool => $row->valueOf('number') === 5));
@@ -415,17 +422,17 @@ final class RowsTest extends TestCase
     {
         $this->expectException(RuntimeException::class);
 
-        (new Rows())->first();
+        (rows())->first();
     }
 
     public function test_flat_map() : void
     {
-        $rows = new Rows(
-            Row::create(
-                new IntegerEntry('id', 1234),
+        $rows = rows(
+            row(
+                int_entry('id', 1234),
             ),
-            Row::create(
-                new IntegerEntry('id', 4567),
+            row(
+                int_entry('id', 4567),
             )
         );
 
@@ -445,56 +452,94 @@ final class RowsTest extends TestCase
         );
     }
 
+    public function test_merge_empty_rows_with_partitioned_rows() : void
+    {
+        $rows1 = rows(row(int_entry('id', 1), str_entry('group', 'a')))->partitionBy(ref('group'))[0];
+        $rows2 = rows();
+
+        $this->assertEquals(
+            \Flow\ETL\DSL\partitions(partition('group', 'a')),
+            $rows1->merge($rows2)->partitions()
+        );
+        $this->assertCount(1, $rows1->merge($rows2));
+    }
+
     public function test_merge_row_with_another_row_that_has_duplicated_entries() : void
     {
         $this->expectExceptionMessage('Merged entries names must be unique, given: [id] + [id]');
         $this->expectException(InvalidArgumentException::class);
 
-        Row::create(new IntegerEntry('id', 1))
-            ->merge(Row::create(new IntegerEntry('id', 2)), $prefix = '');
+        row(int_entry('id', 1))
+            ->merge(row(int_entry('id', 2)), $prefix = '');
     }
 
-    public function test_merge_row_with_another_row_using_prefix() : void
+    public function test_merge_rows_from_different_partition() : void
     {
-        $this->assertSame(
-            [
-                'id' => 1,
-                '_id' => 2,
-            ],
-            Row::create(new IntegerEntry('id', 1))
-                ->merge(Row::create(new IntegerEntry('id', 2)), $prefix = '_')
-                ->toArray()
+        $rows1 = rows(row(int_entry('id', 1), str_entry('group', 'a')))->partitionBy(ref('group'))[0];
+        $rows2 = rows(row(int_entry('id', 2), str_entry('group', 'b')))->partitionBy(ref('group'))[0];
+
+        $this->assertEquals(
+            \Flow\ETL\DSL\partitions(),
+            $rows1->merge($rows2)->partitions()
         );
+        $this->assertCount(2, $rows1->merge($rows2));
+    }
+
+    public function test_merge_rows_from_same_partition() : void
+    {
+        $rows1 = rows(row(int_entry('id', 1), str_entry('group', 'a')))->partitionBy(ref('group'))[0];
+        $rows2 = rows(row(int_entry('id', 2), str_entry('group', 'a')))->partitionBy(ref('group'))[0];
+
+        $this->assertEquals(
+            \Flow\ETL\DSL\partitions(partition('group', 'a')),
+            $rows1->merge($rows2)->partitions()
+        );
+        $this->assertCount(2, $rows1->merge($rows2));
+    }
+
+    public function test_merge_rows_from_same_partitions() : void
+    {
+        $rows1 = rows(row(int_entry('id', 1), str_entry('group', 'a'), str_entry('sub_group', '1')))
+            ->partitionBy(ref('group'), ref('sub_group'))[0];
+
+        $rows2 = rows(row(int_entry('id', 2), str_entry('group', 'a'), str_entry('sub_group', '1')))
+            ->partitionBy(ref('sub_group'), ref('group'))[0];
+
+        $this->assertEquals(
+            \Flow\ETL\DSL\partitions(partition('group', 'a'), partition('sub_group', '1')),
+            $rows1->merge($rows2)->partitions()
+        );
+        $this->assertCount(2, $rows1->merge($rows2));
     }
 
     public function test_merges_collection_together() : void
     {
-        $rowsOne = new Rows(
-            Row::create(new IntegerEntry('id', 1)),
-            Row::create(new IntegerEntry('id', 2)),
+        $rowsOne = rows(
+            row(int_entry('id', 1)),
+            row(int_entry('id', 2)),
         );
-        $rowsTwo = new Rows(
-            Row::create(new IntegerEntry('id', 3)),
-            Row::create(new IntegerEntry('id', 4)),
-            Row::create(new IntegerEntry('id', 5))
-        );
-
-        $rowsThree = new Rows(
-            Row::create(new IntegerEntry('id', 6)),
-            Row::create(new IntegerEntry('id', 7)),
+        $rowsTwo = rows(
+            row(int_entry('id', 3)),
+            row(int_entry('id', 4)),
+            row(int_entry('id', 5))
         );
 
-        $merged = $rowsOne->merge($rowsTwo, $rowsThree);
+        $rowsThree = rows(
+            row(int_entry('id', 6)),
+            row(int_entry('id', 7)),
+        );
+
+        $merged = $rowsOne->merge($rowsTwo)->merge($rowsThree);
 
         $this->assertEquals(
-            new Rows(
-                Row::create(new IntegerEntry('id', 1)),
-                Row::create(new IntegerEntry('id', 2)),
-                Row::create(new IntegerEntry('id', 3)),
-                Row::create(new IntegerEntry('id', 4)),
-                Row::create(new IntegerEntry('id', 5)),
-                Row::create(new IntegerEntry('id', 6)),
-                Row::create(new IntegerEntry('id', 7))
+            rows(
+                row(int_entry('id', 1)),
+                row(int_entry('id', 2)),
+                row(int_entry('id', 3)),
+                row(int_entry('id', 4)),
+                row(int_entry('id', 5)),
+                row(int_entry('id', 6)),
+                row(int_entry('id', 7))
             ),
             $merged
         );
@@ -504,58 +549,58 @@ final class RowsTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
 
-        (new Rows())->offsetExists('a');
+        (rows())->offsetExists('a');
     }
 
     public function test_offset_get_on_empty_rows() : void
     {
         $this->expectException(InvalidArgumentException::class);
 
-        (new Rows())[5];
+        (rows())[5];
     }
 
     public function test_partition_rows_by_multiple_duplicated_entries() : void
     {
         $this->assertEquals(
             [
-                Rows::partitioned(
+                rows_partitioned(
                     [
-                        Row::create(int_entry('num', 1), str_entry('cat', 'a')),
-                        Row::create(int_entry('num', 1), str_entry('cat', 'a')),
+                        row(int_entry('num', 1), str_entry('cat', 'a')),
+                        row(int_entry('num', 1), str_entry('cat', 'a')),
                     ],
                     [
-                        new Partition('num', '1'),
-                        new Partition('cat', 'a'),
+                        partition('num', '1'),
+                        partition('cat', 'a'),
                     ]
                 ),
-                Rows::partitioned(
-                    [Row::create(int_entry('num', 1), str_entry('cat', 'b'))],
+                rows_partitioned(
+                    [row(int_entry('num', 1), str_entry('cat', 'b'))],
                     [
-                        new Partition('num', '1'),
-                        new Partition('cat', 'b'),
+                        partition('num', '1'),
+                        partition('cat', 'b'),
                     ]
                 ),
-                Rows::partitioned(
-                    [Row::create(int_entry('num', 3), str_entry('cat', 'a'))],
+                rows_partitioned(
+                    [row(int_entry('num', 3), str_entry('cat', 'a'))],
                     [
-                        new Partition('num', '3'),
-                        new Partition('cat', 'a'),
+                        partition('num', '3'),
+                        partition('cat', 'a'),
                     ]
                 ),
-                Rows::partitioned(
-                    [Row::create(int_entry('num', 2), str_entry('cat', 'b'))],
+                rows_partitioned(
+                    [row(int_entry('num', 2), str_entry('cat', 'b'))],
                     [
-                        new Partition('num', '2'),
-                        new Partition('cat', 'b'),
+                        partition('num', '2'),
+                        partition('cat', 'b'),
                     ]
                 ),
             ],
-            (new Rows(
-                Row::create(int_entry('num', 1), str_entry('cat', 'a')),
-                Row::create(int_entry('num', 3), str_entry('cat', 'a')),
-                Row::create(int_entry('num', 1), str_entry('cat', 'b')),
-                Row::create(int_entry('num', 2), str_entry('cat', 'b')),
-                Row::create(int_entry('num', 1), str_entry('cat', 'a')),
+            (rows(
+                row(int_entry('num', 1), str_entry('cat', 'a')),
+                row(int_entry('num', 3), str_entry('cat', 'a')),
+                row(int_entry('num', 1), str_entry('cat', 'b')),
+                row(int_entry('num', 2), str_entry('cat', 'b')),
+                row(int_entry('num', 1), str_entry('cat', 'a')),
             ))->partitionBy('num', 'num', 'cat')
         );
     }
@@ -564,44 +609,44 @@ final class RowsTest extends TestCase
     {
         $this->assertEquals(
             [
-                Rows::partitioned(
+                rows_partitioned(
                     [
-                        Row::create(int_entry('num', 1), str_entry('cat', 'a')),
-                        Row::create(int_entry('num', 1), str_entry('cat', 'a')),
+                        row(int_entry('num', 1), str_entry('cat', 'a')),
+                        row(int_entry('num', 1), str_entry('cat', 'a')),
                     ],
                     [
-                        new Partition('num', '1'),
-                        new Partition('cat', 'a'),
+                        partition('num', '1'),
+                        partition('cat', 'a'),
                     ]
                 ),
-                Rows::partitioned(
-                    [Row::create(int_entry('num', 1), str_entry('cat', 'b'))],
+                rows_partitioned(
+                    [row(int_entry('num', 1), str_entry('cat', 'b'))],
                     [
-                        new Partition('num', '1'),
-                        new Partition('cat', 'b'),
+                        partition('num', '1'),
+                        partition('cat', 'b'),
                     ]
                 ),
-                Rows::partitioned(
-                    [Row::create(int_entry('num', 3), str_entry('cat', 'a'))],
+                rows_partitioned(
+                    [row(int_entry('num', 3), str_entry('cat', 'a'))],
                     [
-                        new Partition('num', '3'),
-                        new Partition('cat', 'a'),
+                        partition('num', '3'),
+                        partition('cat', 'a'),
                     ]
                 ),
-                Rows::partitioned(
-                    [Row::create(int_entry('num', 2), str_entry('cat', 'b'))],
+                rows_partitioned(
+                    [row(int_entry('num', 2), str_entry('cat', 'b'))],
                     [
-                        new Partition('num', '2'),
-                        new Partition('cat', 'b'),
+                        partition('num', '2'),
+                        partition('cat', 'b'),
                     ]
                 ),
             ],
-            (new Rows(
-                Row::create(int_entry('num', 1), str_entry('cat', 'a')),
-                Row::create(int_entry('num', 3), str_entry('cat', 'a')),
-                Row::create(int_entry('num', 1), str_entry('cat', 'b')),
-                Row::create(int_entry('num', 2), str_entry('cat', 'b')),
-                Row::create(int_entry('num', 1), str_entry('cat', 'a')),
+            (rows(
+                row(int_entry('num', 1), str_entry('cat', 'a')),
+                row(int_entry('num', 3), str_entry('cat', 'a')),
+                row(int_entry('num', 1), str_entry('cat', 'b')),
+                row(int_entry('num', 2), str_entry('cat', 'b')),
+                row(int_entry('num', 1), str_entry('cat', 'a')),
             ))->partitionBy('num', 'cat')
         );
     }
@@ -611,12 +656,12 @@ final class RowsTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Entry "test" does not exist');
 
-        (new Rows(
-            Row::create(new IntegerEntry('number', 1)),
-            Row::create(new IntegerEntry('number', 1)),
-            Row::create(new IntegerEntry('number', 3)),
-            Row::create(new IntegerEntry('number', 2)),
-            Row::create(new IntegerEntry('number', 4)),
+        (rows(
+            row(int_entry('number', 1)),
+            row(int_entry('number', 1)),
+            row(int_entry('number', 3)),
+            row(int_entry('number', 2)),
+            row(int_entry('number', 4)),
         ))->partitionBy('test');
     }
 
@@ -624,45 +669,45 @@ final class RowsTest extends TestCase
     {
         $this->assertEquals(
             [
-                Rows::partitioned(
-                    [Row::create(new IntegerEntry('number', 1)), Row::create(new IntegerEntry('number', 1))],
-                    [new Partition('number', '1')]
+                rows_partitioned(
+                    [row(int_entry('number', 1)), row(int_entry('number', 1))],
+                    [partition('number', '1')]
                 ),
-                Rows::partitioned([Row::create(new IntegerEntry('number', 3))], [new Partition('number', '3')]),
-                Rows::partitioned([Row::create(new IntegerEntry('number', 2))], [new Partition('number', '2')]),
-                Rows::partitioned([Row::create(new IntegerEntry('number', 4))], [new Partition('number', '4')]),
+                rows_partitioned([row(int_entry('number', 3))], [partition('number', '3')]),
+                rows_partitioned([row(int_entry('number', 2))], [partition('number', '2')]),
+                rows_partitioned([row(int_entry('number', 4))], [partition('number', '4')]),
             ],
-            (new Rows(
-                Row::create(new IntegerEntry('number', 1)),
-                Row::create(new IntegerEntry('number', 1)),
-                Row::create(new IntegerEntry('number', 3)),
-                Row::create(new IntegerEntry('number', 2)),
-                Row::create(new IntegerEntry('number', 4)),
+            (rows(
+                row(int_entry('number', 1)),
+                row(int_entry('number', 1)),
+                row(int_entry('number', 3)),
+                row(int_entry('number', 2)),
+                row(int_entry('number', 4)),
             ))->partitionBy('number')
         );
     }
 
     public function test_partitions() : void
     {
-        $rows = (new Rows(
-            Row::create(int_entry('number', 1), str_entry('group', 'a')),
-            Row::create(int_entry('number', 2), str_entry('group', 'a')),
-            Row::create(int_entry('number', 3), str_entry('group', 'a')),
-            Row::create(int_entry('number', 4), str_entry('group', 'a')),
+        $rows = (rows(
+            row(int_entry('number', 1), str_entry('group', 'a')),
+            row(int_entry('number', 2), str_entry('group', 'a')),
+            row(int_entry('number', 3), str_entry('group', 'a')),
+            row(int_entry('number', 4), str_entry('group', 'a')),
         ))->partitionBy('group');
 
         $this->assertEquals(
-            [new Partition('group', 'a')],
+            new Partitions(partition('group', 'a')),
             $rows[0]->partitions()
         );
     }
 
     public function test_remove() : void
     {
-        $rows = new Rows(
-            Row::create(new IntegerEntry('id', 1)),
-            Row::create(new IntegerEntry('id', 2)),
-            Row::create(new IntegerEntry('id', 3)),
+        $rows = rows(
+            row(int_entry('id', 1)),
+            row(int_entry('id', 2)),
+            row(int_entry('id', 3)),
         );
 
         $rows = $rows->remove(1);
@@ -676,15 +721,15 @@ final class RowsTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
 
-        (new Rows())->remove(1);
+        (rows())->remove(1);
     }
 
     public function test_returns_first_row() : void
     {
-        $rows = new Rows(
-            $first = Row::create(new IntegerEntry('number', 3), new StringEntry('name', 'three')),
-            Row::create(new IntegerEntry('number', 1), new StringEntry('name', 'one')),
-            Row::create(new IntegerEntry('number', 2), new StringEntry('name', 'two')),
+        $rows = rows(
+            $first = row(int_entry('number', 3), new StringEntry('name', 'three')),
+            row(int_entry('number', 1), new StringEntry('name', 'one')),
+            row(int_entry('number', 2), new StringEntry('name', 'two')),
         );
 
         $this->assertEquals($first, $rows->first());
@@ -692,10 +737,10 @@ final class RowsTest extends TestCase
 
     public function test_reverse() : void
     {
-        $rows = new Rows(
-            Row::create(new IntegerEntry('id', 1)),
-            Row::create(new IntegerEntry('id', 2)),
-            Row::create(new IntegerEntry('id', 3)),
+        $rows = rows(
+            row(int_entry('id', 1)),
+            row(int_entry('id', 2)),
+            row(int_entry('id', 3)),
         );
 
         $rows = $rows->reverse();
@@ -724,11 +769,11 @@ final class RowsTest extends TestCase
 
     public function test_rows_schema() : void
     {
-        $rows = new Rows(
-            Row::create(int_entry('id', 1), str_entry('name', 'foo')),
-            Row::create(int_entry('id', 1), null_entry('name'), list_entry('list', [1, 2], type_list(type_int()))),
-            Row::create(int_entry('id', 1), str_entry('name', 'bar'), array_entry('tags', ['a', 'b'])),
-            Row::create(int_entry('id', 1), int_entry('name', 25)),
+        $rows = rows(
+            row(int_entry('id', 1), str_entry('name', 'foo')),
+            row(int_entry('id', 1), null_entry('name'), list_entry('list', [1, 2], type_list(type_int()))),
+            row(int_entry('id', 1), str_entry('name', 'bar'), array_entry('tags', ['a', 'b'])),
+            row(int_entry('id', 1), int_entry('name', 25)),
         );
 
         $this->assertEquals(
@@ -744,9 +789,9 @@ final class RowsTest extends TestCase
 
     public function test_rows_schema_when_rows_have_different_list_types() : void
     {
-        $rows = new Rows(
-            Row::create(list_entry('list', ['one', 'two'], type_list(type_string()))),
-            Row::create(list_entry('list', [1, 2], type_list(type_int()))),
+        $rows = rows(
+            row(list_entry('list', ['one', 'two'], type_list(type_string()))),
+            row(list_entry('list', [1, 2], type_list(type_int()))),
         );
 
         $this->assertEquals(
@@ -757,10 +802,10 @@ final class RowsTest extends TestCase
 
     public function test_rows_serialization() : void
     {
-        $rows = new Rows(
-            Row::create(new IntegerEntry('id', 1)),
-            Row::create(new IntegerEntry('id', 2)),
-            Row::create(new IntegerEntry('id', 3)),
+        $rows = rows(
+            row(int_entry('id', 1)),
+            row(int_entry('id', 2)),
+            row(int_entry('id', 3)),
         );
 
         $serialized = \serialize($rows);
@@ -776,24 +821,24 @@ final class RowsTest extends TestCase
     /**
      * @dataProvider unique_rows_provider
      */
-    public function test_rows_unique(Rows $expected, Rows $notUnique, Row\Comparator $comparator = new NativeComparator()) : void
+    public function test_rows_unique(Rows $expected, Rows $notUnique, Comparator $comparator = new NativeComparator()) : void
     {
         $this->assertEquals($expected, $notUnique->unique($comparator));
     }
 
     public function test_sort() : void
     {
-        $rows = new Rows(
-            $three = Row::create(new IntegerEntry('number', 3), new StringEntry('name', 'three')),
-            $one = Row::create(new IntegerEntry('number', 1), new StringEntry('name', 'one')),
-            $five = Row::create(new IntegerEntry('number', 5), new StringEntry('name', 'five')),
-            $two = Row::create(new IntegerEntry('number', 2), new StringEntry('name', 'two')),
-            $four = Row::create(new IntegerEntry('number', 4), new StringEntry('name', 'four')),
+        $rows = rows(
+            $three = row(int_entry('number', 3), new StringEntry('name', 'three')),
+            $one = row(int_entry('number', 1), new StringEntry('name', 'one')),
+            $five = row(int_entry('number', 5), new StringEntry('name', 'five')),
+            $two = row(int_entry('number', 2), new StringEntry('name', 'two')),
+            $four = row(int_entry('number', 4), new StringEntry('name', 'four')),
         );
 
         $sort = $rows->sort(fn (Row $row, Row $nextRow) : int => $row->valueOf('number') <=> $nextRow->valueOf('number'));
 
-        $this->assertEquals(new Rows($one, $two, $three, $four, $five), $sort);
+        $this->assertEquals(rows($one, $two, $three, $four, $five), $sort);
         $this->assertNotEquals($sort, $rows);
     }
 
@@ -802,13 +847,13 @@ final class RowsTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Entry "c" does not exist');
 
-        $rows = new Rows(
-            Row::create(new IntegerEntry('a', 3), new IntegerEntry('b', 2)),
-            Row::create(new IntegerEntry('a', 1), new IntegerEntry('b', 5)),
-            Row::create(new IntegerEntry('a', 1), new IntegerEntry('b', 4)),
-            Row::create(new IntegerEntry('a', 2), new IntegerEntry('b', 7)),
-            Row::create(new IntegerEntry('a', 3), new IntegerEntry('b', 10)),
-            Row::create(new IntegerEntry('a', 2), new IntegerEntry('b', 4)),
+        $rows = rows(
+            row(int_entry('a', 3), int_entry('b', 2)),
+            row(int_entry('a', 1), int_entry('b', 5)),
+            row(int_entry('a', 1), int_entry('b', 4)),
+            row(int_entry('a', 2), int_entry('b', 7)),
+            row(int_entry('a', 3), int_entry('b', 10)),
+            row(int_entry('a', 2), int_entry('b', 4)),
         );
 
         $rows->sortBy(ref('c'), ref('b')->desc());
@@ -816,13 +861,13 @@ final class RowsTest extends TestCase
 
     public function test_sort_rows_by_two_columns() : void
     {
-        $rows = new Rows(
-            Row::create(new IntegerEntry('a', 3), new IntegerEntry('b', 2)),
-            Row::create(new IntegerEntry('a', 1), new IntegerEntry('b', 5)),
-            Row::create(new IntegerEntry('a', 1), new IntegerEntry('b', 4)),
-            Row::create(new IntegerEntry('a', 2), new IntegerEntry('b', 7)),
-            Row::create(new IntegerEntry('a', 3), new IntegerEntry('b', 10)),
-            Row::create(new IntegerEntry('a', 2), new IntegerEntry('b', 4)),
+        $rows = rows(
+            row(int_entry('a', 3), int_entry('b', 2)),
+            row(int_entry('a', 1), int_entry('b', 5)),
+            row(int_entry('a', 1), int_entry('b', 4)),
+            row(int_entry('a', 2), int_entry('b', 7)),
+            row(int_entry('a', 3), int_entry('b', 10)),
+            row(int_entry('a', 2), int_entry('b', 4)),
         );
 
         $ascending = $rows->sortBy(ref('a'), ref('b')->desc());
@@ -844,36 +889,36 @@ final class RowsTest extends TestCase
 
     public function test_sort_rows_without_changing_original_collection() : void
     {
-        $rows = new Rows(
-            $three = Row::create(new IntegerEntry('number', 3), new StringEntry('name', 'three')),
-            $one = Row::create(new IntegerEntry('number', 1), new StringEntry('name', 'one')),
-            $five = Row::create(new IntegerEntry('number', 5), new StringEntry('name', 'five')),
-            $two = Row::create(new IntegerEntry('number', 2), new StringEntry('name', 'two')),
-            $four = Row::create(new IntegerEntry('number', 4), new StringEntry('name', 'four')),
+        $rows = rows(
+            $three = row(int_entry('number', 3), new StringEntry('name', 'three')),
+            $one = row(int_entry('number', 1), new StringEntry('name', 'one')),
+            $five = row(int_entry('number', 5), new StringEntry('name', 'five')),
+            $two = row(int_entry('number', 2), new StringEntry('name', 'two')),
+            $four = row(int_entry('number', 4), new StringEntry('name', 'four')),
         );
 
         $ascending = $rows->sortAscending(ref('number'));
         $descending = $rows->sortDescending(ref('number'));
 
-        $this->assertEquals(new Rows($one, $two, $three, $four, $five), $ascending);
-        $this->assertEquals(new Rows($five, $four, $three, $two, $one), $descending);
+        $this->assertEquals(rows($one, $two, $three, $four, $five), $ascending);
+        $this->assertEquals(rows($five, $four, $three, $two, $one), $descending);
         $this->assertNotEquals($ascending, $rows);
         $this->assertNotEquals($descending, $rows);
     }
 
     public function test_sorts_entries_in_all_rows() : void
     {
-        $rows = new Rows(
-            Row::create(
-                $rowOneId = new IntegerEntry('id', 1),
+        $rows = rows(
+            row(
+                $rowOneId = int_entry('id', 1),
                 $rowOneDeleted = new BooleanEntry('deleted', true),
                 $rowOnePhase = new NullEntry('phase'),
                 $rowOneCreatedAt = new DateTimeEntry('created-at', new \DateTimeImmutable('2020-08-13 15:00')),
             ),
-            Row::create(
+            row(
                 $rowTwoDeleted = new BooleanEntry('deleted', true),
                 $rowTwoCreatedAt = new DateTimeEntry('created-at', new \DateTimeImmutable('2020-08-13 15:00')),
-                $rowTwoId = new IntegerEntry('id', 1),
+                $rowTwoId = int_entry('id', 1),
                 $rowTwoPhase = new NullEntry('phase'),
             ),
         );
@@ -881,17 +926,17 @@ final class RowsTest extends TestCase
         $sorted = $rows->sortEntries();
 
         $this->assertEquals(
-            new Rows(
-                Row::create(
+            rows(
+                row(
                     $rowOneCreatedAt = new DateTimeEntry('created-at', new \DateTimeImmutable('2020-08-13 15:00')),
                     $rowOneDeleted = new BooleanEntry('deleted', true),
-                    $rowOneId = new IntegerEntry('id', 1),
+                    $rowOneId = int_entry('id', 1),
                     $rowOnePhase = new NullEntry('phase'),
                 ),
-                Row::create(
+                row(
                     $rowTwoCreatedAt = new DateTimeEntry('created-at', new \DateTimeImmutable('2020-08-13 15:00')),
                     $rowTwoDeleted = new BooleanEntry('deleted', true),
-                    $rowTwoId = new IntegerEntry('id', 1),
+                    $rowTwoId = int_entry('id', 1),
                     $rowTwoPhase = new NullEntry('phase'),
                 )
             ),
@@ -901,10 +946,10 @@ final class RowsTest extends TestCase
 
     public function test_take() : void
     {
-        $rows = new Rows(
-            Row::create(new IntegerEntry('id', 1)),
-            Row::create(new IntegerEntry('id', 2)),
-            Row::create(new IntegerEntry('id', 3)),
+        $rows = rows(
+            row(int_entry('id', 1)),
+            row(int_entry('id', 2)),
+            row(int_entry('id', 3)),
         );
 
         $rows = $rows->take(1);
@@ -915,10 +960,10 @@ final class RowsTest extends TestCase
 
     public function test_take_all() : void
     {
-        $rows = new Rows(
-            Row::create(new IntegerEntry('id', 1)),
-            Row::create(new IntegerEntry('id', 2)),
-            Row::create(new IntegerEntry('id', 3)),
+        $rows = rows(
+            row(int_entry('id', 1)),
+            row(int_entry('id', 2)),
+            row(int_entry('id', 3)),
         );
 
         $rows = $rows->take(3);
@@ -931,10 +976,10 @@ final class RowsTest extends TestCase
 
     public function test_take_more_than_exists() : void
     {
-        $rows = new Rows(
-            Row::create(new IntegerEntry('id', 1)),
-            Row::create(new IntegerEntry('id', 2)),
-            Row::create(new IntegerEntry('id', 3)),
+        $rows = rows(
+            row(int_entry('id', 1)),
+            row(int_entry('id', 2)),
+            row(int_entry('id', 3)),
         );
 
         $rows = $rows->take(4);
@@ -947,10 +992,10 @@ final class RowsTest extends TestCase
 
     public function test_take_right() : void
     {
-        $rows = new Rows(
-            Row::create(new IntegerEntry('id', 1)),
-            Row::create(new IntegerEntry('id', 2)),
-            Row::create(new IntegerEntry('id', 3)),
+        $rows = rows(
+            row(int_entry('id', 1)),
+            row(int_entry('id', 2)),
+            row(int_entry('id', 3)),
         );
 
         $rows = $rows->takeRight(1);
@@ -961,10 +1006,10 @@ final class RowsTest extends TestCase
 
     public function test_take_right_all() : void
     {
-        $rows = new Rows(
-            Row::create(new IntegerEntry('id', 1)),
-            Row::create(new IntegerEntry('id', 2)),
-            Row::create(new IntegerEntry('id', 3)),
+        $rows = rows(
+            row(int_entry('id', 1)),
+            row(int_entry('id', 2)),
+            row(int_entry('id', 3)),
         );
 
         $rows = $rows->takeRight(3);
@@ -977,10 +1022,10 @@ final class RowsTest extends TestCase
 
     public function test_take_right_more_than_exists() : void
     {
-        $rows = new Rows(
-            Row::create(new IntegerEntry('id', 1)),
-            Row::create(new IntegerEntry('id', 2)),
-            Row::create(new IntegerEntry('id', 3)),
+        $rows = rows(
+            row(int_entry('id', 1)),
+            row(int_entry('id', 2)),
+            row(int_entry('id', 3)),
         );
 
         $rows = $rows->takeRight(4);
@@ -993,14 +1038,14 @@ final class RowsTest extends TestCase
 
     public function test_transforms_rows_to_array() : void
     {
-        $rows = new Rows(
-            Row::create(
-                new IntegerEntry('id', 1234),
+        $rows = rows(
+            row(
+                int_entry('id', 1234),
                 new BooleanEntry('deleted', false),
                 new NullEntry('phase'),
             ),
-            Row::create(
-                new IntegerEntry('id', 4321),
+            row(
+                int_entry('id', 4321),
                 new BooleanEntry('deleted', true),
                 new StringEntry('phase', 'launch'),
             )


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <li>Displaying partitions under data when using to_output or DataFrame::display</li>
    <li>dsl functions for save modes</li>
    <li>DataFrame::saveMode as an aliast for DataFrame::mode</li>
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>Inconsistent behavior of DataFrame::fetch for partitioned rows</li>
    <li>Merging rows from the same partition makes new rows keep that partition</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Rows::merge accepts only one instance of Rows instead of many</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

<!-- Please provide a short description of changes in this section, feel free to use markdown syntax -->
