### PR TITLE
Fixed printing null type entries in schema formatter

### DIFF
--- a/src/core/etl/src/Flow/ETL/Row/Schema/Formatter/ASCIISchemaFormatter.php
+++ b/src/core/etl/src/Flow/ETL/Row/Schema/Formatter/ASCIISchemaFormatter.php
@@ -88,6 +88,10 @@ final class ASCIISchemaFormatter implements SchemaFormatter
             $definitionTypes[] = $definitionType->toString();
         }
 
+        if ($nullable && !\count($definitionTypes)) {
+            return ['null'];
+        }
+
         return $definitionTypes;
     }
 

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Schema/Formatter/ASCIISchemaFormatterTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Schema/Formatter/ASCIISchemaFormatterTest.php
@@ -43,7 +43,8 @@ final class ASCIISchemaFormatterTest extends TestCase
             Schema\Definition::string('name', nullable: true),
             Schema\Definition::array('tags'),
             Schema\Definition::boolean('active'),
-            Schema\Definition::xml('xml')
+            Schema\Definition::xml('xml'),
+            Schema\Definition::null('null')
         );
 
         $this->assertSame(
@@ -61,6 +62,7 @@ schema
 |-- tags: array<mixed>
 |-- active: boolean
 |-- xml: object<DOMDocument>
+|-- null: null
 
 SCHEMA,
             (new ASCIISchemaFormatter())->format($schema)


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>printing null type entries in schema formatted</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

<!-- Please provide a short description of changes in this section, feel free to use markdown syntax -->
