### PR TITLE
Make sure that partitions order is not changed during partitioning

### DIFF
--- a/src/core/etl/src/Flow/ETL/DataFrame/PartitionedDataFrame.php
+++ b/src/core/etl/src/Flow/ETL/DataFrame/PartitionedDataFrame.php
@@ -57,6 +57,14 @@ final class PartitionedDataFrame
         return $this;
     }
 
+    /**
+     * @param null|callable(Rows $rows): void $callback
+     */
+    public function run(?callable $callback = null) : void
+    {
+        $this->df->run($callback);
+    }
+
     public function write(Loader $loader) : DataFrame
     {
         return $this->df->write($loader);

--- a/src/core/etl/src/Flow/ETL/Partitions.php
+++ b/src/core/etl/src/Flow/ETL/Partitions.php
@@ -14,8 +14,6 @@ final class Partitions implements \ArrayAccess, \Countable, \IteratorAggregate
 
     public function __construct(Partition ...$partitions)
     {
-        \uasort($partitions, static fn (Partition $a, Partition $b) => $a->name <=> $b->name);
-
         $this->partitions = $partitions;
     }
 
@@ -42,9 +40,12 @@ final class Partitions implements \ArrayAccess, \Countable, \IteratorAggregate
 
     public function id() : string
     {
+        $partitions = $this->partitions;
+        \uasort($partitions, static fn (Partition $a, Partition $b) => $a->name <=> $b->name);
+
         $id = '|';
 
-        foreach ($this->partitions as $partition) {
+        foreach ($partitions as $partition) {
             $id .= $partition->name . '_' . $partition->value . '|';
         }
 


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>changing partitions order during partitioning</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

<!-- Please provide a short description of changes in this section, feel free to use markdown syntax -->
