### PR TITLE
Make sure that entries are "stringable"

### DIFF
--- a/src/core/etl/src/Flow/ETL/Row/Entry.php
+++ b/src/core/etl/src/Flow/ETL/Row/Entry.php
@@ -10,7 +10,7 @@ use Flow\ETL\Row\Schema\Definition;
 /**
  * @template TValue
  */
-interface Entry
+interface Entry extends \Stringable
 {
     public function __toString() : string;
 

--- a/src/core/etl/src/Flow/ETL/Row/Entry/ArrayEntry.php
+++ b/src/core/etl/src/Flow/ETL/Row/Entry/ArrayEntry.php
@@ -16,7 +16,7 @@ use Flow\ETL\Row\Schema\Definition;
 /**
  * @implements Entry<array>
  */
-final class ArrayEntry implements \Stringable, Entry
+final class ArrayEntry implements Entry
 {
     use EntryRef;
 

--- a/src/core/etl/src/Flow/ETL/Row/Entry/BooleanEntry.php
+++ b/src/core/etl/src/Flow/ETL/Row/Entry/BooleanEntry.php
@@ -15,7 +15,7 @@ use Flow\ETL\Row\Schema\Definition;
 /**
  * @implements Entry<bool>
  */
-final class BooleanEntry implements \Stringable, Entry
+final class BooleanEntry implements Entry
 {
     use EntryRef;
 

--- a/src/core/etl/src/Flow/ETL/Row/Entry/DateTimeEntry.php
+++ b/src/core/etl/src/Flow/ETL/Row/Entry/DateTimeEntry.php
@@ -15,7 +15,7 @@ use Flow\ETL\Row\Schema\Definition;
 /**
  * @implements Entry<\DateTimeInterface>
  */
-final class DateTimeEntry implements \Stringable, Entry
+final class DateTimeEntry implements Entry
 {
     use EntryRef;
 

--- a/src/core/etl/src/Flow/ETL/Row/Entry/FloatEntry.php
+++ b/src/core/etl/src/Flow/ETL/Row/Entry/FloatEntry.php
@@ -15,7 +15,7 @@ use Flow\ETL\Row\Schema\Definition;
 /**
  * @implements Entry<float>
  */
-final class FloatEntry implements \Stringable, Entry
+final class FloatEntry implements Entry
 {
     use EntryRef;
 

--- a/src/core/etl/src/Flow/ETL/Row/Entry/IntegerEntry.php
+++ b/src/core/etl/src/Flow/ETL/Row/Entry/IntegerEntry.php
@@ -15,7 +15,7 @@ use Flow\ETL\Row\Schema\Definition;
 /**
  * @implements Entry<int>
  */
-final class IntegerEntry implements \Stringable, Entry
+final class IntegerEntry implements Entry
 {
     use EntryRef;
 

--- a/src/core/etl/src/Flow/ETL/Row/Entry/JsonEntry.php
+++ b/src/core/etl/src/Flow/ETL/Row/Entry/JsonEntry.php
@@ -16,7 +16,7 @@ use Flow\ETL\Row\Schema\Definition;
 /**
  * @implements Entry<string>
  */
-final class JsonEntry implements \Stringable, Entry
+final class JsonEntry implements Entry
 {
     use EntryRef;
 

--- a/src/core/etl/src/Flow/ETL/Row/Entry/NullEntry.php
+++ b/src/core/etl/src/Flow/ETL/Row/Entry/NullEntry.php
@@ -14,7 +14,7 @@ use Flow\ETL\Row\Schema\Definition;
 /**
  * @implements Entry<null>
  */
-final class NullEntry implements \Stringable, Entry
+final class NullEntry implements Entry
 {
     use EntryRef;
 

--- a/src/core/etl/src/Flow/ETL/Row/Entry/ObjectEntry.php
+++ b/src/core/etl/src/Flow/ETL/Row/Entry/ObjectEntry.php
@@ -15,7 +15,7 @@ use Flow\ETL\Row\Schema\Definition;
 /**
  * @implements Entry<object>
  */
-final class ObjectEntry implements \Stringable, Entry
+final class ObjectEntry implements Entry
 {
     use EntryRef;
 

--- a/src/core/etl/src/Flow/ETL/Row/Entry/StringEntry.php
+++ b/src/core/etl/src/Flow/ETL/Row/Entry/StringEntry.php
@@ -15,7 +15,7 @@ use Flow\ETL\Row\Schema\Definition;
 /**
  * @implements Entry<string>
  */
-final class StringEntry implements \Stringable, Entry
+final class StringEntry implements Entry
 {
     use EntryRef;
 
@@ -24,7 +24,7 @@ final class StringEntry implements \Stringable, Entry
     /**
      * @throws InvalidArgumentException
      */
-    public function __construct(private readonly string $name, private string $value)
+    public function __construct(private readonly string $name, private readonly string $value)
     {
         if ('' === $name) {
             throw InvalidArgumentException::because('Entry name cannot be empty');

--- a/src/core/etl/src/Flow/ETL/Row/Entry/StructureEntry.php
+++ b/src/core/etl/src/Flow/ETL/Row/Entry/StructureEntry.php
@@ -16,7 +16,7 @@ use Flow\ETL\Row\Schema\Definition;
 /**
  * @implements Entry<array<array-key, mixed>>
  */
-final class StructureEntry implements \Stringable, Entry
+final class StructureEntry implements Entry
 {
     use EntryRef;
 

--- a/src/core/etl/src/Flow/ETL/Row/Entry/UuidEntry.php
+++ b/src/core/etl/src/Flow/ETL/Row/Entry/UuidEntry.php
@@ -15,7 +15,7 @@ use Flow\ETL\Row\Schema\Definition;
 /**
  * @implements Entry<Entry\Type\Uuid>
  */
-final class UuidEntry implements \Stringable, Entry
+final class UuidEntry implements Entry
 {
     use EntryRef;
 

--- a/src/core/etl/src/Flow/ETL/Row/Entry/XMLEntry.php
+++ b/src/core/etl/src/Flow/ETL/Row/Entry/XMLEntry.php
@@ -13,7 +13,7 @@ use Flow\ETL\Row\Schema\Definition;
 /**
  * @implements Entry<\DOMDocument>
  */
-final class XMLEntry implements \Stringable, Entry
+final class XMLEntry implements Entry
 {
     use EntryRef;
 

--- a/src/core/etl/src/Flow/ETL/Row/Entry/XMLNodeEntry.php
+++ b/src/core/etl/src/Flow/ETL/Row/Entry/XMLNodeEntry.php
@@ -12,7 +12,7 @@ use Flow\ETL\Row\Schema\Definition;
 /**
  * @implements Entry<\DOMNode>
  */
-final class XMLNodeEntry implements \Stringable, Entry
+final class XMLNodeEntry implements Entry
 {
     use EntryRef;
 


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Make sure that entries are "stringable"</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

Almost all `Entry` related classes implement the `\Stringable` interface, but even if not those classes have the magic method `__toString()` declared cause it's required by the `Entry` interface itself. This change makes the code of entries a bit more clear.
