### PR TITLE
Added DataFrame::schema method to just read schema from dataset

### DIFF
--- a/src/core/etl/src/Flow/ETL/DSL/functions.php
+++ b/src/core/etl/src/Flow/ETL/DSL/functions.php
@@ -985,6 +985,14 @@ function list_schema(string $name, ListType $type, bool $nullable = false, ?Sche
 }
 
 /**
+ * @param array<class-string<Row\Entry>> $entry_classes
+ */
+function union_schema(string $name, array $entry_classes, ?Schema\Constraint $constraint = null, ?Schema\Metadata $metadata = null) : Definition
+{
+    return Definition::union($name, $entry_classes, $constraint, $metadata);
+}
+
+/**
  * @param class-string<\UnitEnum> $type
  */
 function enum_schema(string $name, string $type, bool $nullable = false, ?Schema\Constraint $constraint = null, ?Schema\Metadata $metadata = null) : Definition

--- a/src/core/etl/src/Flow/ETL/DataFrame.php
+++ b/src/core/etl/src/Flow/ETL/DataFrame.php
@@ -770,6 +770,20 @@ final class DataFrame
     }
 
     /**
+     * @trigger
+     */
+    public function schema() : Schema
+    {
+        $schema = new Schema();
+
+        foreach ($this->pipeline->process($this->context) as $rows) {
+            $schema = $schema->merge($rows->schema());
+        }
+
+        return $schema;
+    }
+
+    /**
      * @lazy
      * Keep only given entries.
      */

--- a/src/core/etl/src/Flow/ETL/Row/Schema.php
+++ b/src/core/etl/src/Flow/ETL/Row/Schema.php
@@ -104,6 +104,17 @@ final class Schema implements \Countable
         return new self(...\array_values($newDefinitions));
     }
 
+    public function narrow() : self
+    {
+        $definitions = [];
+
+        foreach ($this->definitions as $definition) {
+            $definitions[] = $definition->narrow();
+        }
+
+        return new self(...$definitions);
+    }
+
     public function nullable() : self
     {
         $definitions = [];

--- a/src/core/etl/src/Flow/ETL/Row/Schema/Definition.php
+++ b/src/core/etl/src/Flow/ETL/Row/Schema/Definition.php
@@ -283,6 +283,15 @@ final class Definition
         return $this->metadata;
     }
 
+    public function narrow() : self
+    {
+        if (!$this->isUnion()) {
+            return $this;
+        }
+
+        return self::string($this->ref, $this->isNullable(), $this->constraint, $this->metadata);
+    }
+
     public function nullable() : self
     {
         if (!\in_array(NullEntry::class, $this->classes, true)) {

--- a/src/core/etl/tests/Flow/ETL/Tests/Integration/DataFrame/SchemaTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Integration/DataFrame/SchemaTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Tests\Integration\DataFrame;
+
+use function Flow\ETL\DSL\array_to_rows;
+use function Flow\ETL\DSL\bool_schema;
+use function Flow\ETL\DSL\df;
+use function Flow\ETL\DSL\from_rows;
+use function Flow\ETL\DSL\int_schema;
+use function Flow\ETL\DSL\schema;
+use function Flow\ETL\DSL\str_schema;
+use function Flow\ETL\DSL\union_schema;
+use Flow\ETL\Row\Entry\IntegerEntry;
+use Flow\ETL\Row\Entry\StringEntry;
+use Flow\ETL\Tests\Integration\IntegrationTestCase;
+
+final class SchemaTest extends IntegrationTestCase
+{
+    public function test_getting_schema() : void
+    {
+        $rows = array_to_rows(\array_map(
+            function ($i) {
+                return [
+                    'id' => $i,
+                    'name' => 'name_' . $i,
+                    'active' => $i % 2 === 0,
+                ];
+            },
+            \range(1, 100)
+        ));
+
+        $this->assertEquals(
+            schema(
+                int_schema('id'),
+                str_schema('name'),
+                bool_schema('active')
+            ),
+            df()
+                ->read(from_rows($rows))
+                ->autoCast()
+                ->schema()
+        );
+    }
+
+    public function test_getting_schema_from_limited_rows() : void
+    {
+        $rows = array_to_rows(\array_map(
+            function ($i) {
+                return [
+                    'id' => $i,
+                    'name' => 'name_' . $i,
+                    'active' => $i % 2 === 0,
+                    'union' => $i > 50 ? 'string' : 1,
+                ];
+            },
+            \range(1, 100)
+        ));
+
+        $this->assertEquals(
+            schema(
+                int_schema('id'),
+                str_schema('name'),
+                bool_schema('active'),
+                int_schema('union')
+            ),
+            df()
+                ->read(from_rows($rows))
+                ->autoCast()
+                ->limit(50)
+                ->schema()
+        );
+    }
+
+    public function test_getting_schema_with_union_type() : void
+    {
+        $rows = array_to_rows(\array_map(
+            function ($i) {
+                return [
+                    'id' => $i,
+                    'name' => 'name_' . $i,
+                    'active' => $i % 2 === 0,
+                    'union' => $i > 50 ? 'string' : 1,
+                ];
+            },
+            \range(1, 100)
+        ));
+
+        $this->assertEquals(
+            schema(
+                int_schema('id'),
+                str_schema('name'),
+                bool_schema('active'),
+                union_schema('union', [IntegerEntry::class, StringEntry::class])
+            ),
+            df()
+                ->read(from_rows($rows))
+                ->autoCast()
+                ->schema()
+        );
+    }
+}

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Schema/DefinitionTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Schema/DefinitionTest.php
@@ -6,8 +6,10 @@ namespace Flow\ETL\Tests\Unit\Row\Schema;
 
 use function Flow\ETL\DSL\bool_entry;
 use function Flow\ETL\DSL\int_entry;
+use function Flow\ETL\DSL\int_schema;
 use function Flow\ETL\DSL\null_entry;
 use function Flow\ETL\DSL\str_entry;
+use function Flow\ETL\DSL\str_schema;
 use function Flow\ETL\DSL\struct_element;
 use function Flow\ETL\DSL\struct_entry;
 use function Flow\ETL\DSL\struct_type;
@@ -17,6 +19,7 @@ use Flow\ETL\Exception\InvalidArgumentException;
 use Flow\ETL\PHP\Type\Logical\List\ListElement;
 use Flow\ETL\PHP\Type\Logical\ListType;
 use Flow\ETL\PHP\Type\Logical\StructureType;
+use Flow\ETL\Row\Entry\DateTimeEntry;
 use Flow\ETL\Row\Entry\IntegerEntry;
 use Flow\ETL\Row\Entry\ListEntry;
 use Flow\ETL\Row\Entry\NullEntry;
@@ -173,6 +176,36 @@ final class DefinitionTest extends TestCase
     public function test_multi_types_is_not_union() : void
     {
         $this->assertTrue(Definition::union('id', [IntegerEntry::class, StringEntry::class, NullEntry::class])->isUnion());
+    }
+
+    public function test_narrow_non_union_type() : void
+    {
+        $def = int_schema('int');
+
+        $this->assertSame(
+            $def,
+            $def->narrow()
+        );
+    }
+
+    public function test_narrow_nullable_union_type() : void
+    {
+        $def = Definition::union('test', [IntegerEntry::class, StringEntry::class, DateTimeEntry::class, NullEntry::class]);
+
+        $this->assertEquals(
+            str_schema('test', true),
+            $def->narrow()
+        );
+    }
+
+    public function test_narrow_union_type() : void
+    {
+        $def = Definition::union('test', [IntegerEntry::class, StringEntry::class, DateTimeEntry::class]);
+
+        $this->assertEquals(
+            str_schema('test'),
+            $def->narrow()
+        );
     }
 
     public function test_not_matches_when_constraint_not_satisfied() : void

--- a/src/lib/parquet/tests/Flow/Parquet/Tests/Unit/ParquetFile/SchemaTest.php
+++ b/src/lib/parquet/tests/Flow/Parquet/Tests/Unit/ParquetFile/SchemaTest.php
@@ -2,7 +2,13 @@
 
 namespace Flow\Parquet\Tests\Unit\ParquetFile;
 
+use function Flow\ETL\DSL\int_schema;
+use function Flow\ETL\DSL\str_schema;
+use function Flow\ETL\DSL\union_schema;
 use Flow\ETL\Adapter\Elasticsearch\Tests\Integration\TestCase;
+use Flow\ETL\Row\Entry\IntegerEntry;
+use Flow\ETL\Row\Entry\NullEntry;
+use Flow\ETL\Row\Entry\StringEntry;
 use Flow\Parquet\ParquetFile\Schema;
 use Flow\Parquet\ParquetFile\Schema\FlatColumn;
 use Flow\Parquet\ParquetFile\Schema\ListElement;
@@ -104,5 +110,21 @@ final class SchemaTest extends TestCase
         foreach ($schema->columnsFlat() as $column) {
             $this->assertInstanceOf(FlatColumn::class, $column);
         }
+    }
+
+    public function test_narrowing_schema_with_union_types() : void
+    {
+        $schema = \Flow\ETL\DSL\schema(
+            int_schema('id'),
+            union_schema('tracking_number', [StringEntry::class, IntegerEntry::class, NullEntry::class]),
+        )->narrow();
+
+        $this->assertEquals(
+            \Flow\ETL\DSL\schema(
+                int_schema('id'),
+                str_schema('tracking_number', true),
+            ),
+            $schema
+        );
     }
 }


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <li>DataFrame::schema method to just read schema from dataset</li>
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

<!-- Please provide a short description of changes in this section, feel free to use markdown syntax -->
