### PR TITLE
Entry factory schema

### DIFF
--- a/src/adapter/etl-adapter-csv/src/Flow/ETL/Adapter/CSV/CSVExtractor.php
+++ b/src/adapter/etl-adapter-csv/src/Flow/ETL/Adapter/CSV/CSVExtractor.php
@@ -15,6 +15,7 @@ use Flow\ETL\Extractor\Signal;
 use Flow\ETL\Filesystem\Path;
 use Flow\ETL\Filesystem\Stream\Mode;
 use Flow\ETL\FlowContext;
+use Flow\ETL\Row\Schema;
 
 final class CSVExtractor implements Extractor, FileExtractor, LimitableExtractor, PartitionsExtractor
 {
@@ -31,7 +32,8 @@ final class CSVExtractor implements Extractor, FileExtractor, LimitableExtractor
         private readonly string|null $separator = null,
         private readonly string|null $enclosure = null,
         private readonly string|null $escape = null,
-        private readonly int $charactersReadInLine = 1000
+        private readonly int $charactersReadInLine = 1000,
+        private readonly Schema|null $schema = null
     ) {
         $this->resetLimit();
     }
@@ -98,7 +100,7 @@ final class CSVExtractor implements Extractor, FileExtractor, LimitableExtractor
                     $row['_input_file_uri'] = $stream->path()->uri();
                 }
 
-                $signal = yield array_to_rows($row, $context->entryFactory(), $path->partitions());
+                $signal = yield array_to_rows($row, $context->entryFactory(), $path->partitions(), $this->schema);
                 $this->countRow();
 
                 if ($signal === Signal::STOP || $this->reachedLimit()) {

--- a/src/adapter/etl-adapter-csv/src/Flow/ETL/Adapter/CSV/functions.php
+++ b/src/adapter/etl-adapter-csv/src/Flow/ETL/Adapter/CSV/functions.php
@@ -10,6 +10,7 @@ use Flow\ETL\Adapter\CSV\Detector\Options;
 use Flow\ETL\Extractor;
 use Flow\ETL\Filesystem\Path;
 use Flow\ETL\Loader;
+use Flow\ETL\Row\Schema;
 
 /**
  * @param int<0, max> $characters_read_in_line
@@ -21,7 +22,8 @@ function from_csv(
     string|null $delimiter = null,
     string|null $enclosure = null,
     string|null $escape = null,
-    int $characters_read_in_line = 1000
+    int $characters_read_in_line = 1000,
+    Schema|null $schema = null
 ) : Extractor {
     if (\is_array($path)) {
         $extractors = [];
@@ -35,6 +37,7 @@ function from_csv(
                 $enclosure,
                 $escape,
                 $characters_read_in_line,
+                $schema
             );
         }
 
@@ -49,6 +52,7 @@ function from_csv(
         $enclosure,
         $escape,
         $characters_read_in_line,
+        $schema
     );
 }
 

--- a/src/adapter/etl-adapter-json/src/Flow/ETL/Adapter/JSON/JSONMachine/JsonExtractor.php
+++ b/src/adapter/etl-adapter-json/src/Flow/ETL/Adapter/JSON/JSONMachine/JsonExtractor.php
@@ -15,6 +15,7 @@ use Flow\ETL\Extractor\Signal;
 use Flow\ETL\Filesystem\Path;
 use Flow\ETL\Filesystem\Stream\Mode;
 use Flow\ETL\FlowContext;
+use Flow\ETL\Row\Schema;
 use JsonMachine\Items;
 use JsonMachine\JsonDecoder\ExtJsonDecoder;
 
@@ -26,6 +27,7 @@ final class JsonExtractor implements Extractor, FileExtractor, LimitableExtracto
     public function __construct(
         private readonly Path $path,
         private readonly ?string $pointer = null,
+        private readonly Schema|null $schema = null,
     ) {
         $this->resetLimit();
     }
@@ -46,7 +48,7 @@ final class JsonExtractor implements Extractor, FileExtractor, LimitableExtracto
                     $row['_input_file_uri'] = $filePath->uri();
                 }
 
-                $signal = yield array_to_rows($row, $context->entryFactory(), $filePath->partitions());
+                $signal = yield array_to_rows($row, $context->entryFactory(), $filePath->partitions(), $this->schema);
                 $this->countRow();
 
                 if ($signal === Signal::STOP || $this->reachedLimit()) {

--- a/src/adapter/etl-adapter-json/src/Flow/ETL/Adapter/JSON/functions.php
+++ b/src/adapter/etl-adapter-json/src/Flow/ETL/Adapter/JSON/functions.php
@@ -9,6 +9,7 @@ use Flow\ETL\Adapter\JSON\JSONMachine\JsonExtractor;
 use Flow\ETL\Extractor;
 use Flow\ETL\Filesystem\Path;
 use Flow\ETL\Loader;
+use Flow\ETL\Row\Schema;
 
 /**
  * @param array<Path|string>|Path|string $path - string is internally turned into stream
@@ -19,6 +20,7 @@ use Flow\ETL\Loader;
 function from_json(
     string|Path|array $path,
     ?string $pointer = null,
+    Schema|null $schema = null,
 ) : Extractor {
     if (\is_array($path)) {
         $extractors = [];
@@ -27,6 +29,7 @@ function from_json(
             $extractors[] = new JsonExtractor(
                 \is_string($file) ? Path::realpath($file) : $file,
                 $pointer,
+                $schema
             );
         }
 
@@ -36,6 +39,7 @@ function from_json(
     return new JsonExtractor(
         \is_string($path) ? Path::realpath($path) : $path,
         $pointer,
+        $schema
     );
 }
 

--- a/src/adapter/etl-adapter-json/tests/Flow/ETL/Adapter/JSON/Tests/Integration/JSONMachine/JsonExtractorTest.php
+++ b/src/adapter/etl-adapter-json/tests/Flow/ETL/Adapter/JSON/Tests/Integration/JSONMachine/JsonExtractorTest.php
@@ -98,7 +98,7 @@ final class JsonExtractorTest extends TestCase
             <<<'SCHEMA'
 schema
 |-- timezones: list<string>
-|-- latlng: array<mixed>
+|-- latlng: list<float>
 |-- name: string
 |-- country_code: string
 |-- capital: ?string

--- a/src/core/etl/src/Flow/ETL/DSL/functions.php
+++ b/src/core/etl/src/Flow/ETL/DSL/functions.php
@@ -358,6 +358,11 @@ function struct_entry(string $name, array $value, StructureType $type) : Row\Ent
     return new Row\Entry\StructureEntry($name, $value, $type);
 }
 
+function structure_entry(string $name, array $value, StructureType $type) : Row\Entry\StructureEntry
+{
+    return new Row\Entry\StructureEntry($name, $value, $type);
+}
+
 /**
  * @param array<string, StructureElement> $elements
  */
@@ -366,7 +371,17 @@ function struct_type(array $elements, bool $nullable = false) : StructureType
     return new StructureType($elements, $nullable);
 }
 
+function structure_type(array $elements, bool $nullable = false) : StructureType
+{
+    return new StructureType($elements, $nullable);
+}
+
 function struct_element(string $name, Type $type) : StructureElement
+{
+    return new StructureElement($name, $type);
+}
+
+function structure_element(string $name, Type $type) : StructureElement
 {
     return new StructureElement($name, $type);
 }

--- a/src/core/etl/src/Flow/ETL/DSL/functions.php
+++ b/src/core/etl/src/Flow/ETL/DSL/functions.php
@@ -420,6 +420,11 @@ function type_int(bool $nullable = false) : ScalarType
     return ScalarType::integer($nullable);
 }
 
+function type_integer(bool $nullable = false) : ScalarType
+{
+    return ScalarType::integer($nullable);
+}
+
 function type_string(bool $nullable = false) : ScalarType
 {
     return ScalarType::string($nullable);

--- a/src/core/etl/src/Flow/ETL/DSL/functions.php
+++ b/src/core/etl/src/Flow/ETL/DSL/functions.php
@@ -110,6 +110,7 @@ use Flow\ETL\PHP\Type\Native\ObjectType;
 use Flow\ETL\PHP\Type\Native\ResourceType;
 use Flow\ETL\PHP\Type\Native\ScalarType;
 use Flow\ETL\PHP\Type\Type;
+use Flow\ETL\PHP\Type\TypeDetector;
 use Flow\ETL\Pipeline;
 use Flow\ETL\Row;
 use Flow\ETL\Row\EntryFactory;
@@ -666,7 +667,7 @@ function hash(ScalarFunction $function, string $algorithm = 'xxh128', bool $bina
     return new Hash($function, $algorithm, $binary, $options);
 }
 
-function cast(ScalarFunction $function, string $type) : Cast
+function cast(ScalarFunction $function, string|Type $type) : Cast
 {
     return new Cast($function, $type);
 }
@@ -1112,4 +1113,9 @@ function exception_if_exists() : SaveMode
 function append() : SaveMode
 {
     return SaveMode::Append;
+}
+
+function get_type(mixed $value) : Type
+{
+    return (new TypeDetector())->detectType($value);
 }

--- a/src/core/etl/src/Flow/ETL/DSL/functions.php
+++ b/src/core/etl/src/Flow/ETL/DSL/functions.php
@@ -868,7 +868,7 @@ function number_format(ScalarFunction $function, ?ScalarFunction $decimals = nul
  * @param array<array<mixed>>|array<mixed|string> $data
  * @param array<Partition>|\Flow\ETL\Partitions $partitions
  */
-function array_to_rows(array $data, EntryFactory $entryFactory = new NativeEntryFactory(), array|\Flow\ETL\Partitions $partitions = []) : Rows
+function array_to_rows(array $data, EntryFactory $entryFactory = new NativeEntryFactory(), array|\Flow\ETL\Partitions $partitions = [], ?Schema $schema = null) : Rows
 {
     $partitions = \is_array($partitions) ? new \Flow\ETL\Partitions(...$partitions) : $partitions;
 
@@ -888,12 +888,12 @@ function array_to_rows(array $data, EntryFactory $entryFactory = new NativeEntry
         foreach ($data as $key => $value) {
             $name = \is_int($key) ? 'e' . \str_pad((string) $key, 2, '0', STR_PAD_LEFT) : $key;
 
-            $entries[$name] = $entryFactory->create($name, $value);
+            $entries[$name] = $entryFactory->create($name, $value, $schema);
         }
 
         foreach ($partitions as $partition) {
             if (!\array_key_exists($partition->name, $entries)) {
-                $entries[$partition->name] = $entryFactory->create($partition->name, $partition->value);
+                $entries[$partition->name] = $entryFactory->create($partition->name, $partition->value, $schema);
             }
         }
 
@@ -907,12 +907,12 @@ function array_to_rows(array $data, EntryFactory $entryFactory = new NativeEntry
 
         foreach ($row as $column => $value) {
             $name = \is_int($column) ? 'e' . \str_pad((string) $column, 2, '0', STR_PAD_LEFT) : $column;
-            $entries[$name] = $entryFactory->create(\is_int($column) ? 'e' . \str_pad((string) $column, 2, '0', STR_PAD_LEFT) : $column, $value);
+            $entries[$name] = $entryFactory->create(\is_int($column) ? 'e' . \str_pad((string) $column, 2, '0', STR_PAD_LEFT) : $column, $value, $schema);
         }
 
         foreach ($partitions as $partition) {
             if (!\array_key_exists($partition->name, $entries)) {
-                $entries[$partition->name] = $entryFactory->create($partition->name, $partition->value);
+                $entries[$partition->name] = $entryFactory->create($partition->name, $partition->value, $schema);
             }
         }
 
@@ -1118,4 +1118,14 @@ function append() : SaveMode
 function get_type(mixed $value) : Type
 {
     return (new TypeDetector())->detectType($value);
+}
+
+function print_schema(Schema $schema, ?SchemaFormatter $formatter = null) : string
+{
+    return ($formatter ?? new ASCIISchemaFormatter())->format($schema);
+}
+
+function print_rows(Rows $rows, int|bool $truncate = false, ?Formatter $formatter = null) : string
+{
+    return ($formatter ?? new Formatter\AsciiTableFormatter())->format($rows, $truncate);
 }

--- a/src/core/etl/src/Flow/ETL/DataFrame.php
+++ b/src/core/etl/src/Flow/ETL/DataFrame.php
@@ -21,6 +21,8 @@ use Flow\ETL\Join\Join;
 use Flow\ETL\Loader\SchemaValidationLoader;
 use Flow\ETL\Loader\StreamLoader\Output;
 use Flow\ETL\Partition\ScalarFunctionFilter;
+use Flow\ETL\PHP\Type\AutoCaster;
+use Flow\ETL\PHP\Type\Caster;
 use Flow\ETL\Pipeline\BatchingPipeline;
 use Flow\ETL\Pipeline\CachingPipeline;
 use Flow\ETL\Pipeline\CollectingPipeline;
@@ -151,7 +153,7 @@ final class DataFrame
 
     public function autoCast() : self
     {
-        $this->pipeline->add(new AutoCastTransformer());
+        $this->pipeline->add(new AutoCastTransformer(new AutoCaster(Caster::default())));
 
         return $this;
     }

--- a/src/core/etl/src/Flow/ETL/Exception/CastingException.php
+++ b/src/core/etl/src/Flow/ETL/Exception/CastingException.php
@@ -8,8 +8,12 @@ use Flow\ETL\PHP\Type\Type;
 
 final class CastingException extends RuntimeException
 {
-    public function __construct(public readonly mixed $value, public readonly Type $type)
+    public function __construct(public readonly mixed $value, public readonly Type $type, ?\Throwable $previous = null)
     {
-        parent::__construct(\sprintf("Can't cast \"%s\" into \"%s\" type", \gettype($value), $type->toString()));
+        parent::__construct(
+            \sprintf("Can't cast \"%s\" into \"%s\" type", \gettype($value), $type->toString()),
+            0,
+            $previous
+        );
     }
 }

--- a/src/core/etl/src/Flow/ETL/Exception/CastingException.php
+++ b/src/core/etl/src/Flow/ETL/Exception/CastingException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Exception;
+
+use Flow\ETL\PHP\Type\Type;
+
+final class CastingException extends RuntimeException
+{
+    public function __construct(public readonly mixed $value, public readonly Type $type)
+    {
+        parent::__construct(\sprintf("Can't cast \"%s\" into \"%s\" type", \gettype($value), $type->toString()));
+    }
+}

--- a/src/core/etl/src/Flow/ETL/Function/ScalarFunctionChain.php
+++ b/src/core/etl/src/Flow/ETL/Function/ScalarFunctionChain.php
@@ -10,6 +10,7 @@ use Flow\ETL\Function;
 use Flow\ETL\Function\ArrayExpand\ArrayExpand;
 use Flow\ETL\Function\ArraySort\Sort;
 use Flow\ETL\Function\Between\Boundary;
+use Flow\ETL\PHP\Type\Type;
 use Flow\ETL\Row\Entry;
 
 abstract class ScalarFunctionChain implements ScalarFunction
@@ -59,7 +60,7 @@ abstract class ScalarFunctionChain implements ScalarFunction
         return new Capitalize($this);
     }
 
-    public function cast(string $type) : self
+    public function cast(string|Type $type) : self
     {
         return new Cast($this, $type);
     }

--- a/src/core/etl/src/Flow/ETL/PHP/Type/ArrayContentDetector.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/ArrayContentDetector.php
@@ -15,16 +15,16 @@ final class ArrayContentDetector
 
     private readonly ?Type $firstValueType;
 
-    private readonly int $uniqueKeysCount;
+    private readonly int $uniqueKeysTypeCount;
 
-    private readonly int $uniqueValuesCount;
+    private readonly int $uniqueValuesTypeCount;
 
     public function __construct(Types $uniqueKeysType, Types $uniqueValuesType)
     {
         $this->firstKeyType = $uniqueKeysType->first();
         $this->firstValueType = $uniqueValuesType->first();
-        $this->uniqueKeysCount = $uniqueKeysType->count();
-        $this->uniqueValuesCount = $uniqueValuesType->without(type_array(true), type_null())->count();
+        $this->uniqueKeysTypeCount = $uniqueKeysType->count();
+        $this->uniqueValuesTypeCount = $uniqueValuesType->without(type_array(true), type_null())->count();
     }
 
     public function firstKeyType() : ?ScalarType
@@ -43,12 +43,12 @@ final class ArrayContentDetector
 
     public function isList() : bool
     {
-        return 1 === $this->uniqueValuesCount && $this->firstKeyType()?->isInteger();
+        return 1 === $this->uniqueValuesTypeCount && $this->firstKeyType()?->isInteger();
     }
 
     public function isMap() : bool
     {
-        if (1 === $this->uniqueValuesCount && 1 === $this->uniqueKeysCount) {
+        if (1 === $this->uniqueValuesTypeCount && 1 === $this->uniqueKeysTypeCount) {
             return !$this->firstKeyType()?->isInteger();
         }
 
@@ -61,8 +61,8 @@ final class ArrayContentDetector
             return false;
         }
 
-        return 0 !== $this->uniqueValuesCount
-            && 1 === $this->uniqueKeysCount
+        return 0 !== $this->uniqueValuesTypeCount
+            && 1 === $this->uniqueKeysTypeCount
             && $this->firstKeyType()?->isString();
     }
 }

--- a/src/core/etl/src/Flow/ETL/PHP/Type/AutoCaster.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/AutoCaster.php
@@ -4,13 +4,14 @@ declare(strict_types=1);
 
 namespace Flow\ETL\PHP\Type;
 
+use function Flow\ETL\DSL\get_type;
 use function Flow\ETL\DSL\type_boolean;
 use function Flow\ETL\DSL\type_datetime;
 use function Flow\ETL\DSL\type_float;
 use function Flow\ETL\DSL\type_integer;
 use function Flow\ETL\DSL\type_json;
 use function Flow\ETL\DSL\type_uuid;
-use Flow\ETL\PHP\Type\Caster\StringTypeChecker;
+use Flow\ETL\PHP\Type\Caster\StringCastingHandler\StringTypeChecker;
 
 final class AutoCaster
 {
@@ -20,10 +21,44 @@ final class AutoCaster
 
     public function cast(mixed $value) : mixed
     {
-        if (!\is_string($value)) {
-            return $value;
+        if (\is_string($value)) {
+            return $this->castToString($value);
         }
 
+        if (\is_array($value)) {
+            return $this->castArray($value);
+        }
+
+        return $value;
+    }
+
+    private function castArray(array $value) : array
+    {
+        $keyTypes = [];
+        $valueTypes = [];
+
+        foreach ($value as $key => $item) {
+            $keyType = get_type($key);
+            $valueType = get_type($item);
+            $keyTypes[$keyType->toString()] = $keyType;
+            $valueTypes[$valueType->toString()] = $valueType;
+        }
+
+        if (isset($valueTypes['integer'], $valueTypes['float']) && \count($valueTypes) === 2) {
+            $castedArray = [];
+
+            foreach ($value as $key => $item) {
+                $castedArray[$key] = $this->caster->to(type_float())->value($item);
+            }
+
+            return $castedArray;
+        }
+
+        return $value;
+    }
+
+    private function castToString(string $value) : mixed
+    {
         $typeChecker = new StringTypeChecker($value);
 
         if ($typeChecker->isNull()) {

--- a/src/core/etl/src/Flow/ETL/PHP/Type/AutoCaster.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/AutoCaster.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\PHP\Type;
+
+use function Flow\ETL\DSL\type_boolean;
+use function Flow\ETL\DSL\type_datetime;
+use function Flow\ETL\DSL\type_float;
+use function Flow\ETL\DSL\type_integer;
+use function Flow\ETL\DSL\type_json;
+use function Flow\ETL\DSL\type_uuid;
+use Flow\ETL\PHP\Type\Caster\StringTypeChecker;
+
+final class AutoCaster
+{
+    public function __construct(private readonly Caster $caster)
+    {
+    }
+
+    public function cast(mixed $value) : mixed
+    {
+        if (!\is_string($value)) {
+            return $value;
+        }
+
+        $typeChecker = new StringTypeChecker($value);
+
+        if ($typeChecker->isNull()) {
+            return null;
+        }
+
+        if ($typeChecker->isInteger()) {
+            return $this->caster->to(type_integer())->value($value);
+        }
+
+        if ($typeChecker->isFloat()) {
+            return $this->caster->to(type_float())->value($value);
+        }
+
+        if ($typeChecker->isBoolean()) {
+            return $this->caster->to(type_boolean())->value($value);
+        }
+
+        if ($typeChecker->isJson()) {
+            return $this->caster->to(type_json())->value($value);
+        }
+
+        if ($typeChecker->isUuid()) {
+            return $this->caster->to(type_uuid())->value($value);
+        }
+
+        if ($typeChecker->isDateTime()) {
+            return $this->caster->to(type_datetime())->value($value);
+        }
+
+        return $value;
+    }
+}

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Caster.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Caster.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\PHP\Type;
+
+use Flow\ETL\Exception\RuntimeException;
+use Flow\ETL\PHP\Type\Caster\ArrayCastingHandler;
+use Flow\ETL\PHP\Type\Caster\BooleanCastingHandler;
+use Flow\ETL\PHP\Type\Caster\CastingContext;
+use Flow\ETL\PHP\Type\Caster\CastingHandler;
+use Flow\ETL\PHP\Type\Caster\DateTimeCastingHandler;
+use Flow\ETL\PHP\Type\Caster\EnumCastingHandler;
+use Flow\ETL\PHP\Type\Caster\FloatCastingHandler;
+use Flow\ETL\PHP\Type\Caster\IntegerCastingHandler;
+use Flow\ETL\PHP\Type\Caster\JsonCastingHandler;
+use Flow\ETL\PHP\Type\Caster\ListCastingHandler;
+use Flow\ETL\PHP\Type\Caster\MapCastingHandler;
+use Flow\ETL\PHP\Type\Caster\NullCastingHandler;
+use Flow\ETL\PHP\Type\Caster\ObjectCastingHandler;
+use Flow\ETL\PHP\Type\Caster\StringCastingHandler;
+use Flow\ETL\PHP\Type\Caster\StructureCastingHandler;
+use Flow\ETL\PHP\Type\Caster\UuidCastingHandler;
+use Flow\ETL\PHP\Type\Caster\XMLCastingHandler;
+
+final class Caster
+{
+    /**
+     * @param array<CastingHandler> $handlers
+     */
+    public function __construct(private readonly array $handlers)
+    {
+    }
+
+    public static function default() : self
+    {
+        return new self([
+            new StringCastingHandler(),
+            new IntegerCastingHandler(),
+            new BooleanCastingHandler(),
+            new FloatCastingHandler(),
+            new XMLCastingHandler(),
+            new UuidCastingHandler(),
+            new ObjectCastingHandler(),
+            new DateTimeCastingHandler(),
+            new JsonCastingHandler(),
+            new ArrayCastingHandler(),
+            new ListCastingHandler(),
+            new MapCastingHandler(),
+            new StructureCastingHandler(),
+            new NullCastingHandler(),
+            new EnumCastingHandler(),
+        ]);
+    }
+
+    public function to(Type $type) : CastingContext
+    {
+        foreach ($this->handlers as $handler) {
+            if ($handler->supports($type)) {
+                return new CastingContext($handler, $type);
+            }
+        }
+
+        throw new RuntimeException("There is no casting handler for \"{$type->toString()}\" type");
+    }
+}

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Caster.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Caster.php
@@ -4,6 +4,16 @@ declare(strict_types=1);
 
 namespace Flow\ETL\PHP\Type;
 
+use function Flow\ETL\DSL\type_array;
+use function Flow\ETL\DSL\type_boolean;
+use function Flow\ETL\DSL\type_datetime;
+use function Flow\ETL\DSL\type_float;
+use function Flow\ETL\DSL\type_integer;
+use function Flow\ETL\DSL\type_json;
+use function Flow\ETL\DSL\type_null;
+use function Flow\ETL\DSL\type_string;
+use function Flow\ETL\DSL\type_uuid;
+use function Flow\ETL\DSL\type_xml;
 use Flow\ETL\Exception\RuntimeException;
 use Flow\ETL\PHP\Type\Caster\ArrayCastingHandler;
 use Flow\ETL\PHP\Type\Caster\BooleanCastingHandler;
@@ -35,26 +45,30 @@ final class Caster
     public static function default() : self
     {
         return new self([
-            new StringCastingHandler(),
-            new IntegerCastingHandler(),
-            new BooleanCastingHandler(),
-            new FloatCastingHandler(),
-            new XMLCastingHandler(),
-            new UuidCastingHandler(),
-            new ObjectCastingHandler(),
-            new DateTimeCastingHandler(),
-            new JsonCastingHandler(),
-            new ArrayCastingHandler(),
-            new ListCastingHandler(),
-            new MapCastingHandler(),
-            new StructureCastingHandler(),
-            new NullCastingHandler(),
-            new EnumCastingHandler(),
+            type_string()->toString() => new StringCastingHandler(),
+            type_integer()->toString() => new IntegerCastingHandler(),
+            type_boolean()->toString() => new BooleanCastingHandler(),
+            type_float()->toString() => new FloatCastingHandler(),
+            type_xml()->toString() => new XMLCastingHandler(),
+            type_uuid()->toString() => new UuidCastingHandler(),
+            'object' => new ObjectCastingHandler(),
+            type_datetime()->toString() => new DateTimeCastingHandler(),
+            type_json()->toString() => new JsonCastingHandler(),
+            type_array()->toString() => new ArrayCastingHandler(),
+            'list' => new ListCastingHandler(),
+            'map', new MapCastingHandler(),
+            'structure', new StructureCastingHandler(),
+            type_null()->toString() => new NullCastingHandler(),
+            'enum' => new EnumCastingHandler(),
         ]);
     }
 
     public function to(Type $type) : CastingContext
     {
+        if (\array_key_exists($type->toString(), $this->handlers)) {
+            return new CastingContext($this->handlers[$type->toString()], $type);
+        }
+
         foreach ($this->handlers as $handler) {
             if ($handler->supports($type)) {
                 return new CastingContext($handler, $type);

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Caster.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Caster.php
@@ -56,8 +56,8 @@ final class Caster
             type_json()->toString() => new JsonCastingHandler(),
             type_array()->toString() => new ArrayCastingHandler(),
             'list' => new ListCastingHandler(),
-            'map', new MapCastingHandler(),
-            'structure', new StructureCastingHandler(),
+            'map' => new MapCastingHandler(),
+            'structure' => new StructureCastingHandler(),
             type_null()->toString() => new NullCastingHandler(),
             'enum' => new EnumCastingHandler(),
         ]);
@@ -66,12 +66,12 @@ final class Caster
     public function to(Type $type) : CastingContext
     {
         if (\array_key_exists($type->toString(), $this->handlers)) {
-            return new CastingContext($this->handlers[$type->toString()], $type);
+            return new CastingContext($this->handlers[$type->toString()], $type, $this);
         }
 
         foreach ($this->handlers as $handler) {
             if ($handler->supports($type)) {
-                return new CastingContext($handler, $type);
+                return new CastingContext($handler, $type, $this);
             }
         }
 

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Caster/ArrayCastingHandler.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Caster/ArrayCastingHandler.php
@@ -20,12 +20,12 @@ final class ArrayCastingHandler implements CastingHandler
     public function value(mixed $value, Type $type, Caster $caster) : mixed
     {
         try {
-            if (\is_string($value) && (\str_starts_with($value, '{') || \str_starts_with($value, '['))) {
-                return \json_decode($value, true, 512, \JSON_THROW_ON_ERROR);
-            }
-
             if (\is_array($value)) {
                 return $value;
+            }
+
+            if (\is_string($value) && (\str_starts_with($value, '{') || \str_starts_with($value, '['))) {
+                return \json_decode($value, true, 512, \JSON_THROW_ON_ERROR);
             }
 
             if ($value instanceof \DOMDocument) {

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Caster/ArrayCastingHandler.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Caster/ArrayCastingHandler.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Flow\ETL\PHP\Type\Caster;
 
 use Flow\ETL\Exception\CastingException;
+use Flow\ETL\PHP\Type\Caster\XML\XMLConverter;
 use Flow\ETL\PHP\Type\Native\ArrayType;
 use Flow\ETL\PHP\Type\Type;
 
@@ -18,12 +19,16 @@ final class ArrayCastingHandler implements CastingHandler
     public function value(mixed $value, Type $type) : mixed
     {
         try {
-            if (\is_string($value)) {
+            if (\is_string($value) && (\str_starts_with($value, '{') || \str_starts_with($value, '['))) {
                 return \json_decode($value, true, 512, \JSON_THROW_ON_ERROR);
             }
 
             if (\is_array($value)) {
                 return $value;
+            }
+
+            if ($value instanceof \DOMDocument) {
+                return (new XMLConverter())->toArray($value);
             }
 
             if (\is_object($value)) {

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Caster/ArrayCastingHandler.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Caster/ArrayCastingHandler.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Flow\ETL\PHP\Type\Caster;
 
 use Flow\ETL\Exception\CastingException;
+use Flow\ETL\PHP\Type\Caster;
 use Flow\ETL\PHP\Type\Caster\XML\XMLConverter;
 use Flow\ETL\PHP\Type\Native\ArrayType;
 use Flow\ETL\PHP\Type\Type;
@@ -16,7 +17,7 @@ final class ArrayCastingHandler implements CastingHandler
         return $type instanceof ArrayType;
     }
 
-    public function value(mixed $value, Type $type) : mixed
+    public function value(mixed $value, Type $type, Caster $caster) : mixed
     {
         try {
             if (\is_string($value) && (\str_starts_with($value, '{') || \str_starts_with($value, '['))) {

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Caster/ArrayCastingHandler.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Caster/ArrayCastingHandler.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\PHP\Type\Caster;
+
+use Flow\ETL\Exception\CastingException;
+use Flow\ETL\PHP\Type\Native\ArrayType;
+use Flow\ETL\PHP\Type\Type;
+
+final class ArrayCastingHandler implements CastingHandler
+{
+    public function supports(Type $type) : bool
+    {
+        return $type instanceof ArrayType;
+    }
+
+    public function value(mixed $value, Type $type) : mixed
+    {
+        try {
+            if (\is_string($value)) {
+                return \json_decode($value, true, 512, \JSON_THROW_ON_ERROR);
+            }
+
+            if (\is_array($value)) {
+                return $value;
+            }
+
+            if (\is_object($value)) {
+                return \json_decode(\json_encode($value, JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR);
+            }
+
+            return (array) $value;
+        } catch (\Throwable $e) {
+            throw new CastingException($value, $type);
+        }
+    }
+}

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Caster/BooleanCastingHandler.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Caster/BooleanCastingHandler.php
@@ -18,6 +18,10 @@ final class BooleanCastingHandler implements CastingHandler
 
     public function value(mixed $value, Type $type, Caster $caster) : mixed
     {
+        if (\is_bool($value)) {
+            return $value;
+        }
+
         if (\is_string($value)) {
             if (\in_array(\mb_strtolower($value), ['true', '1', 'yes', 'on'], true)) {
                 return true;

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Caster/BooleanCastingHandler.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Caster/BooleanCastingHandler.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Flow\ETL\PHP\Type\Caster;
 
 use Flow\ETL\Exception\CastingException;
+use Flow\ETL\PHP\Type\Caster;
 use Flow\ETL\PHP\Type\Native\ScalarType;
 use Flow\ETL\PHP\Type\Type;
 
@@ -15,7 +16,7 @@ final class BooleanCastingHandler implements CastingHandler
         return $type instanceof ScalarType && $type->isBoolean();
     }
 
-    public function value(mixed $value, Type $type) : mixed
+    public function value(mixed $value, Type $type, Caster $caster) : mixed
     {
         if (\is_string($value)) {
             if (\in_array(\mb_strtolower($value), ['true', '1', 'yes', 'on'], true)) {

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Caster/BooleanCastingHandler.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Caster/BooleanCastingHandler.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\PHP\Type\Caster;
+
+use Flow\ETL\Exception\CastingException;
+use Flow\ETL\PHP\Type\Native\ScalarType;
+use Flow\ETL\PHP\Type\Type;
+
+final class BooleanCastingHandler implements CastingHandler
+{
+    public function supports(Type $type) : bool
+    {
+        return $type instanceof ScalarType && $type->isBoolean();
+    }
+
+    public function value(mixed $value, Type $type) : mixed
+    {
+        if (\is_string($value)) {
+            if (\in_array(\mb_strtolower($value), ['true', '1', 'yes', 'on'], true)) {
+                return true;
+            }
+
+            if (\in_array(\mb_strtolower($value), ['false', '0', 'no', 'off'], true)) {
+                return false;
+            }
+        }
+
+        try {
+            return (bool) $value;
+            /* @phpstan-ignore-next-line */
+        } catch (\Throwable $e) {
+            throw new CastingException($value, $type);
+        }
+    }
+}

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Caster/CastingContext.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Caster/CastingContext.php
@@ -4,16 +4,29 @@ declare(strict_types=1);
 
 namespace Flow\ETL\PHP\Type\Caster;
 
+use Flow\ETL\Exception\CastingException;
+use Flow\ETL\PHP\Type\Caster;
 use Flow\ETL\PHP\Type\Type;
 
 final class CastingContext
 {
-    public function __construct(private readonly CastingHandler $handler, private readonly Type $type)
-    {
+    public function __construct(
+        private readonly CastingHandler $handler,
+        private readonly Type $type,
+        private readonly Caster $caster
+    ) {
     }
 
     public function value(mixed $value) : mixed
     {
-        return $this->handler->value($value, $this->type);
+        if ($value === null && $this->type->nullable()) {
+            return null;
+        }
+
+        if ($value === null && !$this->type->nullable()) {
+            throw new CastingException($value, $this->type);
+        }
+
+        return $this->handler->value($value, $this->type, $this->caster);
     }
 }

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Caster/CastingContext.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Caster/CastingContext.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\PHP\Type\Caster;
+
+use Flow\ETL\PHP\Type\Type;
+
+final class CastingContext
+{
+    public function __construct(private readonly CastingHandler $handler, private readonly Type $type)
+    {
+
+    }
+
+    public function value(mixed $value) : mixed
+    {
+        return $this->handler->value($value, $this->type);
+    }
+}

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Caster/CastingContext.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Caster/CastingContext.php
@@ -10,7 +10,6 @@ final class CastingContext
 {
     public function __construct(private readonly CastingHandler $handler, private readonly Type $type)
     {
-
     }
 
     public function value(mixed $value) : mixed

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Caster/CastingHandler.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Caster/CastingHandler.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\PHP\Type\Caster;
+
+use Flow\ETL\PHP\Type\Type;
+
+interface CastingHandler
+{
+    public function supports(Type $type) : bool;
+
+    public function value(mixed $value, Type $type) : mixed;
+}

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Caster/CastingHandler.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Caster/CastingHandler.php
@@ -4,11 +4,12 @@ declare(strict_types=1);
 
 namespace Flow\ETL\PHP\Type\Caster;
 
+use Flow\ETL\PHP\Type\Caster;
 use Flow\ETL\PHP\Type\Type;
 
 interface CastingHandler
 {
     public function supports(Type $type) : bool;
 
-    public function value(mixed $value, Type $type) : mixed;
+    public function value(mixed $value, Type $type, Caster $caster) : mixed;
 }

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Caster/DateTimeCastingHandler.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Caster/DateTimeCastingHandler.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\PHP\Type\Caster;
+
+use function Flow\ETL\DSL\type_datetime;
+use Flow\ETL\Exception\CastingException;
+use Flow\ETL\PHP\Type\Logical\DateTimeType;
+use Flow\ETL\PHP\Type\Type;
+
+final class DateTimeCastingHandler implements CastingHandler
+{
+    public function supports(Type $type) : bool
+    {
+        return $type instanceof DateTimeType;
+    }
+
+    public function value(mixed $value, Type $type) : mixed
+    {
+        if ($value instanceof \DateTimeImmutable) {
+            return $value;
+        }
+
+        if ($value instanceof \DateTime) {
+            return \DateTimeImmutable::createFromMutable($value);
+        }
+
+        try {
+            if (\is_string($value)) {
+                return new \DateTimeImmutable($value);
+            }
+
+            if (\is_numeric($value)) {
+                return new \DateTimeImmutable('@' . $value);
+            }
+
+            if (\is_bool($value)) {
+                /* @phpstan-ignore-next-line */
+                return new \DateTimeImmutable('@' . $value);
+            }
+
+            if ($value instanceof \DateInterval) {
+                return (new \DateTimeImmutable('@0'))->add($value);
+
+            }
+        } catch (\Throwable $e) {
+            throw new CastingException($value, type_datetime());
+        }
+
+        throw new CastingException($value, $type);
+    }
+}

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Caster/DateTimeCastingHandler.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Caster/DateTimeCastingHandler.php
@@ -6,6 +6,7 @@ namespace Flow\ETL\PHP\Type\Caster;
 
 use function Flow\ETL\DSL\type_datetime;
 use Flow\ETL\Exception\CastingException;
+use Flow\ETL\PHP\Type\Caster;
 use Flow\ETL\PHP\Type\Logical\DateTimeType;
 use Flow\ETL\PHP\Type\Type;
 
@@ -16,7 +17,7 @@ final class DateTimeCastingHandler implements CastingHandler
         return $type instanceof DateTimeType;
     }
 
-    public function value(mixed $value, Type $type) : mixed
+    public function value(mixed $value, Type $type, Caster $caster) : mixed
     {
         if ($value instanceof \DateTimeImmutable) {
             return $value;

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Caster/EnumCastingHandler.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Caster/EnumCastingHandler.php
@@ -18,6 +18,11 @@ final class EnumCastingHandler implements CastingHandler
 
     public function value(mixed $value, Type $type, Caster $caster) : mixed
     {
+        /** @var EnumType $type */
+        if ($value instanceof $type->class) {
+            return $value;
+        }
+
         try {
             /** @var EnumType $type */
             $enumClass = $type->class;

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Caster/EnumCastingHandler.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Caster/EnumCastingHandler.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Flow\ETL\PHP\Type\Caster;
 
 use Flow\ETL\Exception\CastingException;
+use Flow\ETL\PHP\Type\Caster;
 use Flow\ETL\PHP\Type\Native\EnumType;
 use Flow\ETL\PHP\Type\Type;
 
@@ -15,7 +16,7 @@ final class EnumCastingHandler implements CastingHandler
         return $type instanceof EnumType;
     }
 
-    public function value(mixed $value, Type $type) : mixed
+    public function value(mixed $value, Type $type, Caster $caster) : mixed
     {
         try {
             /** @var EnumType $type */

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Caster/EnumCastingHandler.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Caster/EnumCastingHandler.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\PHP\Type\Caster;
+
+use Flow\ETL\Exception\CastingException;
+use Flow\ETL\PHP\Type\Native\EnumType;
+use Flow\ETL\PHP\Type\Type;
+
+final class EnumCastingHandler implements CastingHandler
+{
+    public function supports(Type $type) : bool
+    {
+        return $type instanceof EnumType;
+    }
+
+    public function value(mixed $value, Type $type) : mixed
+    {
+        try {
+            /** @var EnumType $type */
+            $enumClass = $type->class;
+
+            if (\is_a($enumClass, \BackedEnum::class, true)) {
+                return $enumClass::from($value);
+            }
+
+            throw new CastingException($value, $type);
+        } catch (\Throwable $e) {
+            throw new CastingException($value, $type);
+        }
+    }
+}

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Caster/FloatCastingHandler.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Caster/FloatCastingHandler.php
@@ -18,6 +18,10 @@ final class FloatCastingHandler implements CastingHandler
 
     public function value(mixed $value, Type $type, Caster $caster) : mixed
     {
+        if (\is_float($value)) {
+            return $value;
+        }
+
         if ($value instanceof \DateTimeImmutable) {
             return (float) $value->format('Uu');
         }

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Caster/FloatCastingHandler.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Caster/FloatCastingHandler.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\PHP\Type\Caster;
+
+use Flow\ETL\Exception\CastingException;
+use Flow\ETL\PHP\Type\Native\ScalarType;
+use Flow\ETL\PHP\Type\Type;
+
+final class FloatCastingHandler implements CastingHandler
+{
+    public function supports(Type $type) : bool
+    {
+        return $type instanceof ScalarType && $type->isFloat();
+    }
+
+    public function value(mixed $value, Type $type) : mixed
+    {
+        if ($value instanceof \DateTimeImmutable) {
+            return (float) $value->format('Uu');
+        }
+
+        if ($value instanceof \DateInterval) {
+            $reference = new \DateTimeImmutable();
+            $endTime = $reference->add($value);
+
+            return (float) ($endTime->format('Uu')) - (float) ($reference->format('Uu'));
+        }
+
+        try {
+            return (float) $value;
+            /* @phpstan-ignore-next-line */
+        } catch (\Throwable $e) {
+            throw new CastingException($value, $type);
+        }
+    }
+}

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Caster/FloatCastingHandler.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Caster/FloatCastingHandler.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Flow\ETL\PHP\Type\Caster;
 
 use Flow\ETL\Exception\CastingException;
+use Flow\ETL\PHP\Type\Caster;
 use Flow\ETL\PHP\Type\Native\ScalarType;
 use Flow\ETL\PHP\Type\Type;
 
@@ -15,7 +16,7 @@ final class FloatCastingHandler implements CastingHandler
         return $type instanceof ScalarType && $type->isFloat();
     }
 
-    public function value(mixed $value, Type $type) : mixed
+    public function value(mixed $value, Type $type, Caster $caster) : mixed
     {
         if ($value instanceof \DateTimeImmutable) {
             return (float) $value->format('Uu');

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Caster/IntegerCastingHandler.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Caster/IntegerCastingHandler.php
@@ -18,6 +18,10 @@ final class IntegerCastingHandler implements CastingHandler
 
     public function value(mixed $value, Type $type, Caster $caster) : mixed
     {
+        if (\is_int($value)) {
+            return $value;
+        }
+
         if ($value instanceof \DateTimeImmutable) {
             return (int) $value->format('Uu');
         }

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Caster/IntegerCastingHandler.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Caster/IntegerCastingHandler.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Flow\ETL\PHP\Type\Caster;
 
 use Flow\ETL\Exception\CastingException;
+use Flow\ETL\PHP\Type\Caster;
 use Flow\ETL\PHP\Type\Native\ScalarType;
 use Flow\ETL\PHP\Type\Type;
 
@@ -15,7 +16,7 @@ final class IntegerCastingHandler implements CastingHandler
         return $type instanceof ScalarType && $type->isInteger();
     }
 
-    public function value(mixed $value, Type $type) : mixed
+    public function value(mixed $value, Type $type, Caster $caster) : mixed
     {
         if ($value instanceof \DateTimeImmutable) {
             return (int) $value->format('Uu');

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Caster/IntegerCastingHandler.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Caster/IntegerCastingHandler.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\PHP\Type\Caster;
+
+use Flow\ETL\Exception\CastingException;
+use Flow\ETL\PHP\Type\Native\ScalarType;
+use Flow\ETL\PHP\Type\Type;
+
+final class IntegerCastingHandler implements CastingHandler
+{
+    public function supports(Type $type) : bool
+    {
+        return $type instanceof ScalarType && $type->isInteger();
+    }
+
+    public function value(mixed $value, Type $type) : mixed
+    {
+        if ($value instanceof \DateTimeImmutable) {
+            return (int) $value->format('Uu');
+        }
+
+        if ($value instanceof \DateInterval) {
+            $reference = new \DateTimeImmutable();
+            $endTime = $reference->add($value);
+
+            return (int) ($endTime->format('Uu')) - (int) ($reference->format('Uu'));
+        }
+
+        try {
+            return (int) $value;
+            /* @phpstan-ignore-next-line */
+        } catch (\Throwable $e) {
+            throw new CastingException($value, $type);
+        }
+    }
+}

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Caster/JsonCastingHandler.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Caster/JsonCastingHandler.php
@@ -6,6 +6,7 @@ namespace Flow\ETL\PHP\Type\Caster;
 
 use function Flow\ETL\DSL\type_json;
 use Flow\ETL\Exception\CastingException;
+use Flow\ETL\PHP\Type\Caster;
 use Flow\ETL\PHP\Type\Logical\JsonType;
 use Flow\ETL\PHP\Type\Type;
 
@@ -16,7 +17,7 @@ final class JsonCastingHandler implements CastingHandler
         return $type instanceof JsonType;
     }
 
-    public function value(mixed $value, Type $type) : mixed
+    public function value(mixed $value, Type $type, Caster $caster) : mixed
     {
         try {
             if (\is_string($value)) {

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Caster/JsonCastingHandler.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Caster/JsonCastingHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\PHP\Type\Caster;
+
+use function Flow\ETL\DSL\type_json;
+use Flow\ETL\Exception\CastingException;
+use Flow\ETL\PHP\Type\Logical\JsonType;
+use Flow\ETL\PHP\Type\Type;
+
+final class JsonCastingHandler implements CastingHandler
+{
+    public function supports(Type $type) : bool
+    {
+        return $type instanceof JsonType;
+    }
+
+    public function value(mixed $value, Type $type) : mixed
+    {
+        try {
+            if (\is_string($value)) {
+                return \json_encode(\json_decode($value, true, 512, \JSON_THROW_ON_ERROR), JSON_THROW_ON_ERROR);
+            }
+
+            if (\is_scalar($value)) {
+                throw new CastingException($value, type_json());
+            }
+
+            return \json_encode($value, JSON_THROW_ON_ERROR);
+        } catch (\Throwable $e) {
+            throw new CastingException($value, $type);
+        }
+    }
+}

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Caster/ListCastingHandler.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Caster/ListCastingHandler.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Flow\ETL\PHP\Type\Caster;
 
 use Flow\ETL\Exception\CastingException;
+use Flow\ETL\PHP\Type\Caster;
 use Flow\ETL\PHP\Type\Logical\ListType;
 use Flow\ETL\PHP\Type\Type;
 
@@ -15,18 +16,25 @@ final class ListCastingHandler implements CastingHandler
         return $type instanceof ListType;
     }
 
-    public function value(mixed $value, Type $type) : mixed
+    public function value(mixed $value, Type $type, Caster $caster) : mixed
     {
-        if (\is_array($value)) {
-            return $value;
-        }
-
+        /** @var ListType $type */
         try {
-            if (\is_string($value)) {
+            if (\is_string($value) && (\str_starts_with($value, '{') || \str_starts_with($value, '['))) {
                 return \json_decode($value, true, 512, \JSON_THROW_ON_ERROR);
             }
 
-            return (array) $value;
+            if (!\is_array($value)) {
+                return [$caster->to($type->element()->type())->value($value)];
+            }
+
+            $castedList = [];
+
+            foreach ($value as $key => $item) {
+                $castedList[$key] = $caster->to($type->element()->type())->value($item);
+            }
+
+            return $castedList;
         } catch (\Throwable $e) {
             throw new CastingException($value, $type);
         }

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Caster/ListCastingHandler.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Caster/ListCastingHandler.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\PHP\Type\Caster;
+
+use Flow\ETL\Exception\CastingException;
+use Flow\ETL\PHP\Type\Logical\ListType;
+use Flow\ETL\PHP\Type\Type;
+
+final class ListCastingHandler implements CastingHandler
+{
+    public function supports(Type $type) : bool
+    {
+        return $type instanceof ListType;
+    }
+
+    public function value(mixed $value, Type $type) : mixed
+    {
+        if (\is_array($value)) {
+            return $value;
+        }
+
+        try {
+            if (\is_string($value)) {
+                return \json_decode($value, true, 512, \JSON_THROW_ON_ERROR);
+            }
+
+            return (array) $value;
+        } catch (\Throwable $e) {
+            throw new CastingException($value, $type);
+        }
+    }
+}

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Caster/MapCastingHandler.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Caster/MapCastingHandler.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Flow\ETL\PHP\Type\Caster;
 
 use Flow\ETL\Exception\CastingException;
+use Flow\ETL\PHP\Type\Caster;
 use Flow\ETL\PHP\Type\Logical\MapType;
 use Flow\ETL\PHP\Type\Type;
 
@@ -15,20 +16,35 @@ final class MapCastingHandler implements CastingHandler
         return $type instanceof MapType;
     }
 
-    public function value(mixed $value, Type $type) : mixed
+    public function value(mixed $value, Type $type, Caster $caster) : mixed
     {
-        if (\is_array($value)) {
-            return $value;
-        }
-
+        /** @var MapType $type */
         try {
-            if (\is_string($value)) {
+            if (\is_string($value) && (\str_starts_with($value, '{') || \str_starts_with($value, '['))) {
                 return \json_decode($value, true, 512, \JSON_THROW_ON_ERROR);
             }
 
-            return (array) $value;
+            if (!\is_array($value)) {
+                return [
+                    $caster->to($type->key()->type())->value(0) => $caster->to($type->value()->type())->value($value),
+                ];
+            }
+
+            $castedMap = [];
+
+            foreach ($value as $key => $item) {
+                $castedKey = $caster->to($type->key()->type())->value($key);
+
+                if (\array_key_exists($castedKey, $castedMap)) {
+                    throw new CastingException($value, $type);
+                }
+
+                $castedMap[$caster->to($type->key()->type())->value($key)] = $caster->to($type->value()->type())->value($item);
+            }
+
+            return $castedMap;
         } catch (\Throwable $e) {
-            throw new CastingException($value, $type);
+            throw new CastingException($value, $type, $e);
         }
     }
 }

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Caster/MapCastingHandler.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Caster/MapCastingHandler.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\PHP\Type\Caster;
+
+use Flow\ETL\Exception\CastingException;
+use Flow\ETL\PHP\Type\Logical\MapType;
+use Flow\ETL\PHP\Type\Type;
+
+final class MapCastingHandler implements CastingHandler
+{
+    public function supports(Type $type) : bool
+    {
+        return $type instanceof MapType;
+    }
+
+    public function value(mixed $value, Type $type) : mixed
+    {
+        if (\is_array($value)) {
+            return $value;
+        }
+
+        try {
+            if (\is_string($value)) {
+                return \json_decode($value, true, 512, \JSON_THROW_ON_ERROR);
+            }
+
+            return (array) $value;
+        } catch (\Throwable $e) {
+            throw new CastingException($value, $type);
+        }
+    }
+}

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Caster/NullCastingHandler.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Caster/NullCastingHandler.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\PHP\Type\Caster;
+
+use Flow\ETL\PHP\Type\Native\NullType;
+use Flow\ETL\PHP\Type\Type;
+
+final class NullCastingHandler implements CastingHandler
+{
+    public function supports(Type $type) : bool
+    {
+        return $type instanceof NullType;
+    }
+
+    public function value(mixed $value, Type $type) : mixed
+    {
+        return null;
+    }
+}

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Caster/NullCastingHandler.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Caster/NullCastingHandler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Flow\ETL\PHP\Type\Caster;
 
+use Flow\ETL\PHP\Type\Caster;
 use Flow\ETL\PHP\Type\Native\NullType;
 use Flow\ETL\PHP\Type\Type;
 
@@ -14,7 +15,7 @@ final class NullCastingHandler implements CastingHandler
         return $type instanceof NullType;
     }
 
-    public function value(mixed $value, Type $type) : mixed
+    public function value(mixed $value, Type $type, Caster $caster) : mixed
     {
         return null;
     }

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Caster/ObjectCastingHandler.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Caster/ObjectCastingHandler.php
@@ -19,6 +19,10 @@ final class ObjectCastingHandler implements CastingHandler
 
     public function value(mixed $value, Type $type, Caster $caster) : mixed
     {
+        if (\is_object($value)) {
+            return $value;
+        }
+
         /** @var ObjectType $type */
         try {
             $object = (object) $value;

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Caster/ObjectCastingHandler.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Caster/ObjectCastingHandler.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\PHP\Type\Caster;
+
+use function Flow\ETL\DSL\type_object;
+use Flow\ETL\Exception\CastingException;
+use Flow\ETL\PHP\Type\Native\ObjectType;
+use Flow\ETL\PHP\Type\Type;
+
+final class ObjectCastingHandler implements CastingHandler
+{
+    public function supports(Type $type) : bool
+    {
+        return $type instanceof ObjectType;
+    }
+
+    public function value(mixed $value, Type $type) : mixed
+    {
+        /** @var ObjectType $type */
+        try {
+            $object = (object) $value;
+
+            if (!$object instanceof $type->class) {
+                throw new CastingException($value, type_object($type->class));
+            }
+
+            return $object;
+        } catch (\Throwable $e) {
+            throw new CastingException($value, $type);
+        }
+    }
+}

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Caster/ObjectCastingHandler.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Caster/ObjectCastingHandler.php
@@ -6,6 +6,7 @@ namespace Flow\ETL\PHP\Type\Caster;
 
 use function Flow\ETL\DSL\type_object;
 use Flow\ETL\Exception\CastingException;
+use Flow\ETL\PHP\Type\Caster;
 use Flow\ETL\PHP\Type\Native\ObjectType;
 use Flow\ETL\PHP\Type\Type;
 
@@ -16,7 +17,7 @@ final class ObjectCastingHandler implements CastingHandler
         return $type instanceof ObjectType;
     }
 
-    public function value(mixed $value, Type $type) : mixed
+    public function value(mixed $value, Type $type, Caster $caster) : mixed
     {
         /** @var ObjectType $type */
         try {

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Caster/StringCastingHandler.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Caster/StringCastingHandler.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\PHP\Type\Caster;
+
+use Flow\ETL\Exception\CastingException;
+use Flow\ETL\PHP\Type\Native\ScalarType;
+use Flow\ETL\PHP\Type\Type;
+
+final class StringCastingHandler implements CastingHandler
+{
+    public function supports(Type $type) : bool
+    {
+        return $type instanceof ScalarType && $type->isString();
+    }
+
+    public function value(mixed $value, Type $type) : mixed
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if (\is_string($value)) {
+            return $value;
+        }
+
+        if (\is_bool($value)) {
+            return $value ? 'true' : 'false';
+        }
+
+        if (\is_array($value)) {
+            return \json_encode($value, JSON_THROW_ON_ERROR);
+        }
+
+        if ($value instanceof \DateTimeInterface) {
+            return $value->format(\DateTimeInterface::RFC3339);
+        }
+
+        if ($value instanceof \Stringable) {
+            return (string) $value;
+        }
+
+        if ($value instanceof \DOMDocument) {
+            return $value->saveXML() ?: null;
+        }
+
+        try {
+            return (string) $value;
+            /* @phpstan-ignore-next-line */
+        } catch (\Throwable $e) {
+            throw new CastingException($value, $type);
+        }
+    }
+}

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Caster/StringCastingHandler.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Caster/StringCastingHandler.php
@@ -18,10 +18,6 @@ final class StringCastingHandler implements CastingHandler
 
     public function value(mixed $value, Type $type, Caster $caster) : mixed
     {
-        if ($value === null) {
-            return null;
-        }
-
         if (\is_string($value)) {
             return $value;
         }

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Caster/StringCastingHandler.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Caster/StringCastingHandler.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Flow\ETL\PHP\Type\Caster;
 
 use Flow\ETL\Exception\CastingException;
+use Flow\ETL\PHP\Type\Caster;
 use Flow\ETL\PHP\Type\Native\ScalarType;
 use Flow\ETL\PHP\Type\Type;
 
@@ -15,7 +16,7 @@ final class StringCastingHandler implements CastingHandler
         return $type instanceof ScalarType && $type->isString();
     }
 
-    public function value(mixed $value, Type $type) : mixed
+    public function value(mixed $value, Type $type, Caster $caster) : mixed
     {
         if ($value === null) {
             return null;

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Caster/StringCastingHandler/StringTypeChecker.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Caster/StringCastingHandler/StringTypeChecker.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Flow\ETL\PHP\Type\Caster;
+namespace Flow\ETL\PHP\Type\Caster\StringCastingHandler;
 
 use Flow\ETL\Row\Entry\Type\Uuid;
 

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Caster/StringTypeChecker.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Caster/StringTypeChecker.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Flow\ETL\Row\Factory;
+namespace Flow\ETL\PHP\Type\Caster;
 
 use Flow\ETL\Row\Entry\Type\Uuid;
 
@@ -21,7 +21,7 @@ final class StringTypeChecker
             return false;
         }
 
-        return \in_array(\strtolower($this->string), ['true', 'false'], true);
+        return \in_array(\strtolower($this->string), ['true', 'false', 'yes', 'no', 'on', 'off'], true);
     }
 
     public function isDateTime() : bool

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Caster/StructureCastingHandler.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Caster/StructureCastingHandler.php
@@ -18,10 +18,6 @@ final class StructureCastingHandler implements CastingHandler
 
     public function value(mixed $value, Type $type, Caster $caster) : mixed
     {
-        if ($value === null && !$type->nullable()) {
-            throw new CastingException($value, $type);
-        }
-
         /** @var StructureType $type */
         try {
             if (\is_string($value) && (\str_starts_with($value, '{') || \str_starts_with($value, '['))) {

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Caster/StructureCastingHandler.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Caster/StructureCastingHandler.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Flow\ETL\PHP\Type\Caster;
 
 use Flow\ETL\Exception\CastingException;
+use Flow\ETL\PHP\Type\Caster;
 use Flow\ETL\PHP\Type\Logical\StructureType;
 use Flow\ETL\PHP\Type\Type;
 
@@ -15,20 +16,31 @@ final class StructureCastingHandler implements CastingHandler
         return $type instanceof StructureType;
     }
 
-    public function value(mixed $value, Type $type) : mixed
+    public function value(mixed $value, Type $type, Caster $caster) : mixed
     {
-        if (\is_array($value)) {
-            return $value;
+        if ($value === null && !$type->nullable()) {
+            throw new CastingException($value, $type);
         }
 
+        /** @var StructureType $type */
         try {
-            if (\is_string($value)) {
+            if (\is_string($value) && (\str_starts_with($value, '{') || \str_starts_with($value, '['))) {
                 return \json_decode($value, true, 512, \JSON_THROW_ON_ERROR);
             }
 
-            return (array) $value;
+            $castedStructure = [];
+
+            foreach ($type->elements() as $element) {
+                $elementName = $element->name();
+
+                $castedStructure[$elementName] = (\is_array($value) && \array_key_exists($elementName, $value))
+                    ? $caster->to($element->type())->value($value[$elementName])
+                    : $caster->to($element->type())->value(null);
+            }
+
+            return $castedStructure;
         } catch (\Throwable $e) {
-            throw new CastingException($value, $type);
+            throw new CastingException($value, $type, $e);
         }
     }
 }

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Caster/StructureCastingHandler.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Caster/StructureCastingHandler.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\PHP\Type\Caster;
+
+use Flow\ETL\Exception\CastingException;
+use Flow\ETL\PHP\Type\Logical\StructureType;
+use Flow\ETL\PHP\Type\Type;
+
+final class StructureCastingHandler implements CastingHandler
+{
+    public function supports(Type $type) : bool
+    {
+        return $type instanceof StructureType;
+    }
+
+    public function value(mixed $value, Type $type) : mixed
+    {
+        if (\is_array($value)) {
+            return $value;
+        }
+
+        try {
+            if (\is_string($value)) {
+                return \json_decode($value, true, 512, \JSON_THROW_ON_ERROR);
+            }
+
+            return (array) $value;
+        } catch (\Throwable $e) {
+            throw new CastingException($value, $type);
+        }
+    }
+}

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Caster/UuidCastingHandler.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Caster/UuidCastingHandler.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Flow\ETL\PHP\Type\Caster;
 
 use Flow\ETL\Exception\CastingException;
+use Flow\ETL\PHP\Type\Caster;
 use Flow\ETL\PHP\Type\Logical\UuidType;
 use Flow\ETL\PHP\Type\Type;
 use Flow\ETL\Row\Entry\Type\Uuid;
@@ -16,7 +17,7 @@ final class UuidCastingHandler implements CastingHandler
         return $type instanceof UuidType;
     }
 
-    public function value(mixed $value, Type $type) : mixed
+    public function value(mixed $value, Type $type, Caster $caster) : mixed
     {
         if (\is_string($value)) {
             return new Uuid($value);

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Caster/UuidCastingHandler.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Caster/UuidCastingHandler.php
@@ -19,6 +19,10 @@ final class UuidCastingHandler implements CastingHandler
 
     public function value(mixed $value, Type $type, Caster $caster) : mixed
     {
+        if ($value instanceof Uuid) {
+            return $value;
+        }
+
         if (\is_string($value)) {
             return new Uuid($value);
         }

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Caster/UuidCastingHandler.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Caster/UuidCastingHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\PHP\Type\Caster;
+
+use Flow\ETL\Exception\CastingException;
+use Flow\ETL\PHP\Type\Logical\UuidType;
+use Flow\ETL\PHP\Type\Type;
+use Flow\ETL\Row\Entry\Type\Uuid;
+
+final class UuidCastingHandler implements CastingHandler
+{
+    public function supports(Type $type) : bool
+    {
+        return $type instanceof UuidType;
+    }
+
+    public function value(mixed $value, Type $type) : mixed
+    {
+        if (\is_string($value)) {
+            return new Uuid($value);
+        }
+
+        if ($value instanceof \Ramsey\Uuid\UuidInterface) {
+            return new Uuid($value);
+        }
+
+        if ($value instanceof \Symfony\Component\Uid\Uuid) {
+            return new Uuid($value->toRfc4122());
+        }
+
+        throw new CastingException($value, $type);
+    }
+}

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Caster/XML/XMLConverter.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Caster/XML/XMLConverter.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace Flow\ETL\Function\Cast;
+namespace Flow\ETL\PHP\Type\Caster\XML;
 
 final class XMLConverter
 {

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Caster/XMLCastingHandler.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Caster/XMLCastingHandler.php
@@ -6,6 +6,7 @@ namespace Flow\ETL\PHP\Type\Caster;
 
 use function Flow\ETL\DSL\type_xml;
 use Flow\ETL\Exception\CastingException;
+use Flow\ETL\PHP\Type\Caster;
 use Flow\ETL\PHP\Type\Logical\XMLType;
 use Flow\ETL\PHP\Type\Type;
 
@@ -16,7 +17,7 @@ final class XMLCastingHandler implements CastingHandler
         return $type instanceof XMLType;
     }
 
-    public function value(mixed $value, Type $type) : mixed
+    public function value(mixed $value, Type $type, Caster $caster) : mixed
     {
         if (\is_string($value)) {
             $doc = new \DOMDocument();

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Caster/XMLCastingHandler.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Caster/XMLCastingHandler.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\PHP\Type\Caster;
+
+use function Flow\ETL\DSL\type_xml;
+use Flow\ETL\Exception\CastingException;
+use Flow\ETL\PHP\Type\Logical\XMLType;
+use Flow\ETL\PHP\Type\Type;
+
+final class XMLCastingHandler implements CastingHandler
+{
+    public function supports(Type $type) : bool
+    {
+        return $type instanceof XMLType;
+    }
+
+    public function value(mixed $value, Type $type) : mixed
+    {
+        if (\is_string($value)) {
+            $doc = new \DOMDocument();
+
+            if (!@$doc->loadXML($value)) {
+                throw new CastingException($value, type_xml());
+            }
+
+            return $doc;
+        }
+
+        if ($value instanceof \DOMDocument) {
+            return $value;
+        }
+
+        throw new CastingException($value, $type);
+    }
+}

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Logical/JsonType.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Logical/JsonType.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Flow\ETL\PHP\Type\Logical;
 
 use Flow\ETL\Exception\InvalidArgumentException;
-use Flow\ETL\PHP\Type\Caster\StringTypeChecker;
+use Flow\ETL\PHP\Type\Caster\StringCastingHandler\StringTypeChecker;
 use Flow\ETL\PHP\Type\Native\NullType;
 use Flow\ETL\PHP\Type\Type;
 

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Logical/JsonType.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Logical/JsonType.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Flow\ETL\PHP\Type\Logical;
 
 use Flow\ETL\Exception\InvalidArgumentException;
+use Flow\ETL\PHP\Type\Caster\StringTypeChecker;
 use Flow\ETL\PHP\Type\Native\NullType;
 use Flow\ETL\PHP\Type\Type;
-use Flow\ETL\Row\Factory\StringTypeChecker;
 
 final class JsonType implements LogicalType
 {

--- a/src/core/etl/src/Flow/ETL/Row/Factory/NativeEntryFactory.php
+++ b/src/core/etl/src/Flow/ETL/Row/Factory/NativeEntryFactory.php
@@ -23,6 +23,7 @@ use function Flow\ETL\DSL\xml_entry;
 use function Flow\ETL\DSL\xml_node_entry;
 use Flow\ETL\Exception\InvalidArgumentException;
 use Flow\ETL\Exception\RuntimeException;
+use Flow\ETL\PHP\Type\Caster;
 use Flow\ETL\PHP\Type\Logical\DateTimeType;
 use Flow\ETL\PHP\Type\Logical\JsonType;
 use Flow\ETL\PHP\Type\Logical\ListType;
@@ -161,74 +162,69 @@ final class NativeEntryFactory implements EntryFactory
 
     private function fromDefinition(Schema\Definition $definition, mixed $value) : Entry
     {
-        if ($definition->isNullable() && null === $value) {
-            return null_entry($definition->entry()->name());
+        if ($definition->isNullable()) {
+            if (null === $value) {
+                return null_entry($definition->entry()->name());
+            }
+
+            throw new InvalidArgumentException("Entry \"{$definition->entry()}\" is not nullable, but null value was given");
         }
+
+        $caster = Caster::default();
 
         try {
             if ($definition->type() instanceof ScalarType) {
                 return match ($definition->type()->type()) {
-                    ScalarType::STRING => str_entry($definition->entry()->name(), $value),
-                    ScalarType::INTEGER => int_entry($definition->entry()->name(), $value),
-                    ScalarType::FLOAT => float_entry($definition->entry()->name(), $value),
-                    ScalarType::BOOLEAN => bool_entry($definition->entry()->name(), $value),
+                    ScalarType::STRING => str_entry($definition->entry()->name(), $caster->to($definition->type())->value($value)),
+                    ScalarType::INTEGER => int_entry($definition->entry()->name(), $caster->to($definition->type())->value($value)),
+                    ScalarType::FLOAT => float_entry($definition->entry()->name(), $caster->to($definition->type())->value($value)),
+                    ScalarType::BOOLEAN => bool_entry($definition->entry()->name(), $caster->to($definition->type())->value($value)),
                     default => throw new InvalidArgumentException("Can't convert value into entry \"{$definition->entry()}\""),
                 };
             }
 
             if ($definition->type() instanceof XMLType) {
-                return xml_entry($definition->entry()->name(), $value);
+                return xml_entry($definition->entry()->name(), $caster->to($definition->type())->value($value));
             }
 
             if ($definition->type() instanceof UuidType) {
-                return uuid_entry($definition->entry()->name(), $value);
+                return uuid_entry($definition->entry()->name(), $caster->to($definition->type())->value($value));
             }
 
             if ($definition->type() instanceof ObjectType) {
-                return obj_entry($definition->entry()->name(), $value);
+                return obj_entry($definition->entry()->name(), $caster->to($definition->type())->value($value));
             }
 
             if ($definition->type() instanceof DateTimeType) {
-                return datetime_entry($definition->entry()->name(), $value);
+                return datetime_entry($definition->entry()->name(), $caster->to($definition->type())->value($value));
             }
 
             if ($definition->type() instanceof EnumType) {
-                /** @var class-string<\UnitEnum> $enumClass */
-                $enumClass = $definition->type()->class;
-                /** @var array<\UnitEnum> $cases */
-                $cases = $definition->type()->class::cases();
-
-                foreach ($cases as $case) {
-                    if ($case->name === $value) {
-                        return enum_entry($definition->entry()->name(), $case);
-                    }
-                }
-
-                throw new InvalidArgumentException("Value \"{$value}\" can't be converted to " . $enumClass . ' enum');
+                return enum_entry($definition->entry()->name(), $caster->to($definition->type())->value($value));
             }
 
             if ($definition->type() instanceof JsonType) {
                 try {
-                    return json_object_entry($definition->entry()->name(), $value);
+                    return json_object_entry($definition->entry()->name(), $caster->to($definition->type())->value($value));
                 } catch (InvalidArgumentException) {
-                    return json_entry($definition->entry()->name(), $value);
+                    return json_entry($definition->entry()->name(), $caster->to($definition->type())->value($value));
                 }
             }
 
             if ($definition->type() instanceof ArrayType) {
-                return array_entry($definition->entry()->name(), $value);
+                return array_entry($definition->entry()->name(), $caster->to($definition->type())->value($value));
             }
 
             if ($definition->type() instanceof MapType) {
-                return map_entry($definition->entry()->name(), $value, $definition->type());
+                return map_entry($definition->entry()->name(), $caster->to($definition->type())->value($value), $definition->type());
             }
 
             if ($definition->type() instanceof StructureType) {
-                return struct_entry($definition->entry()->name(), $value, $definition->type());
+                return struct_entry($definition->entry()->name(), $caster->to($definition->type())->value($value), $definition->type());
             }
 
             if ($definition->type() instanceof ListType) {
-                return new Entry\ListEntry($definition->entry()->name(), $value, $definition->type());
+                return new Entry\ListEntry($definition->entry()->name(), $caster->to($definition->type())->value($value), $definition->type());
             }
         } catch (InvalidArgumentException|\TypeError $e) {
             throw new InvalidArgumentException("Field \"{$definition->entry()}\" conversion exception. {$e->getMessage()}", previous: $e);

--- a/src/core/etl/src/Flow/ETL/Row/Factory/NativeEntryFactory.php
+++ b/src/core/etl/src/Flow/ETL/Row/Factory/NativeEntryFactory.php
@@ -24,6 +24,7 @@ use function Flow\ETL\DSL\xml_node_entry;
 use Flow\ETL\Exception\InvalidArgumentException;
 use Flow\ETL\Exception\RuntimeException;
 use Flow\ETL\PHP\Type\Caster;
+use Flow\ETL\PHP\Type\Caster\StringTypeChecker;
 use Flow\ETL\PHP\Type\Logical\DateTimeType;
 use Flow\ETL\PHP\Type\Logical\JsonType;
 use Flow\ETL\PHP\Type\Logical\ListType;

--- a/src/core/etl/src/Flow/ETL/Row/Factory/NativeEntryFactory.php
+++ b/src/core/etl/src/Flow/ETL/Row/Factory/NativeEntryFactory.php
@@ -24,7 +24,7 @@ use function Flow\ETL\DSL\xml_node_entry;
 use Flow\ETL\Exception\InvalidArgumentException;
 use Flow\ETL\Exception\RuntimeException;
 use Flow\ETL\PHP\Type\Caster;
-use Flow\ETL\PHP\Type\Caster\StringTypeChecker;
+use Flow\ETL\PHP\Type\Caster\StringCastingHandler\StringTypeChecker;
 use Flow\ETL\PHP\Type\Logical\DateTimeType;
 use Flow\ETL\PHP\Type\Logical\JsonType;
 use Flow\ETL\PHP\Type\Logical\ListType;

--- a/src/core/etl/src/Flow/ETL/Row/Schema/Definition.php
+++ b/src/core/etl/src/Flow/ETL/Row/Schema/Definition.php
@@ -312,7 +312,17 @@ final class Definition
             );
         }
 
-        throw new RuntimeException(\sprintf('Cannot merge definitions for entries, "%s" and "%s"', $this->ref->name(), $definition->ref->name()));
+        if (\in_array(ArrayEntry::class, $entryClasses, true)) {
+            return new self(
+                $this->ref,
+                ArrayEntry::class,
+                type_array(false, $this->isNullable() || $definition->isNullable()),
+                $constraint,
+                $this->metadata->merge($definition->metadata)
+            );
+        }
+
+        throw new RuntimeException(\sprintf('Cannot merge definitions for entries, "%s (%s)" and "%s (%s)"', $this->ref->name(), $this->type->toString(), $definition->ref->name(), $definition->type->toString()));
     }
 
     public function metadata() : Metadata

--- a/src/core/etl/src/Flow/ETL/Row/Schema/Definition.php
+++ b/src/core/etl/src/Flow/ETL/Row/Schema/Definition.php
@@ -11,6 +11,7 @@ use function Flow\ETL\DSL\type_enum;
 use function Flow\ETL\DSL\type_float;
 use function Flow\ETL\DSL\type_int;
 use function Flow\ETL\DSL\type_json;
+use function Flow\ETL\DSL\type_list;
 use function Flow\ETL\DSL\type_null;
 use function Flow\ETL\DSL\type_string;
 use function Flow\ETL\DSL\type_uuid;
@@ -252,6 +253,21 @@ final class Definition
 
         if ($definition->constraint instanceof VoidConstraint) {
             $constraint = $this->constraint;
+        }
+
+        if ($this->type instanceof ListType && $definition->type instanceof ListType && !$this->type->isEqual($definition->type)) {
+            $thisTypeString = $this->type->element()->toString();
+            $definitionTypeString = $definition->type->element()->toString();
+
+            if (\in_array($thisTypeString, ['integer', 'float', '?integer', '?float'], true) && \in_array($definitionTypeString, ['integer', 'float', '?integer', '?float'], true)) {
+                return new self(
+                    $this->ref,
+                    $this->entryClass,
+                    type_list(type_float($this->type->element()->type()->nullable() || $definition->type->element()->type()->nullable())),
+                    $constraint,
+                    $this->metadata->merge($definition->metadata)
+                );
+            }
         }
 
         if ($this->entryClass === $definition->entryClass && \in_array($this->entryClass, [ListEntry::class, MapEntry::class, StructureEntry::class], true)) {

--- a/src/core/etl/src/Flow/ETL/Transformer/AutoCastTransformer.php
+++ b/src/core/etl/src/Flow/ETL/Transformer/AutoCastTransformer.php
@@ -22,9 +22,9 @@ final class AutoCastTransformer implements Transformer
     {
         return $rows->map(function (Row $row) use ($context) {
             return $row->map(function (Entry $entry) use ($context) {
-                if (!$entry instanceof StringEntry) {
-                    return $entry;
-                }
+                //                if (!$entry instanceof StringEntry) {
+                //                    return $entry;
+                //                }
 
                 return $context->entryFactory()->create($entry->name(), $this->caster->cast($entry->value()));
             });

--- a/src/core/etl/src/Flow/ETL/Transformer/AutoCastTransformer.php
+++ b/src/core/etl/src/Flow/ETL/Transformer/AutoCastTransformer.php
@@ -4,14 +4,8 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Transformer;
 
-use function Flow\ETL\DSL\bool_entry;
-use function Flow\ETL\DSL\datetime_entry;
-use function Flow\ETL\DSL\float_entry;
-use function Flow\ETL\DSL\int_entry;
-use function Flow\ETL\DSL\json_entry;
-use function Flow\ETL\DSL\null_entry;
-use function Flow\ETL\DSL\uuid_entry;
 use Flow\ETL\FlowContext;
+use Flow\ETL\PHP\Type\AutoCaster;
 use Flow\ETL\Row;
 use Flow\ETL\Row\Entry;
 use Flow\ETL\Row\Entry\StringEntry;
@@ -20,50 +14,19 @@ use Flow\ETL\Transformer;
 
 final class AutoCastTransformer implements Transformer
 {
-    public function autoCast(Entry $entry) : Entry
+    public function __construct(private readonly AutoCaster $caster)
     {
-        if (!$entry instanceof StringEntry) {
-            return $entry;
-        }
-
-        $typeChecker = new Row\Factory\StringTypeChecker($entry->value());
-
-        if ($typeChecker->isNull()) {
-            return null_entry($entry->name());
-        }
-
-        if ($typeChecker->isInteger()) {
-            return int_entry($entry->name(), (int) $entry->value());
-        }
-
-        if ($typeChecker->isFloat()) {
-            return float_entry($entry->name(), (float) $entry->value());
-        }
-
-        if ($typeChecker->isBoolean()) {
-            return bool_entry($entry->name(), (bool) $entry->value());
-        }
-
-        if ($typeChecker->isJson()) {
-            return json_entry($entry->name(), $entry->value());
-        }
-
-        if ($typeChecker->isUuid()) {
-            return uuid_entry($entry->name(), $entry->value());
-        }
-
-        if ($typeChecker->isDateTime()) {
-            return datetime_entry($entry->name(), $entry->value());
-        }
-
-        return $entry;
     }
 
     public function transform(Rows $rows, FlowContext $context) : Rows
     {
-        return $rows->map(function (Row $row) {
-            return $row->map(function (Entry $entry) {
-                return $this->autoCast($entry);
+        return $rows->map(function (Row $row) use ($context) {
+            return $row->map(function (Entry $entry) use ($context) {
+                if (!$entry instanceof StringEntry) {
+                    return $entry;
+                }
+
+                return $context->entryFactory()->create($entry->name(), $this->caster->cast($entry->value()));
             });
         });
     }

--- a/src/core/etl/tests/Flow/ETL/Tests/Benchmark/TypeDetectorBench.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Benchmark/TypeDetectorBench.php
@@ -2,7 +2,7 @@
 
 namespace Flow\ETL\Tests\Benchmark;
 
-use Flow\ETL\PHP\Type\TypeDetector;
+use function Flow\ETL\DSL\get_type;
 use PhpBench\Attributes\Groups;
 use PhpBench\Attributes\ParamProviders;
 
@@ -12,7 +12,7 @@ final class TypeDetectorBench
     #[ParamProviders('provideRows')]
     public function bench_type_detector(array $params) : void
     {
-        (new TypeDetector())->detectType($params['data']);
+        get_type($params['data']);
     }
 
     public function provideRows() : \Generator

--- a/src/core/etl/tests/Flow/ETL/Tests/Integration/PHP/Type/CasterTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Integration/PHP/Type/CasterTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Tests\Integration\PHP\Type;
+
+use function Flow\ETL\DSL\type_boolean;
+use function Flow\ETL\DSL\type_datetime;
+use function Flow\ETL\DSL\type_integer;
+use function Flow\ETL\DSL\type_json;
+use function Flow\ETL\DSL\type_null;
+use function Flow\ETL\DSL\type_string;
+use function Flow\ETL\DSL\type_uuid;
+use function Flow\ETL\DSL\type_xml;
+use Flow\ETL\PHP\Type\Caster;
+use Flow\ETL\Row\Entry\Type\Uuid;
+use PHPUnit\Framework\TestCase;
+
+final class CasterTest extends TestCase
+{
+    public function test_casting_array_to_json() : void
+    {
+        $this->assertSame(
+            '{"items":{"item":1}}',
+            (Caster::default())->to(type_json())->value(['items' => ['item' => 1]])
+        );
+    }
+
+    public function test_casting_string_to_datetime() : void
+    {
+        $this->assertSame(
+            '2021-01-01 00:00:00.000000',
+            (Caster::default())->to(type_datetime())->value('2021-01-01 00:00:00 UTC')->format('Y-m-d H:i:s.u')
+        );
+    }
+
+    public function test_casting_string_to_uuid() : void
+    {
+        $this->assertEquals(
+            new Uuid('6c2f6e0e-8d8e-4e9e-8f0e-5a2d9c1c4f6e'),
+            (Caster::default())->to(type_uuid())->value('6c2f6e0e-8d8e-4e9e-8f0e-5a2d9c1c4f6e')
+        );
+    }
+
+    public function test_casting_string_to_xml() : void
+    {
+        $this->assertSame(
+            '<?xml version="1.0"?>' . "\n" . '<items><item>1</item></items>' . "\n",
+            (Caster::default())->to(type_xml())->value('<items><item>1</item></items>')->saveXML()
+        );
+    }
+
+    public function test_casting_to_boolean() : void
+    {
+        $this->assertTrue(
+            (Caster::default())->to(type_boolean())->value('true')
+        );
+    }
+
+    public function test_casting_to_integer() : void
+    {
+        $this->assertSame(
+            1,
+            (Caster::default())->to(type_integer())->value('1')
+        );
+    }
+
+    public function test_casting_to_string() : void
+    {
+        $this->assertSame(
+            '1',
+            (Caster::default())->to(type_string())->value(1)
+        );
+    }
+
+    public function test_casting_values_to_null() : void
+    {
+        $this->assertNull(
+            (Caster::default())->to(type_null())->value('qweqwqw')
+        );
+    }
+}

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/PHP/Type/AutoCasterTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/PHP/Type/AutoCasterTest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Tests\Unit\PHP\Type;
+
+use Flow\ETL\PHP\Type\AutoCaster;
+use Flow\ETL\PHP\Type\Caster;
+use PHPUnit\Framework\TestCase;
+
+final class AutoCasterTest extends TestCase
+{
+    public function test_auto_casting_array_of_ints_and_floats_into_array_of_floats() : void
+    {
+        $this->assertSame(
+            [1.0, 2.0, 3.0],
+            (new AutoCaster(Caster::default()))->cast([1, 2, 3.0])
+        );
+    }
+}

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/PHP/Type/Caster/ArrayCastingHandlerTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/PHP/Type/Caster/ArrayCastingHandlerTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Tests\Unit\PHP\Type\Caster;
+
+use function Flow\ETL\DSL\type_array;
+use Flow\ETL\PHP\Type\Caster\ArrayCastingHandler;
+use PHPUnit\Framework\TestCase;
+
+final class ArrayCastingHandlerTest extends TestCase
+{
+    public function test_casting_boolean_to_array() : void
+    {
+        $this->assertEquals(
+            [true],
+            (new ArrayCastingHandler())->value(true, type_array())
+        );
+    }
+
+    public function test_casting_datetime_to_array() : void
+    {
+        $this->assertEquals(
+            ['date' => '2021-01-01 00:00:00.000000', 'timezone_type' => 3, 'timezone' => 'UTC'],
+            (new ArrayCastingHandler())->value(new \DateTimeImmutable('2021-01-01 00:00:00 UTC'), type_array())
+        );
+    }
+
+    public function test_casting_float_to_array() : void
+    {
+        $this->assertEquals(
+            [1.1],
+            (new ArrayCastingHandler())->value(1.1, type_array())
+        );
+    }
+
+    public function test_casting_integer_to_array() : void
+    {
+        $this->assertEquals(
+            [1],
+            (new ArrayCastingHandler())->value(1, type_array())
+        );
+    }
+
+    public function test_casting_string_to_array() : void
+    {
+        $this->assertSame(
+            ['items' => ['item' => 1]],
+            (new ArrayCastingHandler())->value('{"items":{"item":1}}', type_array())
+        );
+    }
+}

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/PHP/Type/Caster/ArrayCastingHandlerTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/PHP/Type/Caster/ArrayCastingHandlerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Flow\ETL\Tests\Unit\PHP\Type\Caster;
 
 use function Flow\ETL\DSL\type_array;
+use Flow\ETL\PHP\Type\Caster;
 use Flow\ETL\PHP\Type\Caster\ArrayCastingHandler;
 use PHPUnit\Framework\TestCase;
 
@@ -14,7 +15,7 @@ final class ArrayCastingHandlerTest extends TestCase
     {
         $this->assertEquals(
             [true],
-            (new ArrayCastingHandler())->value(true, type_array())
+            (new ArrayCastingHandler())->value(true, type_array(), Caster::default())
         );
     }
 
@@ -22,7 +23,7 @@ final class ArrayCastingHandlerTest extends TestCase
     {
         $this->assertEquals(
             ['date' => '2021-01-01 00:00:00.000000', 'timezone_type' => 3, 'timezone' => 'UTC'],
-            (new ArrayCastingHandler())->value(new \DateTimeImmutable('2021-01-01 00:00:00 UTC'), type_array())
+            (new ArrayCastingHandler())->value(new \DateTimeImmutable('2021-01-01 00:00:00 UTC'), type_array(), Caster::default())
         );
     }
 
@@ -30,7 +31,7 @@ final class ArrayCastingHandlerTest extends TestCase
     {
         $this->assertEquals(
             [1.1],
-            (new ArrayCastingHandler())->value(1.1, type_array())
+            (new ArrayCastingHandler())->value(1.1, type_array(), Caster::default())
         );
     }
 
@@ -38,7 +39,7 @@ final class ArrayCastingHandlerTest extends TestCase
     {
         $this->assertEquals(
             [1],
-            (new ArrayCastingHandler())->value(1, type_array())
+            (new ArrayCastingHandler())->value(1, type_array(), Caster::default())
         );
     }
 
@@ -46,7 +47,7 @@ final class ArrayCastingHandlerTest extends TestCase
     {
         $this->assertSame(
             ['items' => ['item' => 1]],
-            (new ArrayCastingHandler())->value('{"items":{"item":1}}', type_array())
+            (new ArrayCastingHandler())->value('{"items":{"item":1}}', type_array(), Caster::default())
         );
     }
 
@@ -57,7 +58,7 @@ final class ArrayCastingHandlerTest extends TestCase
 
         $this->assertSame(
             ['root' => ['foo' => ['@attributes' => ['baz' => 'buz'], '@value' => 'bar']]],
-            (new ArrayCastingHandler())->value($xml, type_array())
+            (new ArrayCastingHandler())->value($xml, type_array(), Caster::default())
         );
     }
 }

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/PHP/Type/Caster/ArrayCastingHandlerTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/PHP/Type/Caster/ArrayCastingHandlerTest.php
@@ -49,4 +49,15 @@ final class ArrayCastingHandlerTest extends TestCase
             (new ArrayCastingHandler())->value('{"items":{"item":1}}', type_array())
         );
     }
+
+    public function test_casting_xml_document_to_array() : void
+    {
+        $xml = new \DOMDocument();
+        $xml->loadXML($xmlString = '<root><foo baz="buz">bar</foo></root>');
+
+        $this->assertSame(
+            ['root' => ['foo' => ['@attributes' => ['baz' => 'buz'], '@value' => 'bar']]],
+            (new ArrayCastingHandler())->value($xml, type_array())
+        );
+    }
 }

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/PHP/Type/Caster/BooleanCastingHandlerTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/PHP/Type/Caster/BooleanCastingHandlerTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Tests\Unit\PHP\Type\Caster;
+
+use function Flow\ETL\DSL\type_boolean;
+use Flow\ETL\PHP\Type\Caster\BooleanCastingHandler;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class BooleanCastingHandlerTest extends TestCase
+{
+    public static function boolean_castable_data_provider() : \Generator
+    {
+        yield 'string' => ['string', true];
+        yield 'string true' => ['true', true];
+        yield 'string 1' => ['1', true];
+        yield 'string yes' => ['yes', true];
+        yield 'string on' => ['on', true];
+        yield 'string false' => ['false', false];
+        yield 'string 0' => ['0', false];
+        yield 'string no' => ['no', false];
+        yield 'string off' => ['off', false];
+        yield 'int' => [1, true];
+        yield 'float' => [1.1, true];
+        yield 'bool' => [true, true];
+        yield 'array' => [[1, 2, 3], true];
+        yield 'DateTimeInterface' => [new \DateTimeImmutable('2021-01-01 00:00:00'), true];
+        yield 'DateInterval' => [new \DateInterval('P1D'), true];
+        yield 'DOMDocument' => [new \DOMDocument(), true];
+    }
+
+    #[DataProvider('boolean_castable_data_provider')]
+    public function test_casting_different_data_types_to_integer(mixed $value, bool $expected) : void
+    {
+        $this->assertSame($expected, (new BooleanCastingHandler())->value($value, type_boolean()));
+    }
+}

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/PHP/Type/Caster/BooleanCastingHandlerTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/PHP/Type/Caster/BooleanCastingHandlerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Flow\ETL\Tests\Unit\PHP\Type\Caster;
 
 use function Flow\ETL\DSL\type_boolean;
+use Flow\ETL\PHP\Type\Caster;
 use Flow\ETL\PHP\Type\Caster\BooleanCastingHandler;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -34,6 +35,6 @@ final class BooleanCastingHandlerTest extends TestCase
     #[DataProvider('boolean_castable_data_provider')]
     public function test_casting_different_data_types_to_integer(mixed $value, bool $expected) : void
     {
-        $this->assertSame($expected, (new BooleanCastingHandler())->value($value, type_boolean()));
+        $this->assertSame($expected, (new BooleanCastingHandler())->value($value, type_boolean(), Caster::default()));
     }
 }

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/PHP/Type/Caster/DateTimeCastingHandlerTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/PHP/Type/Caster/DateTimeCastingHandlerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Flow\ETL\Tests\Unit\PHP\Type\Caster;
 
 use function Flow\ETL\DSL\type_datetime;
+use Flow\ETL\PHP\Type\Caster;
 use Flow\ETL\PHP\Type\Caster\DateTimeCastingHandler;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -24,6 +25,6 @@ final class DateTimeCastingHandlerTest extends TestCase
     #[DataProvider('datetime_castable_data_provider')]
     public function test_casting_different_data_types_to_datetime(mixed $value, \DateTimeImmutable $expected) : void
     {
-        $this->assertEquals($expected, (new DateTimeCastingHandler())->value($value, type_datetime()));
+        $this->assertEquals($expected, (new DateTimeCastingHandler())->value($value, type_datetime(), Caster::default()));
     }
 }

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/PHP/Type/Caster/DateTimeCastingHandlerTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/PHP/Type/Caster/DateTimeCastingHandlerTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Tests\Unit\PHP\Type\Caster;
+
+use function Flow\ETL\DSL\type_datetime;
+use Flow\ETL\PHP\Type\Caster\DateTimeCastingHandler;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class DateTimeCastingHandlerTest extends TestCase
+{
+    public static function datetime_castable_data_provider() : \Generator
+    {
+        yield 'string' => ['2021-01-01 00:00:00', new \DateTimeImmutable('2021-01-01 00:00:00')];
+        yield 'int' => [1609459200, new \DateTimeImmutable('2021-01-01 00:00:00')];
+        yield 'float' => [1609459200.0, new \DateTimeImmutable('2021-01-01 00:00:00')];
+        yield 'bool' => [true, new \DateTimeImmutable('1970-01-01 00:00:01')];
+        yield 'DateTimeInterface' => [new \DateTimeImmutable('2021-01-01 00:00:00'), new \DateTimeImmutable('2021-01-01 00:00:00')];
+        yield 'DateInterval' => [new \DateInterval('P1D'), new \DateTimeImmutable('1970-01-02 00:00:00')];
+    }
+
+    #[DataProvider('datetime_castable_data_provider')]
+    public function test_casting_different_data_types_to_datetime(mixed $value, \DateTimeImmutable $expected) : void
+    {
+        $this->assertEquals($expected, (new DateTimeCastingHandler())->value($value, type_datetime()));
+    }
+}

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/PHP/Type/Caster/EnumCastingHandlerTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/PHP/Type/Caster/EnumCastingHandlerTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Tests\Unit\PHP\Type\Caster;
+
+use function Flow\ETL\DSL\type_enum;
+use Flow\ETL\Exception\CastingException;
+use Flow\ETL\PHP\Type\Caster\EnumCastingHandler;
+use Flow\ETL\Tests\Unit\PHP\Type\Caster\Fixtures\ColorsEnum;
+use PHPUnit\Framework\TestCase;
+
+final class EnumCastingHandlerTest extends TestCase
+{
+    public function test_casting_integer_to_enum() : void
+    {
+        $this->expectException(CastingException::class);
+        $this->expectExceptionMessage('Can\'t cast "integer" into "enum<Flow\ETL\Tests\Unit\PHP\Type\Caster\Fixtures\ColorsEnum>" type');
+
+        (new EnumCastingHandler())->value(1, type_enum(ColorsEnum::class));
+    }
+
+    public function test_casting_string_to_enum() : void
+    {
+        $this->assertEquals(
+            ColorsEnum::RED,
+            (new EnumCastingHandler())->value('red', type_enum(ColorsEnum::class))
+        );
+    }
+}

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/PHP/Type/Caster/EnumCastingHandlerTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/PHP/Type/Caster/EnumCastingHandlerTest.php
@@ -6,6 +6,7 @@ namespace Flow\ETL\Tests\Unit\PHP\Type\Caster;
 
 use function Flow\ETL\DSL\type_enum;
 use Flow\ETL\Exception\CastingException;
+use Flow\ETL\PHP\Type\Caster;
 use Flow\ETL\PHP\Type\Caster\EnumCastingHandler;
 use Flow\ETL\Tests\Unit\PHP\Type\Caster\Fixtures\ColorsEnum;
 use PHPUnit\Framework\TestCase;
@@ -17,14 +18,14 @@ final class EnumCastingHandlerTest extends TestCase
         $this->expectException(CastingException::class);
         $this->expectExceptionMessage('Can\'t cast "integer" into "enum<Flow\ETL\Tests\Unit\PHP\Type\Caster\Fixtures\ColorsEnum>" type');
 
-        (new EnumCastingHandler())->value(1, type_enum(ColorsEnum::class));
+        (new EnumCastingHandler())->value(1, type_enum(ColorsEnum::class), Caster::default());
     }
 
     public function test_casting_string_to_enum() : void
     {
         $this->assertEquals(
             ColorsEnum::RED,
-            (new EnumCastingHandler())->value('red', type_enum(ColorsEnum::class))
+            (new EnumCastingHandler())->value('red', type_enum(ColorsEnum::class), Caster::default())
         );
     }
 }

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/PHP/Type/Caster/Fixtures/ColorsEnum.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/PHP/Type/Caster/Fixtures/ColorsEnum.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Tests\Unit\PHP\Type\Caster\Fixtures;
+
+enum ColorsEnum : string
+{
+    case BLUE = 'blue';
+    case GREEN = 'green';
+    case RED = 'red';
+}

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/PHP/Type/Caster/FloatCastingHandlerTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/PHP/Type/Caster/FloatCastingHandlerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Flow\ETL\Tests\Unit\PHP\Type\Caster;
 
 use function Flow\ETL\DSL\type_float;
+use Flow\ETL\PHP\Type\Caster;
 use Flow\ETL\PHP\Type\Caster\FloatCastingHandler;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -25,6 +26,6 @@ final class FloatCastingHandlerTest extends TestCase
     #[DataProvider('float_castable_data_provider')]
     public function test_casting_different_data_types_to_float(mixed $value, float $expected) : void
     {
-        $this->assertSame($expected, (new FloatCastingHandler())->value($value, type_float()));
+        $this->assertSame($expected, (new FloatCastingHandler())->value($value, type_float(), Caster::default()));
     }
 }

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/PHP/Type/Caster/FloatCastingHandlerTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/PHP/Type/Caster/FloatCastingHandlerTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Tests\Unit\PHP\Type\Caster;
+
+use function Flow\ETL\DSL\type_float;
+use Flow\ETL\PHP\Type\Caster\FloatCastingHandler;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class FloatCastingHandlerTest extends TestCase
+{
+    public static function float_castable_data_provider() : \Generator
+    {
+        yield 'string' => ['string', 0.0];
+        yield 'int' => [1, 1.0];
+        yield 'float' => [1.1, 1.1];
+        yield 'bool' => [true, 1.0];
+        yield 'array' => [[1, 2, 3], 1.0];
+        yield 'DateTimeInterface' => [new \DateTimeImmutable('2021-01-01 00:00:00'), 1609459200000000.0];
+        yield 'DateInterval' => [new \DateInterval('P1D'), 86400000000.0];
+    }
+
+    #[DataProvider('float_castable_data_provider')]
+    public function test_casting_different_data_types_to_float(mixed $value, float $expected) : void
+    {
+        $this->assertSame($expected, (new FloatCastingHandler())->value($value, type_float()));
+    }
+}

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/PHP/Type/Caster/IntegerCastingHandlerTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/PHP/Type/Caster/IntegerCastingHandlerTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Tests\Unit\PHP\Type\Caster;
+
+use function Flow\ETL\DSL\type_integer;
+use Flow\ETL\PHP\Type\Caster\IntegerCastingHandler;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class IntegerCastingHandlerTest extends TestCase
+{
+    public static function integer_castable_data_provider() : \Generator
+    {
+        yield 'string' => ['string', 0];
+        yield 'int' => [1, 1];
+        yield 'float' => [1.1, 1];
+        yield 'bool' => [true, 1];
+        yield 'array' => [[1, 2, 3], 1];
+        yield 'DateTimeInterface' => [new \DateTimeImmutable('2021-01-01 00:00:00'), 1609459200000000];
+        yield 'DateInterval' => [new \DateInterval('P1D'), 86400000000];
+    }
+
+    #[DataProvider('integer_castable_data_provider')]
+    public function test_casting_different_data_types_to_integer(mixed $value, int $expected) : void
+    {
+        $this->assertSame($expected, (new IntegerCastingHandler())->value($value, type_integer()));
+    }
+}

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/PHP/Type/Caster/IntegerCastingHandlerTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/PHP/Type/Caster/IntegerCastingHandlerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Flow\ETL\Tests\Unit\PHP\Type\Caster;
 
 use function Flow\ETL\DSL\type_integer;
+use Flow\ETL\PHP\Type\Caster;
 use Flow\ETL\PHP\Type\Caster\IntegerCastingHandler;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -25,6 +26,6 @@ final class IntegerCastingHandlerTest extends TestCase
     #[DataProvider('integer_castable_data_provider')]
     public function test_casting_different_data_types_to_integer(mixed $value, int $expected) : void
     {
-        $this->assertSame($expected, (new IntegerCastingHandler())->value($value, type_integer()));
+        $this->assertSame($expected, (new IntegerCastingHandler())->value($value, type_integer(), Caster::default()));
     }
 }

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/PHP/Type/Caster/JsonCastingHandlerTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/PHP/Type/Caster/JsonCastingHandlerTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Tests\Unit\PHP\Type\Caster;
+
+use function Flow\ETL\DSL\type_json;
+use Flow\ETL\Exception\CastingException;
+use Flow\ETL\PHP\Type\Caster\JsonCastingHandler;
+use PHPUnit\Framework\TestCase;
+
+final class JsonCastingHandlerTest extends TestCase
+{
+    public function test_casting_array_to_json() : void
+    {
+        $this->assertSame(
+            '{"items":{"item":1}}',
+            (new JsonCastingHandler())->value(['items' => ['item' => 1]], type_json())
+        );
+    }
+
+    public function test_casting_datetime_to_json() : void
+    {
+        $this->assertSame(
+            '{"date":"2021-01-01 00:00:00.000000","timezone_type":3,"timezone":"UTC"}',
+            (new JsonCastingHandler())->value(new \DateTimeImmutable('2021-01-01 00:00:00 UTC'), type_json())
+        );
+    }
+
+    public function test_casting_integer_to_json() : void
+    {
+        $this->expectException(CastingException::class);
+        $this->expectExceptionMessage('Can\'t cast "integer" into "json" type');
+
+        (new JsonCastingHandler())->value(1, type_json());
+    }
+
+    public function test_casting_json_string_to_json() : void
+    {
+        $this->assertSame(
+            '{"items":{"item":1}}',
+            (new JsonCastingHandler())->value('{"items":{"item":1}}', type_json())
+        );
+    }
+
+    public function test_casting_non_json_string_to_json() : void
+    {
+        $this->expectException(CastingException::class);
+        $this->expectExceptionMessage('Can\'t cast "string" into "json" type');
+
+        (new JsonCastingHandler())->value('string', type_json());
+    }
+}

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/PHP/Type/Caster/JsonCastingHandlerTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/PHP/Type/Caster/JsonCastingHandlerTest.php
@@ -6,6 +6,7 @@ namespace Flow\ETL\Tests\Unit\PHP\Type\Caster;
 
 use function Flow\ETL\DSL\type_json;
 use Flow\ETL\Exception\CastingException;
+use Flow\ETL\PHP\Type\Caster;
 use Flow\ETL\PHP\Type\Caster\JsonCastingHandler;
 use PHPUnit\Framework\TestCase;
 
@@ -15,7 +16,7 @@ final class JsonCastingHandlerTest extends TestCase
     {
         $this->assertSame(
             '{"items":{"item":1}}',
-            (new JsonCastingHandler())->value(['items' => ['item' => 1]], type_json())
+            (new JsonCastingHandler())->value(['items' => ['item' => 1]], type_json(), Caster::default())
         );
     }
 
@@ -23,7 +24,7 @@ final class JsonCastingHandlerTest extends TestCase
     {
         $this->assertSame(
             '{"date":"2021-01-01 00:00:00.000000","timezone_type":3,"timezone":"UTC"}',
-            (new JsonCastingHandler())->value(new \DateTimeImmutable('2021-01-01 00:00:00 UTC'), type_json())
+            (new JsonCastingHandler())->value(new \DateTimeImmutable('2021-01-01 00:00:00 UTC'), type_json(), Caster::default())
         );
     }
 
@@ -32,14 +33,14 @@ final class JsonCastingHandlerTest extends TestCase
         $this->expectException(CastingException::class);
         $this->expectExceptionMessage('Can\'t cast "integer" into "json" type');
 
-        (new JsonCastingHandler())->value(1, type_json());
+        (new JsonCastingHandler())->value(1, type_json(), Caster::default());
     }
 
     public function test_casting_json_string_to_json() : void
     {
         $this->assertSame(
             '{"items":{"item":1}}',
-            (new JsonCastingHandler())->value('{"items":{"item":1}}', type_json())
+            (new JsonCastingHandler())->value('{"items":{"item":1}}', type_json(), Caster::default())
         );
     }
 
@@ -48,6 +49,6 @@ final class JsonCastingHandlerTest extends TestCase
         $this->expectException(CastingException::class);
         $this->expectExceptionMessage('Can\'t cast "string" into "json" type');
 
-        (new JsonCastingHandler())->value('string', type_json());
+        (new JsonCastingHandler())->value('string', type_json(), Caster::default());
     }
 }

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/PHP/Type/Caster/ListCastingHandlerTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/PHP/Type/Caster/ListCastingHandlerTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Tests\Unit\PHP\Type\Caster;
+
+use function Flow\ETL\DSL\type_float;
+use function Flow\ETL\DSL\type_int;
+use function Flow\ETL\DSL\type_list;
+use Flow\ETL\PHP\Type\Caster;
+use Flow\ETL\PHP\Type\Caster\ListCastingHandler;
+use PHPUnit\Framework\TestCase;
+
+final class ListCastingHandlerTest extends TestCase
+{
+    public function test_casting_list_of_ints_to_list_of_floats() : void
+    {
+        $this->assertSame(
+            [1.0, 2.0, 3.0],
+            (new ListCastingHandler())->value([1, 2, 3], type_list(type_float()), Caster::default())
+        );
+    }
+
+    public function test_casting_string_to_list_of_ints() : void
+    {
+        $this->assertSame(
+            [1],
+            (new ListCastingHandler())->value(['1'], type_list(type_int()), Caster::default())
+        );
+    }
+}

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/PHP/Type/Caster/MapCastingHandlerTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/PHP/Type/Caster/MapCastingHandlerTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Tests\Unit\PHP\Type\Caster;
+
+use function Flow\ETL\DSL\type_float;
+use function Flow\ETL\DSL\type_int;
+use function Flow\ETL\DSL\type_integer;
+use function Flow\ETL\DSL\type_map;
+use function Flow\ETL\DSL\type_string;
+use Flow\ETL\Exception\CastingException;
+use Flow\ETL\PHP\Type\Caster;
+use Flow\ETL\PHP\Type\Caster\MapCastingHandler;
+use PHPUnit\Framework\TestCase;
+
+final class MapCastingHandlerTest extends TestCase
+{
+    public function test_casting_map_of_ints_into_map_of_floats() : void
+    {
+        $this->assertSame(
+            [
+                'a' => 1.0,
+                'b' => 2.0,
+                'c' => 3.0,
+            ],
+            (new MapCastingHandler())->value(['a' => 1, 'b' => 2, 'c' => 3], type_map(type_string(), type_float()), Caster::default())
+        );
+    }
+
+    public function test_casting_map_of_string_to_ints_into_map_of_int_to_float() : void
+    {
+        $this->expectException(CastingException::class);
+        $this->expectExceptionMessage('Can\'t cast "array" into "map<integer, float>"');
+
+        $this->assertSame(
+            [
+                'a' => 1.0,
+                'b' => 2.0,
+                'c' => 3.0,
+            ],
+            (new MapCastingHandler())->value(['a' => 1, 'b' => 2, 'c' => 3], type_map(type_int(), type_float()), Caster::default())
+        );
+    }
+
+    public function test_casting_scalar_to_map() : void
+    {
+        $this->assertSame(
+            [
+                '0' => 2,
+            ],
+            (new MapCastingHandler())->value('2', type_map(type_string(), type_integer()), Caster::default())
+        );
+    }
+}

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/PHP/Type/Caster/ObjectCastingHandlerTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/PHP/Type/Caster/ObjectCastingHandlerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Flow\ETL\Tests\Unit\PHP\Type\Caster;
 
 use function Flow\ETL\DSL\type_object;
+use Flow\ETL\PHP\Type\Caster;
 use Flow\ETL\PHP\Type\Caster\ObjectCastingHandler;
 use PHPUnit\Framework\TestCase;
 
@@ -14,11 +15,11 @@ final class ObjectCastingHandlerTest extends TestCase
     {
         $this->assertEquals(
             (object) ['foo' => 'bar'],
-            (new ObjectCastingHandler())->value((object) ['foo' => 'bar'], type_object(\stdClass::class))
+            (new ObjectCastingHandler())->value((object) ['foo' => 'bar'], type_object(\stdClass::class), Caster::default())
         );
         $this->assertInstanceOf(
             \stdClass::class,
-            (new ObjectCastingHandler())->value((object) ['foo' => 'bar'], type_object(\stdClass::class))
+            (new ObjectCastingHandler())->value((object) ['foo' => 'bar'], type_object(\stdClass::class), Caster::default())
         );
     }
 }

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/PHP/Type/Caster/ObjectCastingHandlerTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/PHP/Type/Caster/ObjectCastingHandlerTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Tests\Unit\PHP\Type\Caster;
+
+use function Flow\ETL\DSL\type_object;
+use Flow\ETL\PHP\Type\Caster\ObjectCastingHandler;
+use PHPUnit\Framework\TestCase;
+
+final class ObjectCastingHandlerTest extends TestCase
+{
+    public function test_casting_string_to_object() : void
+    {
+        $this->assertEquals(
+            (object) ['foo' => 'bar'],
+            (new ObjectCastingHandler())->value((object) ['foo' => 'bar'], type_object(\stdClass::class))
+        );
+        $this->assertInstanceOf(
+            \stdClass::class,
+            (new ObjectCastingHandler())->value((object) ['foo' => 'bar'], type_object(\stdClass::class))
+        );
+    }
+}

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/PHP/Type/Caster/StringCastingHandler/StringTypeCheckerTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/PHP/Type/Caster/StringCastingHandler/StringTypeCheckerTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Flow\ETL\Tests\Unit\PHP\Type\Caster;
+namespace Flow\ETL\Tests\Unit\PHP\Type\Caster\StringCastingHandler;
 
-use Flow\ETL\PHP\Type\Caster\StringTypeChecker;
+use Flow\ETL\PHP\Type\Caster\StringCastingHandler\StringTypeChecker;
 use PHPUnit\Framework\TestCase;
 
 final class StringTypeCheckerTest extends TestCase

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/PHP/Type/Caster/StringCastingHandlerTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/PHP/Type/Caster/StringCastingHandlerTest.php
@@ -6,6 +6,7 @@ namespace Flow\ETL\Tests\Unit\PHP\Type\Caster;
 
 use function Flow\ETL\DSL\type_string;
 use Flow\ETL\Exception\CastingException;
+use Flow\ETL\PHP\Type\Caster;
 use Flow\ETL\PHP\Type\Caster\StringCastingHandler;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -32,7 +33,7 @@ final class StringCastingHandlerTest extends TestCase
     #[DataProvider('string_castable_data_provider')]
     public function test_casting_different_data_types_to_string(mixed $value, string $expected) : void
     {
-        $this->assertSame($expected, \trim((new StringCastingHandler())->value($value, type_string())));
+        $this->assertSame($expected, \trim((new StringCastingHandler())->value($value, type_string(), Caster::default())));
     }
 
     public function test_casting_object_to_string() : void
@@ -40,6 +41,6 @@ final class StringCastingHandlerTest extends TestCase
         $this->expectException(CastingException::class);
         $this->expectExceptionMessage('Can\'t cast "object" into "string" type');
 
-        (new StringCastingHandler())->value(new class() {}, type_string());
+        (new StringCastingHandler())->value(new class() {}, type_string(), Caster::default());
     }
 }

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/PHP/Type/Caster/StringCastingHandlerTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/PHP/Type/Caster/StringCastingHandlerTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Tests\Unit\PHP\Type\Caster;
+
+use function Flow\ETL\DSL\type_string;
+use Flow\ETL\Exception\CastingException;
+use Flow\ETL\PHP\Type\Caster\StringCastingHandler;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class StringCastingHandlerTest extends TestCase
+{
+    public static function string_castable_data_provider() : \Generator
+    {
+        yield 'string' => ['string', 'string'];
+        yield 'int' => [1, '1'];
+        yield 'float' => [1.1, '1.1'];
+        yield 'bool' => [true, 'true'];
+        yield 'array' => [[1, 2, 3], '[1,2,3]'];
+        yield 'DateTimeInterface' => [new \DateTimeImmutable('2021-01-01 00:00:00'), '2021-01-01T00:00:00+00:00'];
+        yield 'Stringable' => [new class() implements \Stringable {
+            public function __toString() : string
+            {
+                return 'stringable';
+            }
+        }, 'stringable'];
+        yield 'DOMDocument' => [new \DOMDocument(), '<?xml version="1.0"?>'];
+    }
+
+    #[DataProvider('string_castable_data_provider')]
+    public function test_casting_different_data_types_to_string(mixed $value, string $expected) : void
+    {
+        $this->assertSame($expected, \trim((new StringCastingHandler())->value($value, type_string())));
+    }
+
+    public function test_casting_object_to_string() : void
+    {
+        $this->expectException(CastingException::class);
+        $this->expectExceptionMessage('Can\'t cast "object" into "string" type');
+
+        (new StringCastingHandler())->value(new class() {}, type_string());
+    }
+}

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/PHP/Type/Caster/StringTypeCheckerTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/PHP/Type/Caster/StringTypeCheckerTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Flow\ETL\Tests\Unit\Row\Factory;
+namespace Flow\ETL\Tests\Unit\PHP\Type\Caster;
 
-use Flow\ETL\Row\Factory\StringTypeChecker;
+use Flow\ETL\PHP\Type\Caster\StringTypeChecker;
 use PHPUnit\Framework\TestCase;
 
 final class StringTypeCheckerTest extends TestCase
@@ -13,6 +13,10 @@ final class StringTypeCheckerTest extends TestCase
     {
         $this->assertTrue((new StringTypeChecker('true'))->isBoolean());
         $this->assertTrue((new StringTypeChecker('false'))->isBoolean());
+        $this->assertTrue((new StringTypeChecker('yes'))->isBoolean());
+        $this->assertTrue((new StringTypeChecker('no'))->isBoolean());
+        $this->assertTrue((new StringTypeChecker('on'))->isBoolean());
+        $this->assertTrue((new StringTypeChecker('off'))->isBoolean());
         $this->assertFalse((new StringTypeChecker('0'))->isBoolean());
         $this->assertFalse((new StringTypeChecker('not bool'))->isBoolean());
     }

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/PHP/Type/Caster/StructureCastingHandlerTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/PHP/Type/Caster/StructureCastingHandlerTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Tests\Unit\PHP\Type\Caster;
+
+use function Flow\ETL\DSL\struct_type;
+use function Flow\ETL\DSL\structure_element;
+use function Flow\ETL\DSL\structure_type;
+use function Flow\ETL\DSL\type_integer;
+use function Flow\ETL\DSL\type_string;
+use Flow\ETL\PHP\Type\Caster;
+use Flow\ETL\PHP\Type\Caster\StructureCastingHandler;
+use PHPUnit\Framework\TestCase;
+
+final class StructureCastingHandlerTest extends TestCase
+{
+    public function test_casting_array_into_structure() : void
+    {
+        $this->assertSame(
+            [
+                'name' => 'Norbert Orzechowicz',
+                'age' => 30,
+                'address' => [
+                    'street' => 'Polna',
+                    'city' => 'Warsaw',
+                ],
+            ],
+            (new StructureCastingHandler())->value(
+                [
+                    'name' => 'Norbert Orzechowicz',
+                    'age' => 30,
+                    'address' => [
+                        'street' => 'Polna',
+                        'city' => 'Warsaw',
+                    ],
+                ],
+                struct_type([
+                    structure_element('name', type_string()),
+                    structure_element('age', type_integer()),
+                    structure_element(
+                        'address',
+                        structure_type([
+                            structure_element('street', type_string()),
+                            structure_element('city', type_string()),
+                        ])
+                    ),
+                ]),
+                Caster::default()
+            )
+        );
+    }
+
+    public function test_casting_structure_with_empty_not_nullable_fields() : void
+    {
+        $this->assertSame(
+            [
+                'name' => 'Norbert Orzechowicz',
+                'age' => 30,
+                'address' => [
+                    'street' => null,
+                    'city' => null,
+                ],
+            ],
+            (new StructureCastingHandler())->value(
+                [
+                    'name' => 'Norbert Orzechowicz',
+                    'age' => 30,
+                    'address' => [],
+                ],
+                struct_type([
+                    structure_element('name', type_string()),
+                    structure_element('age', type_integer()),
+                    structure_element(
+                        'address',
+                        structure_type([
+                            structure_element('street', type_string(true)),
+                            structure_element('city', type_string(true)),
+                        ])
+                    ),
+                ]),
+                Caster::default()
+            )
+        );
+    }
+
+    public function test_casting_structure_with_missing_nullable_fields() : void
+    {
+        $this->assertSame(
+            [
+                'name' => 'Norbert Orzechowicz',
+                'age' => 30,
+                'address' => null,
+            ],
+            (new StructureCastingHandler())->value(
+                [
+                    'name' => 'Norbert Orzechowicz',
+                    'age' => 30,
+                ],
+                struct_type([
+                    structure_element('name', type_string()),
+                    structure_element('age', type_integer()),
+                    structure_element(
+                        'address',
+                        structure_type([
+                            structure_element('street', type_string()),
+                            structure_element('city', type_string()),
+                        ], true)
+                    ),
+                ], true),
+                Caster::default()
+            )
+        );
+    }
+}

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/PHP/Type/Caster/UuidCastingHandlerTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/PHP/Type/Caster/UuidCastingHandlerTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Flow\ETL\Tests\Unit\PHP\Type\Caster;
 
 use function Flow\ETL\DSL\type_uuid;
+use Flow\ETL\Exception\CastingException;
+use Flow\ETL\PHP\Type\Caster;
 use Flow\ETL\PHP\Type\Caster\UuidCastingHandler;
 use Flow\ETL\Row\Entry\Type\Uuid;
 use PHPUnit\Framework\TestCase;
@@ -13,17 +15,17 @@ final class UuidCastingHandlerTest extends TestCase
 {
     public function test_casting_integer_to_uuid() : void
     {
-        $this->expectException(\Flow\ETL\Exception\CastingException::class);
+        $this->expectException(CastingException::class);
         $this->expectExceptionMessage('Can\'t cast "integer" into "uuid" type');
 
-        (new UuidCastingHandler())->value(1, type_uuid());
+        (new UuidCastingHandler())->value(1, type_uuid(), Caster::default());
     }
 
     public function test_casting_ramsey_uuid_to_uuid() : void
     {
         $this->assertEquals(
             new Uuid('6c2f6e0e-8d8e-4e9e-8f0e-5a2d9c1c4f6e'),
-            (new UuidCastingHandler())->value(\Ramsey\Uuid\Uuid::fromString('6c2f6e0e-8d8e-4e9e-8f0e-5a2d9c1c4f6e'), type_uuid())
+            (new UuidCastingHandler())->value(\Ramsey\Uuid\Uuid::fromString('6c2f6e0e-8d8e-4e9e-8f0e-5a2d9c1c4f6e'), type_uuid(), Caster::default())
         );
     }
 
@@ -31,7 +33,7 @@ final class UuidCastingHandlerTest extends TestCase
     {
         $this->assertEquals(
             new Uuid('6c2f6e0e-8d8e-4e9e-8f0e-5a2d9c1c4f6e'),
-            (new UuidCastingHandler())->value('6c2f6e0e-8d8e-4e9e-8f0e-5a2d9c1c4f6e', type_uuid())
+            (new UuidCastingHandler())->value('6c2f6e0e-8d8e-4e9e-8f0e-5a2d9c1c4f6e', type_uuid(), Caster::default())
         );
     }
 }

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/PHP/Type/Caster/UuidCastingHandlerTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/PHP/Type/Caster/UuidCastingHandlerTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Tests\Unit\PHP\Type\Caster;
+
+use function Flow\ETL\DSL\type_uuid;
+use Flow\ETL\PHP\Type\Caster\UuidCastingHandler;
+use Flow\ETL\Row\Entry\Type\Uuid;
+use PHPUnit\Framework\TestCase;
+
+final class UuidCastingHandlerTest extends TestCase
+{
+    public function test_casting_integer_to_uuid() : void
+    {
+        $this->expectException(\Flow\ETL\Exception\CastingException::class);
+        $this->expectExceptionMessage('Can\'t cast "integer" into "uuid" type');
+
+        (new UuidCastingHandler())->value(1, type_uuid());
+    }
+
+    public function test_casting_ramsey_uuid_to_uuid() : void
+    {
+        $this->assertEquals(
+            new Uuid('6c2f6e0e-8d8e-4e9e-8f0e-5a2d9c1c4f6e'),
+            (new UuidCastingHandler())->value(\Ramsey\Uuid\Uuid::fromString('6c2f6e0e-8d8e-4e9e-8f0e-5a2d9c1c4f6e'), type_uuid())
+        );
+    }
+
+    public function test_casting_string_to_uuid() : void
+    {
+        $this->assertEquals(
+            new Uuid('6c2f6e0e-8d8e-4e9e-8f0e-5a2d9c1c4f6e'),
+            (new UuidCastingHandler())->value('6c2f6e0e-8d8e-4e9e-8f0e-5a2d9c1c4f6e', type_uuid())
+        );
+    }
+}

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/PHP/Type/Caster/XMLCastingHandlerTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/PHP/Type/Caster/XMLCastingHandlerTest.php
@@ -6,6 +6,7 @@ namespace Flow\ETL\Tests\Unit\PHP\Type\Caster;
 
 use function Flow\ETL\DSL\type_xml;
 use Flow\ETL\Exception\CastingException;
+use Flow\ETL\PHP\Type\Caster;
 use Flow\ETL\PHP\Type\Caster\XMLCastingHandler;
 use PHPUnit\Framework\TestCase;
 
@@ -16,14 +17,14 @@ final class XMLCastingHandlerTest extends TestCase
         $this->expectException(CastingException::class);
         $this->expectExceptionMessage('Can\'t cast "integer" into "xml" type');
 
-        (new XMLCastingHandler())->value(1, type_xml())->saveXML();
+        (new XMLCastingHandler())->value(1, type_xml(), Caster::default())->saveXML();
     }
 
     public function test_casting_string_to_xml() : void
     {
         $this->assertSame(
             '<?xml version="1.0"?>' . "\n" . '<items><item>1</item></items>' . "\n",
-            (new XMLCastingHandler())->value('<items><item>1</item></items>', type_xml())->saveXML()
+            (new XMLCastingHandler())->value('<items><item>1</item></items>', type_xml(), Caster::default())->saveXML()
         );
     }
 }

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/PHP/Type/Caster/XMLCastingHandlerTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/PHP/Type/Caster/XMLCastingHandlerTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Tests\Unit\PHP\Type\Caster;
+
+use function Flow\ETL\DSL\type_xml;
+use Flow\ETL\Exception\CastingException;
+use Flow\ETL\PHP\Type\Caster\XMLCastingHandler;
+use PHPUnit\Framework\TestCase;
+
+final class XMLCastingHandlerTest extends TestCase
+{
+    public function test_casting_integer_to_xml() : void
+    {
+        $this->expectException(CastingException::class);
+        $this->expectExceptionMessage('Can\'t cast "integer" into "xml" type');
+
+        (new XMLCastingHandler())->value(1, type_xml())->saveXML();
+    }
+
+    public function test_casting_string_to_xml() : void
+    {
+        $this->assertSame(
+            '<?xml version="1.0"?>' . "\n" . '<items><item>1</item></items>' . "\n",
+            (new XMLCastingHandler())->value('<items><item>1</item></items>', type_xml())->saveXML()
+        );
+    }
+}

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Factory/NativeEntryFactoryTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Factory/NativeEntryFactoryTest.php
@@ -24,6 +24,7 @@ use function Flow\ETL\DSL\type_object;
 use function Flow\ETL\DSL\type_string;
 use function Flow\ETL\DSL\uuid_entry;
 use function Flow\ETL\DSL\xml_entry;
+use Flow\ETL\Exception\CastingException;
 use Flow\ETL\Exception\InvalidArgumentException;
 use Flow\ETL\PHP\Type\Logical\List\ListElement;
 use Flow\ETL\PHP\Type\Logical\ListType;
@@ -103,15 +104,6 @@ final class NativeEntryFactoryTest extends TestCase
         );
     }
 
-    public function test_conversion_to_different_type_with_schema() : void
-    {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage("Field \"e\" conversion exception. Flow\ETL\DSL\str_entry(): Argument #2 (\$value) must be of type string, int given, called in");
-
-        (new NativeEntryFactory())
-            ->create('e', 1, new Schema(Schema\Definition::string('e')));
-    }
-
     public function test_datetime() : void
     {
         $this->assertEquals(
@@ -152,14 +144,14 @@ final class NativeEntryFactoryTest extends TestCase
         $this->assertEquals(
             enum_entry('e', BackedIntEnum::one),
             (new NativeEntryFactory())
-                ->create('e', 'one', new Schema(Schema\Definition::enum('e', BackedIntEnum::class)))
+                ->create('e', 1, new Schema(Schema\Definition::enum('e', BackedIntEnum::class)))
         );
     }
 
     public function test_enum_invalid_value_with_schema() : void
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage("Value \"invalid\" can't be converted to " . BackedIntEnum::class . ' enum');
+        $this->expectException(CastingException::class);
+        $this->expectExceptionMessage("Can't cast \"string\" into \"enum<Flow\ETL\Tests\Fixtures\Enum\BackedIntEnum>\" type");
 
         (new NativeEntryFactory())
             ->create('e', 'invalid', new Schema(Schema\Definition::enum('e', BackedIntEnum::class)));

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Factory/NativeEntryFactoryTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Factory/NativeEntryFactoryTest.php
@@ -247,10 +247,10 @@ final class NativeEntryFactoryTest extends TestCase
 
     public function test_list_int_with_schema_but_string_list() : void
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Field "e" conversion exception. Expected list<integer> got different types: list<string>');
-
-        (new NativeEntryFactory())->create('e', ['1', '2', '3'], new Schema(Schema\Definition::list('e', new ListType(ListElement::integer()))));
+        $this->assertEquals(
+            list_entry('e', ['false', 'true', 'true'], type_list(type_string())),
+            (new NativeEntryFactory())->create('e', [false, true, true], new Schema(Schema\Definition::list('e', new ListType(ListElement::string()))))
+        );
     }
 
     public function test_list_of_datetime_with_schema() : void

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Schema/DefinitionTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Schema/DefinitionTest.php
@@ -179,6 +179,14 @@ final class DefinitionTest extends TestCase
         Definition::integer('int')->merge(Definition::string('string'));
     }
 
+    public function test_merging_list_of_ints_and_floats() : void
+    {
+        $this->assertEquals(
+            Definition::list('list', type_list(type_float())),
+            Definition::list('list', type_list(type_int()))->merge(Definition::list('list', type_list(type_float())))
+        );
+    }
+
     public function test_merging_numeric_types() : void
     {
         $this->assertEquals(

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Transformer/AutoCastTransformerTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Transformer/AutoCastTransformerTest.php
@@ -6,6 +6,8 @@ namespace Flow\ETL\Tests\Unit\Transformer;
 
 use function Flow\ETL\DSL\array_to_rows;
 use function Flow\ETL\DSL\flow_context;
+use Flow\ETL\PHP\Type\AutoCaster;
+use Flow\ETL\PHP\Type\Caster;
 use Flow\ETL\Transformer\AutoCastTransformer;
 use PHPUnit\Framework\TestCase;
 
@@ -13,7 +15,7 @@ final class AutoCastTransformerTest extends TestCase
 {
     public function test_transforming_row() : void
     {
-        $transformer = new AutoCastTransformer();
+        $transformer = new AutoCastTransformer(new AutoCaster(Caster::default()));
 
         $rows = array_to_rows([
             [


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <li>Caster mechanism that works on top of Flow\PHP\Type</li>
    <li>AutoCaster that works on top of Caster</li>
    <li>print_schema function</li>
    <li>print_rows function</li>
    <li>possibility to pass predefined schema to CSVExtractor</li>
    <li>possibility to pass predefined schema to JsonExtractor</li>
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>NativeEntryFactory fully respecting schema definitions</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

This is probably one of the most important changes in 0.6.0
Thanks to the new `Caster` mechanism, EntryFactory will cast values into their native/logical types defined by schema.

Why this is so important? 
Because once we identify the schema of our dataset, processing the same file can be way more efficient: 

[With provided schema to CSV Extractor](https://blackfire.io/profiles/46878ed1-76af-4523-b500-7748a489166b/graph)
[Without provided schema and autoCast](https://blackfire.io/profiles/010dfe9a-03b7-4c18-a2c8-15f5bde2378c/graph)

<img width="688" alt="image" src="https://github.com/flow-php/flow/assets/1921950/a41cc70f-74b7-43a1-86b5-146f78ec8f29">
