### PR TITLE
Automatically cast datetime bulk entries into DateTime objects

### DIFF
--- a/src/lib/doctrine-dbal-bulk/src/Flow/Doctrine/Bulk/BulkData.php
+++ b/src/lib/doctrine-dbal-bulk/src/Flow/Doctrine/Bulk/BulkData.php
@@ -17,8 +17,6 @@ final class BulkData
     private array $rows;
 
     /**
-     * @psalm-suppress DocblockTypeContradiction
-     *
      * @param array<int, array<string, mixed>> $rows
      */
     public function __construct(array $rows)
@@ -29,6 +27,7 @@ final class BulkData
 
         $firstRow = \reset($rows);
 
+        /** @psalm-suppress DocblockTypeContradiction */
         if (!\is_array($firstRow)) {
             throw new RuntimeException('Each row must be an array');
         }
@@ -36,6 +35,7 @@ final class BulkData
         $columns = \array_keys($firstRow);
 
         foreach ($rows as $row) {
+            /** @psalm-suppress DocblockTypeContradiction */
             if (!\is_array($row)) {
                 throw new RuntimeException('Each row must be an array');
             }

--- a/src/lib/doctrine-dbal-bulk/tests/Flow/Doctrine/Bulk/Tests/Integration/PostgreSqlBulkInsertTest.php
+++ b/src/lib/doctrine-dbal-bulk/tests/Flow/Doctrine/Bulk/Tests/Integration/PostgreSqlBulkInsertTest.php
@@ -32,11 +32,13 @@ final class PostgreSqlBulkInsertTest extends PostgreSqlIntegrationTestCase
             ->setPrimaryKey(['id'])
         );
 
+        $date1 = new \DateTimeImmutable();
+
         Bulk::create()->insert(
             $this->databaseContext->connection(),
             $table,
             new BulkData([
-                ['id' => $id1 = \bin2hex(\random_bytes(5)), 'age' => 20, 'name' => 'Name One', 'description' => 'Description One', 'active' => false, 'updated_at' => $date1 = new \DateTimeImmutable(), 'tags' => \json_encode(['a', 'b', 'c'])],
+                ['id' => $id1 = \bin2hex(\random_bytes(5)), 'age' => 20, 'name' => 'Name One', 'description' => 'Description One', 'active' => false, 'updated_at' => $date1->format(\DateTimeInterface::ATOM), 'tags' => \json_encode(['a', 'b', 'c'])],
                 ['id' => $id2 = \bin2hex(\random_bytes(5)), 'age' => 30, 'name' => 'Name Two', 'description' => null, 'active' => true, 'updated_at' => $date2 = new \DateTimeImmutable(), 'tags' => \json_encode(['a', 'b', 'c'])],
                 ['id' => $id3 = \bin2hex(\random_bytes(5)), 'age' => 40, 'name' => 'Name Three', 'description' => 'Description Three', 'active' => false, 'updated_at' => $date3 = new \DateTimeImmutable(), 'tags' => \json_encode(['a', 'b', 'c'])],
             ])


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>Automatically cast datetime bulk entries into DateTime objects</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

<!-- Please provide a short description of changes in this section, feel free to use markdown syntax -->
