### PR TITLE
Make parquet rows normalizer to respect given schema

### DIFF
--- a/src/adapter/etl-adapter-parquet/src/Flow/ETL/Adapter/Parquet/ParquetLoader.php
+++ b/src/adapter/etl-adapter-parquet/src/Flow/ETL/Adapter/Parquet/ParquetLoader.php
@@ -6,6 +6,7 @@ use Flow\ETL\Filesystem\Path;
 use Flow\ETL\FlowContext;
 use Flow\ETL\Loader;
 use Flow\ETL\Loader\Closure;
+use Flow\ETL\PHP\Type\Caster;
 use Flow\ETL\Row\Schema;
 use Flow\ETL\Rows;
 use Flow\Parquet\Options;
@@ -32,7 +33,7 @@ final class ParquetLoader implements Closure, Loader, Loader\FileLoader
         private readonly ?Schema $schema = null,
     ) {
         $this->converter = new SchemaConverter();
-        $this->normalizer = new RowsNormalizer();
+        $this->normalizer = new RowsNormalizer(Caster::default());
 
         if ($this->path->isPattern()) {
             throw new \InvalidArgumentException("ParquetLoader path can't be pattern, given: " . $this->path->path());
@@ -77,7 +78,7 @@ final class ParquetLoader implements Closure, Loader, Loader\FileLoader
                 $this->writers[$stream->path()->uri()]->openForStream($stream->resource(), $this->converter->toParquet($this->schema()));
             }
 
-            $this->writers[$stream->path()->uri()]->writeBatch($this->normalizer->normalize($rows));
+            $this->writers[$stream->path()->uri()]->writeBatch($this->normalizer->normalize($rows, $this->schema()));
         } else {
             $stream = $streams->open($this->path, 'parquet', $context->appendSafe());
 
@@ -90,7 +91,7 @@ final class ParquetLoader implements Closure, Loader, Loader\FileLoader
                 $this->writers[$stream->path()->uri()]->openForStream($stream->resource(), $this->converter->toParquet($this->schema()));
             }
 
-            $this->writers[$stream->path()->uri()]->writeBatch($this->normalizer->normalize($rows));
+            $this->writers[$stream->path()->uri()]->writeBatch($this->normalizer->normalize($rows, $this->schema()));
         }
     }
 

--- a/src/core/etl/src/Flow/ETL/Partition.php
+++ b/src/core/etl/src/Flow/ETL/Partition.php
@@ -68,7 +68,7 @@ final class Partition
 
         $partitions = [];
 
-        foreach (\array_filter(\explode('/', $uri), 'strlen') as $uriPart) {
+        foreach (\array_filter(\explode('/', $uri), static fn (string $s) : bool => (bool) \strlen($s)) as $uriPart) {
             if (\preg_match($regex, $uriPart, $matches)) {
                 $partitions[] = new self($matches[1], $matches[2]);
             }

--- a/src/core/etl/src/Flow/ETL/Row/Factory/NativeEntryFactory.php
+++ b/src/core/etl/src/Flow/ETL/Row/Factory/NativeEntryFactory.php
@@ -106,7 +106,11 @@ final class NativeEntryFactory implements EntryFactory
         }
 
         if ($valueType instanceof UuidType) {
-            return uuid_entry($entryName, $value);
+            if ($value instanceof Entry\Type\Uuid) {
+                return uuid_entry($entryName, $value);
+            }
+
+            return uuid_entry($entryName, (string) $value);
         }
 
         if ($valueType instanceof DateTimeType) {


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>Make parquet rows normalizer to respect given schema</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

Currently even if we decide to tell parquet by passing schema "save id as integer" it would still save the value as is. 
This change takes "id" type from schema (which is either provided or inferred) and it's casting given value the type defined by that schema. 
