### PR TITLE
Added possibility to get a hash from an entire row or all rows

### DIFF
--- a/src/core/etl/src/Flow/ETL/Row.php
+++ b/src/core/etl/src/Flow/ETL/Row.php
@@ -58,6 +58,21 @@ final class Row
         return $this->entries->has($ref);
     }
 
+    public function hash(string $algorithm = 'xxh128', bool $binary = false, array $options = []) : string
+    {
+        if (!\in_array($algorithm, \hash_algos(), true)) {
+            throw new \InvalidArgumentException(\sprintf('Hashing algorithm "%s" is not supported', $algorithm));
+        }
+
+        $string = '';
+
+        foreach ($this->entries->sort()->all() as $entry) {
+            $string .= $entry->name() . $entry->toString();
+        }
+
+        return \hash($algorithm, $string, $binary, $options);
+    }
+
     public function isEqual(self $row) : bool
     {
         return $this->entries->isEqual($row->entries());

--- a/src/core/etl/src/Flow/ETL/Rows.php
+++ b/src/core/etl/src/Flow/ETL/Rows.php
@@ -256,6 +256,21 @@ final class Rows implements \ArrayAccess, \Countable, \IteratorAggregate
         return new \ArrayIterator($this->rows);
     }
 
+    public function hash(string $algorithm = 'xxh128', bool $binary = false, array $options = []) : string
+    {
+        $hashes = [];
+
+        if (!\in_array($algorithm, \hash_algos(), true)) {
+            throw new \InvalidArgumentException(\sprintf('Hashing algorithm "%s" is not supported', $algorithm));
+        }
+
+        foreach ($this->rows as $row) {
+            $hashes[] = $row->hash($algorithm, $binary, $options);
+        }
+
+        return \hash($algorithm, \implode('', $hashes), $binary, $options);
+    }
+
     public function isPartitioned() : bool
     {
         return \count($this->partitions) > 0;

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/RowsTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/RowsTest.php
@@ -452,6 +452,74 @@ final class RowsTest extends TestCase
         );
     }
 
+    public function test_hash() : void
+    {
+        $rows = rows(
+            row(int_entry('id', 1), bool_entry('bool', false)),
+            row(int_entry('id', 2), bool_entry('bool', false)),
+            row(int_entry('id', 3), bool_entry('bool', false)),
+            row(int_entry('id', 4), bool_entry('bool', false))
+        );
+
+        $this->assertSame(
+            $rows->hash(),
+            rows(
+                row(bool_entry('bool', false), int_entry('id', 1)),
+                row(bool_entry('bool', false), int_entry('id', 2)),
+                row(bool_entry('bool', false), int_entry('id', 3)),
+                row(bool_entry('bool', false), int_entry('id', 4))
+            )->hash()
+        );
+    }
+
+    public function test_hash_empty_rows() : void
+    {
+        $this->assertSame(
+            rows()->hash(),
+            rows()->hash(),
+        );
+    }
+
+    public function test_hash_rows_with_different_columns() : void
+    {
+        $rows = rows(
+            row(int_entry('id', 1), bool_entry('bool', false)),
+            row(int_entry('id', 3), bool_entry('bool', false)),
+            row(int_entry('id', 2), bool_entry('bool', false)),
+            row(int_entry('id', 4), bool_entry('bool', false))
+        );
+
+        $this->assertNotSame(
+            $rows->hash(),
+            rows(
+                row(bool_entry('bool', false)),
+                row(bool_entry('bool', false)),
+                row(bool_entry('bool', false)),
+                row(bool_entry('bool', false))
+            )->hash()
+        );
+    }
+
+    public function test_hash_rows_with_different_order() : void
+    {
+        $rows = rows(
+            row(int_entry('id', 1), bool_entry('bool', false)),
+            row(int_entry('id', 3), bool_entry('bool', false)),
+            row(int_entry('id', 2), bool_entry('bool', false)),
+            row(int_entry('id', 4), bool_entry('bool', false))
+        );
+
+        $this->assertNotSame(
+            $rows->hash(),
+            rows(
+                row(bool_entry('bool', false), int_entry('id', 1)),
+                row(bool_entry('bool', false), int_entry('id', 2)),
+                row(bool_entry('bool', false), int_entry('id', 3)),
+                row(bool_entry('bool', false), int_entry('id', 4))
+            )->hash()
+        );
+    }
+
     public function test_merge_empty_rows_with_partitioned_rows() : void
     {
         $rows1 = rows(row(int_entry('id', 1), str_entry('group', 'a')))->partitionBy(ref('group'))[0];


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <li>Row::hash and Rows::hash</li>
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

<!-- Please provide a short description of changes in this section, feel free to use markdown syntax -->
