### PR TITLE
Extracted fetching contributors logic to standalone service

### DIFF
--- a/src/web/landing/config/services.yaml
+++ b/src/web/landing/config/services.yaml
@@ -11,6 +11,9 @@ services:
         exclude:
             - '../src/Flow/Website/Kernel.php'
 
-    Flow\Website\Factory\Github\ContributorsUrlFactory:
+    Flow\Website\Service\:
+        resource: '../src/Flow/Website/Service/'
+
+    Flow\Website\Factory\Github\ContributorsRequestFactory:
         arguments:
             $githubToken: '%env(GITHUB_TOKEN)%'

--- a/src/web/landing/src/Flow/Website/Controller/DefaultController.php
+++ b/src/web/landing/src/Flow/Website/Controller/DefaultController.php
@@ -2,56 +2,22 @@
 
 namespace Flow\Website\Controller;
 
-use function Flow\ETL\DSL\df;
-use function Flow\ETL\DSL\lit;
-use function Flow\ETL\DSL\not;
-use function Flow\ETL\DSL\ref;
-use function Flow\ETL\DSL\to_memory;
-use Flow\ETL\Adapter\Http\PsrHttpClientDynamicExtractor;
-use Flow\ETL\Memory\ArrayMemory;
-use Flow\Website\Factory\Github\ContributorsUrlFactory;
-use Http\Client\Curl\Client;
-use Nyholm\Psr7\Factory\Psr17Factory;
+use Flow\Website\Service\Github;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 
 final class DefaultController extends AbstractController
 {
-    public function __construct(
-        private readonly ContributorsUrlFactory $contributorsUrlFactory
-    ) {
+    public function __construct(private readonly Github $github)
+    {
     }
 
     #[Route('/', name: 'main')]
     public function main() : Response
     {
-        $factory = new Psr17Factory();
-        $client = new Client($factory, $factory);
-
-        df()
-            ->read(
-                new PsrHttpClientDynamicExtractor($client, $this->contributorsUrlFactory)
-            )
-            // Extract response
-            ->withEntry('unpacked', ref('response_body')->jsonDecode())
-            ->select('unpacked')
-            // Extract data as rows & columns
-            ->withEntry('data', ref('unpacked')->expand())
-            ->withEntry('data', ref('data')->unpack())
-            ->renameAll('data.', '')
-            ->drop('unpacked', 'data')
-            // Filter out bots & limit the end list
-            ->filter(not(ref('login')->endsWith(lit('[bot]'))))
-            ->filter(not(ref('login')->equals(lit('aeon-automation'))))
-            ->limit(24)
-            // Store result in memory
-            ->write(to_memory($memory = new ArrayMemory()))
-            // Execute
-            ->run();
-
         return $this->render('main/index.html.twig', [
-            'contributors' => $memory->dump(),
+            'contributors' => $this->github->contributors(),
         ]);
     }
 }

--- a/src/web/landing/src/Flow/Website/Factory/Github/ContributorsRequestFactory.php
+++ b/src/web/landing/src/Flow/Website/Factory/Github/ContributorsRequestFactory.php
@@ -6,9 +6,10 @@ namespace Flow\Website\Factory\Github;
 
 use Flow\ETL\Adapter\Http\DynamicExtractor\NextRequestFactory;
 use Nyholm\Psr7\Factory\Psr17Factory;
-use Psr\Http\Message;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
 
-final class ContributorsUrlFactory implements NextRequestFactory
+final class ContributorsRequestFactory implements NextRequestFactory
 {
     public function __construct(
         private readonly string $githubToken,
@@ -16,9 +17,9 @@ final class ContributorsUrlFactory implements NextRequestFactory
     ) {
     }
 
-    public function create(?Message\ResponseInterface $previousResponse = null) : ?Message\RequestInterface
+    public function create(?ResponseInterface $previousResponse = null) : ?RequestInterface
     {
-        if ($previousResponse instanceof Message\ResponseInterface) {
+        if ($previousResponse instanceof ResponseInterface) {
             return null;
         }
 

--- a/src/web/landing/src/Flow/Website/Service/Github.php
+++ b/src/web/landing/src/Flow/Website/Service/Github.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\Website\Service;
+
+use function Flow\ETL\DSL\config_builder;
+use function Flow\ETL\DSL\df;
+use function Flow\ETL\DSL\from_cache;
+use function Flow\ETL\DSL\lit;
+use function Flow\ETL\DSL\not;
+use function Flow\ETL\DSL\ref;
+use function Flow\ETL\DSL\to_memory;
+use Flow\ETL\Adapter\Http\PsrHttpClientDynamicExtractor;
+use Flow\ETL\Cache\PSRSimpleCache;
+use Flow\ETL\Memory\ArrayMemory;
+use Flow\Website\Factory\Github\ContributorsRequestFactory;
+use Http\Client\Curl\Client;
+use Http\Discovery\Psr17Factory;
+use Symfony\Component\Cache\Adapter\FilesystemAdapter;
+use Symfony\Component\Cache\Psr16Cache;
+use Symfony\Component\DependencyInjection\ParameterBag\ContainerBagInterface;
+
+final class Github
+{
+    public function __construct(
+        private readonly ContributorsRequestFactory $requestFactory,
+        private readonly ContainerBagInterface $parameters
+    ) {
+    }
+
+    public function contributors() : array
+    {
+        $factory = new Psr17Factory();
+        $client = new Client($factory, $factory);
+
+        $adapter = new PSRSimpleCache(
+            new Psr16Cache(
+                new FilesystemAdapter(
+                    'flow-website',
+                    3600 * 24,
+                    directory: $this->parameters->get('kernel.cache_dir') . '/flow-github-contributors'
+                )
+            )
+        );
+
+        $from_github = new PsrHttpClientDynamicExtractor($client, $this->requestFactory);
+
+        try {
+            df(config_builder()->cache($adapter))
+                ->read(
+                    from_cache(
+                        'flow_github_contributors',
+                        $from_github
+                    )
+                )
+                ->cache('flow_github_contributors')
+                ->withEntry('unpacked', ref('response_body')->jsonDecode())
+                ->select('unpacked')
+                ->withEntry('data', ref('unpacked')->expand())
+                ->withEntry('data', ref('data')->unpack())
+                ->renameAll('data.', '')
+                ->drop('unpacked', 'data')
+                ->filter(not(ref('login')->endsWith(lit('[bot]'))))
+                ->filter(not(ref('login')->equals(lit('aeon-automation'))))
+                ->limit(24)
+                ->write(to_memory($memory = new ArrayMemory()))
+                ->run();
+
+            return $memory->dump();
+        } catch (\Exception $e) {
+            return [];
+        }
+    }
+}


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
    <li>Using Flow cache when reading contributors and fallback to GitHub only when cache expires or does not exists</li>
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Extracted fetching contributors logic to standalone service</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

@stloyd @owsiakl - please follow this convention of not putting logic into controllers. 
The same rule applies to stimulus controllers, they should just coordinate services/components, not really hold any logic. 

In case of twig, if there is anything repeatable (like classes) use `{% set classes = [] %}`  and then `{{ classes|join(' ') }}`
For any other twig logic - please extract it to extensions. 