### PR TITLE
Added trailing slash to landing urls to avoid github pages redirections

### DIFF
--- a/web/landing/src/Flow/Website/Controller/DefaultController.php
+++ b/web/landing/src/Flow/Website/Controller/DefaultController.php
@@ -16,7 +16,7 @@ final class DefaultController extends AbstractController
     ) {
     }
 
-    #[Route('/{topic}/{example}', name: 'example')]
+    #[Route('/{topic}/{example}/', name: 'example')]
     public function example(string $topic, string $example) : Response
     {
         $topics = $this->examples->topics();
@@ -54,7 +54,7 @@ final class DefaultController extends AbstractController
         ]);
     }
 
-    #[Route('/{topic}', name: 'topic')]
+    #[Route('/{topic}/', name: 'topic')]
     public function topic(string $topic) : Response
     {
         $topics = $this->examples->topics();


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>Added trailing slash to landing urls to avoid github pages redirections</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

Without that, github pages will always keep redirecting: 

<img width="1237" alt="image" src="https://github.com/flow-php/flow/assets/1921950/9db9c7ee-910d-44e8-a6a8-a8103d4f0be6">
