### PR TITLE
Added Schema::keep - to keep selected schema entries

### DIFF
--- a/src/core/etl/src/Flow/ETL/Row/Schema.php
+++ b/src/core/etl/src/Flow/ETL/Row/Schema.php
@@ -115,6 +115,29 @@ final class Schema implements \Countable
         return $this;
     }
 
+    public function keep(string|Reference ...$entries) : self
+    {
+        $refs = References::init(...$entries);
+
+        $definitions = [];
+
+        foreach ($entries as $entry) {
+            if (!$this->findDefinition($entry)) {
+                throw new SchemaDefinitionNotFoundException((string) $entry);
+            }
+        }
+
+        foreach ($this->definitions as $definition) {
+            if ($refs->has($definition->entry())) {
+                $definitions[] = $definition;
+            }
+        }
+
+        $this->setDefinitions(...$definitions);
+
+        return $this;
+    }
+
     public function merge(self $schema) : self
     {
         $newDefinitions = $this->definitions;

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/SchemaTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/SchemaTest.php
@@ -116,6 +116,36 @@ final class SchemaTest extends TestCase
         );
     }
 
+    public function test_keep_non_existing_entries() : void
+    {
+        $this->expectException(SchemaDefinitionNotFoundException::class);
+
+        schema(
+            int_schema('id'),
+            str_schema('name'),
+            str_schema('surname'),
+            str_schema('email'),
+        )->keep('not-existing');
+    }
+
+    public function test_keep_selected_entries() : void
+    {
+        $schema = schema(
+            int_schema('id'),
+            str_schema('name'),
+            str_schema('surname'),
+            str_schema('email'),
+        );
+
+        $this->assertEquals(
+            schema(
+                str_schema('name'),
+                str_schema('surname'),
+            ),
+            $schema->keep('name', 'surname')
+        );
+    }
+
     public function test_making_whole_schema_nullable() : void
     {
         $schema = new Schema(


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <li>Schema::keep() - keep selected schema entries</li>
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

<!-- Please provide a short description of changes in this section, feel free to use markdown syntax -->
