### PR TITLE
Allow to group by uuid/datetime objects without casting them to scalar first

### DIFF
--- a/src/core/etl/tests/Flow/ETL/Tests/Integration/DataFrame/GroupByTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Integration/DataFrame/GroupByTest.php
@@ -11,6 +11,7 @@ use function Flow\ETL\DSL\from_array;
 use function Flow\ETL\DSL\from_memory;
 use function Flow\ETL\DSL\from_rows;
 use function Flow\ETL\DSL\int_entry;
+use function Flow\ETL\DSL\integer_entry;
 use function Flow\ETL\DSL\lit;
 use function Flow\ETL\DSL\max;
 use function Flow\ETL\DSL\null_entry;
@@ -24,6 +25,7 @@ use Flow\ETL\Memory\ArrayMemory;
 use Flow\ETL\Row;
 use Flow\ETL\Rows;
 use Flow\ETL\Tests\Integration\IntegrationTestCase;
+use Ramsey\Uuid\Uuid;
 
 final class GroupByTest extends IntegrationTestCase
 {
@@ -213,6 +215,28 @@ final class GroupByTest extends IntegrationTestCase
                 ['user' => 'user_04', 'contributions_sum' => 3],
             ],
             $rows->toArray()
+        );
+    }
+
+    public function test_group_by_uuid() : void
+    {
+        $rows = df()
+            ->read(from_array([
+                ['id' => Uuid::uuid4()->toString()],
+                ['id' => Uuid::uuid4()->toString()],
+                ['id' => Uuid::uuid4()->toString()],
+                ['id' => Uuid::uuid4()->toString()],
+                ['id' => Uuid::uuid4()->toString()],
+                ['id' => Uuid::uuid4()->toString()],
+                ['id' => Uuid::uuid4()->toString()],
+                ['id' => Uuid::uuid4()->toString()],
+            ]))
+            ->aggregate(count(ref('id')))
+            ->fetch();
+
+        $this->assertEquals(
+            new Rows(Row::create(integer_entry('id_count', 8))),
+            $rows
         );
     }
 

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/GroupByTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/GroupByTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Tests\Unit;
 
-use function Flow\ETL\DSL\array_entry;
 use function Flow\ETL\DSL\int_entry;
 use function Flow\ETL\DSL\null_entry;
 use function Flow\ETL\DSL\ref;
@@ -21,20 +20,6 @@ use PHPUnit\Framework\TestCase;
 
 final class GroupByTest extends TestCase
 {
-    public function test_group_by_array_entry() : void
-    {
-        $this->expectExceptionMessage('Grouping by non scalar values is not supported, given: array');
-        $this->expectException(RuntimeException::class);
-
-        $groupBy = new GroupBy('array');
-
-        $groupBy->group(new Rows(
-            Row::create(array_entry('array', [1, 2, 3])),
-            Row::create(array_entry('array', [1, 2, 3])),
-            Row::create(array_entry('array', [4, 5, 6]))
-        ));
-    }
-
     public function test_group_by_missing_entry() : void
     {
         $groupBy = new GroupBy('type');


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>group by uuid/datetime objects without casting them to scalar first</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

<!-- Please provide a short description of changes in this section, feel free to use markdown syntax -->
