### PR TITLE
Parquet - Change the way of how dictionary page header is detected while reading column chunks

### DIFF
--- a/src/lib/parquet/src/Flow/Parquet/ParquetFile/Page/Header/Type.php
+++ b/src/lib/parquet/src/Flow/Parquet/ParquetFile/Page/Header/Type.php
@@ -13,4 +13,9 @@ enum Type : int
     {
         return $this->value === self::DATA_PAGE->value || $this->value === self::DATA_PAGE_V2->value;
     }
+
+    public function isDictionaryPage() : bool
+    {
+        return $this->value === self::DICTIONARY_PAGE->value;
+    }
 }

--- a/src/lib/parquet/src/Flow/Parquet/ParquetFile/RowGroup/StatisticsReader.php
+++ b/src/lib/parquet/src/Flow/Parquet/ParquetFile/RowGroup/StatisticsReader.php
@@ -4,6 +4,7 @@ namespace Flow\Parquet\ParquetFile\RowGroup;
 
 use Flow\Parquet\BinaryReader\BinaryBufferReader;
 use Flow\Parquet\ParquetFile\Data\PlainValueUnpacker;
+use Flow\Parquet\ParquetFile\Schema\ColumnPrimitiveType;
 use Flow\Parquet\ParquetFile\Schema\FlatColumn;
 use Flow\Parquet\ParquetFile\Statistics;
 
@@ -24,6 +25,10 @@ final class StatisticsReader
             return null;
         }
 
+        if (ColumnPrimitiveType::isString($column) && \mb_check_encoding($this->statistics->max, 'UTF-8')) {
+            return $this->statistics->max;
+        }
+
         return (new PlainValueUnpacker((new BinaryBufferReader($this->statistics->max))))->unpack($column, 1)[0];
     }
 
@@ -31,6 +36,10 @@ final class StatisticsReader
     {
         if ($this->statistics->maxValue === null) {
             return null;
+        }
+
+        if (ColumnPrimitiveType::isString($column) && \mb_check_encoding($this->statistics->maxValue, 'UTF-8')) {
+            return $this->statistics->maxValue;
         }
 
         return (new PlainValueUnpacker((new BinaryBufferReader($this->statistics->maxValue))))->unpack($column, 1)[0];
@@ -42,6 +51,10 @@ final class StatisticsReader
             return null;
         }
 
+        if (ColumnPrimitiveType::isString($column) && \mb_check_encoding($this->statistics->min, 'UTF-8')) {
+            return $this->statistics->min;
+        }
+
         return (new PlainValueUnpacker((new BinaryBufferReader($this->statistics->min))))->unpack($column, 1)[0];
     }
 
@@ -49,6 +62,10 @@ final class StatisticsReader
     {
         if ($this->statistics->minValue === null) {
             return null;
+        }
+
+        if (ColumnPrimitiveType::isString($column) && \mb_check_encoding($this->statistics->minValue, 'UTF-8')) {
+            return $this->statistics->minValue;
         }
 
         return (new PlainValueUnpacker((new BinaryBufferReader($this->statistics->minValue))))->unpack($column, 1)[0];

--- a/src/lib/parquet/src/Flow/Parquet/ParquetFile/Schema/ColumnPrimitiveType.php
+++ b/src/lib/parquet/src/Flow/Parquet/ParquetFile/Schema/ColumnPrimitiveType.php
@@ -9,6 +9,10 @@ final class ColumnPrimitiveType
         $logicalType = $column->logicalType();
 
         if ($logicalType === null) {
+            if ($column->convertedType() === ConvertedType::UTF8) {
+                return true;
+            }
+
             return false;
         }
 

--- a/src/lib/parquet/src/Flow/Parquet/ParquetFile/Schema/FlatColumn.php
+++ b/src/lib/parquet/src/Flow/Parquet/ParquetFile/Schema/FlatColumn.php
@@ -140,6 +140,11 @@ final class FlatColumn implements Column
         return new self($string, PhysicalType::BYTE_ARRAY, null, LogicalType::uuid(), $repetition);
     }
 
+    public function convertedType() : ?ConvertedType
+    {
+        return $this->convertedType;
+    }
+
     /**
      * @psalm-suppress PossiblyNullOperand
      */


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>Change the way of how dictionary page header is detected while reading column chunks</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

This PR should solve issue mentioned here: https://github.com/flow-php/flow/issues/984#issuecomment-1949891775
Turned out that some files generated by spark do not set properly the metadata, because of that dictionary page header is not properly recognized and without it whole column can't be readed. 
This approach reads the first header and if it's a dictionary header it's using it to read the column dictionary. 
