### PR TITLE
Fixed merging schemas with different entries

### DIFF
--- a/src/core/etl/src/Flow/ETL/Row/Schema.php
+++ b/src/core/etl/src/Flow/ETL/Row/Schema.php
@@ -162,6 +162,12 @@ final class Schema implements \Countable
             }
         }
 
+        foreach ($newDefinitions as $entry => $definition) {
+            if (!\array_key_exists($definition->entry()->name(), $schema->definitions)) {
+                $newDefinitions[$entry] = $definition->nullable();
+            }
+        }
+
         $this->setDefinitions(...\array_values($newDefinitions));
 
         return $this;

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/SchemaMergeTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/SchemaMergeTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Tests\Unit\Row;
+
+use Flow\ETL\Row\{Schema};
+use PHPUnit\Framework\TestCase;
+
+final class SchemaMergeTest extends TestCase
+{
+    public function test_merge_different_schemas() : void
+    {
+        $schema = (new Schema(
+            Schema\Definition::integer('id'),
+            Schema\Definition::string('name', nullable: true)
+        ))->merge(
+            new Schema(
+                Schema\Definition::boolean('test'),
+            )
+        );
+
+        self::assertEquals(
+            new Schema(
+                Schema\Definition::integer('id', nullable: true),
+                Schema\Definition::string('name', nullable: true),
+                Schema\Definition::boolean('test', nullable: true),
+            ),
+            $schema
+        );
+    }
+
+    public function test_merge_different_schemas_with_common_parts_but_different_nullable_definitions() : void
+    {
+        $schema = (new Schema(
+            Schema\Definition::integer('id'),
+            Schema\Definition::string('name', nullable: true)
+        ))->merge(
+            new Schema(
+                Schema\Definition::boolean('test'),
+                Schema\Definition::string('name', nullable: false)
+            )
+        );
+
+        self::assertEquals(
+            new Schema(
+                Schema\Definition::integer('id', nullable: true),
+                Schema\Definition::string('name', nullable: true),
+                Schema\Definition::boolean('test', nullable: true),
+            ),
+            $schema
+        );
+    }
+
+    public function test_merge_different_schemas_with_common_parts() : void
+    {
+        $schema = (new Schema(
+            Schema\Definition::integer('id'),
+            Schema\Definition::string('name')
+        ))->merge(
+            new Schema(
+                Schema\Definition::boolean('test'),
+                Schema\Definition::string('name')
+            )
+        );
+
+        self::assertEquals(
+            new Schema(
+                Schema\Definition::integer('id', nullable: true),
+                Schema\Definition::string('name'),
+                Schema\Definition::boolean('test', nullable: true),
+            ),
+            $schema
+        );
+    }
+
+    public function test_merge_int_empty_schema() : void
+    {
+        $schema = (new Schema())->merge(
+            $notEmptySchema = new Schema(
+                Schema\Definition::integer('id', nullable: true),
+                Schema\Definition::string('name', nullable: true)
+            )
+        );
+
+        self::assertSame(
+            $notEmptySchema,
+            $schema
+        );
+    }
+
+    public function test_merge_schema() : void
+    {
+        $schema = (new Schema(
+            Schema\Definition::integer('id', nullable: true),
+            Schema\Definition::string('name', nullable: true)
+        ))->merge(
+            new Schema(
+                Schema\Definition::null('test'),
+            )
+        );
+
+        self::assertEquals(
+            new Schema(
+                Schema\Definition::integer('id', nullable: true),
+                Schema\Definition::string('name', nullable: true),
+                Schema\Definition::null('test'),
+            ),
+            $schema
+        );
+    }
+
+    public function test_merge_with_empty_schema() : void
+    {
+        $schema = ($notEmptySchema = new Schema(
+            Schema\Definition::integer('id', nullable: true),
+            Schema\Definition::string('name', nullable: true)
+        ))->merge(
+            new Schema()
+        );
+
+        self::assertEquals(
+            $notEmptySchema,
+            $schema
+        );
+    }
+}

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/SchemaMergeTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/SchemaMergeTest.php
@@ -30,28 +30,6 @@ final class SchemaMergeTest extends TestCase
         );
     }
 
-    public function test_merge_different_schemas_with_common_parts_but_different_nullable_definitions() : void
-    {
-        $schema = (new Schema(
-            Schema\Definition::integer('id'),
-            Schema\Definition::string('name', nullable: true)
-        ))->merge(
-            new Schema(
-                Schema\Definition::boolean('test'),
-                Schema\Definition::string('name', nullable: false)
-            )
-        );
-
-        self::assertEquals(
-            new Schema(
-                Schema\Definition::integer('id', nullable: true),
-                Schema\Definition::string('name', nullable: true),
-                Schema\Definition::boolean('test', nullable: true),
-            ),
-            $schema
-        );
-    }
-
     public function test_merge_different_schemas_with_common_parts() : void
     {
         $schema = (new Schema(
@@ -68,6 +46,28 @@ final class SchemaMergeTest extends TestCase
             new Schema(
                 Schema\Definition::integer('id', nullable: true),
                 Schema\Definition::string('name'),
+                Schema\Definition::boolean('test', nullable: true),
+            ),
+            $schema
+        );
+    }
+
+    public function test_merge_different_schemas_with_common_parts_but_different_nullable_definitions() : void
+    {
+        $schema = (new Schema(
+            Schema\Definition::integer('id'),
+            Schema\Definition::string('name', nullable: true)
+        ))->merge(
+            new Schema(
+                Schema\Definition::boolean('test'),
+                Schema\Definition::string('name', nullable: false)
+            )
+        );
+
+        self::assertEquals(
+            new Schema(
+                Schema\Definition::integer('id', nullable: true),
+                Schema\Definition::string('name', nullable: true),
                 Schema\Definition::boolean('test', nullable: true),
             ),
             $schema

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/SchemaTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/SchemaTest.php
@@ -143,57 +143,6 @@ final class SchemaTest extends TestCase
         );
     }
 
-    public function test_merge_int_empty_schema() : void
-    {
-        $schema = (new Schema())->merge(
-            $notEmptySchema = new Schema(
-                Schema\Definition::integer('id', $nullable = true),
-                Schema\Definition::string('name', $nullable = true)
-            )
-        );
-
-        self::assertSame(
-            $notEmptySchema,
-            $schema
-        );
-    }
-
-    public function test_merge_schema() : void
-    {
-        $schema = (new Schema(
-            Schema\Definition::integer('id', $nullable = true),
-            Schema\Definition::string('name', $nullable = true)
-        ))->merge(
-            new Schema(
-                Schema\Definition::null('test'),
-            )
-        );
-
-        self::assertEquals(
-            new Schema(
-                Schema\Definition::integer('id', $nullable = true),
-                Schema\Definition::string('name', $nullable = true),
-                Schema\Definition::null('test'),
-            ),
-            $schema
-        );
-    }
-
-    public function test_merge_with_empty_schema() : void
-    {
-        $schema = ($notEmptySchema = new Schema(
-            Schema\Definition::integer('id', $nullable = true),
-            Schema\Definition::string('name', $nullable = true)
-        ))->merge(
-            new Schema()
-        );
-
-        self::assertEquals(
-            $notEmptySchema,
-            $schema
-        );
-    }
-
     public function test_normalizing_and_recreating_schema() : void
     {
         $schema = schema(


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>merging schemas with different entries</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

Before, when we merged schema with new columns into schema with all non nullable columns, output schema was still not nullable on the left side but nullable on the right side. 
Now when we are merging schema and element is not exactly the same on the other side it will become nullable even if it wasn't nullable before. 