### PR TITLE
Added Schema::match() with strict/evolving matchers

### DIFF
--- a/src/core/etl/src/Flow/ETL/DSL/functions.php
+++ b/src/core/etl/src/Flow/ETL/DSL/functions.php
@@ -25,7 +25,7 @@ use Flow\ETL\PHP\Type\Native\{ArrayType, CallableType, EnumType, NullType, Objec
 use Flow\ETL\PHP\Type\{Type, TypeDetector};
 use Flow\ETL\Row\Factory\NativeEntryFactory;
 use Flow\ETL\Row\Schema\Formatter\ASCIISchemaFormatter;
-use Flow\ETL\Row\Schema\{Definition, SchemaFormatter};
+use Flow\ETL\Row\Schema\{Definition, Matcher\EvolvingSchemaMatcher, Matcher\StrictSchemaMatcher, SchemaFormatter};
 use Flow\ETL\Row\{EntryFactory, EntryReference, Reference, References, Schema};
 use Flow\ETL\{Config, ConfigBuilder, DataFrame, Extractor, Flow, FlowContext, Formatter, Loader, Partition, Pipeline, Row, Rows, Transformer, Window};
 
@@ -972,6 +972,16 @@ function schema_to_json(Schema $schema) : string
 function schema_from_json(string $schema) : Schema
 {
     return Schema::fromArray(\json_decode($schema, true, 512, JSON_THROW_ON_ERROR));
+}
+
+function schema_strict_matcher() : StrictSchemaMatcher
+{
+    return new StrictSchemaMatcher();
+}
+
+function schema_evolving_matcher() : EvolvingSchemaMatcher
+{
+    return new EvolvingSchemaMatcher();
 }
 
 function int_schema(string $name, bool $nullable = false, ?Schema\Metadata $metadata = null) : Definition

--- a/src/core/etl/src/Flow/ETL/Row/Schema.php
+++ b/src/core/etl/src/Flow/ETL/Row/Schema.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Flow\ETL\Row;
 
 use Flow\ETL\Exception\{InvalidArgumentException, SchemaDefinitionNotFoundException, SchemaDefinitionNotUniqueException};
-use Flow\ETL\Row\Schema\Definition;
+use Flow\ETL\Row\Schema\{Definition, Matcher\StrictSchemaMatcher, SchemaMatcher};
 
 final class Schema implements \Countable
 {
@@ -134,6 +134,11 @@ final class Schema implements \Countable
         $this->setDefinitions(...$definitions);
 
         return $this;
+    }
+
+    public function matches(self $schema, SchemaMatcher $matcher = new StrictSchemaMatcher()) : bool
+    {
+        return $matcher->match($this, $schema);
     }
 
     public function merge(self $schema) : self

--- a/src/core/etl/src/Flow/ETL/Row/Schema/Matcher/EvolvingSchemaMatcher.php
+++ b/src/core/etl/src/Flow/ETL/Row/Schema/Matcher/EvolvingSchemaMatcher.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Row\Schema\Matcher;
+
+use Flow\ETL\Row\Schema;
+use Flow\ETL\Row\Schema\SchemaMatcher;
+
+final class EvolvingSchemaMatcher implements SchemaMatcher
+{
+    /**
+     * Rules of evolving schema matching:
+     * - if schemas are the same, return true
+     * - if right schema has less fields than left schema, return false
+     * - if right schema is making a nullable field non-nullable, return false
+     * - if right schema is making a non-nullable field nullable, return true
+     * - if right schema is changing the type of a field, return false
+     * - if right schema is adding a field, return true
+     */
+    public function match(Schema $left, Schema $right) : bool
+    {
+        if ($right->count() < $left->count()) {
+            return false;
+        }
+
+        foreach ($right->definitions() as $rightDefinition) {
+            $leftDefinition = $left->findDefinition($rightDefinition->entry());
+
+            if ($leftDefinition === null) {
+                if ($right->count() === $left->count()) {
+                    return false;
+                }
+
+                continue;
+            }
+
+            if (!$rightDefinition->isNullable() && $leftDefinition->isNullable()) {
+                return false;
+            }
+
+            // making both sides nullable to compare just types of the fields
+            if (!$rightDefinition->type()->makeNullable(true)->isEqual($leftDefinition->type()->makeNullable(true))) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/core/etl/src/Flow/ETL/Row/Schema/Matcher/StrictSchemaMatcher.php
+++ b/src/core/etl/src/Flow/ETL/Row/Schema/Matcher/StrictSchemaMatcher.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Row\Schema\Matcher;
+
+use Flow\ETL\Row\Schema;
+use Flow\ETL\Row\Schema\SchemaMatcher;
+
+final class StrictSchemaMatcher implements SchemaMatcher
+{
+    public function match(Schema $left, Schema $right) : bool
+    {
+        if (\count($left->definitions()) !== \count($right->definitions())) {
+            return false;
+        }
+
+        foreach ($left->definitions() as $leftDefinition) {
+            $rightDefinition = $right->findDefinition($leftDefinition->entry());
+
+            if ($rightDefinition === null) {
+                return false;
+            }
+
+            if (!$leftDefinition->isEqual($rightDefinition)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/core/etl/src/Flow/ETL/Row/Schema/SchemaMatcher.php
+++ b/src/core/etl/src/Flow/ETL/Row/Schema/SchemaMatcher.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Row\Schema;
+
+use Flow\ETL\Row\Schema;
+
+interface SchemaMatcher
+{
+    public function match(Schema $left, Schema $right) : bool;
+}

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Schema/DefinitionTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Schema/DefinitionTest.php
@@ -21,6 +21,22 @@ final class DefinitionTest extends TestCase
         new Definition('name', \DateTimeInterface::class, type_datetime());
     }
 
+    public function test_equals_nullability() : void
+    {
+        $def = Definition::integer('id', nullable: true);
+
+        self::assertFalse(
+            $def->isEqual(
+                Definition::integer('id', nullable: false)
+            )
+        );
+        self::assertTrue(
+            $def->isEqual(
+                Definition::integer('id', nullable: true)
+            )
+        );
+    }
+
     public function test_equals_types() : void
     {
         $def = Definition::list('list', new ListType(ListElement::integer()));

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Schema/Matcher/EvolvingSchemaMatcherTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Schema/Matcher/EvolvingSchemaMatcherTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Tests\Unit\Row\Schema\Matcher;
+
+use function Flow\ETL\DSL\{bool_schema, int_schema, schema, str_schema};
+use Flow\ETL\Row\Schema\Matcher\EvolvingSchemaMatcher;
+use PHPUnit\Framework\TestCase;
+
+final class EvolvingSchemaMatcherTest extends TestCase
+{
+    public function test_right_having_less_definitions_than_left() : void
+    {
+        $left = schema(
+            int_schema('id'),
+            str_schema('name'),
+        );
+
+        $right = schema(
+            int_schema('id'),
+        );
+
+        self::assertFalse((new EvolvingSchemaMatcher())->match($left, $right));
+    }
+
+    public function test_right_having_same_number_of_definitions_but_different_names() : void
+    {
+        $left = schema(
+            int_schema('id'),
+            str_schema('name'),
+        );
+
+        $right = schema(
+            int_schema('id'),
+            str_schema('surname'),
+        );
+
+        self::assertFalse((new EvolvingSchemaMatcher())->match($left, $right));
+    }
+
+    public function test_right_schema_adding_new_field() : void
+    {
+        $left = schema(
+            int_schema('id'),
+            str_schema('name'),
+        );
+
+        $right = schema(
+            int_schema('id'),
+            str_schema('name'),
+            bool_schema('active'),
+        );
+
+        self::assertTrue((new EvolvingSchemaMatcher())->match($left, $right));
+    }
+
+    public function test_right_schema_changing_nullable_field_to_non_nullable() : void
+    {
+        $left = schema(
+            int_schema('id'),
+            str_schema('name', nullable: true),
+        );
+
+        $right = schema(
+            int_schema('id'),
+            str_schema('name'),
+        );
+
+        self::assertFalse((new EvolvingSchemaMatcher())->match($left, $right));
+    }
+
+    public function test_right_schema_changing_type_of_field() : void
+    {
+        $left = schema(
+            int_schema('id'),
+            str_schema('name'),
+        );
+
+        $right = schema(
+            int_schema('id'),
+            bool_schema('name'),
+        );
+
+        self::assertFalse((new EvolvingSchemaMatcher())->match($left, $right));
+    }
+
+    public function test_right_schema_is_the_same_as_left_schema() : void
+    {
+        $left = schema(
+            int_schema('id'),
+            str_schema('name'),
+        );
+
+        $right = schema(
+            int_schema('id'),
+            str_schema('name'),
+        );
+
+        self::assertTrue((new EvolvingSchemaMatcher())->match($left, $right));
+    }
+
+    public function test_right_schema_making_non_nullable_field_into_nullable() : void
+    {
+        $left = schema(
+            int_schema('id'),
+            str_schema('name'),
+        );
+
+        $right = schema(
+            int_schema('id'),
+            str_schema('name', nullable: true),
+        );
+
+        self::assertTrue((new EvolvingSchemaMatcher())->match($left, $right));
+    }
+}

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Schema/Matcher/StrictSchemaMatcherTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Schema/Matcher/StrictSchemaMatcherTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Tests\Unit\Row\Schema\Matcher;
+
+use function Flow\ETL\DSL\{int_schema, schema, str_schema};
+use Flow\ETL\Row\Schema\Matcher\StrictSchemaMatcher;
+use PHPUnit\Framework\TestCase;
+
+final class StrictSchemaMatcherTest extends TestCase
+{
+    public function test_matching_different_schemas() : void
+    {
+        $left = schema(
+            str_schema('id'),
+            str_schema('name'),
+        );
+
+        $right = schema(
+            str_schema('id'),
+            str_schema('name'),
+            int_schema('age'),
+        );
+
+        self::assertFalse((new StrictSchemaMatcher())->match($left, $right));
+    }
+
+    public function test_matching_same_number_of_definitions_but_different_names() : void
+    {
+        $left = schema(
+            str_schema('id'),
+            str_schema('name'),
+        );
+
+        $right = schema(
+            str_schema('id'),
+            str_schema('surname'),
+        );
+
+        self::assertFalse((new StrictSchemaMatcher())->match($left, $right));
+    }
+
+    public function test_matching_schemas_with_different_nullable_fields() : void
+    {
+        $left = schema(
+            str_schema('id'),
+            str_schema('name', nullable: true),
+        );
+
+        $right = schema(
+            str_schema('id'),
+            str_schema('name'),
+        );
+
+        self::assertFalse((new StrictSchemaMatcher())->match($left, $right));
+    }
+
+    public function test_matching_the_same_schema() : void
+    {
+        $left = schema(
+            str_schema('id'),
+            str_schema('name'),
+        );
+
+        $right = schema(
+            str_schema('id'),
+            str_schema('name'),
+        );
+
+        self::assertTrue((new StrictSchemaMatcher())->match($left, $right));
+    }
+}

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/SchemaTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/SchemaTest.php
@@ -4,7 +4,25 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Tests\Unit\Row;
 
-use function Flow\ETL\DSL\{bool_schema, int_schema, json_schema, list_schema, map_schema, schema, schema_from_json, schema_to_json, str_schema, struct_element, structure_schema, type_int, type_list, type_map, type_string, type_structure, uuid_schema};
+use function Flow\ETL\DSL\{bool_schema,
+    int_schema,
+    json_schema,
+    list_schema,
+    map_schema,
+    schema,
+    schema_evolving_matcher,
+    schema_from_json,
+    schema_strict_matcher,
+    schema_to_json,
+    str_schema,
+    struct_element,
+    structure_schema,
+    type_int,
+    type_list,
+    type_map,
+    type_string,
+    type_structure,
+    uuid_schema};
 use Flow\ETL\Exception\{InvalidArgumentException, SchemaDefinitionNotFoundException, SchemaDefinitionNotUniqueException};
 use Flow\ETL\Row\{EntryReference, Schema};
 use PHPUnit\Framework\TestCase;
@@ -141,6 +159,38 @@ final class SchemaTest extends TestCase
             ),
             $schema->nullable()
         );
+    }
+
+    public function test_matching_schema_with_evolving_schema_matcher() : void
+    {
+        $left = schema(
+            int_schema('id'),
+            str_schema('name'),
+        );
+
+        $right = schema(
+            int_schema('id'),
+            str_schema('name'),
+            str_schema('surname'),
+        );
+
+        self::assertTrue($left->matches($right, schema_evolving_matcher()));
+    }
+
+    public function test_matching_schema_with_strict_schema_matcher() : void
+    {
+        $left = schema(
+            int_schema('id'),
+            str_schema('name'),
+        );
+
+        $right = schema(
+            int_schema('id'),
+            str_schema('name'),
+            str_schema('surname'),
+        );
+
+        self::assertFalse($left->matches($right, schema_strict_matcher()));
     }
 
     public function test_normalizing_and_recreating_schema() : void


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <li>Added Schema::match() with strict/evolving matchers</li>
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

This is an introduction to a potential schema evolution feature. Schema evolution is a process where by writing more data to dataset we are making sure that reading from it is still safe to the clients. 
The base assumptions are following: 

- we can safely add new entries
- we can safely make non nullable entries, nullable
- we can safely keep schema the same 

however if we: 
- remove a field
- make a nullable field non nullable
- change field type 

we can impact our dataset clients. 

Using `Schema::matches($schema, schema_evolving_matcher()): bool` should prevent us from making an BC breaks in our datasets. 
