### PR TITLE
Fixed edge case where evolving schema is brings new definition but it's missing some old ones

### DIFF
--- a/src/core/etl/src/Flow/ETL/Row/Schema/Matcher/EvolvingSchemaMatcher.php
+++ b/src/core/etl/src/Flow/ETL/Row/Schema/Matcher/EvolvingSchemaMatcher.php
@@ -24,14 +24,16 @@ final class EvolvingSchemaMatcher implements SchemaMatcher
             return false;
         }
 
+        foreach ($left->definitions() as $definition) {
+            if ($right->findDefinition($definition->entry()) === null) {
+                return false;
+            }
+        }
+
         foreach ($right->definitions() as $rightDefinition) {
             $leftDefinition = $left->findDefinition($rightDefinition->entry());
 
             if ($leftDefinition === null) {
-                if ($right->count() === $left->count()) {
-                    return false;
-                }
-
                 continue;
             }
 

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Schema/Matcher/EvolvingSchemaMatcherTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Schema/Matcher/EvolvingSchemaMatcherTest.php
@@ -114,4 +114,20 @@ final class EvolvingSchemaMatcherTest extends TestCase
 
         self::assertTrue((new EvolvingSchemaMatcher())->match($left, $right));
     }
+
+    public function test_right_totally_different() : void
+    {
+        $left = schema(
+            int_schema('id'),
+            str_schema('name'),
+        );
+
+        $right = schema(
+            int_schema('not_id'),
+            str_schema('surname'),
+            bool_schema('active'),
+        );
+
+        self::assertFalse((new EvolvingSchemaMatcher())->match($left, $right));
+    }
 }


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>Evolving schema matcher, when right side has the same number of definitions but different name</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

<!-- Please provide a short description of changes in this section, feel free to use markdown syntax -->
