### PR TITLE
Added possibility to set cache batch size

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,6 @@
 parameters:
     level: 8
+    treatPhpDocTypesAsCertain: false
     checkGenericClassInNonGenericObjectType: false
     checkMissingIterableValueType: false
     paths:

--- a/psalm.xml
+++ b/psalm.xml
@@ -38,6 +38,7 @@
         </ignoreFiles>
     </projectFiles>
     <issueHandlers>
+        <DocblockTypeContradiction errorLevel="suppress" />
         <RiskyTruthyFalsyComparison errorLevel="suppress" />
         <LessSpecificReturnStatement errorLevel="suppress" />
         <MoreSpecificReturnType errorLevel="suppress" />

--- a/src/adapter/etl-adapter-csv/src/Flow/ETL/Adapter/CSV/CSVDetector.php
+++ b/src/adapter/etl-adapter-csv/src/Flow/ETL/Adapter/CSV/CSVDetector.php
@@ -26,7 +26,6 @@ final class CSVDetector
      */
     public function __construct($resource, ?Option $fallback = new Option(',', '"', '\\'), ?Options $options = null)
     {
-        /** @psalm-suppress DocblockTypeContradiction */
         if (!\is_resource($resource)) {
             throw new InvalidArgumentException('Argument must be a valid resource');
         }

--- a/src/adapter/etl-adapter-google-sheet/src/Flow/ETL/Adapter/GoogleSheet/GoogleSheetExtractor.php
+++ b/src/adapter/etl-adapter-google-sheet/src/Flow/ETL/Adapter/GoogleSheet/GoogleSheetExtractor.php
@@ -48,9 +48,7 @@ final class GoogleSheetExtractor implements Extractor, LimitableExtractor
         /**
          * @var array[] $values
          *
-         * @psalm-suppress RedundantConditionGivenDocblockType, DocblockTypeContradiction
-         *
-         * @phpstan-ignore-next-line
+         * @psalm-suppress RedundantConditionGivenDocblockType
          */
         $values = $response->getValues() ?? [];
 
@@ -116,9 +114,7 @@ final class GoogleSheetExtractor implements Extractor, LimitableExtractor
             /**
              * @var array[] $values
              *
-             * @psalm-suppress RedundantConditionGivenDocblockType, DocblockTypeContradiction
-             *
-             * @phpstan-ignore-next-line
+             * @psalm-suppress RedundantConditionGivenDocblockType
              */
             $values = $response->getValues() ?? [];
         }

--- a/src/core/etl/src/Flow/ETL/Config.php
+++ b/src/core/etl/src/Flow/ETL/Config.php
@@ -27,7 +27,8 @@ final class Config
         private readonly FilesystemStreams $filesystemStreams,
         private readonly Optimizer $optimizer,
         private readonly bool $putInputIntoRows,
-        private readonly EntryFactory $entryFactory
+        private readonly EntryFactory $entryFactory,
+        private readonly int $cacheBatchSize
     ) {
     }
 
@@ -44,6 +45,11 @@ final class Config
     public function cache() : Cache
     {
         return $this->cache;
+    }
+
+    public function cacheBatchSize() : int
+    {
+        return $this->cacheBatchSize;
     }
 
     public function entryFactory() : EntryFactory

--- a/src/core/etl/src/Flow/ETL/Config.php
+++ b/src/core/etl/src/Flow/ETL/Config.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Flow\ETL;
 
+use Flow\ETL\Exception\InvalidArgumentException;
 use Flow\ETL\Filesystem\FilesystemStreams;
 use Flow\ETL\Pipeline\Optimizer;
 use Flow\ETL\Row\EntryFactory;
@@ -19,6 +20,9 @@ final class Config
 
     public const EXTERNAL_SORT_MAX_MEMORY_ENV = 'FLOW_EXTERNAL_SORT_MAX_MEMORY';
 
+    /**
+     * @param int<1, max> $cacheBatchSize
+     */
     public function __construct(
         private readonly string $id,
         private readonly Serializer $serializer,
@@ -30,6 +34,9 @@ final class Config
         private readonly EntryFactory $entryFactory,
         private readonly int $cacheBatchSize
     ) {
+        if ($this->cacheBatchSize < 1) {
+            throw new InvalidArgumentException('Cache batch size must be greater than 0');
+        }
     }
 
     public static function builder() : ConfigBuilder
@@ -47,6 +54,9 @@ final class Config
         return $this->cache;
     }
 
+    /**
+     * @return int<1, max>
+     */
     public function cacheBatchSize() : int
     {
         return $this->cacheBatchSize;

--- a/src/core/etl/src/Flow/ETL/DataFrame.php
+++ b/src/core/etl/src/Flow/ETL/DataFrame.php
@@ -144,9 +144,16 @@ final class DataFrame
      * @lazy
      *
      * @param null|string $id
+     *
+     * @throws InvalidArgumentException
      */
-    public function cache(?string $id = null) : self
+    public function cache(?string $id = null, ?int $cacheBatchSize = null) : self
     {
+        if ($cacheBatchSize !== null && $cacheBatchSize < 1) {
+            throw new InvalidArgumentException('Cache batch size must be greater than 0');
+        }
+
+        $this->batchSize($cacheBatchSize ?? $this->context->config->cacheBatchSize());
         $this->pipeline = new CachingPipeline($this->pipeline, $id);
 
         return $this;

--- a/src/core/etl/src/Flow/ETL/Join/Expression.php
+++ b/src/core/etl/src/Flow/ETL/Join/Expression.php
@@ -18,8 +18,6 @@ final class Expression
     }
 
     /**
-     * @psalm-suppress DocblockTypeContradiction
-     *
      * @param array<string, string>|Comparison $comparison
      */
     public static function on(array|Comparison $comparison, string $joinPrefix = '') : self

--- a/src/core/etl/src/Flow/ETL/Monitoring/Memory/Unit.php
+++ b/src/core/etl/src/Flow/ETL/Monitoring/Memory/Unit.php
@@ -43,10 +43,13 @@ final class Unit
 
         switch (\strtoupper($unit)) {
             case 'K':
+            case 'B':
                 return self::fromKb((int) \substr($limit, 0, -1));
             case 'M':
+            case 'MB':
                 return self::fromMb((int) \substr($limit, 0, -1));
             case 'G':
+            case 'GB':
                 return self::fromGb((int) \substr($limit, 0, -1));
 
             default:

--- a/src/core/etl/src/Flow/ETL/Pipeline/BatchingPipeline.php
+++ b/src/core/etl/src/Flow/ETL/Pipeline/BatchingPipeline.php
@@ -22,11 +22,6 @@ final class BatchingPipeline implements OverridingPipeline, Pipeline
     {
         $this->nextPipeline = $pipeline->cleanCopy();
 
-        /**
-         * @psalm-suppress DocblockTypeContradiction
-         *
-         * @phpstan-ignore-next-line
-         */
         if ($this->size <= 0) {
             throw new InvalidArgumentException('Batch size must be greater than 0, given: ' . $this->size);
         }

--- a/src/core/etl/src/Flow/ETL/Rows.php
+++ b/src/core/etl/src/Flow/ETL/Rows.php
@@ -503,7 +503,6 @@ final class Rows implements \ArrayAccess, \Countable, \IteratorAggregate
      */
     public function offsetExists($offset) : bool
     {
-        /** @psalm-suppress DocblockTypeContradiction */
         if (!\is_int($offset)) {
             throw new InvalidArgumentException('Rows accepts only integer offsets');
         }

--- a/src/core/etl/tests/Flow/ETL/Tests/Integration/DataFrame/SortTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Integration/DataFrame/SortTest.php
@@ -31,15 +31,8 @@ final class SortTest extends IntegrationTestCase
         $cache = \array_diff(\scandir($this->cacheDir), ['..', '.']);
 
         self::assertEmpty($cache);
-        // 50 initial writes
-        // 2500 single row writes
-        // 50 merged writes
-        self::assertSame(2600, $cacheSpy->writes());
-        // 1 main cache
-        // 50 tmp caches
-        // 1 sorted cache
-        // 1 extracted cache
-        self::assertSame(52, $cacheSpy->clears());
+        self::assertSame(2506, $cacheSpy->writes());
+        self::assertSame(5, $cacheSpy->clears());
     }
 
     public function test_etl_sort_by_in_memory() : void
@@ -60,6 +53,6 @@ final class SortTest extends IntegrationTestCase
 
         self::assertEmpty($cache);
         self::assertSame(\range(0, 39), $rows->reduceToArray('int'));
-        self::assertSame(20, $cacheSpy->writes());
+        self::assertSame(1, $cacheSpy->writes());
     }
 }

--- a/src/core/etl/tests/Flow/ETL/Tests/Integration/Window/WindowFunctionsTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Integration/Window/WindowFunctionsTest.php
@@ -31,15 +31,13 @@ final class WindowFunctionsTest extends TestCase
             ->sortBy(ref('department'), ref('rank'))
             ->get();
 
-        self::assertSame(
+        self::assertEquals(
             [
                 [
                     ['id' => 5, 'name' => 'Jane', 'department' => 'Finances', 'salary' => 14_000, 'rank' => 1],
                     ['id' => 3, 'name' => 'Tomas', 'department' => 'Finances', 'salary' => 11_000, 'rank' => 2],
                     ['id' => 4, 'name' => 'John', 'department' => 'Finances', 'salary' => 9000, 'rank' => 3],
                     ['id' => 6, 'name' => 'Janet', 'department' => 'Finances', 'salary' => 4000, 'rank' => 4],
-                ],
-                [
                     ['id' => 1, 'name' => 'Greg', 'department' => 'IT', 'salary' => 6000, 'rank' => 1],
                     ['id' => 2, 'name' => 'Michal', 'department' => 'IT', 'salary' => 5000, 'rank' => 2],
                 ],

--- a/src/lib/doctrine-dbal-bulk/src/Flow/Doctrine/Bulk/BulkData.php
+++ b/src/lib/doctrine-dbal-bulk/src/Flow/Doctrine/Bulk/BulkData.php
@@ -27,7 +27,6 @@ final class BulkData
 
         $firstRow = \reset($rows);
 
-        /** @psalm-suppress DocblockTypeContradiction */
         if (!\is_array($firstRow)) {
             throw new RuntimeException('Each row must be an array');
         }
@@ -35,7 +34,6 @@ final class BulkData
         $columns = \array_keys($firstRow);
 
         foreach ($rows as $row) {
-            /** @psalm-suppress DocblockTypeContradiction */
             if (!\is_array($row)) {
                 throw new RuntimeException('Each row must be an array');
             }

--- a/src/lib/parquet/src/Flow/Parquet/ParquetFile/ColumnChunkReader/WholeChunkReader.php
+++ b/src/lib/parquet/src/Flow/Parquet/ParquetFile/ColumnChunkReader/WholeChunkReader.php
@@ -91,8 +91,6 @@ final class WholeChunkReader implements ColumnChunkReader
 
     /**
      * @param resource $stream
-     *
-     * @psalm-suppress DocblockTypeContradiction
      */
     private function readHeader($stream, int $pageOffset) : ?PageHeader
     {

--- a/src/lib/parquet/src/Flow/Parquet/ParquetFile/ColumnChunkViewer/WholeChunkViewer.php
+++ b/src/lib/parquet/src/Flow/Parquet/ParquetFile/ColumnChunkViewer/WholeChunkViewer.php
@@ -52,8 +52,6 @@ final class WholeChunkViewer implements ColumnChunkViewer
 
     /**
      * @param resource $stream
-     *
-     * @psalm-suppress DocblockTypeContradiction
      */
     private function readHeader($stream, int $pageOffset) : ?PageHeader
     {

--- a/src/lib/parquet/src/Flow/Parquet/ParquetFile/Page/Header/DataPageHeaderV2.php
+++ b/src/lib/parquet/src/Flow/Parquet/ParquetFile/Page/Header/DataPageHeaderV2.php
@@ -27,7 +27,6 @@ final class DataPageHeaderV2
 
     public static function fromThrift(\Flow\Parquet\Thrift\DataPageHeaderV2 $thrift) : self
     {
-        /** @psalm-suppress DocblockTypeContradiction */
         return new self(
             $thrift->num_values,
             $thrift->num_nulls,
@@ -37,7 +36,6 @@ final class DataPageHeaderV2
             $thrift->repetition_levels_byte_length,
             /** @phpstan-ignore-next-line */
             $thrift->is_compressed ?? null,
-            /** @phpstan-ignore-next-line */
             $thrift->statistics ? Statistics::fromThrift($thrift->statistics) : null
         );
     }

--- a/src/lib/parquet/src/Flow/Parquet/ParquetFile/Page/PageHeader.php
+++ b/src/lib/parquet/src/Flow/Parquet/ParquetFile/Page/PageHeader.php
@@ -22,9 +22,6 @@ final class PageHeader
     ) {
     }
 
-    /**
-     * @psalm-suppress DocblockTypeContradiction
-     */
     public static function fromThrift(\Flow\Parquet\Thrift\PageHeader $thrift) : self
     {
         return new self(

--- a/src/lib/parquet/src/Flow/Parquet/ParquetFile/RowGroup/ColumnChunk.php
+++ b/src/lib/parquet/src/Flow/Parquet/ParquetFile/RowGroup/ColumnChunk.php
@@ -40,7 +40,6 @@ final class ColumnChunk
     }
 
     /**
-     * @psalm-suppress DocblockTypeContradiction
      * @psalm-suppress RedundantConditionGivenDocblockType
      */
     public static function fromThrift(\Flow\Parquet\Thrift\ColumnChunk $thrift) : self
@@ -57,7 +56,6 @@ final class ColumnChunk
             $thrift->meta_data->dictionary_page_offset,
             $thrift->meta_data->data_page_offset,
             $thrift->meta_data->index_page_offset,
-            /** @phpstan-ignore-next-line  */
             $thrift->meta_data->statistics ? Statistics::fromThrift($thrift->meta_data->statistics) : null,
         );
     }

--- a/src/lib/parquet/src/Flow/Parquet/ParquetFile/Schema/LogicalType.php
+++ b/src/lib/parquet/src/Flow/Parquet/ParquetFile/Schema/LogicalType.php
@@ -65,7 +65,6 @@ final class LogicalType
     }
 
     /**
-     * @psalm-suppress DocblockTypeContradiction
      * @psalm-suppress RedundantConditionGivenDocblockType
      */
     public static function fromThrift(\Flow\Parquet\Thrift\LogicalType $logicalType) : self

--- a/src/lib/parquet/src/Flow/Parquet/ParquetFile/Schema/NestedColumn.php
+++ b/src/lib/parquet/src/Flow/Parquet/ParquetFile/Schema/NestedColumn.php
@@ -38,7 +38,6 @@ final class NestedColumn implements Column
     }
 
     /**
-     * @psalm-suppress DocblockTypeContradiction
      * @psalm-suppress RedundantConditionGivenDocblockType
      *
      * @param array<Column> $children
@@ -50,7 +49,6 @@ final class NestedColumn implements Column
             $schemaElement->repetition_type ? Repetition::from($schemaElement->repetition_type) : null,
             $children,
             $schemaElement->converted_type ? ConvertedType::from($schemaElement->converted_type) : null,
-            /** @phpstan-ignore-next-line */
             $schemaElement->logicalType ? LogicalType::fromThrift($schemaElement->logicalType) : null
         );
     }

--- a/src/lib/parquet/src/Flow/Parquet/Reader.php
+++ b/src/lib/parquet/src/Flow/Parquet/Reader.php
@@ -41,7 +41,6 @@ final class Reader
      */
     public function readStream($stream) : ParquetFile
     {
-        /** @psalm-suppress DocblockTypeContradiction */
         if (!\is_resource($stream)) {
             throw new InvalidArgumentException('Given argument is not a valid resource');
         }

--- a/src/lib/parquet/src/Flow/Parquet/Writer.php
+++ b/src/lib/parquet/src/Flow/Parquet/Writer.php
@@ -130,7 +130,6 @@ final class Writer
      */
     public function openForStream($resource, Schema $schema) : void
     {
-        /** @psalm-suppress DocblockTypeContradiction */
         if (!\is_resource($resource)) {
             throw new InvalidArgumentException('Given argument is not a valid resource');
         }
@@ -227,7 +226,6 @@ final class Writer
             throw new RuntimeException('Writer is already open');
         }
 
-        /** @psalm-suppress DocblockTypeContradiction */
         if (!\is_resource($resource)) {
             throw new InvalidArgumentException('Given argument is not a valid resource');
         }


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <li>cache batch size configuration</li>

  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Replaced CompressingSerializer with NativeSerizer</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

I recently noticed drastic performance degradation in the sorting operation, and since sort is set up to move to file based sorting only after reaching specific memory consumption, it wasn't that easy to nice it in the first place. 

Pretty much the problem is a missed regression, after I changed the way how extractors/loaders are working (by default one row at time) I missed the fact that it will also hit the caching pipeline which affects sorting. 

To resolve that issue new config entry was added, `cache batch size` which by default is set to 2000. This means that the caching pipeline will process 2000 rows at once, reducing the number of I/O operations. 

On top of that I also changed default CompressingSerializer into NativeSerializer which is not doing any compressions that also gives us some noticeable performance boost. 

Additionally, during the investigation, I noticed that PSRSimpleCache implementation is not the most optimal way of using PSR16Cache, I will create a dedicated issue for that. 