### PR TITLE
Improve performance of merching rows into given batch size

### DIFF
--- a/src/core/etl/src/Flow/ETL/Filesystem/Path.php
+++ b/src/core/etl/src/Flow/ETL/Filesystem/Path.php
@@ -16,6 +16,8 @@ final class Path
 
     private string $filename;
 
+    private ?bool $isPattern = null;
+
     private ?Partitions $partitions = null;
 
     private string $path;
@@ -206,7 +208,13 @@ final class Path
 
     public function isPattern() : bool
     {
-        return $this->isPathPattern($this->path);
+        if ($this->isPattern !== null) {
+            return $this->isPattern;
+        }
+
+        $this->isPattern = $this->isPathPattern($this->path);
+
+        return $this->isPattern;
     }
 
     public function matches(self $path) : bool

--- a/src/core/etl/src/Flow/ETL/Rows.php
+++ b/src/core/etl/src/Flow/ETL/Rows.php
@@ -62,7 +62,7 @@ final class Rows implements \ArrayAccess, \Countable, \IteratorAggregate
     }
 
     /**
-     * return array<Row>.
+     * @return array<Row>
      */
     public function all() : array
     {

--- a/src/core/etl/src/Flow/ETL/Rows.php
+++ b/src/core/etl/src/Flow/ETL/Rows.php
@@ -62,6 +62,14 @@ final class Rows implements \ArrayAccess, \Countable, \IteratorAggregate
     }
 
     /**
+     * return array<Row>.
+     */
+    public function all() : array
+    {
+        return $this->rows;
+    }
+
+    /**
      * @param int<1, max> $size
      *
      * @return \Generator<Rows>


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>Improve performance of merching rows into given batch size</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

Based on https://github.com/flow-php/flow/issues/1044 issue I was able to identify one bottleneck and resolve it: 

Before:
```
Processing: countries.tsv (115Mb) - batchSize: 5000 - limit: no-limit...
DB Entries count: 1 557 190
Total time: 224.21s
```

After: 
```
Processing: countries.tsv (115Mb) - batchSize: 5000 - limit: no-limit...
DB Entries count: 1 557 190
Time: 182.09s
```
