### PR TITLE
Fixed replacing instance of dataframe when using aggregate method

### DIFF
--- a/src/core/etl/src/Flow/ETL/DataFrame.php
+++ b/src/core/etl/src/Flow/ETL/DataFrame.php
@@ -607,16 +607,6 @@ final class DataFrame
 
     /**
      * @lazy
-     *
-     * @param callable(Pipeline $pipeline, FlowContext $context) : DataFrame $callback
-     */
-    public function rebuild(callable $callback) : self
-    {
-        return $callback($this->pipeline, $this->context);
-    }
-
-    /**
-     * @lazy
      */
     public function rename(string $from, string $to) : self
     {

--- a/src/core/etl/src/Flow/ETL/Pipeline/LinkedPipeline.php
+++ b/src/core/etl/src/Flow/ETL/Pipeline/LinkedPipeline.php
@@ -57,9 +57,7 @@ final class LinkedPipeline implements OverridingPipeline, Pipeline
 
     public function process(FlowContext $context) : \Generator
     {
-        foreach ($this->nextPipeline->process($context) as $rows) {
-            yield $rows;
-        }
+        return $this->nextPipeline->process($context);
     }
 
     public function source() : Extractor


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>DataFrame::aggregate returns the same instance of dataframe with updated pipeline</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

<!-- Please provide a short description of changes in this section, feel free to use markdown syntax -->

As much as I hate using reflections I even more hate the idea of exposing Pipelines outside the dataframe. Pipelines are considered to be internal and should not be exposed as it's not something we want to provide BC promise. 

I couldn't find a better compromise between keeping the data frame mutable (it's just a big builder for the pipeline) and allowing it to expose partial builders like in this case GroupBy. Since we are just building a pipeline, returning a new instance of its builder is highly problematic since it's already a different object so it can't be referenced anymore.

```php
<?php

$df = df();
$df->read(...);
$df->withEntry(...);
$df->aggregate(...)
// without reflection this would not work anymore
$df->rename(...)
$rows = $df->fetch();
```

The goal of GroupedDataFrame is to not let users do something like for example `DataFrame::groupBy()->run()`. That would be highly problematic since it would be a source of memory leaks as grouping without aggregation is just collecting all rows. InnerBuilders for more advanced transformations are also improving DX since IDE will guide developers through all possible methods. 