### PR TITLE
Adjust Inflection to run only on changed files

### DIFF
--- a/.github/workflows/test-mutations.yml
+++ b/.github/workflows/test-mutations.yml
@@ -77,4 +77,6 @@ jobs:
         run: "composer install --no-interaction --no-progress --no-suggest"
 
       - name: "Mutation Tests"
-        run: "composer test:mutation -- --logger-github=false"
+        run: |
+          git fetch origin $GITHUB_BASE_REF    
+          composer test:mutation -- --logger-github=false --threads=max --git-diff-lines --git-diff-base=origin/$GITHUB_BASE_REF --ignore-msi-with-no-mutations

--- a/inflection.json5.dist
+++ b/inflection.json5.dist
@@ -1,0 +1,12 @@
+{
+    "$schema": "vendor/infection/infection/resources/schema.json",
+    "testFrameworkOptions": "--testsuite=unit",
+    "source": {
+        "directories": [
+            "src"
+        ]
+    },
+    "mutators": {
+        "@default": true,
+    }
+}

--- a/src/adapter/etl-adapter-text/src/Flow/ETL/Adapter/Text/TextExtractor.php
+++ b/src/adapter/etl-adapter-text/src/Flow/ETL/Adapter/Text/TextExtractor.php
@@ -28,10 +28,6 @@ final class TextExtractor implements Extractor, FileExtractor, LimitableExtracto
 
             $rowData = \fgets($stream->resource());
 
-            if ($rowData === false) {
-                return;
-            }
-
             while ($rowData !== false) {
                 if ($shouldPutInputIntoRows) {
                     $row = [['text' => \rtrim($rowData), '_input_file_uri' => $stream->path()->uri()]];


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Adjust Inflection to run only on changed files</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

Using new feature from https://github.com/infection/infection/pull/1919 to not run Inflection against whole codebase, but only on the changed files.
