### PR TITLE
Added type comparable assertion to scalar comparison functions to avoid unpredictable comparisons between different types

### DIFF
--- a/src/adapter/etl-adapter-filesystem/tests/Flow/ETL/Adapter/Filesystem/Tests/Integration/FlysystemFSTest.php
+++ b/src/adapter/etl-adapter-filesystem/tests/Flow/ETL/Adapter/Filesystem/Tests/Integration/FlysystemFSTest.php
@@ -9,6 +9,7 @@ use Flow\ETL\Adapter\Filesystem\FlysystemFS;
 use Flow\ETL\Filesystem\Path;
 use Flow\ETL\Filesystem\Stream\Mode;
 use Flow\ETL\Partition\{NoopFilter, ScalarFunctionFilter};
+use Flow\ETL\PHP\Type\{AutoCaster, Caster};
 use Flow\ETL\Row\Factory\NativeEntryFactory;
 use PHPUnit\Framework\TestCase;
 
@@ -90,7 +91,8 @@ STRING,
                                 ref('date')->cast('date')->lessThan(lit(new \DateTimeImmutable('2022-01-04 00:00:00')))
                             )
                         ),
-                        new NativeEntryFactory()
+                        new NativeEntryFactory(),
+                        new AutoCaster(Caster::default())
                     )
                 )
         );
@@ -129,7 +131,7 @@ STRING,
                 (new FlysystemFS())
                     ->scan(
                         new Path(__DIR__ . '/Fixtures/partitioned/**/*.txt'),
-                        new ScalarFunctionFilter(ref('partition_01')->equals(lit('b')), new NativeEntryFactory())
+                        new ScalarFunctionFilter(ref('partition_01')->equals(lit('b')), new NativeEntryFactory(), new AutoCaster(Caster::default()))
                     )
             )
         );

--- a/src/core/etl/src/Flow/ETL/Config.php
+++ b/src/core/etl/src/Flow/ETL/Config.php
@@ -6,6 +6,7 @@ namespace Flow\ETL;
 
 use Flow\ETL\Exception\InvalidArgumentException;
 use Flow\ETL\Filesystem\FilesystemStreams;
+use Flow\ETL\PHP\Type\Caster;
 use Flow\ETL\Pipeline\Optimizer;
 use Flow\ETL\Row\EntryFactory;
 use Flow\Serializer\Serializer;
@@ -30,6 +31,7 @@ final class Config
         private readonly ExternalSort $externalSort,
         private readonly FilesystemStreams $filesystemStreams,
         private readonly Optimizer $optimizer,
+        private readonly Caster $caster,
         private readonly bool $putInputIntoRows,
         private readonly EntryFactory $entryFactory,
         private readonly int $cacheBatchSize
@@ -60,6 +62,11 @@ final class Config
     public function cacheBatchSize() : int
     {
         return $this->cacheBatchSize;
+    }
+
+    public function caster() : Caster
+    {
+        return $this->caster;
     }
 
     public function entryFactory() : EntryFactory

--- a/src/core/etl/src/Flow/ETL/ConfigBuilder.php
+++ b/src/core/etl/src/Flow/ETL/ConfigBuilder.php
@@ -9,6 +9,7 @@ use Flow\ETL\Exception\InvalidArgumentException;
 use Flow\ETL\ExternalSort\MemorySort;
 use Flow\ETL\Filesystem\{FilesystemStreams, LocalFilesystem};
 use Flow\ETL\Monitoring\Memory\Unit;
+use Flow\ETL\PHP\Type\Caster;
 use Flow\ETL\Pipeline\Optimizer;
 use Flow\ETL\Row\Factory\NativeEntryFactory;
 use Flow\Serializer\{Base64Serializer, NativePHPSerializer, Serializer};
@@ -21,6 +22,8 @@ final class ConfigBuilder
      * @var int<1, max>
      */
     private int $cacheBatchSize = 1000;
+
+    private ?Caster $caster;
 
     private ?ExternalSort $externalSort;
 
@@ -43,6 +46,7 @@ final class ConfigBuilder
         $this->filesystem = null;
         $this->putInputIntoRows = false;
         $this->optimizer = null;
+        $this->caster = null;
     }
 
     /**
@@ -89,6 +93,8 @@ final class ConfigBuilder
             new Optimizer\BatchSizeOptimization(batchSize: 1000)
         );
 
+        $this->caster ??= Caster::default();
+
         return new Config(
             $this->id,
             $this->serializer,
@@ -96,6 +102,7 @@ final class ConfigBuilder
             $this->externalSort,
             new FilesystemStreams($this->filesystem),
             $this->optimizer,
+            $this->caster,
             $this->putInputIntoRows,
             $entryFactory,
             $this->cacheBatchSize

--- a/src/core/etl/src/Flow/ETL/DataFrame.php
+++ b/src/core/etl/src/Flow/ETL/DataFrame.php
@@ -16,7 +16,7 @@ use Flow\ETL\Join\{Expression, Join};
 use Flow\ETL\Loader\SchemaValidationLoader;
 use Flow\ETL\Loader\StreamLoader\Output;
 use Flow\ETL\Partition\ScalarFunctionFilter;
-use Flow\ETL\PHP\Type\{AutoCaster, Caster};
+use Flow\ETL\PHP\Type\{AutoCaster};
 use Flow\ETL\Pipeline\{BatchingPipeline,
     CachingPipeline,
     CollectingPipeline,
@@ -137,7 +137,7 @@ final class DataFrame
 
     public function autoCast() : self
     {
-        $this->pipeline->add(new AutoCastTransformer(new AutoCaster(Caster::default())));
+        $this->pipeline->add(new AutoCastTransformer(new AutoCaster($this->context->config->caster())));
 
         return $this;
     }
@@ -374,7 +374,13 @@ final class DataFrame
             return $this;
         }
 
-        $extractor->addPartitionFilter(new ScalarFunctionFilter($filter, $this->context->entryFactory()));
+        $extractor->addPartitionFilter(
+            new ScalarFunctionFilter(
+                $filter,
+                $this->context->entryFactory(),
+                new AutoCaster($this->context->config->caster())
+            )
+        );
 
         return $this;
     }

--- a/src/core/etl/src/Flow/ETL/Function/Comparison/Comparable.php
+++ b/src/core/etl/src/Flow/ETL/Function/Comparison/Comparable.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Function\Comparison;
+
+use Flow\ETL\Exception\InvalidArgumentException;
+use Flow\ETL\PHP\Type\TypeDetector;
+
+trait Comparable
+{
+    public function assertComparable(mixed $base, mixed $next, string $symbol) : void
+    {
+        $detector = new TypeDetector();
+        $baseType = $detector->detectType($base);
+        $nextType = $detector->detectType($next);
+
+        if (!$baseType->isComparableWith($nextType)) {
+            throw new InvalidArgumentException(\sprintf("Can't compare '(%s %s %s)' due to data type mismatch.", $baseType->toString(), $symbol, $nextType->toString()));
+        }
+    }
+}

--- a/src/core/etl/src/Flow/ETL/Function/Concat.php
+++ b/src/core/etl/src/Flow/ETL/Function/Concat.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Function;
 
+use function Flow\ETL\DSL\type_string;
+use Flow\ETL\PHP\Type\Caster;
 use Flow\ETL\Row;
 
 final class Concat extends ScalarFunctionChain
@@ -22,7 +24,7 @@ final class Concat extends ScalarFunctionChain
     public function eval(Row $row) : mixed
     {
         $values = \array_map(function (ScalarFunction $ref) use ($row) : mixed {
-            return (new Cast($ref, 'string'))->eval($row);
+            return Caster::default()->to(type_string(true))->value($ref->eval($row));
         }, $this->refs);
 
         foreach ($values as $value) {

--- a/src/core/etl/src/Flow/ETL/Function/Equals.php
+++ b/src/core/etl/src/Flow/ETL/Function/Equals.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Function;
 
+use Flow\ETL\Function\Comparison\Comparable;
 use Flow\ETL\Row;
 
 final class Equals extends ScalarFunctionChain
 {
+    use Comparable;
+
     public function __construct(
         private readonly ScalarFunction $base,
         private readonly ScalarFunction $next
@@ -18,6 +21,8 @@ final class Equals extends ScalarFunctionChain
     {
         $base = $this->base->eval($row);
         $next = $this->next->eval($row);
+
+        $this->assertComparable($base, $next, '==');
 
         return $base == $next;
     }

--- a/src/core/etl/src/Flow/ETL/Function/GreaterThan.php
+++ b/src/core/etl/src/Flow/ETL/Function/GreaterThan.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Function;
 
+use Flow\ETL\Function\Comparison\Comparable;
 use Flow\ETL\Row;
 
 final class GreaterThan extends ScalarFunctionChain
 {
+    use Comparable;
+
     public function __construct(
         private readonly ScalarFunction $base,
         private readonly ScalarFunction $next
@@ -18,6 +21,8 @@ final class GreaterThan extends ScalarFunctionChain
     {
         $base = $this->base->eval($row);
         $next = $this->next->eval($row);
+
+        $this->assertComparable($base, $next, '>');
 
         return $base > $next;
     }

--- a/src/core/etl/src/Flow/ETL/Function/GreaterThanEqual.php
+++ b/src/core/etl/src/Flow/ETL/Function/GreaterThanEqual.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Function;
 
+use Flow\ETL\Function\Comparison\Comparable;
 use Flow\ETL\Row;
 
 final class GreaterThanEqual extends ScalarFunctionChain
 {
+    use Comparable;
+
     public function __construct(
         private readonly ScalarFunction $base,
         private readonly ScalarFunction $next
@@ -18,6 +21,8 @@ final class GreaterThanEqual extends ScalarFunctionChain
     {
         $base = $this->base->eval($row);
         $next = $this->next->eval($row);
+
+        $this->assertComparable($base, $next, '>=');
 
         return $base >= $next;
     }

--- a/src/core/etl/src/Flow/ETL/Function/LessThan.php
+++ b/src/core/etl/src/Flow/ETL/Function/LessThan.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Function;
 
+use Flow\ETL\Function\Comparison\Comparable;
 use Flow\ETL\Row;
 
 final class LessThan extends ScalarFunctionChain
 {
+    use Comparable;
+
     public function __construct(
         private readonly ScalarFunction $base,
         private readonly ScalarFunction $next
@@ -18,6 +21,8 @@ final class LessThan extends ScalarFunctionChain
     {
         $base = $this->base->eval($row);
         $next = $this->next->eval($row);
+
+        $this->assertComparable($base, $next, '<');
 
         return $base < $next;
     }

--- a/src/core/etl/src/Flow/ETL/Function/LessThanEqual.php
+++ b/src/core/etl/src/Flow/ETL/Function/LessThanEqual.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Function;
 
+use Flow\ETL\Function\Comparison\Comparable;
 use Flow\ETL\Row;
 
 final class LessThanEqual extends ScalarFunctionChain
 {
+    use Comparable;
+
     public function __construct(
         private readonly ScalarFunction $base,
         private readonly ScalarFunction $next
@@ -18,6 +21,8 @@ final class LessThanEqual extends ScalarFunctionChain
     {
         $base = $this->base->eval($row);
         $next = $this->next->eval($row);
+
+        $this->assertComparable($base, $next, '<=');
 
         return $base <= $next;
     }

--- a/src/core/etl/src/Flow/ETL/Function/NotEquals.php
+++ b/src/core/etl/src/Flow/ETL/Function/NotEquals.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Function;
 
+use Flow\ETL\Function\Comparison\Comparable;
 use Flow\ETL\Row;
 
 final class NotEquals extends ScalarFunctionChain
 {
+    use Comparable;
+
     public function __construct(
         private readonly ScalarFunction $base,
         private readonly ScalarFunction $next
@@ -18,6 +21,8 @@ final class NotEquals extends ScalarFunctionChain
     {
         $base = $this->base->eval($row);
         $next = $this->next->eval($row);
+
+        $this->assertComparable($base, $next, '!=');
 
         return $base != $next;
     }

--- a/src/core/etl/src/Flow/ETL/Function/NotSame.php
+++ b/src/core/etl/src/Flow/ETL/Function/NotSame.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Function;
 
+use Flow\ETL\Function\Comparison\Comparable;
 use Flow\ETL\Row;
 
 final class NotSame extends ScalarFunctionChain
 {
+    use Comparable;
+
     public function __construct(
         private readonly ScalarFunction $base,
         private readonly ScalarFunction $next
@@ -18,6 +21,8 @@ final class NotSame extends ScalarFunctionChain
     {
         $base = $this->base->eval($row);
         $next = $this->next->eval($row);
+
+        $this->assertComparable($base, $next, '!==');
 
         return $base !== $next;
     }

--- a/src/core/etl/src/Flow/ETL/Function/Same.php
+++ b/src/core/etl/src/Flow/ETL/Function/Same.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Function;
 
+use Flow\ETL\Function\Comparison\Comparable;
 use Flow\ETL\Row;
 
 final class Same extends ScalarFunctionChain
 {
+    use Comparable;
+
     public function __construct(
         private readonly ScalarFunction $base,
         private readonly ScalarFunction $next
@@ -18,6 +21,8 @@ final class Same extends ScalarFunctionChain
     {
         $base = $this->base->eval($row);
         $next = $this->next->eval($row);
+
+        $this->assertComparable($base, $next, '===');
 
         return $base === $next;
     }

--- a/src/core/etl/src/Flow/ETL/Function/Sanitize.php
+++ b/src/core/etl/src/Flow/ETL/Function/Sanitize.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Function;
 
+use function Flow\ETL\DSL\{type_int, type_string};
+use Flow\ETL\PHP\Type\Caster;
 use Flow\ETL\Row;
 
 final class Sanitize extends ScalarFunctionChain
@@ -24,8 +26,8 @@ final class Sanitize extends ScalarFunctionChain
             return null;
         }
 
-        $placeholder = (string) $this->placeholder->eval($row);
-        $skipCharacters = (int) $this->skipCharacters->eval($row);
+        $placeholder = Caster::default()->to(type_string(true))->value($this->placeholder->eval($row));
+        $skipCharacters = Caster::default()->to(type_int(true))->value($this->skipCharacters->eval($row));
 
         $size = \mb_strlen($val);
 

--- a/src/core/etl/src/Flow/ETL/Function/StartsWith.php
+++ b/src/core/etl/src/Flow/ETL/Function/StartsWith.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Function;
 
+use function Flow\ETL\DSL\type_string;
+use Flow\ETL\PHP\Type\Caster;
 use Flow\ETL\Row;
 
 final class StartsWith extends ScalarFunctionChain
@@ -16,8 +18,8 @@ final class StartsWith extends ScalarFunctionChain
 
     public function eval(Row $row) : bool
     {
-        $haystack = $this->haystack->eval($row);
-        $needle = $this->needle->eval($row);
+        $haystack = Caster::default()->to(type_string(true))->value($this->haystack->eval($row));
+        $needle = Caster::default()->to(type_string(true))->value($this->needle->eval($row));
 
         if (!\is_string($needle) || !\is_string($haystack)) {
             return false;

--- a/src/core/etl/src/Flow/ETL/Function/StrPad.php
+++ b/src/core/etl/src/Flow/ETL/Function/StrPad.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Function;
 
+use function Flow\ETL\DSL\type_string;
+use Flow\ETL\PHP\Type\Caster;
 use Flow\ETL\Row;
 
 final class StrPad extends ScalarFunctionChain
@@ -18,8 +20,8 @@ final class StrPad extends ScalarFunctionChain
 
     public function eval(Row $row) : mixed
     {
-        /** @var mixed $val */
-        $val = $this->ref->eval($row);
+        /** @var null|string $val */
+        $val = Caster::default()->to(type_string(true))->value($this->ref->eval($row));
 
         if (!\is_string($val)) {
             return null;

--- a/src/core/etl/src/Flow/ETL/Function/StrReplace.php
+++ b/src/core/etl/src/Flow/ETL/Function/StrReplace.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Function;
 
+use function Flow\ETL\DSL\type_string;
+use Flow\ETL\PHP\Type\Caster;
 use Flow\ETL\Row;
 
 final class StrReplace extends ScalarFunctionChain
@@ -21,8 +23,8 @@ final class StrReplace extends ScalarFunctionChain
 
     public function eval(Row $row) : mixed
     {
-        /** @var mixed $val */
-        $val = $this->ref->eval($row);
+        /** @var null|string $val */
+        $val = Caster::default()->to(type_string(true))->value($this->ref->eval($row));
 
         if (!\is_string($val)) {
             return null;

--- a/src/core/etl/src/Flow/ETL/Function/ToMoney.php
+++ b/src/core/etl/src/Flow/ETL/Function/ToMoney.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Function;
 
+use function Flow\ETL\DSL\type_string;
 use Flow\ETL\Exception\RuntimeException;
+use Flow\ETL\PHP\Type\Caster;
 use Flow\ETL\Row;
 use Money\Currencies\ISOCurrencies;
 use Money\Parser\DecimalMoneyParser;
@@ -25,7 +27,7 @@ final class ToMoney extends ScalarFunctionChain
 
     public function eval(Row $row) : ?Money
     {
-        $currency = $this->currencyRef->eval($row);
+        $currency = Caster::default()->to(type_string(true))->value($this->currencyRef->eval($row));
 
         if (!\is_string($currency)) {
             return null;

--- a/src/core/etl/src/Flow/ETL/Function/Trim.php
+++ b/src/core/etl/src/Flow/ETL/Function/Trim.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Function;
 
+use function Flow\ETL\DSL\type_string;
 use Flow\ETL\Function\Trim\Type;
+use Flow\ETL\PHP\Type\Caster;
 use Flow\ETL\Row;
 
 final class Trim extends ScalarFunctionChain
@@ -18,8 +20,8 @@ final class Trim extends ScalarFunctionChain
 
     public function eval(Row $row) : mixed
     {
-        /** @var mixed $value */
-        $value = $this->ref->eval($row);
+        /** @var null|string $value */
+        $value = Caster::default()->to(type_string(true))->value($this->ref->eval($row));
 
         if (!\is_string($value)) {
             return null;

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Logical/DateTimeType.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Logical/DateTimeType.php
@@ -19,6 +19,19 @@ final class DateTimeType implements LogicalType
         return new self($data['nullable'] ?? false);
     }
 
+    public function isComparableWith(Type $type) : bool
+    {
+        if ($type instanceof self) {
+            return true;
+        }
+
+        if ($type instanceof NullType) {
+            return true;
+        }
+
+        return false;
+    }
+
     public function isEqual(Type $type) : bool
     {
         return $type instanceof self;

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Logical/JsonType.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Logical/JsonType.php
@@ -20,6 +20,19 @@ final class JsonType implements LogicalType
         return new self($data['nullable'] ?? false);
     }
 
+    public function isComparableWith(Type $type) : bool
+    {
+        if ($type instanceof self) {
+            return true;
+        }
+
+        if ($type instanceof NullType) {
+            return true;
+        }
+
+        return false;
+    }
+
     public function isEqual(Type $type) : bool
     {
         return $type instanceof self;

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Logical/ListType.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Logical/ListType.php
@@ -25,6 +25,19 @@ final class ListType implements LogicalType
         return $this->element;
     }
 
+    public function isComparableWith(Type $type) : bool
+    {
+        if ($type instanceof self) {
+            return true;
+        }
+
+        if ($type instanceof NullType) {
+            return true;
+        }
+
+        return false;
+    }
+
     public function isEqual(Type $type) : bool
     {
         if (!$type instanceof self) {

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Logical/MapType.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Logical/MapType.php
@@ -20,6 +20,19 @@ final class MapType implements LogicalType
         return new self(MapKey::fromArray($data['key']), MapValue::fromArray($data['value']), $data['nullable'] ?? false);
     }
 
+    public function isComparableWith(Type $type) : bool
+    {
+        if ($type instanceof self) {
+            return true;
+        }
+
+        if ($type instanceof NullType) {
+            return true;
+        }
+
+        return false;
+    }
+
     public function isEqual(Type $type) : bool
     {
         if (!$type instanceof self) {

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Logical/StructureType.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Logical/StructureType.php
@@ -52,6 +52,19 @@ final class StructureType implements LogicalType
         return $this->elements;
     }
 
+    public function isComparableWith(Type $type) : bool
+    {
+        if ($type instanceof self) {
+            return true;
+        }
+
+        if ($type instanceof NullType) {
+            return true;
+        }
+
+        return false;
+    }
+
     public function isEqual(Type $type) : bool
     {
         if (!$type instanceof self) {

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Logical/UuidType.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Logical/UuidType.php
@@ -20,6 +20,19 @@ final class UuidType implements LogicalType
         return new self($data['nullable'] ?? false);
     }
 
+    public function isComparableWith(Type $type) : bool
+    {
+        if ($type instanceof self) {
+            return true;
+        }
+
+        if ($type instanceof NullType) {
+            return true;
+        }
+
+        return false;
+    }
+
     public function isEqual(Type $type) : bool
     {
         return $type instanceof self;

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Logical/XMLElementType.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Logical/XMLElementType.php
@@ -19,6 +19,15 @@ final class XMLElementType implements LogicalType
         return new self($data['nullable'] ?? false);
     }
 
+    public function isComparableWith(Type $type) : bool
+    {
+        if ($type instanceof NullType) {
+            return true;
+        }
+
+        return false;
+    }
+
     public function isEqual(Type $type) : bool
     {
         return $type instanceof self;

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Logical/XMLType.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Logical/XMLType.php
@@ -19,6 +19,15 @@ final class XMLType implements LogicalType
         return new self($data['nullable'] ?? false);
     }
 
+    public function isComparableWith(Type $type) : bool
+    {
+        if ($type instanceof NullType) {
+            return true;
+        }
+
+        return false;
+    }
+
     public function isEqual(Type $type) : bool
     {
         return $type instanceof self;

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Native/ArrayType.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Native/ArrayType.php
@@ -23,6 +23,19 @@ final class ArrayType implements NativeType
         return new self($data['empty'] ?? false, $data['nullable'] ?? false);
     }
 
+    public function isComparableWith(Type $type) : bool
+    {
+        if ($type instanceof NullType) {
+            return true;
+        }
+
+        if ($type instanceof self) {
+            return true;
+        }
+
+        return false;
+    }
+
     public function isEqual(Type $type) : bool
     {
         return $type instanceof self && $this->empty === $type->empty;

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Native/CallableType.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Native/CallableType.php
@@ -19,6 +19,15 @@ final class CallableType implements NativeType
         return new self($data['nullable'] ?? false);
     }
 
+    public function isComparableWith(Type $type) : bool
+    {
+        if ($type instanceof NullType) {
+            return true;
+        }
+
+        return false;
+    }
+
     public function isEqual(Type $type) : bool
     {
         return $type instanceof self && $this->nullable === $type->nullable;

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Native/EnumType.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Native/EnumType.php
@@ -38,6 +38,23 @@ final class EnumType implements NativeType
         return new self($class, $nullable);
     }
 
+    public function isComparableWith(Type $type) : bool
+    {
+        if ($type instanceof self) {
+            return true;
+        }
+
+        if ($type instanceof NullType) {
+            return true;
+        }
+
+        if ($type instanceof ScalarType && \is_a($this->class, \BackedEnum::class, true)) {
+            return true;
+        }
+
+        return false;
+    }
+
     public function isEqual(Type $type) : bool
     {
         return $type instanceof self && $this->class === $type->class && $this->nullable === $type->nullable;

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Native/NullType.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Native/NullType.php
@@ -13,6 +13,11 @@ final class NullType implements NativeType
         return new self();
     }
 
+    public function isComparableWith(Type $type) : bool
+    {
+        return true;
+    }
+
     public function isEqual(Type $type) : bool
     {
         return $type instanceof self;

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Native/ObjectType.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Native/ObjectType.php
@@ -30,6 +30,15 @@ final class ObjectType implements NativeType
         return new self($data['class'], $nullable);
     }
 
+    public function isComparableWith(Type $type) : bool
+    {
+        if ($type instanceof self) {
+            return true;
+        }
+
+        return false;
+    }
+
     public function isEqual(Type $type) : bool
     {
         return $type instanceof self && $this->class === $type->class && $this->nullable === $type->nullable;

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Native/ResourceType.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Native/ResourceType.php
@@ -19,6 +19,15 @@ final class ResourceType implements NativeType
         return new self($data['nullable'] ?? false);
     }
 
+    public function isComparableWith(Type $type) : bool
+    {
+        if ($type instanceof NullType) {
+            return true;
+        }
+
+        return false;
+    }
+
     public function isEqual(Type $type) : bool
     {
         return $type instanceof self && $this->nullable === $type->nullable;

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Native/ScalarType.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Native/ScalarType.php
@@ -66,6 +66,19 @@ final class ScalarType implements NativeType
         return $this->type === self::BOOLEAN;
     }
 
+    public function isComparableWith(Type $type) : bool
+    {
+        if ($type instanceof self) {
+            return true;
+        }
+
+        if ($type instanceof NullType) {
+            return true;
+        }
+
+        return false;
+    }
+
     public function isEqual(Type $type) : bool
     {
         return $type instanceof self && $type->type === $this->type && $this->nullable === $type->nullable;

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Type.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Type.php
@@ -8,6 +8,8 @@ interface Type
 {
     public static function fromArray(array $data) : self;
 
+    public function isComparableWith(self $type) : bool;
+
     public function isEqual(self $type) : bool;
 
     public function isValid(mixed $value) : bool;

--- a/src/core/etl/src/Flow/ETL/Partition/ScalarFunctionFilter.php
+++ b/src/core/etl/src/Flow/ETL/Partition/ScalarFunctionFilter.php
@@ -7,29 +7,27 @@ namespace Flow\ETL\Partition;
 use function Flow\ETL\DSL\row;
 use Flow\ETL\Function\ScalarFunction;
 use Flow\ETL\Partition;
+use Flow\ETL\PHP\Type\AutoCaster;
 use Flow\ETL\Row\EntryFactory;
 
 final class ScalarFunctionFilter implements PartitionFilter
 {
     public function __construct(
         private readonly ScalarFunction $function,
-        private readonly EntryFactory $entryFactory
+        private readonly EntryFactory $entryFactory,
+        private readonly AutoCaster $caster
     ) {
     }
 
     public function keep(Partition ...$partitions) : bool
     {
-        try {
-            return (bool) $this->function->eval(
-                row(
-                    ...\array_map(
-                        fn (Partition $partition) => $this->entryFactory->create($partition->name, $partition->value),
-                        $partitions
-                    )
+        return (bool) $this->function->eval(
+            row(
+                ...\array_map(
+                    fn (Partition $partition) => $this->entryFactory->create($partition->name, $this->caster->cast($partition->value)),
+                    $partitions
                 )
-            );
-        } catch (\Exception $e) {
-            return false;
-        }
+            )
+        );
     }
 }

--- a/src/core/etl/tests/Flow/ETL/Tests/Integration/DataFrame/PartitioningTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Integration/DataFrame/PartitioningTest.php
@@ -191,7 +191,12 @@ final class PartitioningTest extends IntegrationTestCase
     {
         $rows = df()
             ->read(from_text(__DIR__ . '/Fixtures/Partitioning/multi_partition_pruning_test/year=*/month=*/day=*/*.txt'))
-            ->filterPartitions(ref('year')->concat(lit('-'), ref('month')->strPadLeft(2, '0'), lit('-'), ref('day')->strPadLeft(2, '0'))->cast('date')->greaterThanEqual(lit(new \DateTimeImmutable('2023-01-01'))))
+            ->filterPartitions(
+                ref('year')
+                    ->concat(lit('-'), ref('month')->strPadLeft(2, '0'), lit('-'), ref('day')->strPadLeft(2, '0'))
+                    ->cast('date')
+                    ->greaterThanEqual(lit(new \DateTimeImmutable('2023-01-01')))
+            )
             ->collect()
             ->select('year')
             ->withEntry('year', ref('year')->cast('int'))

--- a/src/core/etl/tests/Flow/ETL/Tests/Integration/Filesystem/LocalFilesystemTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Integration/Filesystem/LocalFilesystemTest.php
@@ -8,6 +8,7 @@ use function Flow\ETL\DSL\{all, lit, ref};
 use Flow\ETL\Filesystem\Stream\Mode;
 use Flow\ETL\Filesystem\{LocalFilesystem, Path};
 use Flow\ETL\Partition\{NoopFilter, ScalarFunctionFilter};
+use Flow\ETL\PHP\Type\{AutoCaster, Caster};
 use Flow\ETL\Row\Factory\NativeEntryFactory;
 use PHPUnit\Framework\TestCase;
 
@@ -89,7 +90,8 @@ STRING,
                                 ref('date')->cast('date')->lessThan(lit(new \DateTimeImmutable('2022-01-04')))
                             )
                         ),
-                        new NativeEntryFactory()
+                        new NativeEntryFactory(),
+                        new AutoCaster(Caster::default())
                     )
                 )
         );
@@ -128,7 +130,7 @@ STRING,
                 (new LocalFilesystem())
                     ->scan(
                         new Path(__DIR__ . '/Fixtures/partitioned/**/*.txt'),
-                        new ScalarFunctionFilter(ref('partition_01')->equals(lit('b')), new NativeEntryFactory())
+                        new ScalarFunctionFilter(ref('partition_01')->equals(lit('b')), new NativeEntryFactory(), new AutoCaster(Caster::default()))
                     )
             )
         );

--- a/src/core/etl/tests/Flow/ETL/Tests/Integration/Function/StartsWithTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Integration/Function/StartsWithTest.php
@@ -49,7 +49,7 @@ final class StartsWithTest extends TestCase
 
         self::assertSame(
             [
-                ['id' => 1, 'starts_with' => false],
+                ['id' => 1, 'starts_with' => true],
             ],
             $memory->dump()
         );
@@ -71,7 +71,7 @@ final class StartsWithTest extends TestCase
 
         self::assertSame(
             [
-                ['id' => '1', 'starts_with' => false],
+                ['id' => '1', 'starts_with' => true],
             ],
             $memory->dump()
         );

--- a/src/core/etl/tests/Flow/ETL/Tests/Integration/Function/StrPadTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Integration/Function/StrPadTest.php
@@ -49,7 +49,7 @@ final class StrPadTest extends TestCase
 
         self::assertSame(
             [
-                ['id' => 1, 'strpad' => null],
+                ['id' => 1, 'strpad' => '1         '],
             ],
             $memory->dump()
         );

--- a/src/core/etl/tests/Flow/ETL/Tests/Integration/Function/StrReplaceTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Integration/Function/StrReplaceTest.php
@@ -49,7 +49,7 @@ final class StrReplaceTest extends TestCase
 
         self::assertSame(
             [
-                ['id' => 1, 'str_replace' => null],
+                ['id' => 1, 'str_replace' => '1'],
             ],
             $memory->dump()
         );

--- a/src/core/etl/tests/Flow/ETL/Tests/Integration/Function/TrimTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Integration/Function/TrimTest.php
@@ -94,7 +94,7 @@ final class TrimTest extends TestCase
 
         self::assertSame(
             [
-                ['id' => 1, 'trim' => null],
+                ['id' => 1, 'trim' => '1'],
             ],
             $memory->dump()
         );

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Function/StrPadTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Function/StrPadTest.php
@@ -12,7 +12,8 @@ final class StrPadTest extends TestCase
 {
     public function test_str_pad_on_non_string_value() : void
     {
-        self::assertNull(
+        self::assertSame(
+            '-1000',
             ref('value')->strPad(5, '-', \STR_PAD_LEFT)->eval(Row::create(int_entry('value', 1000))),
         );
     }

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Function/StrReplaceTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Function/StrReplaceTest.php
@@ -12,7 +12,8 @@ final class StrReplaceTest extends TestCase
 {
     public function test_str_replace_on_non_string_value() : void
     {
-        self::assertNull(
+        self::assertSame(
+            '1000',
             ref('value')->strReplace('test', '1')->eval(Row::create(int_entry('value', 1000))),
         );
     }

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Function/TrimTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Function/TrimTest.php
@@ -21,7 +21,8 @@ final class TrimTest extends TestCase
 
     public function test_trim_integer() : void
     {
-        self::assertNull(
+        self::assertSame(
+            '1',
             ref('integer')->trim()->eval(Row::create(int_entry('integer', 1)))
         );
     }

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Partition/ScalarFunctionFilterTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Partition/ScalarFunctionFilterTest.php
@@ -7,6 +7,7 @@ namespace Flow\ETL\Tests\Unit\Partition;
 use function Flow\ETL\DSL\{all, any, lit, ref};
 use Flow\ETL\Partition;
 use Flow\ETL\Partition\ScalarFunctionFilter;
+use Flow\ETL\PHP\Type\{AutoCaster, Caster};
 use Flow\ETL\Row\Factory\NativeEntryFactory;
 use PHPUnit\Framework\TestCase;
 
@@ -16,20 +17,47 @@ final class ScalarFunctionFilterTest extends TestCase
     {
         $filter = new ScalarFunctionFilter(
             ref('foo')->greaterThan(lit(10)),
-            new NativeEntryFactory()
+            new NativeEntryFactory(),
+            new AutoCaster(Caster::default())
         );
 
         self::assertTrue($filter->keep(new Partition('foo', '100')));
         self::assertFalse($filter->keep(new Partition('foo', '5')));
     }
 
+    public function test_filtering_datetime_partitions() : void
+    {
+        $filter = new ScalarFunctionFilter(
+            ref('foo')->greaterThan(lit(new \DateTimeImmutable('2021-01-01'))),
+            new NativeEntryFactory(),
+            new AutoCaster(Caster::default())
+        );
+
+        self::assertTrue($filter->keep(new Partition('foo', '2021-01-02')));
+        self::assertFalse($filter->keep(new Partition('foo', '2020-12-31')));
+    }
+
+    public function test_filtering_datetime_partitions_by_string_value() : void
+    {
+        $filter = new ScalarFunctionFilter(
+            ref('foo')->greaterThan(lit('2021-01-01')),
+            new NativeEntryFactory(),
+            new AutoCaster(Caster::default())
+        );
+
+        $this->expectExceptionMessage("Can't compare '(datetime > string)' due to data type mismatch.");
+        self::assertTrue($filter->keep(new Partition('foo', '2021-01-02')));
+    }
+
     public function test_filtering_when_partition_is_not_covered_by_any_filter() : void
     {
         $filter = new ScalarFunctionFilter(
             ref('foo')->greaterThan(lit(10)),
-            new NativeEntryFactory()
+            new NativeEntryFactory(),
+            new AutoCaster(Caster::default())
         );
 
+        $this->expectExceptionMessage('Entry "foo" does not exist. Did you mean one of the following? ["bar"]');
         self::assertFalse($filter->keep(new Partition('bar', '100')));
     }
 
@@ -40,7 +68,8 @@ final class ScalarFunctionFilterTest extends TestCase
                 ref('foo')->greaterThanEqual(lit(100)),
                 ref('bar')->greaterThanEqual(lit(100))
             ),
-            new NativeEntryFactory()
+            new NativeEntryFactory(),
+            new AutoCaster(Caster::default())
         );
 
         self::assertTrue($filter->keep(new Partition('foo', '100'), new Partition('bar', '100')));
@@ -56,7 +85,8 @@ final class ScalarFunctionFilterTest extends TestCase
                 ref('foo')->greaterThanEqual(lit(100)),
                 ref('bar')->greaterThanEqual(lit(100))
             ),
-            new NativeEntryFactory()
+            new NativeEntryFactory(),
+            new AutoCaster(Caster::default())
         );
 
         self::assertTrue($filter->keep(new Partition('foo', '100'), new Partition('bar', '100')));


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>Scalar comparison functions are now also detecting types of compared values to prevent comparing not compatible values</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>String based Scalar functions are now using caster to cast values to string</li>
    <li>Moved caster to dataframe configuration</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

<!-- Please provide a short description of changes in this section, feel free to use markdown syntax -->
