### PR TITLE
Allow to use max/min aggregations on date time columns

### DIFF
--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Function/MaxTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Function/MaxTest.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Tests\Unit\Function;
 
-use function Flow\ETL\DSL\{float_entry, int_entry, ref, str_entry};
-use Flow\ETL\Row;
+use function Flow\ETL\DSL\{datetime_entry, float_entry, int_entry, ref, row, str_entry};
 use PHPUnit\Framework\TestCase;
 
 final class MaxTest extends TestCase
@@ -14,11 +13,11 @@ final class MaxTest extends TestCase
     {
         $aggregator = \Flow\ETL\DSL\max(ref('int'));
 
-        $aggregator->aggregate(Row::create(str_entry('int', '10')));
-        $aggregator->aggregate(Row::create(str_entry('int', '20')));
-        $aggregator->aggregate(Row::create(str_entry('int', '55')));
-        $aggregator->aggregate(Row::create(str_entry('int', '25')));
-        $aggregator->aggregate(Row::create(str_entry('not_int', null)));
+        $aggregator->aggregate(row(str_entry('int', '10')));
+        $aggregator->aggregate(row(str_entry('int', '20')));
+        $aggregator->aggregate(row(str_entry('int', '55')));
+        $aggregator->aggregate(row(str_entry('int', '25')));
+        $aggregator->aggregate(row(str_entry('not_int', null)));
 
         self::assertSame(
             55,
@@ -30,13 +29,28 @@ final class MaxTest extends TestCase
     {
         $aggregator = \Flow\ETL\DSL\max(ref('int'));
 
-        $aggregator->aggregate(Row::create(int_entry('int', 10)));
-        $aggregator->aggregate(Row::create(int_entry('int', 20)));
-        $aggregator->aggregate(Row::create(int_entry('int', 30)));
-        $aggregator->aggregate(Row::create(str_entry('int', null)));
+        $aggregator->aggregate(row(int_entry('int', 10)));
+        $aggregator->aggregate(row(int_entry('int', 20)));
+        $aggregator->aggregate(row(int_entry('int', 30)));
+        $aggregator->aggregate(row(str_entry('int', null)));
 
         self::assertSame(
             30,
+            $aggregator->result()->value()
+        );
+    }
+
+    public function test_aggregation_max_with_datetime_values() : void
+    {
+        $aggregator = \Flow\ETL\DSL\max(ref('datetime'));
+
+        $aggregator->aggregate(row(datetime_entry('datetime', '2021-01-01 00:00:00')));
+        $aggregator->aggregate(row(datetime_entry('datetime', '2021-01-02 00:00:00')));
+        $aggregator->aggregate(row(datetime_entry('datetime', '2021-01-03 00:00:00')));
+        $aggregator->aggregate(row(datetime_entry('datetime', '2021-01-04 00:00:00')));
+
+        self::assertEquals(
+            new \DateTimeImmutable('2021-01-04 00:00:00'),
             $aggregator->result()->value()
         );
     }
@@ -45,10 +59,10 @@ final class MaxTest extends TestCase
     {
         $aggregator = \Flow\ETL\DSL\max(ref('int'));
 
-        $aggregator->aggregate(Row::create(int_entry('int', 10)));
-        $aggregator->aggregate(Row::create(int_entry('int', 20)));
-        $aggregator->aggregate(Row::create(float_entry('int', 30.5)));
-        $aggregator->aggregate(Row::create(int_entry('int', 25)));
+        $aggregator->aggregate(row(int_entry('int', 10)));
+        $aggregator->aggregate(row(int_entry('int', 20)));
+        $aggregator->aggregate(row(float_entry('int', 30.5)));
+        $aggregator->aggregate(row(int_entry('int', 25)));
 
         self::assertSame(
             30.5,
@@ -60,10 +74,10 @@ final class MaxTest extends TestCase
     {
         $aggregator = \Flow\ETL\DSL\max(ref('int'));
 
-        $aggregator->aggregate(Row::create(int_entry('int', 10)));
-        $aggregator->aggregate(Row::create(int_entry('int', 20)));
-        $aggregator->aggregate(Row::create(int_entry('int', 30)));
-        $aggregator->aggregate(Row::create(int_entry('int', 40)));
+        $aggregator->aggregate(row(int_entry('int', 10)));
+        $aggregator->aggregate(row(int_entry('int', 20)));
+        $aggregator->aggregate(row(int_entry('int', 30)));
+        $aggregator->aggregate(row(int_entry('int', 40)));
 
         self::assertSame(
             40,

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Function/MinTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Function/MinTest.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Tests\Unit\Function;
 
-use function Flow\ETL\DSL\{float_entry, int_entry, min, ref, str_entry};
-use Flow\ETL\Row;
+use function Flow\ETL\DSL\{datetime_entry, float_entry, int_entry, min, ref, row, str_entry};
 use PHPUnit\Framework\TestCase;
 
 final class MinTest extends TestCase
@@ -14,11 +13,11 @@ final class MinTest extends TestCase
     {
         $aggregator = min(ref('int'));
 
-        $aggregator->aggregate(Row::create(str_entry('int', '10')));
-        $aggregator->aggregate(Row::create(str_entry('int', '20')));
-        $aggregator->aggregate(Row::create(str_entry('int', '55')));
-        $aggregator->aggregate(Row::create(str_entry('int', '25')));
-        $aggregator->aggregate(Row::create(str_entry('not_int', null)));
+        $aggregator->aggregate(row(str_entry('int', '10')));
+        $aggregator->aggregate(row(str_entry('int', '20')));
+        $aggregator->aggregate(row(str_entry('int', '55')));
+        $aggregator->aggregate(row(str_entry('int', '25')));
+        $aggregator->aggregate(row(str_entry('not_int', null)));
 
         self::assertSame(
             10,
@@ -30,13 +29,28 @@ final class MinTest extends TestCase
     {
         $aggregator = min(ref('int'));
 
-        $aggregator->aggregate(Row::create(int_entry('int', 10)));
-        $aggregator->aggregate(Row::create(int_entry('int', 20)));
-        $aggregator->aggregate(Row::create(int_entry('int', 30)));
-        $aggregator->aggregate(Row::create(str_entry('int', null)));
+        $aggregator->aggregate(row(int_entry('int', 10)));
+        $aggregator->aggregate(row(int_entry('int', 20)));
+        $aggregator->aggregate(row(int_entry('int', 30)));
+        $aggregator->aggregate(row(str_entry('int', null)));
 
         self::assertSame(
             10,
+            $aggregator->result()->value()
+        );
+    }
+
+    public function test_aggregation_min_with_datetime_values() : void
+    {
+        $aggregator = min(ref('datetime'));
+
+        $aggregator->aggregate(row(datetime_entry('datetime', '2021-01-01 00:00:00')));
+        $aggregator->aggregate(row(datetime_entry('datetime', '2021-01-02 00:00:00')));
+        $aggregator->aggregate(row(datetime_entry('datetime', '2021-01-03 00:00:00')));
+        $aggregator->aggregate(row(datetime_entry('datetime', '2021-01-04 00:00:00')));
+
+        self::assertEquals(
+            new \DateTimeImmutable('2021-01-01 00:00:00'),
             $aggregator->result()->value()
         );
     }
@@ -45,10 +59,10 @@ final class MinTest extends TestCase
     {
         $aggregator = min(ref('int'));
 
-        $aggregator->aggregate(Row::create(float_entry('int', 10.25)));
-        $aggregator->aggregate(Row::create(int_entry('int', 20)));
-        $aggregator->aggregate(Row::create(int_entry('int', 305)));
-        $aggregator->aggregate(Row::create(int_entry('int', 25)));
+        $aggregator->aggregate(row(float_entry('int', 10.25)));
+        $aggregator->aggregate(row(int_entry('int', 20)));
+        $aggregator->aggregate(row(int_entry('int', 305)));
+        $aggregator->aggregate(row(int_entry('int', 25)));
 
         self::assertSame(
             10.25,
@@ -60,10 +74,10 @@ final class MinTest extends TestCase
     {
         $aggregator = min(ref('int'));
 
-        $aggregator->aggregate(Row::create(int_entry('int', 10)));
-        $aggregator->aggregate(Row::create(int_entry('int', 20)));
-        $aggregator->aggregate(Row::create(int_entry('int', 30)));
-        $aggregator->aggregate(Row::create(int_entry('int', 40)));
+        $aggregator->aggregate(row(int_entry('int', 10)));
+        $aggregator->aggregate(row(int_entry('int', 20)));
+        $aggregator->aggregate(row(int_entry('int', 30)));
+        $aggregator->aggregate(row(int_entry('int', 40)));
 
         self::assertSame(
             10,


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <li>Allow to use max/min aggregations on date time columns</li>
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

<!-- Please provide a short description of changes in this section, feel free to use markdown syntax -->
