### PR TITLE
Fix fragile test comparing console output

### DIFF
--- a/src/lib/parquet-viewer/tests/Flow/ParquetViewer/Tests/Integration/ReadMetadataTest.php
+++ b/src/lib/parquet-viewer/tests/Flow/ParquetViewer/Tests/Integration/ReadMetadataTest.php
@@ -6,6 +6,9 @@ namespace Flow\ParquetViewer\Tests\Integration;
 
 use Flow\ParquetViewer\Parquet;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Style\{OutputStyle, SymfonyStyle};
 use Symfony\Component\Console\Tester\ApplicationTester;
 
 final class ReadMetadataTest extends TestCase
@@ -24,10 +27,11 @@ final class ReadMetadataTest extends TestCase
             'file' => $path,
         ]);
 
-        self::assertStringContainsString(
-            'not a valid parquet file',
-            $tester->getDisplay()
+        $expected = $this->captureConsoleOutput(
+            fn (OutputStyle $io) => $io->error("File \"{$path}\" is not a valid parquet file")
         );
+
+        self::assertStringContainsString($expected, $tester->getDisplay());
         self::assertSame(1, $tester->getStatusCode());
     }
 
@@ -55,5 +59,16 @@ final class ReadMetadataTest extends TestCase
         self::assertStringContainsString('Column Chunks Statistics', $tester->getDisplay());
         self::assertStringContainsString('Page Headers', $tester->getDisplay());
         self::assertSame(0, $tester->getStatusCode());
+    }
+
+    private function captureConsoleOutput(\Closure $closure) : string
+    {
+        $output = new BufferedOutput();
+
+        $io = new SymfonyStyle(new ArrayInput([]), $output);
+
+        $closure($io);
+
+        return $output->fetch();
     }
 }


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>Fix fragile test comparing console output</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

Preventing failure like below:
```shell
There was 1 failure:

1) Flow\ParquetViewer\Tests\Integration\ReadMetadataTest::test_reading_metadata_from_non_json_file
Failed asserting that '\n
 [ERROR] File "/Users/stloyd/Documents/flow/src/lib/parquet-viewer/tests/Flow/ParquetViewer/Fixtures/flow.json" is not a\n
         valid parquet file                                                                                             \n
\n
' [ASCII](length: 244) contains "not a valid parquet file" [ASCII](length: 24).

/Users/stloyd/Documents/flow/src/lib/parquet-viewer/tests/Flow/ParquetViewer/Tests/Integration/ReadMetadataTest.php:29
```
