### PR TITLE
Fix deprecated dynamic property usage

### DIFF
--- a/src/adapter/etl-adapter-filesystem/src/Flow/ETL/Adapter/Filesystem/AwsS3Stream.php
+++ b/src/adapter/etl-adapter-filesystem/src/Flow/ETL/Adapter/Filesystem/AwsS3Stream.php
@@ -13,6 +13,11 @@ final class AwsS3Stream extends FlysystemWrapper
 {
     public const PROTOCOL = 'flow-aws-s3';
 
+    /**
+     * @var null|resource
+     */
+    public $context;
+
     public static function register() : void
     {
         if (!\class_exists('League\Flysystem\AwsS3V3\AwsS3V3Adapter')) {

--- a/src/adapter/etl-adapter-filesystem/src/Flow/ETL/Adapter/Filesystem/AzureBlobStream.php
+++ b/src/adapter/etl-adapter-filesystem/src/Flow/ETL/Adapter/Filesystem/AzureBlobStream.php
@@ -16,6 +16,11 @@ final class AzureBlobStream extends FlysystemWrapper
 {
     public const PROTOCOL = 'flow-azure-blob';
 
+    /**
+     * @var null|resource
+     */
+    public $context;
+
     public static function register() : void
     {
         if (!\class_exists('League\Flysystem\AzureBlobStorage\AzureBlobStorageAdapter')) {

--- a/src/core/etl/src/Flow/ETL/Filesystem/Stream/StreamWrapper.php
+++ b/src/core/etl/src/Flow/ETL/Filesystem/Stream/StreamWrapper.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Flow\ETL\Filesystem\Stream;
 
 /**
- * @property resource $context
+ * @property null|resource $context
  */
 interface StreamWrapper
 {

--- a/src/core/etl/src/Flow/ETL/Filesystem/Stream/VoidStreamWrapper.php
+++ b/src/core/etl/src/Flow/ETL/Filesystem/Stream/VoidStreamWrapper.php
@@ -8,6 +8,11 @@ final class VoidStreamWrapper implements StreamWrapper
 {
     public const PROTOCOL = 'void';
 
+    /**
+     * @var null|resource
+     */
+    public $context;
+
     public static function register() : void
     {
         if (!\in_array(self::PROTOCOL, \stream_get_wrappers(), true)) {


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>Fix deprecated dynamic property usage</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

```shell
1) /Users/stloyd/Documents/flow/src/core/etl/src/Flow/ETL/Filesystem/Stream/FileStream.php:29
Creation of dynamic property Flow\ETL\Filesystem\Stream\VoidStreamWrapper::$context is deprecated

Triggered by:

* Flow\ETL\Tests\Integration\Filesystem\FilesystemStreams\NotPartitioned\IgnoreModeTest::test_open_stream_for_existing_file
  /Users/stloyd/Documents/flow/src/core/etl/tests/Flow/ETL/Tests/Integration/Filesystem/FilesystemStreams/NotPartitioned/IgnoreModeTest.php:19

* Flow\ETL\Tests\Integration\Filesystem\FilesystemStreams\Partitioned\IgnoreModeTest::test_open_stream_for_existing_partition_with_existing_file
  /Users/stloyd/Documents/flow/src/core/etl/tests/Flow/ETL/Tests/Integration/Filesystem/FilesystemStreams/Partitioned/IgnoreModeTest.php:20
```
