### PR TITLE
Prepare for PHPUnit 11

### DIFF
--- a/src/adapter/etl-adapter-google-sheet/tests/Flow/ETL/Adapter/GoogleSheet/Tests/Unit/ColumnsTest.php
+++ b/src/adapter/etl-adapter-google-sheet/tests/Flow/ETL/Adapter/GoogleSheet/Tests/Unit/ColumnsTest.php
@@ -6,6 +6,7 @@ namespace Flow\ETL\Adapter\GoogleSheet\Tests\Unit;
 
 use Flow\ETL\Adapter\GoogleSheet\Columns;
 use Flow\ETL\Exception\InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class ColumnsTest extends TestCase
@@ -46,9 +47,7 @@ final class ColumnsTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider invalid_cases
-     */
+    #[DataProvider('invalid_cases')]
     public function test_assertions(string $sheetName, string $startColumn, string $endColumn, string $expectedExceptionMessage) : void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/src/adapter/etl-adapter-google-sheet/tests/Flow/ETL/Adapter/GoogleSheet/Tests/Unit/SheetRangeTest.php
+++ b/src/adapter/etl-adapter-google-sheet/tests/Flow/ETL/Adapter/GoogleSheet/Tests/Unit/SheetRangeTest.php
@@ -6,6 +6,7 @@ namespace Flow\ETL\Adapter\GoogleSheet\Tests\Unit;
 
 use Flow\ETL\Adapter\GoogleSheet\{Columns, SheetRange};
 use Flow\ETL\Exception\InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class SheetRangeTest extends TestCase
@@ -46,9 +47,7 @@ final class SheetRangeTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider invalid_cases
-     */
+    #[DataProvider('invalid_cases')]
     public function test_assertions(int $startRow, int $endRow, string $expectedExceptionMessage) : void
     {
         $this->expectExceptionMessage($expectedExceptionMessage);
@@ -64,9 +63,7 @@ final class SheetRangeTest extends TestCase
         self::assertSame('Sheet2!A21:B40', $range->nextRows(10)->nextRows(20)->toString());
     }
 
-    /**
-     * @dataProvider example_string_ranges
-     */
+    #[DataProvider('example_string_ranges')]
     public function test_range_to_string(SheetRange $range, string $expectedStringRange) : void
     {
         self::assertSame($expectedStringRange, $range->toString());

--- a/src/adapter/etl-adapter-http/tests/Flow/ETL/Adapter/HTTP/Tests/Unit/RequestEntriesFactoryTest.php
+++ b/src/adapter/etl-adapter-http/tests/Flow/ETL/Adapter/HTTP/Tests/Unit/RequestEntriesFactoryTest.php
@@ -7,6 +7,7 @@ namespace Flow\ETL\Adapter\HTTP\Tests\Unit;
 use Flow\ETL\Adapter\Http\RequestEntriesFactory;
 use Flow\ETL\Row\Entry\{JsonEntry, StringEntry};
 use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
 
@@ -44,9 +45,7 @@ final class RequestEntriesFactoryTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider requests
-     */
+    #[DataProvider('requests')]
     public function test_uses_expected_entry_for_request_body(string $expectedRequestBodyEntryClass, RequestInterface $request) : void
     {
         $entryFactory = new RequestEntriesFactory();

--- a/src/core/etl/tests/Flow/ArrayComparison/Tests/Unit/ArrayComparisonTest.php
+++ b/src/core/etl/tests/Flow/ArrayComparison/Tests/Unit/ArrayComparisonTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Flow\ArrayComparison\Tests\Unit;
 
 use Flow\ArrayComparison\ArrayComparison;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class ArrayComparisonTest extends TestCase
@@ -143,17 +144,13 @@ final class ArrayComparisonTest extends TestCase
         );
     }
 
-    /**
-     * @dataProvider equal_arrays
-     */
+    #[DataProvider('equal_arrays')]
     public function test_equals(array $a, array $b) : void
     {
         self::assertTrue((new ArrayComparison())->equals($a, $b));
     }
 
-    /**
-     * @dataProvider not_equal_arrays
-     */
+    #[DataProvider('not_equal_arrays')]
     public function test_not_equals(array $a, array $b) : void
     {
         self::assertFalse((new ArrayComparison())->equals($a, $b));

--- a/src/core/etl/tests/Flow/ArrayComparison/Tests/Unit/ArraySortByKeyTest.php
+++ b/src/core/etl/tests/Flow/ArrayComparison/Tests/Unit/ArraySortByKeyTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Flow\ArrayComparison\Tests\Unit;
 
 use Flow\ArrayComparison\ArraySortByKey;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class ArraySortByKeyTest extends TestCase
@@ -109,9 +110,7 @@ final class ArraySortByKeyTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider arrays
-     */
+    #[DataProvider('arrays')]
     public function test_sorts_array_by_key(array $origin, array $sorted) : void
     {
         // serialize to JSON to be sure that array is sorted exactly as expected

--- a/src/core/etl/tests/Flow/ETL/Tests/Integration/Filesystem/RealpathTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Integration/Filesystem/RealpathTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Flow\ETL\Tests\Integration\Filesystem;
 
 use Flow\ETL\Filesystem\Path;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class RealpathTest extends TestCase
@@ -17,9 +18,7 @@ final class RealpathTest extends TestCase
         yield ['/path/more/nested/..//../file.txt', '/path/file.txt'];
     }
 
-    /**
-     * @dataProvider double_dots_paths
-     */
+    #[DataProvider('double_dots_paths')]
     public function test_double_dots_in_path(string $relative, string $absolute) : void
     {
         self::assertEquals(new Path($absolute), Path::realpath($relative));

--- a/src/core/etl/tests/Flow/ETL/Tests/Integration/Function/HashTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Integration/Function/HashTest.php
@@ -7,6 +7,7 @@ namespace Flow\ETL\Tests\Integration\Function;
 use function Flow\ETL\DSL\{from_array, ref, to_memory};
 use Flow\ETL\Flow;
 use Flow\ETL\Memory\ArrayMemory;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class HashTest extends TestCase
@@ -18,9 +19,7 @@ final class HashTest extends TestCase
         yield 'string' => ['value', 'd7ab8cce59abd5050d59506fb013961a'];
     }
 
-    /**
-     * @dataProvider provideValues
-     */
+    #[DataProvider('provideValues')]
     public function test_hash_on_given_value(mixed $value, string $expected) : void
     {
         (new Flow())

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Formatter/ASCII/ASCIIValueTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Formatter/ASCII/ASCIIValueTest.php
@@ -6,6 +6,7 @@ namespace Flow\ETL\Tests\Unit\Formatter\ASCII;
 
 use function Flow\ETL\DSL\datetime_entry;
 use Flow\ETL\Formatter\ASCII\ASCIIValue;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class ASCIIValueTest extends TestCase
@@ -29,9 +30,7 @@ final class ASCIIValueTest extends TestCase
         yield [['a' => 1, 'b' => 2, 'c' => ['test']], '{"a":1,"b":2,"c":["test"]}'];
     }
 
-    /**
-     * @dataProvider values_without_truncating
-     */
+    #[DataProvider('values_without_truncating')]
     public function test_converting_value_to_ascii_value(mixed $value, string $asciiValue) : void
     {
         self::assertSame(
@@ -40,9 +39,7 @@ final class ASCIIValueTest extends TestCase
         );
     }
 
-    /**
-     * @dataProvider values_with_truncating
-     */
+    #[DataProvider('values_with_truncating')]
     public function test_converting_value_to_ascii_value_with_truncating(mixed $value, string $asciiValue) : void
     {
         self::assertSame(

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Function/CastTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Function/CastTest.php
@@ -8,6 +8,7 @@ use function Flow\ETL\DSL\{cast, ref};
 use Flow\ETL\PHP\Value\Uuid;
 use Flow\ETL\Row;
 use Flow\ETL\Row\Factory\NativeEntryFactory;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class CastTest extends TestCase
@@ -48,9 +49,7 @@ XML;
         ];
     }
 
-    /**
-     * @dataProvider cast_provider
-     */
+    #[DataProvider('cast_provider')]
     public function test_cast(mixed $from, string $to, mixed $expected) : void
     {
         $resultRefCast = ref('value')->cast($to)->eval(Row::create((new NativeEntryFactory())->create('value', $from)));

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/PartitionTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/PartitionTest.php
@@ -8,6 +8,7 @@ use function Flow\ETL\DSL\{datetime_entry, ref, row, xml_entry};
 use Flow\ETL\Exception\InvalidArgumentException;
 use Flow\ETL\Partition;
 use Flow\ETL\Row\Entry\XMLEntry;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class PartitionTest extends TestCase
@@ -84,9 +85,7 @@ final class PartitionTest extends TestCase
         self::assertCount(0, $partitions);
     }
 
-    /**
-     * @dataProvider provider_forbidden_characters_values
-     */
+    #[DataProvider('provider_forbidden_characters_values')]
     public function test_forbidden_names(string $value) : void
     {
         $this->expectException(InvalidArgumentException::class);
@@ -94,9 +93,7 @@ final class PartitionTest extends TestCase
         new Partition($value, 'value');
     }
 
-    /**
-     * @dataProvider provider_forbidden_characters_values
-     */
+    #[DataProvider('provider_forbidden_characters_values')]
     public function test_forbidden_values(string $value) : void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Entry/ArrayEntryTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Entry/ArrayEntryTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Flow\ETL\Tests\Unit\Row\Entry;
 
 use Flow\ETL\Row\Entry\{ArrayEntry, IntegerEntry};
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class ArrayEntryTest extends TestCase
@@ -83,9 +84,7 @@ final class ArrayEntryTest extends TestCase
         self::assertSame('0', (new ArrayEntry('0', ['id' => 1]))->name());
     }
 
-    /**
-     * @dataProvider is_equal_data_provider
-     */
+    #[DataProvider('is_equal_data_provider')]
     public function test_is_equal(bool $equals, ArrayEntry $entry, ArrayEntry $nextEntry) : void
     {
         self::assertSame($equals, $entry->isEqual($nextEntry));

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Entry/BooleanEntryTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Entry/BooleanEntryTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Flow\ETL\Tests\Unit\Row\Entry;
 
 use Flow\ETL\Row\Entry\BooleanEntry;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class BooleanEntryTest extends TestCase
@@ -22,9 +23,7 @@ final class BooleanEntryTest extends TestCase
         self::assertSame('0', (new BooleanEntry('0', true))->name());
     }
 
-    /**
-     * @dataProvider is_equal_data_provider
-     */
+    #[DataProvider('is_equal_data_provider')]
     public function test_is_equal(bool $equals, BooleanEntry $entry, BooleanEntry $nextEntry) : void
     {
         self::assertSame($equals, $entry->isEqual($nextEntry));

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Entry/DateTimeEntryTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Entry/DateTimeEntryTest.php
@@ -6,6 +6,7 @@ namespace Flow\ETL\Tests\Unit\Row\Entry;
 
 use Flow\ETL\Exception\InvalidArgumentException;
 use Flow\ETL\Row\Entry\DateTimeEntry;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class DateTimeEntryTest extends TestCase
@@ -35,9 +36,7 @@ final class DateTimeEntryTest extends TestCase
         new DateTimeEntry('a', 'random string');
     }
 
-    /**
-     * @dataProvider is_equal_data_provider
-     */
+    #[DataProvider('is_equal_data_provider')]
     public function test_is_equal(bool $equals, DateTimeEntry $entry, DateTimeEntry $nextEntry) : void
     {
         self::assertEquals($equals, $entry->isEqual($nextEntry));

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Entry/FloatEntryTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Entry/FloatEntryTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Flow\ETL\Tests\Unit\Row\Entry;
 
 use Flow\ETL\Row\Entry\FloatEntry;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class FloatEntryTest extends TestCase
@@ -24,9 +25,7 @@ final class FloatEntryTest extends TestCase
         self::assertSame('0', (new FloatEntry('0', 0))->name());
     }
 
-    /**
-     * @dataProvider is_equal_data_provider
-     */
+    #[DataProvider('is_equal_data_provider')]
     public function test_is_equal(bool $equals, FloatEntry $entry, FloatEntry $nextEntry) : void
     {
         self::assertSame($equals, $entry->isEqual($nextEntry));

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Entry/IntegerEntryTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Entry/IntegerEntryTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Flow\ETL\Tests\Unit\Row\Entry;
 
 use Flow\ETL\Row\Entry\IntegerEntry;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class IntegerEntryTest extends TestCase
@@ -22,9 +23,7 @@ final class IntegerEntryTest extends TestCase
         self::assertSame('0', (new IntegerEntry('0', 0))->name());
     }
 
-    /**
-     * @dataProvider is_equal_data_provider
-     */
+    #[DataProvider('is_equal_data_provider')]
     public function test_is_equal(bool $equals, IntegerEntry $entry, IntegerEntry $nextEntry) : void
     {
         self::assertSame($equals, $entry->isEqual($nextEntry));

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Entry/JsonEntryTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Entry/JsonEntryTest.php
@@ -6,6 +6,7 @@ namespace Flow\ETL\Tests\Unit\Row\Entry;
 
 use Flow\ETL\Exception\InvalidArgumentException;
 use Flow\ETL\Row\Entry\{IntegerEntry, JsonEntry};
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class JsonEntryTest extends TestCase
@@ -101,9 +102,7 @@ final class JsonEntryTest extends TestCase
         new JsonEntry('a', 'random string');
     }
 
-    /**
-     * @dataProvider is_equal_data_provider
-     */
+    #[DataProvider('is_equal_data_provider')]
     public function test_is_equal(bool $equals, JsonEntry $entry, JsonEntry $nextEntry) : void
     {
         self::assertSame($equals, $entry->isEqual($nextEntry));

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Entry/JsonObjectEntryTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Entry/JsonObjectEntryTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Flow\ETL\Tests\Unit\Row\Entry;
 
 use Flow\ETL\Row\Entry\{IntegerEntry, JsonEntry};
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class JsonObjectEntryTest extends TestCase
@@ -53,9 +54,7 @@ final class JsonObjectEntryTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider is_equal_data_provider
-     */
+    #[DataProvider('is_equal_data_provider')]
     public function test_is_equal(bool $equals, JsonEntry $entry, JsonEntry $nextEntry) : void
     {
         self::assertSame($equals, $entry->isEqual($nextEntry));

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Entry/ObjectEntryTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Entry/ObjectEntryTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Flow\ETL\Tests\Unit\Row\Entry;
 
 use Flow\ETL\Row\Entry\ObjectEntry;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class ObjectEntryTest extends TestCase
@@ -22,9 +23,7 @@ final class ObjectEntryTest extends TestCase
         self::assertSame('0', (new ObjectEntry('0', new \stdClass()))->name());
     }
 
-    /**
-     * @dataProvider is_equal_data_provider
-     */
+    #[DataProvider('is_equal_data_provider')]
     public function test_is_equal(bool $equals, ObjectEntry $entry, ObjectEntry $nextEntry) : void
     {
         self::assertSame($equals, $entry->isEqual($nextEntry));

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Entry/StringEntryTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Entry/StringEntryTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Flow\ETL\Tests\Unit\Row\Entry;
 
 use Flow\ETL\Row\Entry\StringEntry;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class StringEntryTest extends TestCase
@@ -32,9 +33,7 @@ final class StringEntryTest extends TestCase
         self::assertEquals('IT SHOULD BE UPPERCASE', $entry->value());
     }
 
-    /**
-     * @dataProvider is_equal_data_provider
-     */
+    #[DataProvider('is_equal_data_provider')]
     public function test_is_equal(bool $equals, StringEntry $entry, StringEntry $nextEntry) : void
     {
         self::assertSame($equals, $entry->isEqual($nextEntry));

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Entry/StructureEntryTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Entry/StructureEntryTest.php
@@ -10,6 +10,7 @@ use Flow\ETL\PHP\Type\Logical\Map\{MapKey, MapValue};
 use Flow\ETL\PHP\Type\Logical\MapType;
 use Flow\ETL\Row\Entry\StructureEntry;
 use Flow\ETL\Row\Schema\Definition;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class StructureEntryTest extends TestCase
@@ -166,9 +167,7 @@ final class StructureEntryTest extends TestCase
         );
     }
 
-    /**
-     * @dataProvider is_equal_data_provider
-     */
+    #[DataProvider('is_equal_data_provider')]
     public function test_is_equal(bool $equals, StructureEntry $entry, StructureEntry $nextEntry) : void
     {
         self::assertSame($equals, $entry->isEqual($nextEntry));

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Entry/UuidEntryTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Entry/UuidEntryTest.php
@@ -6,6 +6,7 @@ namespace Flow\ETL\Tests\Unit\Row\Entry;
 
 use Flow\ETL\PHP\Value\Uuid;
 use Flow\ETL\Row\Entry\UuidEntry;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class UuidEntryTest extends TestCase
@@ -49,9 +50,7 @@ final class UuidEntryTest extends TestCase
         }
     }
 
-    /**
-     * @dataProvider valid_string_entries
-     */
+    #[DataProvider('valid_string_entries')]
     public function test_creates_uuid_entry_from_string(string $value) : void
     {
         $entry = UuidEntry::from('entry-name', $value);
@@ -59,9 +58,7 @@ final class UuidEntryTest extends TestCase
         self::assertEquals($value, $entry->value()->toString());
     }
 
-    /**
-     * @dataProvider is_equal_data_provider
-     */
+    #[DataProvider('is_equal_data_provider')]
     public function test_is_equal(bool $equals, UuidEntry $entry, UuidEntry $nextEntry) : void
     {
         self::assertSame($equals, $entry->isEqual($nextEntry));

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Entry/XMLEntryTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Entry/XMLEntryTest.php
@@ -7,6 +7,7 @@ namespace Flow\ETL\Tests\Unit\Row\Entry;
 use function Flow\ETL\DSL\xml_entry;
 use Flow\ETL\Exception\InvalidArgumentException;
 use Flow\ETL\Row\Entry\XMLEntry;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class XMLEntryTest extends TestCase
@@ -126,9 +127,7 @@ XML);
         self::assertSame("<?xml version=\"1.0\"?>\n", $entry->__toString());
     }
 
-    /**
-     * @dataProvider is_equal_data_provider
-     */
+    #[DataProvider('is_equal_data_provider')]
     public function test_is_equal(bool $equals, XMLEntry $entry, XMLEntry $nextEntry) : void
     {
         self::assertSame($equals, $entry->isEqual($nextEntry));

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/RowTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/RowTest.php
@@ -12,6 +12,7 @@ use Flow\ETL\PHP\Type\Logical\{ListType, MapType, StructureType};
 use Flow\ETL\Row\Entry\{ArrayEntry, BooleanEntry, DateTimeEntry, IntegerEntry, MapEntry, StringEntry, StructureEntry};
 use Flow\ETL\Row\Schema;
 use Flow\ETL\Row\Schema\Definition;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class RowTest extends TestCase
@@ -168,9 +169,7 @@ final class RowTest extends TestCase
         );
     }
 
-    /**
-     * @dataProvider is_equal_data_provider
-     */
+    #[DataProvider('is_equal_data_provider')]
     public function test_is_equal(bool $equals, \Flow\ETL\Row $row, \Flow\ETL\Row $nextRow) : void
     {
         self::assertSame($equals, $row->isEqual($nextRow));

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/RowsTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/RowsTest.php
@@ -13,6 +13,7 @@ use Flow\ETL\Row\Entry\{BooleanEntry, DateTimeEntry, ObjectEntry, StringEntry};
 use Flow\ETL\Row\Schema\Definition;
 use Flow\ETL\Row\{Comparator, Schema};
 use Flow\ETL\{Row, Rows};
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class RowsTest extends TestCase
@@ -926,17 +927,13 @@ final class RowsTest extends TestCase
         self::assertSame(1, $rows[2]->valueOf('id'));
     }
 
-    /**
-     * @dataProvider rows_diff_left_provider
-     */
+    #[DataProvider('rows_diff_left_provider')]
     public function test_rows_diff_left(Rows $expected, Rows $left, Rows $right) : void
     {
         self::assertEquals($expected->toArray(), $left->diffLeft($right)->toArray());
     }
 
-    /**
-     * @dataProvider rows_diff_right_provider
-     */
+    #[DataProvider('rows_diff_right_provider')]
     public function test_rows_diff_right(Rows $expected, Rows $left, Rows $right) : void
     {
         self::assertEquals($expected->toArray(), $left->diffRight($right)->toArray());
@@ -993,9 +990,7 @@ final class RowsTest extends TestCase
         self::assertTrue($unserialized[2]->isEqual($rows[2]));
     }
 
-    /**
-     * @dataProvider unique_rows_provider
-     */
+    #[DataProvider('unique_rows_provider')]
     public function test_rows_unique(Rows $expected, Rows $notUnique, Comparator $comparator = new NativeComparator()) : void
     {
         self::assertEquals($expected, $notUnique->unique($comparator));

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Stream/PathTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Stream/PathTest.php
@@ -7,6 +7,7 @@ namespace Flow\ETL\Tests\Unit\Stream;
 use Flow\ETL\Exception\InvalidArgumentException;
 use Flow\ETL\Filesystem\Path;
 use Flow\ETL\{Partition, Partitions};
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class PathTest extends TestCase
@@ -113,9 +114,7 @@ final class PathTest extends TestCase
         );
     }
 
-    /**
-     * @dataProvider directories
-     */
+    #[DataProvider('directories')]
     public function test_directories(string $uri, string $dirPath) : void
     {
         self::assertSame($dirPath, (new Path($uri))->parentDirectory()->path());
@@ -135,9 +134,7 @@ final class PathTest extends TestCase
         self::assertFalse((new Path(__DIR__))->extension());
     }
 
-    /**
-     * @dataProvider paths_with_static_parts
-     */
+    #[DataProvider('paths_with_static_parts')]
     public function test_finding_static_part_of_the_path(string $staticPart, string $uri) : void
     {
         self::assertEquals(new Path($staticPart), (new Path($uri))->staticPart());
@@ -148,9 +145,7 @@ final class PathTest extends TestCase
         self::assertNull((new Path(__FILE__))->context()->resource());
     }
 
-    /**
-     * @dataProvider paths_pattern_matching
-     */
+    #[DataProvider('paths_pattern_matching')]
     public function test_matching_pattern_with_path(string $path, string $pattern, bool $result) : void
     {
         self::assertSame($result, (new Path($path))->matches(new Path($pattern)));
@@ -164,18 +159,14 @@ final class PathTest extends TestCase
         self::assertFalse($path->matches(new Path('flow-file://var/file/partition=1/file.csv')));
     }
 
-    /**
-     * @dataProvider paths
-     */
+    #[DataProvider('paths')]
     public function test_parsing_path(string $uri, string $schema, string $parsedUri) : void
     {
         self::assertEquals($schema, (new Path($uri))->scheme());
         self::assertEquals($parsedUri, (new Path($uri))->uri());
     }
 
-    /**
-     * @dataProvider paths_with_partitions
-     */
+    #[DataProvider('paths_with_partitions')]
     public function test_partitions_in_path(string $uri, Partitions $partitions) : void
     {
         self::assertEquals($partitions, (new Path($uri))->partitions());

--- a/src/lib/doctrine-dbal-bulk/tests/Flow/Doctrine/Bulk/Tests/Unit/DbalPlatformTest.php
+++ b/src/lib/doctrine-dbal-bulk/tests/Flow/Doctrine/Bulk/Tests/Unit/DbalPlatformTest.php
@@ -8,6 +8,7 @@ use Doctrine\DBAL\Platforms\{MariaDBPlatform, MySQL80Platform, OraclePlatform, P
 use Flow\Doctrine\Bulk\DbalPlatform;
 use Flow\Doctrine\Bulk\Dialect\{MySQLDialect, PostgreSQLDialect, SqliteDialect};
 use Flow\Doctrine\Bulk\Exception\RuntimeException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class DbalPlatformTest extends TestCase
@@ -39,9 +40,7 @@ final class DbalPlatformTest extends TestCase
         self::assertInstanceOf(PostgreSQLDialect::class, $platform->dialect());
     }
 
-    /**
-     * @dataProvider provideSQLitePlatform
-     */
+    #[DataProvider('provideSQLitePlatform')]
     public function test_is_sqlite_sql(string $className) : void
     {
         if (\class_exists($className)) {

--- a/src/lib/parquet/tests/Flow/Parquet/Tests/Integration/Binary/BinaryReaderWriterTest.php
+++ b/src/lib/parquet/tests/Flow/Parquet/Tests/Integration/Binary/BinaryReaderWriterTest.php
@@ -6,6 +6,7 @@ namespace Flow\Parquet\Tests\Integration\Binary;
 
 use Flow\Parquet\BinaryReader\BinaryBufferReader;
 use Flow\Parquet\BinaryWriter\BinaryBufferWriter;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class BinaryReaderWriterTest extends TestCase
@@ -36,9 +37,7 @@ final class BinaryReaderWriterTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider decimalProvider
-     */
+    #[DataProvider('decimalProvider')]
     public function test_writing_and_reading_decimals(array $decimals, int $precision, int $scale) : void
     {
         $bitsNeeded = \ceil(\log(10 ** $precision, 2));

--- a/src/lib/rdsl/tests/Flow/RDSL/Tests/Unit/NamespaceTest.php
+++ b/src/lib/rdsl/tests/Flow/RDSL/Tests/Unit/NamespaceTest.php
@@ -7,6 +7,7 @@ namespace Flow\RDSL\Tests\Unit;
 use Flow\RDSL\AccessControl\AllowAll;
 use Flow\RDSL\DSLNamespace;
 use Flow\RDSL\Exception\InvalidArgumentException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class NamespaceTest extends TestCase
@@ -26,18 +27,14 @@ final class NamespaceTest extends TestCase
         yield ['\Foo\Bar\Baz'];
     }
 
-    /**
-     * @dataProvider invalid_namespaces_provider
-     */
+    #[DataProvider('invalid_namespaces_provider')]
     public function test_invalid_namespaces(string $ns) : void
     {
         $this->expectException(InvalidArgumentException::class);
         new DSLNamespace($ns, new AllowAll());
     }
 
-    /**
-     * @dataProvider valid_namespaces_provider
-     */
+    #[DataProvider('valid_namespaces_provider')]
     public function test_valid_namespaces(string $ns) : void
     {
         self::assertInstanceOf(DSLNamespace::class, new DSLNamespace($ns, new AllowAll()));


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Prepare for PHPUnit 11</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

In PHPUnit 11 usage of docbook annotations is deprecated.
