### PR TITLE
Recognize INT32 with deprecated ConvertedType as DateTimeImmutable object

### DIFF
--- a/src/core/etl/src/Flow/ETL/Filesystem/TmpfileBuffer.php
+++ b/src/core/etl/src/Flow/ETL/Filesystem/TmpfileBuffer.php
@@ -32,11 +32,9 @@ final class TmpfileBuffer implements LocalBuffer
     public function stream()
     {
         if ($this->stream === null) {
-            /** @phpstan-ignore-next-line */
             $this->stream = \tmpfile();
         }
 
-        /** @phpstan-ignore-next-line */
         return $this->stream;
     }
 

--- a/src/lib/parquet/src/Flow/Parquet/Data/Converter/BytesStringConverter.php
+++ b/src/lib/parquet/src/Flow/Parquet/Data/Converter/BytesStringConverter.php
@@ -6,7 +6,7 @@ namespace Flow\Parquet\Data\Converter;
 
 use Flow\Parquet\BinaryReader\Bytes;
 use Flow\Parquet\Data\Converter;
-use Flow\Parquet\ParquetFile\Schema\{FlatColumn, PhysicalType};
+use Flow\Parquet\ParquetFile\Schema\{ConvertedType, FlatColumn, PhysicalType};
 use Flow\Parquet\{Option, Options};
 
 final class BytesStringConverter implements Converter

--- a/src/lib/parquet/src/Flow/Parquet/Data/Converter/BytesStringConverter.php
+++ b/src/lib/parquet/src/Flow/Parquet/Data/Converter/BytesStringConverter.php
@@ -6,7 +6,7 @@ namespace Flow\Parquet\Data\Converter;
 
 use Flow\Parquet\BinaryReader\Bytes;
 use Flow\Parquet\Data\Converter;
-use Flow\Parquet\ParquetFile\Schema\{ConvertedType, FlatColumn, PhysicalType};
+use Flow\Parquet\ParquetFile\Schema\{FlatColumn, PhysicalType};
 use Flow\Parquet\{Option, Options};
 
 final class BytesStringConverter implements Converter

--- a/src/lib/parquet/src/Flow/Parquet/Data/Converter/Int32DateConverter.php
+++ b/src/lib/parquet/src/Flow/Parquet/Data/Converter/Int32DateConverter.php
@@ -6,7 +6,7 @@ namespace Flow\Parquet\Data\Converter;
 
 use Flow\Parquet\Data\Converter;
 use Flow\Parquet\Options;
-use Flow\Parquet\ParquetFile\Schema\{FlatColumn, LogicalType, PhysicalType};
+use Flow\Parquet\ParquetFile\Schema\{ConvertedType, FlatColumn, LogicalType, PhysicalType};
 
 final class Int32DateConverter implements Converter
 {
@@ -18,6 +18,10 @@ final class Int32DateConverter implements Converter
     public function isFor(FlatColumn $column, Options $options) : bool
     {
         if ($column->type() === PhysicalType::INT32 && $column->logicalType()?->name() === LogicalType::DATE) {
+            return true;
+        }
+
+        if ($column->type() === PhysicalType::INT32 && $column->convertedType() === ConvertedType::DATE) {
             return true;
         }
 

--- a/src/lib/parquet/tests/Flow/Parquet/Tests/Unit/Data/Converter/Int32DateConverterTest.php
+++ b/src/lib/parquet/tests/Flow/Parquet/Tests/Unit/Data/Converter/Int32DateConverterTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Flow\Parquet\Tests\Unit\Data\Converter;
 
 use Flow\Parquet\Data\Converter\Int32DateConverter;
+use Flow\Parquet\Options;
+use Flow\Parquet\ParquetFile\Schema\{ConvertedType, FlatColumn, PhysicalType};
 use PHPUnit\Framework\TestCase;
 
 final class Int32DateConverterTest extends TestCase
@@ -18,6 +20,23 @@ final class Int32DateConverterTest extends TestCase
         self::assertEquals(
             $date,
             $converter->fromParquetType($converter->toParquetType($date))
+        );
+    }
+
+    public function test_converting_int32_with_deprecated_converted_type() : void
+    {
+        $converter = new Int32DateConverter();
+
+        self::assertTrue(
+            $converter->isFor(
+                new FlatColumn(
+                    'date',
+                    PhysicalType::INT32,
+                    ConvertedType::DATE,
+                    null,
+                ),
+                Options::default()
+            )
         );
     }
 }


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>Recognize INT32 with deprecated ConvertedType as DateTimeImmutable object</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

<!-- Please provide a short description of changes in this section, feel free to use markdown syntax -->
