### PR TITLE
Fixed handling negative numbers in parquet binary reader/writer

### DIFF
--- a/src/lib/parquet/src/Flow/Parquet/BinaryReader.php
+++ b/src/lib/parquet/src/Flow/Parquet/BinaryReader.php
@@ -44,6 +44,11 @@ interface BinaryReader
     /**
      * @return array<int>
      */
+    public function readInts16(int $total) : array;
+
+    /**
+     * @return array<int>
+     */
     public function readInts32(int $total) : array;
 
     /**

--- a/src/lib/parquet/src/Flow/Parquet/BinaryWriter.php
+++ b/src/lib/parquet/src/Flow/Parquet/BinaryWriter.php
@@ -43,6 +43,11 @@ interface BinaryWriter
     /**
      * @param array<int> $ints
      */
+    public function writeInts16(array $ints) : void;
+
+    /**
+     * @param array<int> $ints
+     */
     public function writeInts32(array $ints) : void;
 
     /**

--- a/src/lib/parquet/src/Flow/Parquet/BinaryWriter/BinaryBufferWriter.php
+++ b/src/lib/parquet/src/Flow/Parquet/BinaryWriter/BinaryBufferWriter.php
@@ -108,6 +108,15 @@ final class BinaryBufferWriter implements BinaryWriter
         }
     }
 
+    public function writeInts16(array $ints) : void
+    {
+        $format = $this->byteOrder === ByteOrder::BIG_ENDIAN ? 'n' : 'v';
+
+        foreach ($ints as $int) {
+            $this->buffer .= \pack($format, $int);
+        }
+    }
+
     public function writeInts32(array $ints) : void
     {
         $format = $this->byteOrder === ByteOrder::BIG_ENDIAN ? 'N' : 'V';

--- a/src/lib/parquet/src/Flow/Parquet/Data/DataConverter.php
+++ b/src/lib/parquet/src/Flow/Parquet/Data/DataConverter.php
@@ -4,7 +4,14 @@ declare(strict_types=1);
 
 namespace Flow\Parquet\Data;
 
-use Flow\Parquet\Data\Converter\{BytesStringConverter, Int32DateConverter, Int32DateTimeConverter, Int64DateTimeConverter, Int96DateTimeConverter, JsonConverter, TimeConverter, UuidConverter};
+use Flow\Parquet\Data\Converter\{BytesStringConverter,
+    Int32DateConverter,
+    Int32DateTimeConverter,
+    Int64DateTimeConverter,
+    Int96DateTimeConverter,
+    JsonConverter,
+    TimeConverter,
+    UuidConverter};
 use Flow\Parquet\Exception\DataConversionException;
 use Flow\Parquet\Options;
 use Flow\Parquet\ParquetFile\Schema\FlatColumn;

--- a/src/lib/parquet/src/Flow/Parquet/ParquetFile/Data/PlainValueUnpacker.php
+++ b/src/lib/parquet/src/Flow/Parquet/ParquetFile/Data/PlainValueUnpacker.php
@@ -6,7 +6,7 @@ namespace Flow\Parquet\ParquetFile\Data;
 
 use Flow\Parquet\BinaryReader;
 use Flow\Parquet\Exception\RuntimeException;
-use Flow\Parquet\ParquetFile\Schema\{FlatColumn, LogicalType, PhysicalType};
+use Flow\Parquet\ParquetFile\Schema\{ConvertedType, FlatColumn, LogicalType, PhysicalType};
 
 final class PlainValueUnpacker
 {
@@ -23,7 +23,10 @@ final class PlainValueUnpacker
     public function unpack(FlatColumn $column, int $total) : array
     {
         return match ($column->type()) {
-            PhysicalType::INT32 => $this->reader->readInts32($total),
+            PhysicalType::INT32 => match ($column->convertedType()) {
+                ConvertedType::INT_16 => $this->reader->readInts16($total),
+                default => $this->reader->readInts32($total),
+            },
             PhysicalType::INT64 => $this->reader->readInts64($total),
             PhysicalType::INT96 => $this->reader->readInts96($total),
             PhysicalType::FLOAT => $this->reader->readFloats($total),

--- a/src/lib/parquet/tests/Flow/Parquet/Tests/Integration/Binary/BinaryReaderWriterTest.php
+++ b/src/lib/parquet/tests/Flow/Parquet/Tests/Integration/Binary/BinaryReaderWriterTest.php
@@ -37,6 +37,23 @@ final class BinaryReaderWriterTest extends TestCase
         ];
     }
 
+    public function test_writing_and_reading_big_integers() : void
+    {
+        $buffer = '';
+        $ints = [];
+
+        for ($i = 0; $i < 10000; $i++) {
+            $ints[] = $i;
+            $ints[] = -$i;
+        }
+
+        (new BinaryBufferWriter($buffer))->writeInts64($ints);
+        self::assertEquals(
+            $ints,
+            (new BinaryBufferReader($buffer))->readInts64(\count($ints)),
+        );
+    }
+
     #[DataProvider('decimalProvider')]
     public function test_writing_and_reading_decimals(array $decimals, int $precision, int $scale) : void
     {
@@ -61,6 +78,57 @@ final class BinaryReaderWriterTest extends TestCase
             $floats,
             (new BinaryBufferReader($buffer))->readFloats(\count($floats)),
             0.000001,
+        );
+    }
+
+    public function test_writing_and_reading_integers() : void
+    {
+        $buffer = '';
+        $ints = [];
+
+        for ($i = 0; $i < 10000; $i++) {
+            $ints[] = $i;
+            $ints[] = -$i;
+        }
+
+        (new BinaryBufferWriter($buffer))->writeInts32($ints);
+        self::assertEquals(
+            $ints,
+            (new BinaryBufferReader($buffer))->readInts32(\count($ints)),
+        );
+    }
+
+    public function test_writing_and_reading_large_integers() : void
+    {
+        $buffer = '';
+        $ints = [];
+
+        for ($i = 0; $i < 10000; $i++) {
+            $ints[] = $i;
+            $ints[] = -$i;
+        }
+
+        (new BinaryBufferWriter($buffer))->writeInts96($ints);
+        self::assertEquals(
+            $ints,
+            (new BinaryBufferReader($buffer))->readInts96(\count($ints)),
+        );
+    }
+
+    public function test_writing_and_reading_small_integers() : void
+    {
+        $buffer = '';
+        $ints = [];
+
+        for ($i = 0; $i < 1000; $i++) {
+            $ints[] = $i;
+            $ints[] = -$i;
+        }
+
+        (new BinaryBufferWriter($buffer))->writeInts16($ints);
+        self::assertEquals(
+            $ints,
+            (new BinaryBufferReader($buffer))->readInts16(\count($ints)),
         );
     }
 

--- a/src/lib/parquet/tests/Flow/Parquet/Tests/Integration/Binary/BinaryReaderWriterTest.php
+++ b/src/lib/parquet/tests/Flow/Parquet/Tests/Integration/Binary/BinaryReaderWriterTest.php
@@ -98,23 +98,6 @@ final class BinaryReaderWriterTest extends TestCase
         );
     }
 
-    public function test_writing_and_reading_large_integers() : void
-    {
-        $buffer = '';
-        $ints = [];
-
-        for ($i = 0; $i < 10000; $i++) {
-            $ints[] = $i;
-            $ints[] = -$i;
-        }
-
-        (new BinaryBufferWriter($buffer))->writeInts96($ints);
-        self::assertEquals(
-            $ints,
-            (new BinaryBufferReader($buffer))->readInts96(\count($ints)),
-        );
-    }
-
     public function test_writing_and_reading_small_integers() : void
     {
         $buffer = '';

--- a/src/lib/parquet/tests/Flow/Parquet/Tests/Integration/IO/EdgeCasesReadingTest.php
+++ b/src/lib/parquet/tests/Flow/Parquet/Tests/Integration/IO/EdgeCasesReadingTest.php
@@ -27,7 +27,7 @@ final class EdgeCasesReadingTest extends TestCase
                     'ID' => 8,
                     'Int_Array' => [
                         'list' => [
-                            'element' => 4294967295,
+                            'element' => -1,
                         ],
                     ],
                     'int_array_array' => [
@@ -35,7 +35,7 @@ final class EdgeCasesReadingTest extends TestCase
                             'element' => [
                                 'list' => [
                                     'element' => [
-                                        [4294967295, 4294967294],
+                                        [-1, -2],
                                         [null],
                                     ],
                                 ],
@@ -45,7 +45,7 @@ final class EdgeCasesReadingTest extends TestCase
                     'Int_Map' => [
                         'map' => [
                             'key' => 'k1',
-                            'value' => 4294967295,
+                            'value' => -1,
                         ],
                     ],
                     'int_map_array' => [
@@ -58,10 +58,10 @@ final class EdgeCasesReadingTest extends TestCase
                         ],
                     ],
                     'nested_Struct' => [
-                        'a' => 4294967295,
+                        'a' => -1,
                         'B' => [
                             'list' => [
-                                'element' => 4294967295,
+                                'element' => -1,
                             ],
                         ],
                         'c' => [
@@ -70,7 +70,7 @@ final class EdgeCasesReadingTest extends TestCase
                                     'element' => [
                                         'list' => [
                                             'element' => [
-                                                'e' => 4294967295,
+                                                'e' => -1,
                                                 'f' => 'nonnullable',
                                             ],
                                         ],


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <li>support for parquet deprecated ConvertedType::INT_16 in order to support reading files generated by Amazon Redshift</li>
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>handling negative numbers in parquet binary reader/writer</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

<!-- Please provide a short description of changes in this section, feel free to use markdown syntax -->
