### PR TITLE
chore: Replace `uniqid` with guarantee uniqueness

### DIFF
--- a/src/adapter/etl-adapter-csv/tests/Flow/ETL/Adapter/CSV/Tests/Integration/CSVTest.php
+++ b/src/adapter/etl-adapter-csv/tests/Flow/ETL/Adapter/CSV/Tests/Integration/CSVTest.php
@@ -15,7 +15,7 @@ final class CSVTest extends TestCase
 {
     public function test_loading_array_entry() : void
     {
-        $path = \sys_get_temp_dir() . '/' . \uniqid('flow_php_etl_csv_loader', true) . '.csv';
+        $path = \sys_get_temp_dir() . '/flow_php_etl_csv_loader' . bin2hex(random_bytes(16)) . '.csv';
 
         if (\file_exists($path)) {
             \unlink($path);
@@ -31,7 +31,7 @@ final class CSVTest extends TestCase
 
     public function test_loading_csv_files() : void
     {
-        $path = \sys_get_temp_dir() . '/' . \uniqid('flow_php_etl_csv_loader', true) . '.csv';
+        $path = \sys_get_temp_dir() . '/flow_php_etl_csv_loader' . bin2hex(random_bytes(16)) . '.csv';
 
         if (\file_exists($path)) {
             \unlink($path);

--- a/src/adapter/etl-adapter-elasticsearch/tests/Flow/ETL/Adapter/Elasticsearch/Tests/Integration/ElasticsearchPHP/ElasticsearchLoaderTest.php
+++ b/src/adapter/etl-adapter-elasticsearch/tests/Flow/ETL/Adapter/Elasticsearch/Tests/Integration/ElasticsearchPHP/ElasticsearchLoaderTest.php
@@ -53,19 +53,19 @@ final class ElasticsearchLoaderTest extends TestCase
 
         $loader->load(new Rows(
             Row::create(
-                new Row\Entry\StringEntry('id', \sha1(\uniqid('id', true))),
+                new Row\Entry\StringEntry('id', \sha1('id' . bin2hex(random_bytes(16)))),
                 new Row\Entry\StringEntry('name', 'Łukasz')
             ),
             Row::create(
-                new Row\Entry\StringEntry('id', \sha1(\uniqid('id', true))),
+                new Row\Entry\StringEntry('id', \sha1('id' . bin2hex(random_bytes(16)))),
                 new Row\Entry\StringEntry('name', 'Norbert')
             ),
             Row::create(
-                new Row\Entry\StringEntry('id', \sha1(\uniqid('id', true))),
+                new Row\Entry\StringEntry('id', \sha1('id' . bin2hex(random_bytes(16)))),
                 new Row\Entry\StringEntry('name', 'Dawid')
             ),
             Row::create(
-                new Row\Entry\StringEntry('id', \sha1(\uniqid('id', true))),
+                new Row\Entry\StringEntry('id', \sha1('id' . bin2hex(random_bytes(16)))),
                 new Row\Entry\StringEntry('name', 'Tomek')
             ),
         ), new FlowContext(Config::default()));

--- a/src/adapter/etl-adapter-filesystem/tests/Flow/ETL/Adapter/Filesystem/Tests/Integration/FlysystemFSTest.php
+++ b/src/adapter/etl-adapter-filesystem/tests/Flow/ETL/Adapter/Filesystem/Tests/Integration/FlysystemFSTest.php
@@ -70,7 +70,7 @@ STRING,
 
     public function test_open_file_stream_for_non_existing_file() : void
     {
-        $path = \sys_get_temp_dir() . '/' . \uniqid('flow_php_test_file_', true) . '.txt';
+        $path = \sys_get_temp_dir() . '/flow_php_test_file_' . bin2hex(random_bytes(16)) . '.txt';
 
         $stream = (new FlysystemFS())->open(new Path($path), Mode::WRITE);
 

--- a/src/adapter/etl-adapter-json/tests/Flow/ETL/Adapter/JSON/Tests/Integration/JsonTest.php
+++ b/src/adapter/etl-adapter-json/tests/Flow/ETL/Adapter/JSON/Tests/Integration/JsonTest.php
@@ -17,7 +17,7 @@ final class JsonTest extends TestCase
 {
     public function test_json_loader() : void
     {
-        $path = \sys_get_temp_dir() . '/' . \uniqid('flow_php_etl_json_loader', true) . '.json';
+        $path = \sys_get_temp_dir() . '/flow_php_etl_json_loader' . bin2hex(random_bytes(16)) . '.json';
 
         if (\file_exists($path)) {
             \unlink($path);
@@ -40,7 +40,7 @@ final class JsonTest extends TestCase
 
     public function test_json_loader_loading_empty_string() : void
     {
-        $stream = \sys_get_temp_dir() . '/' . \uniqid('flow_php_etl_json_loader', true) . '.json';
+        $stream = \sys_get_temp_dir() . '/flow_php_etl_json_loader' . bin2hex(random_bytes(16)) . '.json';
 
         $loader = new JsonLoader(Path::realpath($stream));
 

--- a/src/adapter/etl-adapter-meilisearch/tests/Flow/ETL/Adapter/Meilisearch/Tests/Integration/MeilisearchPHP/MeilisearchLoaderTest.php
+++ b/src/adapter/etl-adapter-meilisearch/tests/Flow/ETL/Adapter/Meilisearch/Tests/Integration/MeilisearchPHP/MeilisearchLoaderTest.php
@@ -43,19 +43,19 @@ final class MeilisearchLoaderTest extends TestCase
         $loader = to_meilisearch_bulk_index($this->meilisearchContext->clientConfig(), self::INDEX_NAME);
         $loader->load(new Rows(
             Row::create(
-                new Row\Entry\StringEntry('id', \sha1(\uniqid('id', true))),
+                new Row\Entry\StringEntry('id', \sha1('id' . bin2hex(random_bytes(16)))),
                 new Row\Entry\StringEntry('name', 'Łukasz')
             ),
             Row::create(
-                new Row\Entry\StringEntry('id', \sha1(\uniqid('id', true))),
+                new Row\Entry\StringEntry('id', \sha1('id' . bin2hex(random_bytes(16)))),
                 new Row\Entry\StringEntry('name', 'Norbert')
             ),
             Row::create(
-                new Row\Entry\StringEntry('id', \sha1(\uniqid('id', true))),
+                new Row\Entry\StringEntry('id', \sha1('id' . bin2hex(random_bytes(16)))),
                 new Row\Entry\StringEntry('name', 'Dawid')
             ),
             Row::create(
-                new Row\Entry\StringEntry('id', \sha1(\uniqid('id', true))),
+                new Row\Entry\StringEntry('id', \sha1('id' . bin2hex(random_bytes(16)))),
                 new Row\Entry\StringEntry('name', 'Tomek')
             ),
         ), new FlowContext(Config::default()));

--- a/src/adapter/etl-adapter-text/tests/Flow/ETL/Adapter/Text/Tests/Integration/TextTest.php
+++ b/src/adapter/etl-adapter-text/tests/Flow/ETL/Adapter/Text/Tests/Integration/TextTest.php
@@ -13,7 +13,7 @@ final class TextTest extends TestCase
 {
     public function test_loading_text_files() : void
     {
-        $path = \sys_get_temp_dir() . '/' . \uniqid('flow_php_etl_csv_loader', true) . '.csv';
+        $path = \sys_get_temp_dir() . '/flow_php_etl_csv_loader' . bin2hex(random_bytes(16)) . '.csv';
 
         (new Flow())
             ->process(

--- a/src/core/etl/src/Flow/ETL/ConfigBuilder.php
+++ b/src/core/etl/src/Flow/ETL/ConfigBuilder.php
@@ -54,7 +54,7 @@ final class ConfigBuilder
      */
     public function build() : Config
     {
-        $this->id ??= \uniqid('flow_php', true);
+        $this->id ??= 'flow_php' . bin2hex(random_bytes(16));
         $entryFactory = new NativeEntryFactory();
         $this->serializer ??= new Base64Serializer(new NativePHPSerializer());
         $cachePath = \is_string(\getenv(Config::CACHE_DIR_ENV)) && \realpath(\getenv(Config::CACHE_DIR_ENV))

--- a/src/core/etl/src/Flow/ETL/Filesystem/Path.php
+++ b/src/core/etl/src/Flow/ETL/Filesystem/Path.php
@@ -143,7 +143,7 @@ final class Path
 
     public static function tmpFile(string $extension, ?string $name = null) : self
     {
-        $name = \ltrim($name ?? \str_replace('.', '', \uniqid('', true)), '/');
+        $name = \ltrim($name ?? bin2hex(random_bytes(16)), '/');
 
         return new self(\sys_get_temp_dir() . DIRECTORY_SEPARATOR . $name . '.' . $extension);
     }
@@ -302,7 +302,7 @@ final class Path
         $base = \trim(\mb_substr($this->path(), 0, \mb_strrpos($this->path(), $this->basename())), DIRECTORY_SEPARATOR);
 
         return new self(
-            $this->scheme . '://' . $base . DIRECTORY_SEPARATOR . $this->filename . '_' . \str_replace('.', '', \uniqid('', true)) . $extension,
+            $this->scheme . '://' . $base . DIRECTORY_SEPARATOR . $this->filename . '_' . bin2hex(random_bytes(16)) . $extension,
             $this->options
         );
     }

--- a/src/core/etl/tests/Flow/ETL/Tests/Integration/Cache/PSRSimpleCacheTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Integration/Cache/PSRSimpleCacheTest.php
@@ -17,7 +17,7 @@ final class PSRSimpleCacheTest extends IntegrationTestCase
     {
         $cache = new PSRSimpleCache(
             new Psr16Cache(
-                new FilesystemAdapter(directory: \sys_get_temp_dir() . '/' . \uniqid('flow-etl-cache-', true))
+                new FilesystemAdapter(directory: \sys_get_temp_dir() . '/flow-etl-cache-' . bin2hex(random_bytes(16)))
             ),
         );
 

--- a/src/core/etl/tests/Flow/ETL/Tests/Integration/DataFrame/PartitioningTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Integration/DataFrame/PartitioningTest.php
@@ -166,7 +166,7 @@ final class PartitioningTest extends IntegrationTestCase
 
                         for ($d = 0; $d < $maxItems; $d++) {
                             $data[] = [
-                                'id' => \uniqid('', true),
+                                'id' => bin2hex(random_bytes(16)),
                                 'created_at' => (new \DateTimeImmutable('2020-01-01'))->add(new \DateInterval('P' . $i . 'D'))->setTime(\random_int(0, 23), \random_int(0, 59), \random_int(0, 59)),
                                 'value' => \random_int(1, 1000),
                             ];

--- a/src/core/etl/tests/Flow/ETL/Tests/Integration/Filesystem/LocalFilesystemTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Integration/Filesystem/LocalFilesystemTest.php
@@ -69,7 +69,7 @@ STRING,
 
     public function test_open_file_stream_for_non_existing_file() : void
     {
-        $path = \sys_get_temp_dir() . '/' . \uniqid('flow_php_test_file_', true) . '.txt';
+        $path = \sys_get_temp_dir() . '/flow_php_test_file_' . bin2hex(random_bytes(16)) . '.txt';
 
         $stream = (new LocalFilesystem())->open(new Path($path), Mode::WRITE);
 

--- a/src/lib/parquet/tests/Flow/Parquet/Tests/Integration/IO/CompressionTest.php
+++ b/src/lib/parquet/tests/Flow/Parquet/Tests/Integration/IO/CompressionTest.php
@@ -14,7 +14,7 @@ final class CompressionTest extends TestCase
 {
     public function test_writing_and_reading_file_with_gzip_compression() : void
     {
-        $path = \sys_get_temp_dir() . '/test-writer' . \uniqid('parquet-test-', true) . '.parquet';
+        $path = \sys_get_temp_dir() . '/test-writer-parquet-test-' . bin2hex(random_bytes(16)) . '.parquet';
 
         $writer = new Writer(Compressions::GZIP);
 
@@ -61,7 +61,7 @@ final class CompressionTest extends TestCase
 
     public function test_writing_and_reading_file_with_snappy_compression() : void
     {
-        $path = \sys_get_temp_dir() . '/test-writer' . \uniqid('parquet-test-', true) . '.parquet';
+        $path = \sys_get_temp_dir() . '/test-writer-parquet-test-' . bin2hex(random_bytes(16)) . '.parquet';
 
         $writer = new Writer(Compressions::SNAPPY);
 
@@ -108,7 +108,7 @@ final class CompressionTest extends TestCase
 
     public function test_writing_and_reading_file_with_uncompressed_compression() : void
     {
-        $path = \sys_get_temp_dir() . '/test-writer' . \uniqid('parquet-test-', true) . '.parquet';
+        $path = \sys_get_temp_dir() . '/test-writer-parquet-test-' . bin2hex(random_bytes(16)) . '.parquet';
 
         $writer = new Writer(Compressions::UNCOMPRESSED);
 

--- a/src/lib/parquet/tests/Flow/Parquet/Tests/Integration/IO/ListsWritingTest.php
+++ b/src/lib/parquet/tests/Flow/Parquet/Tests/Integration/IO/ListsWritingTest.php
@@ -14,7 +14,7 @@ final class ListsWritingTest extends TestCase
 {
     public function test_writing_list_of_ints() : void
     {
-        $path = \sys_get_temp_dir() . '/test-writer' . \uniqid('parquet-test-', true) . '.parquet';
+        $path = \sys_get_temp_dir() . '/test-writer-parquet-test-' . bin2hex(random_bytes(16)) . '.parquet';
 
         $writer = new Writer();
         $schema = Schema::with(NestedColumn::list('list_of_ints', ListElement::int32()));
@@ -38,7 +38,7 @@ final class ListsWritingTest extends TestCase
 
     public function test_writing_list_of_strings() : void
     {
-        $path = \sys_get_temp_dir() . '/test-writer' . \uniqid('parquet-test-', true) . '.parquet';
+        $path = \sys_get_temp_dir() . '/test-writer-parquet-test-' . bin2hex(random_bytes(16)) . '.parquet';
 
         $writer = new Writer();
         $schema = Schema::with(NestedColumn::list('list_of_strings', ListElement::string()));
@@ -62,7 +62,7 @@ final class ListsWritingTest extends TestCase
 
     public function test_writing_list_of_structures() : void
     {
-        $path = \sys_get_temp_dir() . '/test-writer' . \uniqid('parquet-test-', true) . '.parquet';
+        $path = \sys_get_temp_dir() . '/test-writer-parquet-test-' . bin2hex(random_bytes(16)) . '.parquet';
 
         $writer = new Writer();
         $schema = Schema::with(
@@ -96,7 +96,7 @@ final class ListsWritingTest extends TestCase
 
     public function test_writing_list_with_nullable_elements() : void
     {
-        $path = \sys_get_temp_dir() . '/test-writer' . \uniqid('parquet-test-', true) . '.parquet';
+        $path = \sys_get_temp_dir() . '/test-writer-parquet-test-' . bin2hex(random_bytes(16)) . '.parquet';
 
         $writer = new Writer();
         $schema = Schema::with(NestedColumn::list('list_of_ints', ListElement::int32()));
@@ -122,7 +122,7 @@ final class ListsWritingTest extends TestCase
 
     public function test_writing_list_with_nullable_list_values() : void
     {
-        $path = \sys_get_temp_dir() . '/test-writer' . \uniqid('parquet-test-', true) . '.parquet';
+        $path = \sys_get_temp_dir() . '/test-writer-parquet-test-' . bin2hex(random_bytes(16)) . '.parquet';
 
         $writer = new Writer();
         $schema = Schema::with(NestedColumn::list('list_of_ints', ListElement::int32()));
@@ -148,7 +148,7 @@ final class ListsWritingTest extends TestCase
 
     public function test_writing_nullable_list_of_ints() : void
     {
-        $path = \sys_get_temp_dir() . '/test-writer' . \uniqid('parquet-test-', true) . '.parquet';
+        $path = \sys_get_temp_dir() . '/test-writer-parquet-test-' . bin2hex(random_bytes(16)) . '.parquet';
 
         $writer = new Writer();
         $schema = Schema::with(NestedColumn::list('list_of_ints', ListElement::int32()));
@@ -174,7 +174,7 @@ final class ListsWritingTest extends TestCase
 
     public function test_writing_nullable_list_of_structures() : void
     {
-        $path = \sys_get_temp_dir() . '/test-writer' . \uniqid('parquet-test-', true) . '.parquet';
+        $path = \sys_get_temp_dir() . '/test-writer-parquet-test-' . bin2hex(random_bytes(16)) . '.parquet';
 
         $writer = new Writer();
         $schema = Schema::with(

--- a/src/lib/parquet/tests/Flow/Parquet/Tests/Integration/IO/MapsWritingTest.php
+++ b/src/lib/parquet/tests/Flow/Parquet/Tests/Integration/IO/MapsWritingTest.php
@@ -14,7 +14,7 @@ final class MapsWritingTest extends TestCase
 {
     public function test_writing_map_of_int_int() : void
     {
-        $path = \sys_get_temp_dir() . '/test-writer' . \uniqid('parquet-test-', true) . '.parquet';
+        $path = \sys_get_temp_dir() . '/test-writer-parquet-test-' . bin2hex(random_bytes(16)) . '.parquet';
 
         $writer = new Writer();
         $schema = Schema::with(NestedColumn::map('map_int_int', MapKey::int32(), MapValue::int32()));
@@ -43,7 +43,7 @@ final class MapsWritingTest extends TestCase
 
     public function test_writing_map_of_int_string() : void
     {
-        $path = \sys_get_temp_dir() . '/test-writer' . \uniqid('parquet-test-', true) . '.parquet';
+        $path = \sys_get_temp_dir() . '/test-writer-parquet-test-' . bin2hex(random_bytes(16)) . '.parquet';
 
         $writer = new Writer();
         $schema = Schema::with(NestedColumn::map('map_int_string', MapKey::int32(), MapValue::string()));
@@ -72,7 +72,7 @@ final class MapsWritingTest extends TestCase
 
     public function test_writing_nullable_map_of_int_int() : void
     {
-        $path = \sys_get_temp_dir() . '/test-writer' . \uniqid('parquet-test-', true) . '.parquet';
+        $path = \sys_get_temp_dir() . '/test-writer-parquet-test-' . bin2hex(random_bytes(16)) . '.parquet';
 
         $writer = new Writer();
         $schema = Schema::with(NestedColumn::map('map_int_int', MapKey::int32(), MapValue::int32()));

--- a/src/lib/parquet/tests/Flow/Parquet/Tests/Integration/IO/SimpleTypesWritingTest.php
+++ b/src/lib/parquet/tests/Flow/Parquet/Tests/Integration/IO/SimpleTypesWritingTest.php
@@ -14,7 +14,7 @@ final class SimpleTypesWritingTest extends TestCase
 {
     public function test_writing_bool_column() : void
     {
-        $path = \sys_get_temp_dir() . '/test-writer' . \uniqid('parquet-test-', true) . '.parquet';
+        $path = \sys_get_temp_dir() . '/test-writer-parquet-test-' . bin2hex(random_bytes(16)) . '.parquet';
 
         $writer = new Writer();
         $schema = Schema::with(FlatColumn::boolean('boolean'));
@@ -40,7 +40,7 @@ final class SimpleTypesWritingTest extends TestCase
 
     public function test_writing_bool_nullable_column() : void
     {
-        $path = \sys_get_temp_dir() . '/test-writer' . \uniqid('parquet-test-', true) . '.parquet';
+        $path = \sys_get_temp_dir() . '/test-writer-parquet-test-' . bin2hex(random_bytes(16)) . '.parquet';
 
         $writer = new Writer();
         $schema = Schema::with(FlatColumn::boolean('boolean'));
@@ -66,7 +66,7 @@ final class SimpleTypesWritingTest extends TestCase
 
     public function test_writing_date_column() : void
     {
-        $path = \sys_get_temp_dir() . '/test-writer' . \uniqid('parquet-test-', true) . '.parquet';
+        $path = \sys_get_temp_dir() . '/test-writer-parquet-test-' . bin2hex(random_bytes(16)) . '.parquet';
 
         $writer = new Writer();
         $schema = Schema::with(FlatColumn::date('date'));
@@ -94,7 +94,7 @@ final class SimpleTypesWritingTest extends TestCase
 
     public function test_writing_date_nullable_column() : void
     {
-        $path = \sys_get_temp_dir() . '/test-writer' . \uniqid('parquet-test-', true) . '.parquet';
+        $path = \sys_get_temp_dir() . '/test-writer-parquet-test-' . bin2hex(random_bytes(16)) . '.parquet';
 
         $writer = new Writer();
         $schema = Schema::with(FlatColumn::date('date'));
@@ -122,7 +122,7 @@ final class SimpleTypesWritingTest extends TestCase
 
     public function test_writing_decimal_column() : void
     {
-        $path = \sys_get_temp_dir() . '/test-writer' . \uniqid('parquet-test-', true) . '.parquet';
+        $path = \sys_get_temp_dir() . '/test-writer-parquet-test-' . bin2hex(random_bytes(16)) . '.parquet';
 
         $writer = new Writer();
         $schema = Schema::with(FlatColumn::decimal('decimal'));
@@ -150,7 +150,7 @@ final class SimpleTypesWritingTest extends TestCase
 
     public function test_writing_decimal_nullable_column() : void
     {
-        $path = \sys_get_temp_dir() . '/test-writer' . \uniqid('parquet-test-', true) . '.parquet';
+        $path = \sys_get_temp_dir() . '/test-writer-parquet-test-' . bin2hex(random_bytes(16)) . '.parquet';
 
         $writer = new Writer();
         $schema = Schema::with(FlatColumn::decimal('decimal'));
@@ -178,7 +178,7 @@ final class SimpleTypesWritingTest extends TestCase
 
     public function test_writing_double_column() : void
     {
-        $path = \sys_get_temp_dir() . '/test-writer' . \uniqid('parquet-test-', true) . '.parquet';
+        $path = \sys_get_temp_dir() . '/test-writer-parquet-test-' . bin2hex(random_bytes(16)) . '.parquet';
 
         $writer = new Writer();
         $schema = Schema::with(FlatColumn::double('double'));
@@ -206,7 +206,7 @@ final class SimpleTypesWritingTest extends TestCase
 
     public function test_writing_double_nullable_column() : void
     {
-        $path = \sys_get_temp_dir() . '/test-writer' . \uniqid('parquet-test-', true) . '.parquet';
+        $path = \sys_get_temp_dir() . '/test-writer-parquet-test-' . bin2hex(random_bytes(16)) . '.parquet';
 
         $writer = new Writer();
         $schema = Schema::with(FlatColumn::double('double'));
@@ -234,7 +234,7 @@ final class SimpleTypesWritingTest extends TestCase
 
     public function test_writing_enum_column() : void
     {
-        $path = \sys_get_temp_dir() . '/test-writer' . \uniqid('parquet-test-', true) . '.parquet';
+        $path = \sys_get_temp_dir() . '/test-writer-parquet-test-' . bin2hex(random_bytes(16)) . '.parquet';
 
         $writer = new Writer();
         $schema = Schema::with(FlatColumn::enum('enum'));
@@ -262,7 +262,7 @@ final class SimpleTypesWritingTest extends TestCase
 
     public function test_writing_float_column() : void
     {
-        $path = \sys_get_temp_dir() . '/test-writer' . \uniqid('parquet-test-', true) . '.parquet';
+        $path = \sys_get_temp_dir() . '/test-writer-parquet-test-' . bin2hex(random_bytes(16)) . '.parquet';
 
         $writer = new Writer();
         $schema = Schema::with(FlatColumn::float('float'));
@@ -288,7 +288,7 @@ final class SimpleTypesWritingTest extends TestCase
 
     public function test_writing_float_nullable_column() : void
     {
-        $path = \sys_get_temp_dir() . '/test-writer' . \uniqid('parquet-test-', true) . '.parquet';
+        $path = \sys_get_temp_dir() . '/test-writer-parquet-test-' . bin2hex(random_bytes(16)) . '.parquet';
 
         $writer = new Writer();
         $schema = Schema::with(FlatColumn::float('float'));
@@ -314,7 +314,7 @@ final class SimpleTypesWritingTest extends TestCase
 
     public function test_writing_int32_column() : void
     {
-        $path = \sys_get_temp_dir() . '/test-writer' . \uniqid('parquet-test-', true) . '.parquet';
+        $path = \sys_get_temp_dir() . '/test-writer-parquet-test-' . bin2hex(random_bytes(16)) . '.parquet';
 
         $writer = new Writer();
         $schema = Schema::with(FlatColumn::int32('int32'));
@@ -342,7 +342,7 @@ final class SimpleTypesWritingTest extends TestCase
 
     public function test_writing_int32_nullable_column() : void
     {
-        $path = \sys_get_temp_dir() . '/test-writer' . \uniqid('parquet-test-', true) . '.parquet';
+        $path = \sys_get_temp_dir() . '/test-writer-parquet-test-' . bin2hex(random_bytes(16)) . '.parquet';
 
         $writer = new Writer();
         $schema = Schema::with(FlatColumn::int32('int32'));
@@ -370,7 +370,7 @@ final class SimpleTypesWritingTest extends TestCase
 
     public function test_writing_int64() : void
     {
-        $path = \sys_get_temp_dir() . '/test-writer' . \uniqid('parquet-test-', true) . '.parquet';
+        $path = \sys_get_temp_dir() . '/test-writer-parquet-test-' . bin2hex(random_bytes(16)) . '.parquet';
 
         $writer = new Writer();
         $schema = Schema::with(FlatColumn::int64('int64'));
@@ -397,7 +397,7 @@ final class SimpleTypesWritingTest extends TestCase
 
     public function test_writing_int64_nullable_column() : void
     {
-        $path = \sys_get_temp_dir() . '/test-writer' . \uniqid('parquet-test-', true) . '.parquet';
+        $path = \sys_get_temp_dir() . '/test-writer-parquet-test-' . bin2hex(random_bytes(16)) . '.parquet';
 
         $writer = new Writer();
         $schema = Schema::with(FlatColumn::int64('int64'));
@@ -424,7 +424,7 @@ final class SimpleTypesWritingTest extends TestCase
 
     public function test_writing_json_column() : void
     {
-        $path = \sys_get_temp_dir() . '/test-writer' . \uniqid('parquet-test-', true) . '.parquet';
+        $path = \sys_get_temp_dir() . '/test-writer-parquet-test-' . bin2hex(random_bytes(16)) . '.parquet';
 
         $writer = new Writer();
         $schema = Schema::with(FlatColumn::json('json'));
@@ -451,7 +451,7 @@ final class SimpleTypesWritingTest extends TestCase
 
     public function test_writing_json_nullable_column() : void
     {
-        $path = \sys_get_temp_dir() . '/test-writer' . \uniqid('parquet-test-', true) . '.parquet';
+        $path = \sys_get_temp_dir() . '/test-writer-parquet-test-' . bin2hex(random_bytes(16)) . '.parquet';
 
         $writer = new Writer();
         $schema = Schema::with(FlatColumn::json('json'));
@@ -480,7 +480,7 @@ final class SimpleTypesWritingTest extends TestCase
 
     public function test_writing_string_column() : void
     {
-        $path = \sys_get_temp_dir() . '/test-writer' . \uniqid('parquet-test-', true) . '.parquet';
+        $path = \sys_get_temp_dir() . '/test-writer-parquet-test-' . bin2hex(random_bytes(16)) . '.parquet';
 
         $writer = new Writer();
         $schema = Schema::with(FlatColumn::string('string'));
@@ -507,7 +507,7 @@ final class SimpleTypesWritingTest extends TestCase
 
     public function test_writing_string_nullable_column() : void
     {
-        $path = \sys_get_temp_dir() . '/test-writer' . \uniqid('parquet-test-', true) . '.parquet';
+        $path = \sys_get_temp_dir() . '/test-writer-parquet-test-' . bin2hex(random_bytes(16)) . '.parquet';
 
         $writer = new Writer();
         $schema = Schema::with(FlatColumn::string('string'));
@@ -534,7 +534,7 @@ final class SimpleTypesWritingTest extends TestCase
 
     public function test_writing_time_column() : void
     {
-        $path = \sys_get_temp_dir() . '/test-writer' . \uniqid('parquet-test-', true) . '.parquet';
+        $path = \sys_get_temp_dir() . '/test-writer-parquet-test-' . bin2hex(random_bytes(16)) . '.parquet';
 
         $writer = new Writer();
         $schema = Schema::with(FlatColumn::time('time'));
@@ -559,7 +559,7 @@ final class SimpleTypesWritingTest extends TestCase
 
     public function test_writing_time_nullable_column() : void
     {
-        $path = \sys_get_temp_dir() . '/test-writer' . \uniqid('parquet-test-', true) . '.parquet';
+        $path = \sys_get_temp_dir() . '/test-writer-parquet-test-' . bin2hex(random_bytes(16)) . '.parquet';
 
         $writer = new Writer();
         $schema = Schema::with(FlatColumn::time('time'));
@@ -584,7 +584,7 @@ final class SimpleTypesWritingTest extends TestCase
 
     public function test_writing_timestamp_column() : void
     {
-        $path = \sys_get_temp_dir() . '/test-writer' . \uniqid('parquet-test-', true) . '.parquet';
+        $path = \sys_get_temp_dir() . '/test-writer-parquet-test-' . bin2hex(random_bytes(16)) . '.parquet';
 
         $writer = new Writer();
         $schema = Schema::with(FlatColumn::dateTime('dateTime'));
@@ -611,7 +611,7 @@ final class SimpleTypesWritingTest extends TestCase
 
     public function test_writing_timestamp_nullable_column() : void
     {
-        $path = \sys_get_temp_dir() . '/test-writer' . \uniqid('parquet-test-', true) . '.parquet';
+        $path = \sys_get_temp_dir() . '/test-writer-parquet-test-' . bin2hex(random_bytes(16)) . '.parquet';
 
         $writer = new Writer();
         $schema = Schema::with(FlatColumn::dateTime('dateTime'));
@@ -638,7 +638,7 @@ final class SimpleTypesWritingTest extends TestCase
 
     public function test_writing_uuid_column() : void
     {
-        $path = \sys_get_temp_dir() . '/test-writer' . \uniqid('parquet-test-', true) . '.parquet';
+        $path = \sys_get_temp_dir() . '/test-writer-parquet-test-' . bin2hex(random_bytes(16)) . '.parquet';
 
         $writer = new Writer();
         $schema = Schema::with(FlatColumn::uuid('uuid'));
@@ -665,7 +665,7 @@ final class SimpleTypesWritingTest extends TestCase
 
     public function test_writing_uuid_nullable_column() : void
     {
-        $path = \sys_get_temp_dir() . '/test-writer' . \uniqid('parquet-test-', true) . '.parquet';
+        $path = \sys_get_temp_dir() . '/test-writer-parquet-test-' . bin2hex(random_bytes(16)) . '.parquet';
 
         $writer = new Writer();
         $schema = Schema::with(FlatColumn::uuid('uuid'));

--- a/src/lib/parquet/tests/Flow/Parquet/Tests/Integration/IO/StructsWritingTest.php
+++ b/src/lib/parquet/tests/Flow/Parquet/Tests/Integration/IO/StructsWritingTest.php
@@ -14,7 +14,7 @@ final class StructsWritingTest extends TestCase
 {
     public function test_writing_flat_nullable_structure() : void
     {
-        $path = \sys_get_temp_dir() . '/test-writer' . \uniqid('parquet-test-', true) . '.parquet';
+        $path = \sys_get_temp_dir() . '/test-writer-parquet-test-' . bin2hex(random_bytes(16)) . '.parquet';
 
         $writer = new Writer();
         $schema = Schema::with(NestedColumn::struct('struct', [
@@ -60,7 +60,7 @@ final class StructsWritingTest extends TestCase
 
     public function test_writing_flat_structure() : void
     {
-        $path = \sys_get_temp_dir() . '/test-writer' . \uniqid('parquet-test-', true) . '.parquet';
+        $path = \sys_get_temp_dir() . '/test-writer-parquet-test-' . bin2hex(random_bytes(16)) . '.parquet';
 
         $writer = new Writer();
         $schema = Schema::with(NestedColumn::struct('struct', [
@@ -104,7 +104,7 @@ final class StructsWritingTest extends TestCase
 
     public function test_writing_flat_structure_with_nullable_elements() : void
     {
-        $path = \sys_get_temp_dir() . '/test-writer' . \uniqid('parquet-test-', true) . '.parquet';
+        $path = \sys_get_temp_dir() . '/test-writer-parquet-test-' . bin2hex(random_bytes(16)) . '.parquet';
 
         $writer = new Writer();
         $schema = Schema::with(NestedColumn::struct('struct', [

--- a/src/lib/parquet/tests/Flow/Parquet/Tests/Integration/IO/WriterTest.php
+++ b/src/lib/parquet/tests/Flow/Parquet/Tests/Integration/IO/WriterTest.php
@@ -18,7 +18,7 @@ final class WriterTest extends TestCase
     {
         $writer = new Writer();
 
-        $path = \sys_get_temp_dir() . '/test-writer' . \uniqid('parquet-test-', true) . '.parquet';
+        $path = \sys_get_temp_dir() . '/test-writer-parquet-test-' . bin2hex(random_bytes(16)) . '.parquet';
 
         $schema = $this->createSchema();
         $row = $this->createRow();
@@ -39,7 +39,7 @@ final class WriterTest extends TestCase
     {
         $writer = new Writer();
 
-        $path = \sys_get_temp_dir() . '/test-writer' . \uniqid('parquet-test-', true) . '.parquet';
+        $path = \sys_get_temp_dir() . '/test-writer-parquet-test-' . bin2hex(random_bytes(16)) . '.parquet';
 
         $schema = $this->createSchema();
         $row = $this->createRow();
@@ -66,7 +66,7 @@ final class WriterTest extends TestCase
     {
         $writer = new Writer();
 
-        $path = \sys_get_temp_dir() . '/test-writer' . \uniqid('parquet-test-', true) . '.parquet';
+        $path = \sys_get_temp_dir() . '/test-writer-parquet-test-' . bin2hex(random_bytes(16)) . '.parquet';
 
         $schema = $this->createSchema();
         $row = $this->createRow();
@@ -101,7 +101,7 @@ final class WriterTest extends TestCase
     {
         $writer = new Writer();
 
-        $path = \sys_get_temp_dir() . '/test-writer' . \uniqid('parquet-test-', true) . '.parquet';
+        $path = \sys_get_temp_dir() . '/test-writer-parquet-test-' . bin2hex(random_bytes(16)) . '.parquet';
 
         $schema = $this->createSchema();
         $writer->open($path, $schema);
@@ -116,7 +116,7 @@ final class WriterTest extends TestCase
     {
         $writer = new Writer();
 
-        $path = \sys_get_temp_dir() . '/test-writer' . \uniqid('parquet-test-', true) . '.parquet';
+        $path = \sys_get_temp_dir() . '/test-writer-parquet-test-' . bin2hex(random_bytes(16)) . '.parquet';
 
         $schema = $this->createSchema();
 
@@ -145,7 +145,7 @@ final class WriterTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Given stream is not opened in write mode, expected wb, got: rb+');
 
-        $path = \sys_get_temp_dir() . '/test-writer' . \uniqid('parquet-test-', true) . '.parquet';
+        $path = \sys_get_temp_dir() . '/test-writer-parquet-test-' . bin2hex(random_bytes(16)) . '.parquet';
         \file_put_contents($path, 'test');
         $stream = \fopen($path, 'rb+');
 
@@ -161,7 +161,7 @@ final class WriterTest extends TestCase
                 ->set(Option::WRITER_VERSION, 1)
         );
 
-        $path = \sys_get_temp_dir() . '/test-writer' . \uniqid('parquet-test-v2-', true) . '.parquet';
+        $path = \sys_get_temp_dir() . '/test-writer-parquet-test-v2-' . bin2hex(random_bytes(16)) . '.parquet';
 
         $schema = Schema::with($column = FlatColumn::int32('int32'));
 
@@ -190,7 +190,7 @@ final class WriterTest extends TestCase
                 ->set(Option::WRITER_VERSION, 2)
         );
 
-        $path = \sys_get_temp_dir() . '/test-writer' . \uniqid('parquet-test-v2-', true) . '.parquet';
+        $path = \sys_get_temp_dir() . '/test-writer-parquet-test-v2-' . bin2hex(random_bytes(16)) . '.parquet';
 
         $schema = Schema::with($column = FlatColumn::int32('int32'));
 
@@ -217,7 +217,7 @@ final class WriterTest extends TestCase
     {
         $writer = new Writer();
 
-        $path = \sys_get_temp_dir() . '/test-writer' . \uniqid('parquet-test-', true) . '.parquet';
+        $path = \sys_get_temp_dir() . '/test-writer-parquet-test-' . bin2hex(random_bytes(16)) . '.parquet';
 
         $schema = $this->createSchema();
 
@@ -244,7 +244,7 @@ final class WriterTest extends TestCase
     {
         $writer = new Writer();
 
-        $path = \sys_get_temp_dir() . '/test-writer' . \uniqid('parquet-test-', true) . '.parquet';
+        $path = \sys_get_temp_dir() . '/test-writer-parquet-test-' . bin2hex(random_bytes(16)) . '.parquet';
 
         $schema = $this->createSchema();
 
@@ -270,7 +270,7 @@ final class WriterTest extends TestCase
     {
         $writer = new Writer();
 
-        $path = \sys_get_temp_dir() . '/test-writer' . \uniqid('parquet-test-', true) . '.parquet';
+        $path = \sys_get_temp_dir() . '/test-writer-parquet-test-' . bin2hex(random_bytes(16)) . '.parquet';
 
         $schema = $this->createSchema();
 
@@ -308,7 +308,7 @@ final class WriterTest extends TestCase
     {
         $writer = new Writer();
 
-        $path = \sys_get_temp_dir() . '/test-writer' . \uniqid('parquet-test-', true) . '.parquet';
+        $path = \sys_get_temp_dir() . '/test-writer-parquet-test-' . bin2hex(random_bytes(16)) . '.parquet';
 
         $schema = $this->createSchema();
         $row = $this->createRow();
@@ -330,7 +330,7 @@ final class WriterTest extends TestCase
                 ->set(Option::WRITER_VERSION, 2)
         );
 
-        $path = \sys_get_temp_dir() . '/test-writer' . \uniqid('parquet-test-v2-', true) . '.parquet';
+        $path = \sys_get_temp_dir() . '/test-writer-parquet-test-v2-' . bin2hex(random_bytes(16)) . '.parquet';
 
         $schema = $this->createSchema();
         $row = $this->createRow();
@@ -350,7 +350,7 @@ final class WriterTest extends TestCase
     {
         $writer = new Writer();
 
-        $path = \sys_get_temp_dir() . '/test-writer' . \uniqid('parquet-test-', true) . '.parquet';
+        $path = \sys_get_temp_dir() . '/test-writer-parquet-test-' . bin2hex(random_bytes(16)) . '.parquet';
 
         $schema = $this->createSchema();
         $row = $this->createRow();

--- a/src/lib/parquet/tests/Flow/Parquet/Tests/Integration/IO/WriterValidatorTest.php
+++ b/src/lib/parquet/tests/Flow/Parquet/Tests/Integration/IO/WriterValidatorTest.php
@@ -15,7 +15,7 @@ final class WriterValidatorTest extends TestCase
         $this->expectExceptionMessage('Column "string" is required');
 
         $writer = new Writer();
-        $path = \sys_get_temp_dir() . '/test-writer-validator' . \uniqid('parquet-test-', true) . '.parquet';
+        $path = \sys_get_temp_dir() . '/test-writer-validator-parquet-test-' . bin2hex(random_bytes(16)) . '.parquet';
 
         $schema = Schema::with(
             Schema\FlatColumn::int32('id'),
@@ -30,7 +30,7 @@ final class WriterValidatorTest extends TestCase
         $this->expectExceptionMessage('Column "string" is not string, got "integer" instead');
 
         $writer = new Writer();
-        $path = \sys_get_temp_dir() . '/test-writer-validator' . \uniqid('parquet-test-', true) . '.parquet';
+        $path = \sys_get_temp_dir() . '/test-writer-validator-parquet-test-' . bin2hex(random_bytes(16)) . '.parquet';
 
         $schema = Schema::with(Schema\FlatColumn::string('string'));
 
@@ -42,7 +42,7 @@ final class WriterValidatorTest extends TestCase
         $this->expectExceptionMessage('Column "list" is required');
 
         $writer = new Writer();
-        $path = \sys_get_temp_dir() . '/test-writer-validator' . \uniqid('parquet-test-', true) . '.parquet';
+        $path = \sys_get_temp_dir() . '/test-writer-validator-parquet-test-' . bin2hex(random_bytes(16)) . '.parquet';
 
         $schema = Schema::with(Schema\NestedColumn::list('list', Schema\ListElement::string())->makeRequired());
 
@@ -54,7 +54,7 @@ final class WriterValidatorTest extends TestCase
         $this->expectExceptionMessage('Column "list.list.element" is not string, got "NULL" instead');
 
         $writer = new Writer();
-        $path = \sys_get_temp_dir() . '/test-writer-validator' . \uniqid('parquet-test-', true) . '.parquet';
+        $path = \sys_get_temp_dir() . '/test-writer-validator-parquet-test-' . bin2hex(random_bytes(16)) . '.parquet';
 
         $schema = Schema::with(Schema\NestedColumn::list('list', Schema\ListElement::string(required: true)));
 
@@ -66,7 +66,7 @@ final class WriterValidatorTest extends TestCase
         $this->expectExceptionMessage('Column "map.key_value.value" is not string, got "NULL" instead');
 
         $writer = new Writer();
-        $path = \sys_get_temp_dir() . '/test-writer-validator' . \uniqid('parquet-test-', true) . '.parquet';
+        $path = \sys_get_temp_dir() . '/test-writer-validator-parquet-test-' . bin2hex(random_bytes(16)) . '.parquet';
 
         $schema = Schema::with(Schema\NestedColumn::map('map', Schema\MapKey::string(), Schema\MapValue::string(required: true)));
 
@@ -78,7 +78,7 @@ final class WriterValidatorTest extends TestCase
         $this->expectExceptionMessage('Column "map" is required');
 
         $writer = new Writer();
-        $path = \sys_get_temp_dir() . '/test-writer-validator' . \uniqid('parquet-test-', true) . '.parquet';
+        $path = \sys_get_temp_dir() . '/test-writer-validator-parquet-test-' . bin2hex(random_bytes(16)) . '.parquet';
 
         $schema = Schema::with(Schema\NestedColumn::map('map', Schema\MapKey::string(), Schema\MapValue::string())->makeRequired());
 
@@ -90,7 +90,7 @@ final class WriterValidatorTest extends TestCase
         $this->expectExceptionMessage('Column "string" is required');
 
         $writer = new Writer();
-        $path = \sys_get_temp_dir() . '/test-writer-validator' . \uniqid('parquet-test-', true) . '.parquet';
+        $path = \sys_get_temp_dir() . '/test-writer-validator-parquet-test-' . bin2hex(random_bytes(16)) . '.parquet';
 
         $schema = Schema::with(Schema\FlatColumn::string('string')->makeRequired());
 
@@ -100,7 +100,7 @@ final class WriterValidatorTest extends TestCase
     public function test_writing_row_with_missing_optional_columns() : void
     {
         $writer = new Writer();
-        $path = \sys_get_temp_dir() . '/test-writer-validator' . \uniqid('parquet-test-', true) . '.parquet';
+        $path = \sys_get_temp_dir() . '/test-writer-validator-parquet-test-' . bin2hex(random_bytes(16)) . '.parquet';
 
         $schema = Schema::with(
             Schema\FlatColumn::int32('id'),
@@ -134,7 +134,7 @@ final class WriterValidatorTest extends TestCase
     public function test_writing_row_with_missing_optional_columns_in_different_columns() : void
     {
         $writer = new Writer();
-        $path = \sys_get_temp_dir() . '/test-writer-validator' . \uniqid('parquet-test-', true) . '.parquet';
+        $path = \sys_get_temp_dir() . '/test-writer-validator-parquet-test-' . bin2hex(random_bytes(16)) . '.parquet';
 
         $schema = Schema::with(
             Schema\FlatColumn::int32('id'),


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Replace `uniqid` with guarantee uniqueness</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

Reason is upcoming deprecation and that `uniqid` is not so unique in the end:
https://wiki.php.net/rfc/deprecations_php_8_4#deprecate_uniqid
