### PR TITLE
Simplify making schema definitions nullable

### DIFF
--- a/src/core/etl/src/Flow/ETL/Pipeline/HashJoinPipeline.php
+++ b/src/core/etl/src/Flow/ETL/Pipeline/HashJoinPipeline.php
@@ -64,7 +64,7 @@ final class HashJoinPipeline implements Pipeline
 
         if ($this->join === Join::left) {
             foreach ($rightSchema->definitions() as $rightEntryDefinition) {
-                $rightEntries[] = $context->entryFactory()->create($rightEntryDefinition->entry()->name(), null, $rightEntryDefinition->nullable());
+                $rightEntries[] = $context->entryFactory()->create($rightEntryDefinition->entry()->name(), null, $rightEntryDefinition->makeNullable());
             }
         }
 
@@ -104,7 +104,7 @@ final class HashJoinPipeline implements Pipeline
 
         if ($this->join === Join::right) {
             foreach ($leftSchema->definitions() as $leftEntryDefinition) {
-                $leftEntries[] = $context->entryFactory()->create($leftEntryDefinition->entry()->name(), null, $leftEntryDefinition->nullable());
+                $leftEntries[] = $context->entryFactory()->create($leftEntryDefinition->entry()->name(), null, $leftEntryDefinition->makeNullable());
             }
 
             foreach ($hashTable->unmatchedRows() as $unmatchedRow) {

--- a/src/core/etl/src/Flow/ETL/Row/Schema.php
+++ b/src/core/etl/src/Flow/ETL/Row/Schema.php
@@ -136,6 +136,26 @@ final class Schema implements \Countable
         return $this;
     }
 
+    /**
+     * Makes all schema definitions nullable.
+     */
+    public function makeNullable() : self
+    {
+        $definitions = [];
+
+        foreach ($this->definitions as $definition) {
+            if (!$definition->isNullable()) {
+                $definitions[] = $definition->makeNullable();
+            } else {
+                $definitions[] = $definition;
+            }
+        }
+
+        $this->setDefinitions(...$definitions);
+
+        return $this;
+    }
+
     public function matches(self $schema, SchemaMatcher $matcher = new StrictSchemaMatcher()) : bool
     {
         return $matcher->match($this, $schema);
@@ -155,7 +175,7 @@ final class Schema implements \Countable
 
         foreach ($schema->definitions as $entry => $definition) {
             if (!\array_key_exists($definition->entry()->name(), $newDefinitions)) {
-                $newDefinitions[$entry] = $definition->nullable();
+                $newDefinitions[$entry] = $definition->makeNullable();
             } elseif (!$newDefinitions[$entry]->isEqual($definition)) {
                 $newDefinitions[$entry] = $newDefinitions[$entry]->merge($definition);
             }
@@ -163,13 +183,13 @@ final class Schema implements \Countable
 
         foreach ($schema->definitions as $entry => $definition) {
             if (!\array_key_exists($definition->entry()->name(), $newDefinitions)) {
-                $newDefinitions[$entry] = $definition->nullable();
+                $newDefinitions[$entry] = $definition->makeNullable();
             }
         }
 
         foreach ($newDefinitions as $entry => $definition) {
             if (!\array_key_exists($definition->entry()->name(), $schema->definitions)) {
-                $newDefinitions[$entry] = $definition->nullable();
+                $newDefinitions[$entry] = $definition->makeNullable();
             }
         }
 
@@ -189,21 +209,12 @@ final class Schema implements \Countable
         return $definitions;
     }
 
+    /**
+     * @deprecated use makeNullable instead
+     */
     public function nullable() : self
     {
-        $definitions = [];
-
-        foreach ($this->definitions as $definition) {
-            if (!$definition->isNullable()) {
-                $definitions[] = $definition->nullable();
-            } else {
-                $definitions[] = $definition;
-            }
-        }
-
-        $this->setDefinitions(...$definitions);
-
-        return $this;
+        return $this->makeNullable();
     }
 
     public function remove(string|Reference ...$entries) : self

--- a/src/core/etl/src/Flow/ETL/Row/Schema/Definition.php
+++ b/src/core/etl/src/Flow/ETL/Row/Schema/Definition.php
@@ -218,6 +218,11 @@ final class Definition
         return $this->type->nullable();
     }
 
+    public function makeNullable(bool $nullable = true) : self
+    {
+        return new self($this->ref, $this->entryClass, $this->type->makeNullable($nullable), $this->metadata);
+    }
+
     public function matches(Entry $entry) : bool
     {
         if ($this->isNullable() && $entry->is($this->ref)) {
@@ -317,9 +322,12 @@ final class Definition
         ];
     }
 
+    /**
+     * @deprecated Use makeNullable() instead
+     */
     public function nullable() : self
     {
-        return new self($this->ref, $this->entryClass, $this->type->makeNullable(true), $this->metadata);
+        return $this->makeNullable();
     }
 
     public function rename(string $newName) : self

--- a/src/core/etl/src/Flow/ETL/Rows.php
+++ b/src/core/etl/src/Flow/ETL/Rows.php
@@ -383,7 +383,7 @@ final class Rows implements \ArrayAccess, \Countable, \IteratorAggregate
                 $entries = [];
 
                 foreach ($rightSchema->definitions() as $definition) {
-                    $entries[] = $entryFactory->create($definition->entry()->name(), null, $definition->nullable());
+                    $entries[] = $entryFactory->create($definition->entry()->name(), null, $definition->makeNullable());
                 }
 
                 $joinedRow = $leftRow->merge(row(...$entries), $expression->prefix());
@@ -457,7 +457,7 @@ final class Rows implements \ArrayAccess, \Countable, \IteratorAggregate
                 $entries = [];
 
                 foreach ($leftSchema->definitions() as $definition) {
-                    $entries[] = $entryFactory->create($definition->entry()->name(), null, $definition->nullable());
+                    $entries[] = $entryFactory->create($definition->entry()->name(), null, $definition->makeNullable());
                 }
 
                 $joined[] = row(...$entries)->merge($rightRow, $expression->prefix());

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/SchemaTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/SchemaTest.php
@@ -157,7 +157,7 @@ final class SchemaTest extends TestCase
                 Schema\Definition::integer('id', $nullable = true),
                 Schema\Definition::string('name', $nullable = true)
             ),
-            $schema->nullable()
+            $schema->makeNullable()
         );
     }
 


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Simplify making schema definitions nullable</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <li>Schema::nullable() in favor of Schema::makeNullable()</li>
    <li>Definition::nullable() in favor of Definition::makeNullable(bool $nullable)</li>
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

<!-- Please provide a short description of changes in this section, feel free to use markdown syntax -->
