### PR TITLE
chore: Rework `References` to do fewer loops

### DIFF
--- a/src/core/etl/src/Flow/ETL/Row/References.php
+++ b/src/core/etl/src/Flow/ETL/Row/References.php
@@ -136,15 +136,13 @@ final class References implements \ArrayAccess, \Countable, \IteratorAggregate
     public function without(string|Reference ...$reference) : self
     {
         foreach ($reference as $ref) {
-            $this->without[$ref instanceof Reference ? $ref->name() : $ref] = true;
-        }
+            $refName = $ref instanceof Reference ? $ref->name() : $ref;
 
-        foreach ($this->refs as $refName => $ref) {
-            if (!\array_key_exists($refName, $this->without)) {
-                continue;
+            $this->without[$refName] = true;
+
+            if (\array_key_exists($refName, $this->refs)) {
+                unset($this->refs[$refName]);
             }
-
-            unset($this->refs[$refName]);
         }
 
         return $this;

--- a/src/core/etl/src/Flow/ETL/Row/References.php
+++ b/src/core/etl/src/Flow/ETL/Row/References.php
@@ -15,40 +15,32 @@ final class References implements \ArrayAccess, \Countable, \IteratorAggregate
     /**
      * @var array<string, Reference>
      */
-    private array $refs;
+    private array $refs = [];
 
     /**
-     * @var array<string>
+     * @var array<string, true>
      */
     private array $without = [];
 
-    public function __construct(string|Reference ...$reference)
+    public function __construct(string|Reference ...$references)
     {
-        $refs = [];
+        foreach ($references as $ref) {
+            $ref = EntryReference::init($ref);
 
-        foreach ($reference as $ref) {
-            $refs[] = EntryReference::init($ref);
+            $this->refs[$ref->name()] = $ref;
         }
-
-        $indexedRefs = [];
-
-        foreach ($refs as $ref) {
-            $indexedRefs[$ref->name()] = $ref;
-        }
-
-        $this->refs = $indexedRefs;
     }
 
-    public static function init(string|Reference ...$reference) : self
+    public static function init(string|Reference ...$references) : self
     {
-        return new self(...$reference);
+        return new self(...$references);
     }
 
     public function add(string|Reference $ref) : self
     {
         $reference = EntryReference::init($ref);
 
-        if (\in_array($reference->name(), $this->without, true)) {
+        if (\array_key_exists($reference->name(), $this->without)) {
             return $this;
         }
 
@@ -89,8 +81,10 @@ final class References implements \ArrayAccess, \Countable, \IteratorAggregate
 
     public function has(string|Reference $reference) : bool
     {
+        $reference = EntryReference::init($reference);
+
         foreach ($this->refs as $ref) {
-            if ($ref->is(EntryReference::init($reference))) {
+            if ($ref->is($reference)) {
                 return true;
             }
         }
@@ -141,28 +135,17 @@ final class References implements \ArrayAccess, \Countable, \IteratorAggregate
 
     public function without(string|Reference ...$reference) : self
     {
-        /**
-         * @var array<string>
-         */
-        $without = [];
-
         foreach ($reference as $ref) {
-            $without[] = $ref instanceof Reference ? $ref->name() : $ref;
+            $this->without[$ref instanceof Reference ? $ref->name() : $ref] = true;
         }
 
-        $this->without = \array_values(\array_unique(\array_merge($this->without, $without)));
-
-        $keepReferences = [];
-
         foreach ($this->refs as $refName => $ref) {
-            if (\in_array($refName, $without, true)) {
+            if (!\array_key_exists($refName, $this->without)) {
                 continue;
             }
 
-            $keepReferences[$ref->name()] = $ref;
+            unset($this->refs[$refName]);
         }
-
-        $this->refs = $keepReferences;
 
         return $this;
     }


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Rework `References` to do fewer loops</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

While looking on this class I noticed quite extensive amount of loops and array operations, unfortunately I don't have Blackfire (or alternative) installed right now to provide numbers.
