### PR TITLE
Deprecate Schema::entries in favor to Schema::references

### DIFF
--- a/src/core/etl/src/Flow/ETL/Row/References.php
+++ b/src/core/etl/src/Flow/ETL/Row/References.php
@@ -93,6 +93,20 @@ final class References implements \ArrayAccess, \Countable, \IteratorAggregate
     }
 
     /**
+     * @return array<string>
+     */
+    public function names() : array
+    {
+        $names = [];
+
+        foreach ($this->refs as $ref) {
+            $names[] = $ref->name();
+        }
+
+        return $names;
+    }
+
+    /**
      * @param string $offset
      *
      * @return bool

--- a/src/core/etl/src/Flow/ETL/Row/Schema.php
+++ b/src/core/etl/src/Flow/ETL/Row/Schema.php
@@ -55,17 +55,13 @@ final class Schema implements \Countable
     }
 
     /**
+     * @deprecated use references() : References instead
+     *
      * @return array<Reference>
      */
     public function entries() : array
     {
-        $refs = [];
-
-        foreach ($this->definitions as $definition) {
-            $refs[] = $definition->entry();
-        }
-
-        return $refs;
+        return $this->references()->all();
     }
 
     public function findDefinition(string|Reference $ref) : ?Definition
@@ -209,6 +205,17 @@ final class Schema implements \Countable
     public function nullable() : self
     {
         return $this->makeNullable();
+    }
+
+    public function references() : References
+    {
+        $refs = [];
+
+        foreach ($this->definitions as $definition) {
+            $refs[] = $definition->entry();
+        }
+
+        return References::init(...$refs);
     }
 
     public function remove(string|Reference ...$entries) : self

--- a/src/core/etl/src/Flow/ETL/Row/Schema/SelectiveValidator.php
+++ b/src/core/etl/src/Flow/ETL/Row/Schema/SelectiveValidator.php
@@ -15,7 +15,7 @@ final class SelectiveValidator implements SchemaValidator
 {
     public function isValid(Rows $rows, Schema $schema) : bool
     {
-        foreach ($schema->entries() as $ref) {
+        foreach ($schema->references() as $ref) {
             $definition = $schema->getDefinition($ref);
 
             foreach ($rows as $row) {

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/ReferencesTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/ReferencesTest.php
@@ -20,6 +20,16 @@ final class ReferencesTest extends TestCase
         );
     }
 
+    public function test_references_names() : void
+    {
+        $refs = refs('id', 'name');
+
+        self::assertEquals(
+            ['id', 'name'],
+            $refs->names()
+        );
+    }
+
     public function test_that_reference_with_alias_exists() : void
     {
         $refs = new References(ref('id')->as('test'), ref('name'));


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Deprecate Schema::entries in favor to Schema::references</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

<!-- Please provide a short description of changes in this section, feel free to use markdown syntax -->
