### PR TITLE
Added missing split function to ScalarFunctionChain

### DIFF
--- a/src/core/etl/src/Flow/ETL/DSL/functions.php
+++ b/src/core/etl/src/Flow/ETL/DSL/functions.php
@@ -648,10 +648,7 @@ function date_time_format(ScalarFunction $ref, string $format) : DateTimeFormat
     return new DateTimeFormat($ref, $format);
 }
 
-/**
- * @param non-empty-string $separator
- */
-function split(ScalarFunction $ref, string $separator, int $limit = PHP_INT_MAX) : Split
+function split(ScalarFunction $ref, ScalarFunction|string $separator, ScalarFunction|int $limit = PHP_INT_MAX) : Split
 {
     return new Split($ref, $separator, $limit);
 }

--- a/src/core/etl/src/Flow/ETL/Function/ScalarFunctionChain.php
+++ b/src/core/etl/src/Flow/ETL/Function/ScalarFunctionChain.php
@@ -349,6 +349,11 @@ abstract class ScalarFunctionChain implements ScalarFunction
         return new Size($this);
     }
 
+    public function split(ScalarFunction|string $separator, ScalarFunction|int $limit = PHP_INT_MAX) : self
+    {
+        return new Split($this, $separator, $limit);
+    }
+
     public function sprintf(ScalarFunction ...$params) : self
     {
         return new Sprintf($this, ...$params);

--- a/src/core/etl/src/Flow/ETL/Function/Split.php
+++ b/src/core/etl/src/Flow/ETL/Function/Split.php
@@ -8,24 +8,24 @@ use Flow\ETL\Row;
 
 final class Split extends ScalarFunctionChain
 {
-    /**
-     * @param non-empty-string $separator
-     */
     public function __construct(
         private readonly ScalarFunction $ref,
-        private readonly string $separator,
-        private readonly int $limit = PHP_INT_MAX,
+        private readonly ScalarFunction|string $separator,
+        private readonly ScalarFunction|int $limit = PHP_INT_MAX,
     ) {
     }
 
     public function eval(Row $row) : mixed
     {
+        $separator = $this->separator instanceof ScalarFunction ? $this->separator->eval($row) : $this->separator;
+        $limit = $this->limit instanceof ScalarFunction ? $this->limit->eval($row) : $this->limit;
+
         $val = $this->ref->eval($row);
 
-        if (!\is_string($val)) {
+        if (!\is_string($val) || !\is_string($separator) || !\is_int($limit) || $limit < 1 || $separator === '') {
             return $val;
         }
 
-        return \explode($this->separator, $val, $this->limit);
+        return \explode($separator, $val, $limit);
     }
 }


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>Added missing split function to ScalarFunctionChain</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

Now we can use it like this: 

```
ref('photo_links')->split(lit('|'))
ref('photo_links')->split('|')
```

I think what we should start doing from now is to make ScalarFunction to accept union type arguments, like for example: 

`ScalarFuncton|string` so in case it's not string, then we should execute scalar functon. 

We might want to create some simple ScalarFunctionResolver that would give us: 

```
ScalarFunctionResolver::eval(ScalarFunction $function) : ScalarFunctionResult

ScalarFunctionResult::asInt() : ?int
ScalarFunctionResult::asString() : ?string
ScalarFunctionResult::cast(Type $to) : mixed
```
