### PR TITLE
Use basenamePrefix instead of suffix when creating temporary file in overwrite save mode

### DIFF
--- a/src/adapter/etl-adapter-json/tests/Flow/ETL/Adapter/JSON/Tests/Integration/JsonTest.php
+++ b/src/adapter/etl-adapter-json/tests/Flow/ETL/Adapter/JSON/Tests/Integration/JsonTest.php
@@ -6,7 +6,7 @@ namespace Flow\ETL\Adapter\JSON\Tests\Integration;
 
 use function Flow\ETL\Adapter\JSON\from_json;
 use function Flow\ETL\Adapter\Json\to_json;
-use function Flow\ETL\DSL\df;
+use function Flow\ETL\DSL\{df, overwrite};
 use function Flow\Filesystem\DSL\path;
 use Flow\ETL\Adapter\JSON\JsonLoader;
 use Flow\ETL\Tests\Double\FakeExtractor;
@@ -47,6 +47,33 @@ final class JsonTest extends TestCase
 ]
 JSON,
             \file_get_contents($path)
+        );
+
+        if (\file_exists($path)) {
+            \unlink($path);
+        }
+    }
+
+    public function test_json_loader_overwrite_mode() : void
+    {
+
+        df()
+            ->read(new FakeExtractor(100))
+            ->write(to_json($path = __DIR__ . '/var/test_json_loader.json'))
+            ->run();
+
+        df()
+            ->read(new FakeExtractor(100))
+            ->mode(overwrite())
+            ->write(to_json($path = __DIR__ . '/var/test_json_loader.json'))
+            ->run();
+
+        $content = \file_get_contents($path);
+        self::stringEndsWith(']', $content);
+
+        self::assertEquals(
+            100,
+            df()->read(from_json($path))->count()
         );
 
         if (\file_exists($path)) {

--- a/src/core/etl/src/Flow/ETL/Filesystem/FilesystemStreams.php
+++ b/src/core/etl/src/Flow/ETL/Filesystem/FilesystemStreams.php
@@ -13,7 +13,7 @@ use Flow\Filesystem\{FilesystemTable, Partition};
  */
 final class FilesystemStreams implements \Countable, \IteratorAggregate
 {
-    public const FLOW_TMP_SUFFIX = '._flow_tmp';
+    public const FLOW_TMP_FILE_PREFIX = '._flow_php_tmp.';
 
     private SaveMode $saveMode;
 
@@ -47,7 +47,7 @@ final class FilesystemStreams implements \Countable, \IteratorAggregate
                             $partitionFilesPatter = new Path($fileStream->path()->parentDirectory()->path() . '/*', $fileStream->path()->options());
 
                             foreach ($fs->list($partitionFilesPatter) as $partitionFile) {
-                                if (\str_ends_with($partitionFile->path->path(), self::FLOW_TMP_SUFFIX)) {
+                                if (\str_contains($partitionFile->path->path(), self::FLOW_TMP_FILE_PREFIX)) {
                                     continue;
                                 }
 
@@ -58,7 +58,7 @@ final class FilesystemStreams implements \Countable, \IteratorAggregate
                         $fs->mv(
                             $fileStream->path(),
                             new Path(
-                                \str_replace(self::FLOW_TMP_SUFFIX, '', $fileStream->path()->uri()),
+                                \str_replace(self::FLOW_TMP_FILE_PREFIX, '', $fileStream->path()->uri()),
                                 $fileStream->path()->options()
                             )
                         );
@@ -199,7 +199,7 @@ final class FilesystemStreams implements \Countable, \IteratorAggregate
             }
 
             if ($this->saveMode === SaveMode::Overwrite) {
-                $outputPath = new Path($outputPath->uri() . self::FLOW_TMP_SUFFIX, $outputPath->options());
+                $outputPath = $outputPath->basenamePrefix(self::FLOW_TMP_FILE_PREFIX);
             }
 
             if ($this->saveMode === SaveMode::ExceptionIfExists) {

--- a/src/core/etl/tests/Flow/ETL/Tests/Integration/Filesystem/FilesystemStreams/NotPartitioned/OverwriteModeTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Integration/Filesystem/FilesystemStreams/NotPartitioned/OverwriteModeTest.php
@@ -27,7 +27,7 @@ final class OverwriteModeTest extends FilesystemStreamsTestCase
         ]);
 
         $fileStream = $streams->writeTo($path = $this->getPath(__FUNCTION__ . '/existing-file.txt'));
-        self::assertStringEndsWith(FilesystemStreams::FLOW_TMP_SUFFIX, $fileStream->path()->path());
+        self::assertStringContainsString(FilesystemStreams::FLOW_TMP_FILE_PREFIX, $fileStream->path()->path());
         $fileStream->append('some other content');
         self::assertSame('some content', \file_get_contents($path->path()));
 

--- a/src/lib/filesystem/src/Flow/Filesystem/Path.php
+++ b/src/lib/filesystem/src/Flow/Filesystem/Path.php
@@ -150,6 +150,14 @@ final class Path
         return $this->basename;
     }
 
+    public function basenamePrefix(string $prefix) : self
+    {
+        return new self(
+            $this->parentDirectory()->uri() . DIRECTORY_SEPARATOR . $prefix . $this->basename(),
+            $this->options()
+        );
+    }
+
     public function context() : ResourceContext
     {
         return ResourceContext::from($this);

--- a/src/lib/filesystem/tests/Flow/Filesystem/Tests/Unit/PathTest.php
+++ b/src/lib/filesystem/tests/Flow/Filesystem/Tests/Unit/PathTest.php
@@ -125,6 +125,39 @@ final class PathTest extends TestCase
         self::assertFalse((new Path(__DIR__))->extension());
     }
 
+    public function test_file_prefix() : void
+    {
+        $path = new Path('flow-file://var/dir/file.csv', []);
+
+        self::assertSame(
+            'flow-file://var/dir/._flow_tmp.file.csv',
+            $path->basenamePrefix('._flow_tmp.')->uri()
+        );
+        self::assertSame('csv', $path->extension());
+    }
+
+    public function test_file_prefix_on_directory() : void
+    {
+        $path = new Path('flow-file://var/dir/', []);
+
+        self::assertSame(
+            'flow-file://var/._flow_tmp.dir',
+            $path->basenamePrefix('._flow_tmp.')->uri()
+        );
+        self::assertFalse($path->extension());
+    }
+
+    public function test_file_prefix_on_root_directory() : void
+    {
+        $path = new Path('flow-file://', []);
+
+        self::assertSame(
+            'flow-file://._flow_tmp.',
+            $path->basenamePrefix('._flow_tmp.')->uri()
+        );
+        self::assertFalse($path->extension());
+    }
+
     #[DataProvider('paths_with_static_parts')]
     public function test_finding_static_part_of_the_path(string $staticPart, string $uri) : void
     {


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>Use basenamePrefix instead of suffix when creating temporary file in overwrite save mode</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

<!-- Please provide a short description of changes in this section, feel free to use markdown syntax -->

Previously FilesystemStreams mechanism was adding `._flow_tmp` suffix to a destination path when it was creating a temporary file. This creates one problem, if path is a file path with CSV, suffix will prevent Path object from properly detecting extension from `file.csv._flow_tmp`. 

So let say we want to write to a `/var/files/file.csv` using `df->saveMode(overwrite())`. 

Flow will first create a temporary file: 

- `/var/files/file.csv._flow_tmp`

To avoid overwriting an existing file which is a safety mechanism that is preventing overwriting existing file by unfinished transformation pipelines. 

That's why instead of adding file suffix it's now adding basenamePrefix() which instead creates something like this: 

- `/var/files/._flow_php_tmp.file.csv`

Why detecting extension is important? There are Loaders like JsonLoader for example that are closing open streams by extension. 
