### PR TITLE
Improved reading XML's DX

### DIFF
--- a/src/adapter/etl-adapter-xml/src/Flow/ETL/Adapter/XML/XMLReaderExtractor.php
+++ b/src/adapter/etl-adapter-xml/src/Flow/ETL/Adapter/XML/XMLReaderExtractor.php
@@ -66,8 +66,8 @@ final class XMLReaderExtractor implements Extractor, FileExtractor, LimitableExt
                     $currentPath = \implode('/', $currentPathBreadCrumbs);
 
                     if ($currentPath === $this->xmlNodePath || ($this->xmlNodePath === '' && $xmlReader->depth === 0)) {
-                        $node = new \DOMDocument('1.0', '');
-                        $node->loadXML($xmlReader->readOuterXml());
+                        $dom = new \DOMDocument('1.0', '');
+                        $node = $xmlReader->expand($dom);
 
                         if ($shouldPutInputIntoRows) {
                             $rowData = [

--- a/src/adapter/etl-adapter-xml/tests/Flow/ETL/Adapter/XML/Tests/Integration/XMLReaderExtractorTest.php
+++ b/src/adapter/etl-adapter-xml/tests/Flow/ETL/Adapter/XML/Tests/Integration/XMLReaderExtractorTest.php
@@ -5,14 +5,13 @@ declare(strict_types=1);
 namespace Flow\ETL\Adapter\XML\Tests\Integration;
 
 use function Flow\ETL\Adapter\XML\from_xml;
-use function Flow\ETL\DSL\xml_entry;
+use function Flow\ETL\DSL\type_string;
 use Flow\ETL\Adapter\XML\XMLReaderExtractor;
 use Flow\ETL\Extractor\Signal;
-use Flow\ETL\{Config, Flow, FlowContext, Row, Rows};
+use Flow\ETL\{Config, Flow, FlowContext, PHP\Type\Caster, Tests\Integration\IntegrationTestCase};
 use Flow\Filesystem\Path;
-use PHPUnit\Framework\TestCase;
 
-final class XMLReaderExtractorTest extends TestCase
+final class XMLReaderExtractorTest extends IntegrationTestCase
 {
     public function test_limit() : void
     {
@@ -28,31 +27,11 @@ final class XMLReaderExtractorTest extends TestCase
     public function test_reading_deep_xml() : void
     {
         self::assertEquals(
-            new Rows(
-                Row::create(xml_entry(
-                    'node',
-                    '<deep id_attribute="1"><leaf id_attribute="1">1</leaf></deep>'
-                )),
-                Row::create(xml_entry(
-                    'node',
-                    '<deep id_attribute="2"><leaf id_attribute="2">2</leaf></deep>'
-                )),
-                Row::create(xml_entry(
-                    'node',
-                    '<deep id_attribute="3"><leaf id_attribute="3">3</leaf></deep>'
-                )),
-                Row::create(xml_entry(
-                    'node',
-                    '<deep id_attribute="4"><leaf id_attribute="4">4</leaf></deep>'
-                )),
-                Row::create(xml_entry(
-                    'node',
-                    '<deep id_attribute="5"><leaf id_attribute="5">5</leaf></deep>'
-                )),
-            ),
+            5,
             (new Flow())
                 ->read(from_xml(__DIR__ . '/../Fixtures/deepest_items_flat.xml', 'root/items/item/deep'))
                 ->fetch()
+                ->count()
         );
     }
 
@@ -62,58 +41,72 @@ final class XMLReaderExtractorTest extends TestCase
         $xml->load(__DIR__ . '/../Fixtures/simple_items.xml');
 
         self::assertEquals(
-            (new Rows(Row::create(xml_entry('node', $xml)))),
+            1,
             (new Flow())
                 ->read(from_xml(__DIR__ . '/../Fixtures/simple_items.xml'))
                 ->fetch()
+                ->count()
         );
     }
 
     public function test_reading_xml_each_collection_item() : void
     {
-        self::assertEquals(
-            new Rows(
-                Row::create(xml_entry('node', '<item item_attribute_01="1"><id id_attribute_01="1">1</id></item>')),
-                Row::create(xml_entry('node', '<item item_attribute_01="2"><id id_attribute_01="2">2</id></item>')),
-                Row::create(xml_entry('node', '<item item_attribute_01="3"><id id_attribute_01="3">3</id></item>')),
-                Row::create(xml_entry('node', '<item item_attribute_01="4"><id id_attribute_01="4">4</id></item>')),
-                Row::create(xml_entry('node', '<item item_attribute_01="5"><id id_attribute_01="5">5</id></item>')),
-            ),
-            (new Flow())
-                ->read(from_xml(__DIR__ . '/../Fixtures/simple_items_flat.xml', 'root/items/item'))
-                ->fetch()
+        self::assertXmlStringEqualsXmlString(
+            <<<'XML'
+<item item_attribute_01="1">
+  <id id_attribute_01="1">1</id>
+</item>
+XML,
+            Caster::default()->to(type_string())->value(
+                (new Flow())
+                    ->read(from_xml(__DIR__ . '/../Fixtures/simple_items_flat.xml', 'root/items/item'))
+                    ->fetch()[0]
+                    ->valueOf('node')
+            )
+        );
+
+        self::assertXmlStringEqualsXmlString(
+            <<<'XML'
+<item item_attribute_01="5">
+  <id id_attribute_01="5">5</id>
+</item>
+XML,
+            Caster::default()->to(type_string())->value(
+                (new Flow())
+                    ->read(from_xml(__DIR__ . '/../Fixtures/simple_items_flat.xml', 'root/items/item'))
+                    ->fetch()[4]
+                    ->valueOf('node')
+            )
         );
     }
 
     public function test_reading_xml_from_path() : void
     {
-        $xml = new \DOMDocument();
-        $xml->loadXML(<<<'XML'
-<?xml version="1.0"?>
+        self::assertXmlStringEqualsXmlString(
+            <<<'XML'
 <items items_attribute_01="1" items_attribute_02="2">
-        <item item_attribute_01="1">
-            <id id_attribute_01="1">1</id>
-        </item>
-        <item item_attribute_01="2">
-            <id id_attribute_01="2">2</id>
-        </item>
-        <item item_attribute_01="3">
-            <id id_attribute_01="3">3</id>
-        </item>
-        <item item_attribute_01="4">
-            <id id_attribute_01="4">4</id>
-        </item>
-        <item item_attribute_01="5">
-            <id id_attribute_01="5">5</id>
-        </item>
-    </items>
-
-XML);
-        self::assertEquals(
-            new Rows(Row::create(xml_entry('node', $xml))),
-            (new Flow())
-                ->read(from_xml(__DIR__ . '/../Fixtures/simple_items.xml', 'root/items'))
-                ->fetch()
+    <item item_attribute_01="1">
+        <id id_attribute_01="1">1</id>
+    </item>
+    <item item_attribute_01="2">
+        <id id_attribute_01="2">2</id>
+    </item>
+    <item item_attribute_01="3">
+        <id id_attribute_01="3">3</id>
+    </item>
+    <item item_attribute_01="4">
+        <id id_attribute_01="4">4</id>
+    </item>
+    <item item_attribute_01="5">
+        <id id_attribute_01="5">5</id>
+    </item>
+</items>
+XML,
+            Caster::default()->to(type_string())->value(
+                (new Flow())
+                    ->read(from_xml(__DIR__ . '/../Fixtures/simple_items.xml', 'root/items'))
+                    ->fetch()[0]->valueOf('node')
+            )
         );
     }
 

--- a/src/adapter/etl-adapter-xml/tests/Flow/ETL/Adapter/XML/Tests/Integration/XMLTest.php
+++ b/src/adapter/etl-adapter-xml/tests/Flow/ETL/Adapter/XML/Tests/Integration/XMLTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Adapter\XML\Tests\Integration;
+
+use function Flow\ETL\Adapter\XML\from_xml;
+use function Flow\ETL\DSL\{df, int_schema, ref, schema, type_int};
+use Flow\ETL\Tests\Integration\IntegrationTestCase;
+use Flow\Filesystem\Path;
+
+final class XMLTest extends IntegrationTestCase
+{
+    public function test_reading_xml_and_converting_it_to_rows() : void
+    {
+        $rows = df()
+            ->read(from_xml(Path::realpath(__DIR__ . '/../Fixtures/simple_items.xml'), 'root/items'))
+            ->withEntry('parent_attribute_01', ref('node')->domElementAttributeValue('items_attribute_01')->cast(type_int()))
+            ->withEntry('parent_attribute_02', ref('node')->domElementAttributeValue('items_attribute_02')->cast(type_int()))
+            ->withEntry('items', ref('node')->xpath('/*/item'))
+            ->withEntry('item', ref('items')->expand())
+            ->withEntry('item_attribute_01', ref('item')->domElementAttributeValue('item_attribute_01')->cast(type_int()))
+            ->withEntry('value', ref('item')->cast(type_int()))
+            ->drop('node', 'items', 'item')
+            ->fetch();
+
+        self::assertEquals(
+            [
+                ['parent_attribute_01' => 1, 'parent_attribute_02' => 2, 'item_attribute_01' => 1, 'value' => 1],
+                ['parent_attribute_01' => 1, 'parent_attribute_02' => 2, 'item_attribute_01' => 2, 'value' => 2],
+                ['parent_attribute_01' => 1, 'parent_attribute_02' => 2, 'item_attribute_01' => 3, 'value' => 3],
+                ['parent_attribute_01' => 1, 'parent_attribute_02' => 2, 'item_attribute_01' => 4, 'value' => 4],
+                ['parent_attribute_01' => 1, 'parent_attribute_02' => 2, 'item_attribute_01' => 5, 'value' => 5],
+            ],
+            $rows->toArray()
+        );
+
+        self::assertEquals(
+            schema(
+                int_schema('parent_attribute_01'),
+                int_schema('parent_attribute_02'),
+                int_schema('item_attribute_01'),
+                int_schema('value')
+            ),
+            $rows->schema()
+        );
+    }
+}

--- a/src/core/etl/src/Flow/ETL/DSL/functions.php
+++ b/src/core/etl/src/Flow/ETL/DSL/functions.php
@@ -1297,3 +1297,15 @@ function random_string(
 ) : RandomString {
     return new RandomString($length, $generator);
 }
+
+function dom_element_to_string(\DOMElement $element, bool $format_output = false, bool $preserver_white_space = false) : string|false
+{
+    $doc = new \DOMDocument('1.0', 'UTF-8');
+    $doc->formatOutput = $format_output;
+    $doc->preserveWhiteSpace = $preserver_white_space;
+
+    $importedNode = $doc->importNode($element, true);
+    $doc->appendChild($importedNode);
+
+    return $doc->saveXML($doc->documentElement);
+}

--- a/src/core/etl/src/Flow/ETL/Function/DOMElementAttributeValue.php
+++ b/src/core/etl/src/Flow/ETL/Function/DOMElementAttributeValue.php
@@ -6,9 +6,9 @@ namespace Flow\ETL\Function;
 
 use Flow\ETL\Row;
 
-final class DOMElementAttribute extends ScalarFunctionChain
+final class DOMElementAttributeValue extends ScalarFunctionChain
 {
-    public function __construct(private readonly ScalarFunction $ref, private readonly string $attribute)
+    public function __construct(private readonly ScalarFunction $ref, private readonly ScalarFunction|string $attribute)
     {
     }
 
@@ -28,9 +28,15 @@ final class DOMElementAttribute extends ScalarFunctionChain
             return null;
         }
 
+        $attributeName = \is_string($this->attribute) ? $this->attribute : $this->attribute->eval($row);
+
+        if (!\is_string($attributeName)) {
+            return null;
+        }
+
         $attributes = $value->attributes;
 
-        if (!$namedItem = $attributes->getNamedItem($this->attribute)) {
+        if (!$namedItem = $attributes->getNamedItem($attributeName)) {
             return null;
         }
 

--- a/src/core/etl/src/Flow/ETL/Function/DOMElementAttributesCount.php
+++ b/src/core/etl/src/Flow/ETL/Function/DOMElementAttributesCount.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Function;
+
+use Flow\ETL\Row;
+
+final class DOMElementAttributesCount extends ScalarFunctionChain
+{
+    public function __construct(private readonly ScalarFunction $ref)
+    {
+    }
+
+    public function eval(Row $row) : ?int
+    {
+        $value = $this->ref->eval($row);
+
+        if ($value instanceof \DOMAttr) {
+            return null;
+        }
+
+        if (!$value instanceof \DOMElement) {
+            return null;
+        }
+
+        if (!$value->hasAttributes()) {
+            return 0;
+        }
+
+        return $value->attributes->length;
+    }
+}

--- a/src/core/etl/src/Flow/ETL/Function/ScalarFunctionChain.php
+++ b/src/core/etl/src/Flow/ETL/Function/ScalarFunctionChain.php
@@ -91,9 +91,22 @@ abstract class ScalarFunctionChain implements ScalarFunction
         return new Divide($this, $ref);
     }
 
-    public function domElementAttribute(string $attribute) : self
+    /**
+     * @deprecated Use domElementAttributeValue instead
+     */
+    public function domElementAttribute(ScalarFunction|string $attribute) : self
     {
-        return new DOMElementAttribute($this, $attribute);
+        return new DOMElementAttributeValue($this, $attribute);
+    }
+
+    public function domElementAttributesCount() : self
+    {
+        return new DOMElementAttributesCount($this);
+    }
+
+    public function domElementAttributeValue(ScalarFunction|string $attribute) : self
+    {
+        return new DOMElementAttributeValue($this, $attribute);
     }
 
     public function domElementValue() : self

--- a/src/core/etl/src/Flow/ETL/Function/XPath.php
+++ b/src/core/etl/src/Flow/ETL/Function/XPath.php
@@ -20,7 +20,10 @@ final class XPath extends ScalarFunctionChain
         $value = $this->ref->eval($row);
 
         if ($value instanceof \DOMNode && !$value instanceof \DOMDocument) {
-            $value = (new \DOMDocument())->importNode($value, true);
+            $dom = new \DOMDocument();
+            $importedNode = $dom->importNode($value, true);
+            $dom->appendChild($importedNode);
+            $value = $dom;
         }
 
         if (!$value instanceof \DOMDocument) {

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Caster.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Caster.php
@@ -4,7 +4,17 @@ declare(strict_types=1);
 
 namespace Flow\ETL\PHP\Type;
 
-use function Flow\ETL\DSL\{type_array, type_boolean, type_datetime, type_float, type_integer, type_json, type_null, type_string, type_uuid, type_xml};
+use function Flow\ETL\DSL\{type_array,
+    type_boolean,
+    type_datetime,
+    type_float,
+    type_integer,
+    type_json,
+    type_null,
+    type_string,
+    type_uuid,
+    type_xml
+    };
 use Flow\ETL\Exception\RuntimeException;
 use Flow\ETL\PHP\Type\Caster\{ArrayCastingHandler, BooleanCastingHandler, CastingContext, CastingHandler, DateTimeCastingHandler, EnumCastingHandler, FloatCastingHandler, IntegerCastingHandler, JsonCastingHandler, ListCastingHandler, MapCastingHandler, NullCastingHandler, ObjectCastingHandler, StringCastingHandler, StructureCastingHandler, UuidCastingHandler, XMLCastingHandler};
 

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Caster.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Caster.php
@@ -14,7 +14,7 @@ use function Flow\ETL\DSL\{type_array,
     type_string,
     type_uuid,
     type_xml
-    };
+};
 use Flow\ETL\Exception\RuntimeException;
 use Flow\ETL\PHP\Type\Caster\{ArrayCastingHandler, BooleanCastingHandler, CastingContext, CastingHandler, DateTimeCastingHandler, EnumCastingHandler, FloatCastingHandler, IntegerCastingHandler, JsonCastingHandler, ListCastingHandler, MapCastingHandler, NullCastingHandler, ObjectCastingHandler, StringCastingHandler, StructureCastingHandler, UuidCastingHandler, XMLCastingHandler};
 

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Caster/BooleanCastingHandler.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Caster/BooleanCastingHandler.php
@@ -21,6 +21,10 @@ final class BooleanCastingHandler implements CastingHandler
             return $value;
         }
 
+        if ($value instanceof \DOMElement) {
+            $value = $value->nodeValue;
+        }
+
         if (\is_string($value)) {
             if (\in_array(\mb_strtolower($value), ['true', '1', 'yes', 'on'], true)) {
                 return true;

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Caster/DateTimeCastingHandler.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Caster/DateTimeCastingHandler.php
@@ -22,6 +22,10 @@ final class DateTimeCastingHandler implements CastingHandler
             return $value;
         }
 
+        if ($value instanceof \DOMElement) {
+            $value = $value->nodeValue;
+        }
+
         if ($value instanceof \DateTime) {
             return \DateTimeImmutable::createFromMutable($value);
         }

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Caster/FloatCastingHandler.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Caster/FloatCastingHandler.php
@@ -21,6 +21,10 @@ final class FloatCastingHandler implements CastingHandler
             return $value;
         }
 
+        if ($value instanceof \DOMElement) {
+            return (float) $value->nodeValue;
+        }
+
         if ($value instanceof \DateTimeImmutable) {
             return (float) $value->format('Uu');
         }

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Caster/IntegerCastingHandler.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Caster/IntegerCastingHandler.php
@@ -21,6 +21,10 @@ final class IntegerCastingHandler implements CastingHandler
             return $value;
         }
 
+        if ($value instanceof \DOMElement) {
+            return (int) $value->nodeValue;
+        }
+
         if ($value instanceof \DateTimeImmutable) {
             return (int) $value->format('Uu');
         }

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Caster/StringCastingHandler.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Caster/StringCastingHandler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Flow\ETL\PHP\Type\Caster;
 
+use function Flow\ETL\DSL\dom_element_to_string;
 use Flow\ETL\Exception\CastingException;
 use Flow\ETL\PHP\Type\Native\ScalarType;
 use Flow\ETL\PHP\Type\{Caster, Type};
@@ -39,6 +40,10 @@ final class StringCastingHandler implements CastingHandler
 
         if ($value instanceof \DOMDocument) {
             return $value->saveXML() ?: null;
+        }
+
+        if ($value instanceof \DOMElement) {
+            return dom_element_to_string($value);
         }
 
         try {

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Caster/UuidCastingHandler.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Caster/UuidCastingHandler.php
@@ -22,6 +22,10 @@ final class UuidCastingHandler implements CastingHandler
             return $value;
         }
 
+        if ($value instanceof \DOMElement) {
+            $value = $value->nodeValue;
+        }
+
         if (\is_string($value)) {
             return new Uuid($value);
         }

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Function/DOMElementAttributeValueTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Function/DOMElementAttributeValueTest.php
@@ -9,7 +9,7 @@ use Flow\ETL\Row;
 use Flow\ETL\Row\Factory\NativeEntryFactory;
 use PHPUnit\Framework\TestCase;
 
-final class DOMElementAttributeTest extends TestCase
+final class DOMElementAttributeValueTest extends TestCase
 {
     public function test_extracting_attribute_from_dom_element_entry() : void
     {
@@ -18,7 +18,7 @@ final class DOMElementAttributeTest extends TestCase
 
         self::assertEquals(
             'buz',
-            ref('value')->domElementAttribute('baz')->eval(
+            ref('value')->domElementAttributeValue('baz')->eval(
                 Row::create((new NativeEntryFactory())->create('value', $xml->documentElement->firstChild))
             )
         );
@@ -30,7 +30,7 @@ final class DOMElementAttributeTest extends TestCase
         $xml->loadXML('<root><foo baz="buz">bar</foo></root>');
 
         self::assertNull(
-            ref('value')->domElementAttribute('bar')->eval(
+            ref('value')->domElementAttributeValue('bar')->eval(
                 Row::create((new NativeEntryFactory())->create('value', $xml->documentElement->firstChild))
             )
         );

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Function/DOMElementAttributesCountTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Function/DOMElementAttributesCountTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Tests\Unit\Function;
+
+use function Flow\ETL\DSL\ref;
+use Flow\ETL\Row;
+use Flow\ETL\Row\Factory\NativeEntryFactory;
+use PHPUnit\Framework\TestCase;
+
+final class DOMElementAttributesCountTest extends TestCase
+{
+    public function test_attributes_count_on_element_with_multiple_attributes() : void
+    {
+        $xml = new \DOMDocument();
+        $xml->loadXML('<root><foo atr-01="1" atr-02="2" atr-03="3">bar</foo></root>');
+
+        self::assertEquals(
+            3,
+            ref('value')->domElementAttributesCount('baz')->eval(
+                Row::create((new NativeEntryFactory())->create('value', $xml->documentElement->firstChild))
+            )
+        );
+    }
+
+    public function test_attributes_count_on_element_with_one_attribute() : void
+    {
+        $xml = new \DOMDocument();
+        $xml->loadXML('<root><foo baz="buz">bar</foo></root>');
+
+        self::assertEquals(
+            1,
+            ref('value')->domElementAttributesCount('baz')->eval(
+                Row::create((new NativeEntryFactory())->create('value', $xml->documentElement->firstChild))
+            )
+        );
+    }
+
+    public function test_attributes_count_on_element_with_zero_attributes() : void
+    {
+        $xml = new \DOMDocument();
+        $xml->loadXML('<root><foo>bar</foo></root>');
+
+        self::assertEquals(
+            0,
+            ref('value')->domElementAttributesCount('baz')->eval(
+                Row::create((new NativeEntryFactory())->create('value', $xml->documentElement->firstChild))
+            )
+        );
+    }
+}

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/PHP/Type/Caster/BooleanCastingHandlerTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/PHP/Type/Caster/BooleanCastingHandlerTest.php
@@ -30,6 +30,8 @@ final class BooleanCastingHandlerTest extends TestCase
         yield 'DateTimeInterface' => [new \DateTimeImmutable('2021-01-01 00:00:00'), true];
         yield 'DateInterval' => [new \DateInterval('P1D'), true];
         yield 'DOMDocument' => [new \DOMDocument(), true];
+        yield 'DOMElement - true' => [new \DOMElement('element', 'true'), true];
+        yield 'DOMElement - false' => [new \DOMElement('element', 'false'), false];
     }
 
     #[DataProvider('boolean_castable_data_provider')]

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/PHP/Type/Caster/DateTimeCastingHandlerTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/PHP/Type/Caster/DateTimeCastingHandlerTest.php
@@ -20,6 +20,7 @@ final class DateTimeCastingHandlerTest extends TestCase
         yield 'bool' => [true, new \DateTimeImmutable('1970-01-01 00:00:01')];
         yield 'DateTimeInterface' => [new \DateTimeImmutable('2021-01-01 00:00:00'), new \DateTimeImmutable('2021-01-01 00:00:00')];
         yield 'DateInterval' => [new \DateInterval('P1D'), new \DateTimeImmutable('1970-01-02 00:00:00')];
+        yield 'DOMElement' => [new \DOMElement('element', '2021-01-01 00:00:00'), new \DateTimeImmutable('2021-01-01 00:00:00')];
     }
 
     #[DataProvider('datetime_castable_data_provider')]

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/PHP/Type/Caster/FloatCastingHandlerTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/PHP/Type/Caster/FloatCastingHandlerTest.php
@@ -21,6 +21,7 @@ final class FloatCastingHandlerTest extends TestCase
         yield 'array' => [[1, 2, 3], 1.0];
         yield 'DateTimeInterface' => [new \DateTimeImmutable('2021-01-01 00:00:00'), 1609459200000000.0];
         yield 'DateInterval' => [new \DateInterval('P1D'), 86400000000.0];
+        yield 'DOMElement' => [new \DOMElement('element', '1.1'), 1.1];
     }
 
     #[DataProvider('float_castable_data_provider')]

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/PHP/Type/Caster/IntegerCastingHandlerTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/PHP/Type/Caster/IntegerCastingHandlerTest.php
@@ -21,6 +21,7 @@ final class IntegerCastingHandlerTest extends TestCase
         yield 'array' => [[1, 2, 3], 1];
         yield 'DateTimeInterface' => [new \DateTimeImmutable('2021-01-01 00:00:00'), 1609459200000000];
         yield 'DateInterval' => [new \DateInterval('P1D'), 86400000000];
+        yield 'DOMElement' => [new \DOMElement('element', '1'), 1];
     }
 
     #[DataProvider('integer_castable_data_provider')]

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/PHP/Type/Caster/StringCastingHandlerTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/PHP/Type/Caster/StringCastingHandlerTest.php
@@ -28,6 +28,7 @@ final class StringCastingHandlerTest extends TestCase
             }
         }, 'stringable'];
         yield 'DOMDocument' => [new \DOMDocument(), '<?xml version="1.0"?>'];
+        yield 'DOMElement' => [new \DOMElement('element'), '<element/>'];
     }
 
     #[DataProvider('string_castable_data_provider')]

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/PHP/Type/Caster/UuidCastingHandlerTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/PHP/Type/Caster/UuidCastingHandlerTest.php
@@ -36,4 +36,14 @@ final class UuidCastingHandlerTest extends TestCase
             (new UuidCastingHandler())->value('6c2f6e0e-8d8e-4e9e-8f0e-5a2d9c1c4f6e', type_uuid(), Caster::default())
         );
     }
+
+    public function test_casting_xml_element_to_uuid() : void
+    {
+        $uuid = \Ramsey\Uuid\Uuid::fromString('6c2f6e0e-8d8e-4e9e-8f0e-5a2d9c1c4f6e')->toString();
+
+        self::assertEquals(
+            $uuid,
+            (new UuidCastingHandler())->value(new \DOMElement('element', $uuid), type_uuid(), Caster::default())
+        );
+    }
 }


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <li>DOMElementAttributesCount scalar function</li>
    <li>DOMElementAttributeValue scalar function</li>
    <li>dom_element_to_string helper function</li>
    <li>Support for casting DOMElement into different types in Caster</li>
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>XMLReaderExtractor will now return each row with node{\DOMElement} instead of node{\DOMDocument} </li>
    <li>DOMElementAttribute scalar function is now deprecated in favor of DOMElementAttributeValue</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

The biggest change of this PR is in how XMLReaderExtractor is yielding rows. 

Previously each row had a `node` entry that was an `XMLEntry` type. This means that value under it was `\DOMDocument` which is counter-intuitive since when we are reading from XML we are reading elements not documents. 

That's why many scalar function couldn't be applied on the node directly (like element value or attribute value). 

Additionally Caster now supports DOMElement when casting to scalar values. 