### PR TITLE
Replace XMLReaderExtractor with XMLParserExtractor implementation that can support reading from remote files

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,8 @@
         "ext-json": "*",
         "ext-mbstring": "*",
         "ext-xmlreader": "*",
+        "ext-xmlwriter": "*",
+        "ext-xml": "*",
         "ext-zlib": "*",
         "composer-runtime-api": "^2.1",
         "coduo/php-humanizer": "^5.0",

--- a/src/adapter/etl-adapter-xml/composer.json
+++ b/src/adapter/etl-adapter-xml/composer.json
@@ -14,6 +14,8 @@
         "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
         "ext-dom": "*",
         "ext-xmlreader": "*",
+        "ext-xml": "*",
+        "ext-writer": "*",
         "flow-php/etl": "^0.8 || 1.x-dev"
     },
     "config": {

--- a/src/adapter/etl-adapter-xml/src/Flow/ETL/Adapter/XML/XMLParserExtractor.php
+++ b/src/adapter/etl-adapter-xml/src/Flow/ETL/Adapter/XML/XMLParserExtractor.php
@@ -1,0 +1,227 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Adapter\XML;
+
+use function Flow\ETL\DSL\array_to_rows;
+use Flow\ETL\Exception\RuntimeException;
+use Flow\ETL\Extractor\{FileExtractor, Limitable, LimitableExtractor, PartitionExtractor, PathFiltering, Signal};
+use Flow\ETL\{Exception\InvalidArgumentException, Extractor, FlowContext};
+use Flow\Filesystem\Path;
+
+final class XMLParserExtractor implements Extractor, FileExtractor, LimitableExtractor, PartitionExtractor
+{
+    use Limitable;
+    use PathFiltering;
+
+    private bool $capturing = false;
+
+    /**
+     * @var array<string>
+     */
+    private array $currentPath = [];
+
+    /**
+     * @var array<string>
+     */
+    private array $elements = [];
+
+    private ?\XMLParser $parser = null;
+
+    private readonly string $targetPath;
+
+    private ?\XMLWriter $writer = null;
+
+    /**
+     * In order to iterate only over <element> nodes us root/elements/element.
+     *
+     * <root>
+     *   <elements>
+     *     <element></element>
+     *     <element></element>
+     *   <elements>
+     * </root>
+     *
+     * $xmlNodePath does not support attributes and it's not xpath, it is just a sequence
+     * of node names separated with slash.
+     *
+     * @param Path $path
+     * @param string $targetPath
+     * @param int<1, max> $bufferSize - size of the chunks to read from the xml file. Bigger chunks means faster reading but more memory usage.
+     */
+    public function __construct(private readonly Path $path, string $targetPath = '', private readonly int $bufferSize = 8096)
+    {
+        if ($this->bufferSize < 1) {
+            throw new InvalidArgumentException('Buffer size must be greater than 0');
+        }
+
+        $this->targetPath = \ltrim($targetPath, '/');
+        $this->resetLimit();
+    }
+
+    public function characterDataHandler(\XMLParser $parser, string $data) : void
+    {
+        if ($this->capturing) {
+            $this->writer()->text($data);
+        }
+    }
+
+    public function endElementHandler(\XMLParser $parser, string $name) : void
+    {
+        if ($this->capturing) {
+            $this->writer()->endElement();
+
+            if (implode('/', $this->currentPath) === $this->targetPath || ($this->targetPath === '' && \count($this->currentPath) === 1)) {
+                $this->capturing = false;
+                $this->elements[] = $this->writer()->outputMemory();
+            }
+        }
+
+        array_pop($this->currentPath);
+    }
+
+    public function extract(FlowContext $context) : \Generator
+    {
+        $shouldPutInputIntoRows = $context->config->shouldPutInputIntoRows();
+
+        foreach ($context->streams()->list($this->path, $this->filter()) as $stream) {
+
+            foreach ($stream->iterate($this->bufferSize) as $chunk) {
+                if (!xml_parse($this->parser(), $chunk)) {
+                    throw new RuntimeException(sprintf(
+                        'XML Error: %s at line %d',
+                        (string) xml_error_string(xml_get_error_code($this->parser())),
+                        xml_get_current_line_number($this->parser())
+                    ));
+                }
+
+                if (\count($this->elements)) {
+                    foreach ($this->elements as $element) {
+                        if ($shouldPutInputIntoRows) {
+                            $rowData = [
+                                'node' => $this->createDOMElement($element),
+                                '_input_file_uri' => $stream->path()->uri(),
+                            ];
+                        } else {
+                            $rowData = ['node' => $this->createDOMElement($element)];
+                        }
+
+                        $signal = yield array_to_rows($rowData, $context->entryFactory(), $stream->path()->partitions());
+
+                        $this->incrementReturnedRows();
+
+                        if ($signal === Signal::STOP || $this->reachedLimit()) {
+                            $context->streams()->closeWriters($this->path);
+                            $this->freeParser();
+
+                            return;
+                        }
+                    }
+                    $this->elements = [];
+                }
+            }
+
+            xml_parse($this->parser(), '', true);
+
+            if (\count($this->elements)) {
+                foreach ($this->elements as $element) {
+                    if ($shouldPutInputIntoRows) {
+                        $rowData = [
+                            'node' => $this->createDOMElement($element),
+                            '_input_file_uri' => $stream->path()->uri(),
+                        ];
+                    } else {
+                        $rowData = ['node' => $this->createDOMElement($element)];
+                    }
+
+                    $signal = yield array_to_rows([$rowData], $context->entryFactory(), $stream->path()->partitions());
+
+                    $this->incrementReturnedRows();
+
+                    if ($signal === Signal::STOP || $this->reachedLimit()) {
+                        $context->streams()->closeWriters($this->path);
+                        $this->freeParser();
+
+                        return;
+                    }
+                }
+                $this->elements = [];
+            }
+
+            $this->freeParser();
+        }
+    }
+
+    public function source() : Path
+    {
+        return $this->path;
+    }
+
+    public function startElementHandler(\XMLParser $parser, string $name, array $attrs) : void
+    {
+        $this->currentPath[] = $name;
+        $currentPathString = implode('/', $this->currentPath);
+
+        if ($currentPathString === $this->targetPath || ($this->targetPath === '' && \count($this->currentPath) === 1)) {
+            $this->capturing = true;
+            $this->writer()->startElement($name);
+
+            foreach ($attrs as $key => $value) {
+                $this->writer()->writeAttribute($key, $value);
+            }
+        } elseif ($this->capturing) {
+            $this->writer()->startElement($name);
+
+            foreach ($attrs as $key => $value) {
+                $this->writer()->writeAttribute($key, $value);
+            }
+        }
+    }
+
+    private function createDOMElement(string $xmlString) : \DOMElement
+    {
+        $doc = new \DOMDocument();
+        $doc->loadXML($xmlString);
+
+        $element = $doc->documentElement;
+
+        if ($element === null) {
+            throw new RuntimeException('Cannot create DOMElement from XML string: ' . $xmlString);
+        }
+
+        return $element;
+    }
+
+    private function freeParser() : void
+    {
+        if ($this->parser !== null) {
+            xml_parser_free($this->parser);
+            $this->parser = null;
+        }
+    }
+
+    private function parser() : \XMLParser
+    {
+        if ($this->parser === null) {
+            $this->parser = xml_parser_create();
+            xml_parser_set_option($this->parser, XML_OPTION_CASE_FOLDING, 0);
+            xml_set_object($this->parser, $this);
+            xml_set_element_handler($this->parser, [$this, 'startElementHandler'], [$this, 'endElementHandler']);
+            xml_set_character_data_handler($this->parser, [$this, 'characterDataHandler']);
+        }
+
+        return $this->parser;
+    }
+
+    private function writer() : \XMLWriter
+    {
+        if ($this->writer === null) {
+            $this->writer = new \XMLWriter();
+            $this->writer->openMemory();
+            $this->writer->setIndent(true);
+        }
+
+        return $this->writer;
+    }
+}

--- a/src/adapter/etl-adapter-xml/src/Flow/ETL/Adapter/XML/XMLReaderExtractor.php
+++ b/src/adapter/etl-adapter-xml/src/Flow/ETL/Adapter/XML/XMLReaderExtractor.php
@@ -6,7 +6,7 @@ namespace Flow\ETL\Adapter\XML;
 
 use function Flow\ETL\DSL\array_to_rows;
 use Flow\ETL\Extractor\{FileExtractor, Limitable, LimitableExtractor, PartitionExtractor, PathFiltering, Signal};
-use Flow\ETL\{Extractor, FlowContext};
+use Flow\ETL\{Exception\InvalidArgumentException, Extractor, FlowContext};
 use Flow\Filesystem\Path;
 
 final class XMLReaderExtractor implements Extractor, FileExtractor, LimitableExtractor, PartitionExtractor
@@ -15,6 +15,8 @@ final class XMLReaderExtractor implements Extractor, FileExtractor, LimitableExt
     use PathFiltering;
 
     /**
+     * @deprecated Use XMLParserExtractor instead, XMLReaderExtractor can't properly handle reading remote files since it requires a local file.
+     *
      * In order to iterate only over <element> nodes us root/elements/element.
      *
      * <root>
@@ -33,6 +35,9 @@ final class XMLReaderExtractor implements Extractor, FileExtractor, LimitableExt
         private readonly Path $path,
         private readonly string $xmlNodePath = ''
     ) {
+        if (!$this->path->isLocal()) {
+            throw new InvalidArgumentException('XMLReaderExtractor supports only local files, please use XMLParserExtractor that depends on php-xml extension.');
+        }
         $this->resetLimit();
     }
 

--- a/src/adapter/etl-adapter-xml/src/Flow/ETL/Adapter/XML/functions.php
+++ b/src/adapter/etl-adapter-xml/src/Flow/ETL/Adapter/XML/functions.php
@@ -23,7 +23,7 @@ function from_xml(
         $extractors = [];
 
         foreach ($path as $next_path) {
-            $extractors[] = new XMLReaderExtractor(
+            $extractors[] = new XMLParserExtractor(
                 \is_string($next_path) ? Path::realpath($next_path) : $next_path,
                 $xml_node_path
             );
@@ -32,7 +32,7 @@ function from_xml(
         return from_all(...$extractors);
     }
 
-    return new XMLReaderExtractor(
+    return new XMLParserExtractor(
         \is_string($path) ? Path::realpath($path) : $path,
         $xml_node_path
     );

--- a/src/adapter/etl-adapter-xml/tests/Flow/ETL/Adapter/XML/Tests/Fixtures/partitioned/date=2024-08-01/file.xml
+++ b/src/adapter/etl-adapter-xml/tests/Flow/ETL/Adapter/XML/Tests/Fixtures/partitioned/date=2024-08-01/file.xml
@@ -1,0 +1,19 @@
+<root root_attribute_01="1">
+    <items items_attribute_01="1" items_attribute_02="2">
+        <item item_attribute_01="1">
+            <id id_attribute_01="1">1</id>
+        </item>
+        <item item_attribute_01="2">
+            <id id_attribute_01="2">2</id>
+        </item>
+        <item item_attribute_01="3">
+            <id id_attribute_01="3">3</id>
+        </item>
+        <item item_attribute_01="4">
+            <id id_attribute_01="4">4</id>
+        </item>
+        <item item_attribute_01="5">
+            <id id_attribute_01="5">5</id>
+        </item>
+    </items>
+</root>

--- a/src/adapter/etl-adapter-xml/tests/Flow/ETL/Adapter/XML/Tests/Fixtures/partitioned/date=2024-08-02/file.xml
+++ b/src/adapter/etl-adapter-xml/tests/Flow/ETL/Adapter/XML/Tests/Fixtures/partitioned/date=2024-08-02/file.xml
@@ -1,0 +1,7 @@
+<root root_attribute_01="1">
+    <items items_attribute_01="1" items_attribute_02="2">
+        <item item_attribute_01="6">
+            <id id_attribute_01="6">6</id>
+        </item>
+    </items>
+</root>

--- a/src/adapter/etl-adapter-xml/tests/Flow/ETL/Adapter/XML/Tests/Fixtures/partitioned/date=2024-08-03/file.xml
+++ b/src/adapter/etl-adapter-xml/tests/Flow/ETL/Adapter/XML/Tests/Fixtures/partitioned/date=2024-08-03/file.xml
@@ -1,0 +1,10 @@
+<root root_attribute_01="1">
+    <items items_attribute_01="1" items_attribute_02="2">
+        <item item_attribute_01="7">
+            <id id_attribute_01="7">7</id>
+        </item>
+        <item item_attribute_01="8">
+            <id id_attribute_01="8">8</id>
+        </item>
+    </items>
+</root>

--- a/src/adapter/etl-adapter-xml/tests/Flow/ETL/Adapter/XML/Tests/Integration/XMLParserExtractorTest.php
+++ b/src/adapter/etl-adapter-xml/tests/Flow/ETL/Adapter/XML/Tests/Integration/XMLParserExtractorTest.php
@@ -4,17 +4,22 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Adapter\XML\Tests\Integration;
 
+use function Flow\ETL\Adapter\XML\from_xml;
 use function Flow\ETL\DSL\type_string;
-use Flow\ETL\Adapter\XML\XMLReaderExtractor;
 use Flow\ETL\Extractor\Signal;
-use Flow\ETL\{Config, Flow, FlowContext, PHP\Type\Caster, Tests\Integration\IntegrationTestCase};
+use Flow\ETL\{Adapter\XML\XMLParserExtractor,
+    Config,
+    Flow,
+    FlowContext,
+    PHP\Type\Caster,
+    Tests\Integration\IntegrationTestCase};
 use Flow\Filesystem\Path;
 
-final class XMLReaderExtractorTest extends IntegrationTestCase
+final class XMLParserExtractorTest extends IntegrationTestCase
 {
     public function test_limit() : void
     {
-        $extractor = new XMLReaderExtractor(Path::realpath(__DIR__ . '/../Fixtures/flow_orders.xml'), 'root/row');
+        $extractor = new XMLParserExtractor(Path::realpath(__DIR__ . '/../Fixtures/flow_orders.xml'), 'root/row');
         $extractor->changeLimit(2);
 
         self::assertCount(
@@ -28,7 +33,7 @@ final class XMLReaderExtractorTest extends IntegrationTestCase
         self::assertEquals(
             5,
             (new Flow())
-                ->read(new XMLReaderExtractor(new Path(__DIR__ . '/../Fixtures/deepest_items_flat.xml'), 'root/items/item/deep'))
+                ->read(from_xml(__DIR__ . '/../Fixtures/deepest_items_flat.xml', 'root/items/item/deep'))
                 ->fetch()
                 ->count()
         );
@@ -42,7 +47,7 @@ final class XMLReaderExtractorTest extends IntegrationTestCase
         self::assertEquals(
             1,
             (new Flow())
-                ->read(new XMLReaderExtractor(new Path(__DIR__ . '/../Fixtures/simple_items.xml')))
+                ->read(from_xml(__DIR__ . '/../Fixtures/simple_items.xml'))
                 ->fetch()
                 ->count()
         );
@@ -58,7 +63,7 @@ final class XMLReaderExtractorTest extends IntegrationTestCase
 XML,
             Caster::default()->to(type_string())->value(
                 (new Flow())
-                    ->read(new XMLReaderExtractor(new Path(__DIR__ . '/../Fixtures/simple_items_flat.xml'), 'root/items/item'))
+                    ->read(from_xml(__DIR__ . '/../Fixtures/simple_items_flat.xml', 'root/items/item'))
                     ->fetch()[0]
                     ->valueOf('node')
             )
@@ -72,7 +77,7 @@ XML,
 XML,
             Caster::default()->to(type_string())->value(
                 (new Flow())
-                    ->read(new XMLReaderExtractor(new Path(__DIR__ . '/../Fixtures/simple_items_flat.xml'), 'root/items/item'))
+                    ->read(from_xml(__DIR__ . '/../Fixtures/simple_items_flat.xml', 'root/items/item'))
                     ->fetch()[4]
                     ->valueOf('node')
             )
@@ -103,7 +108,7 @@ XML,
 XML,
             Caster::default()->to(type_string())->value(
                 (new Flow())
-                    ->read(new XMLReaderExtractor(new Path(__DIR__ . '/../Fixtures/simple_items.xml'), 'root/items'))
+                    ->read(from_xml(__DIR__ . '/../Fixtures/simple_items.xml', 'root/items'))
                     ->fetch()[0]->valueOf('node')
             )
         );
@@ -111,7 +116,7 @@ XML,
 
     public function test_signal_stop() : void
     {
-        $extractor = new XMLReaderExtractor(Path::realpath(__DIR__ . '/../Fixtures/flow_orders.xml'), 'root/row');
+        $extractor = new XMLParserExtractor(Path::realpath(__DIR__ . '/../Fixtures/flow_orders.xml'), 'root/row');
 
         $generator = $extractor->extract(new FlowContext(Config::default()));
 

--- a/src/adapter/etl-adapter-xml/tests/Flow/ETL/Adapter/XML/Tests/Integration/XMLTest.php
+++ b/src/adapter/etl-adapter-xml/tests/Flow/ETL/Adapter/XML/Tests/Integration/XMLTest.php
@@ -4,17 +4,17 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Adapter\XML\Tests\Integration;
 
-use function Flow\ETL\Adapter\XML\from_xml;
-use function Flow\ETL\DSL\{df, int_schema, ref, schema, type_int};
+use function Flow\ETL\DSL\{datetime_schema, df, int_schema, ref, schema, type_int};
+use Flow\ETL\Adapter\XML\XMLParserExtractor;
 use Flow\ETL\Tests\Integration\IntegrationTestCase;
 use Flow\Filesystem\Path;
 
 final class XMLTest extends IntegrationTestCase
 {
-    public function test_reading_xml_and_converting_it_to_rows() : void
+    public function test_transforming_xml_into_a_tabular_dataset() : void
     {
         $rows = df()
-            ->read(from_xml(Path::realpath(__DIR__ . '/../Fixtures/simple_items.xml'), 'root/items'))
+            ->read(new XMLParserExtractor(new Path(__DIR__ . '/../Fixtures/simple_items.xml'), 'root/items'))
             ->withEntry('parent_attribute_01', ref('node')->domElementAttributeValue('items_attribute_01')->cast(type_int()))
             ->withEntry('parent_attribute_02', ref('node')->domElementAttributeValue('items_attribute_02')->cast(type_int()))
             ->withEntry('items', ref('node')->xpath('/*/item'))
@@ -41,6 +41,48 @@ final class XMLTest extends IntegrationTestCase
                 int_schema('parent_attribute_02'),
                 int_schema('item_attribute_01'),
                 int_schema('value')
+            ),
+            $rows->schema()
+        );
+    }
+
+    public function test_transforming_xml_into_a_tabular_dataset_from_partitioned_dataset() : void
+    {
+        $rows = df()
+            ->read(new XMLParserExtractor(new Path(__DIR__ . '/../Fixtures/partitioned/date=*/*.xml'), 'root/items'))
+
+            ->withEntry('parent_attribute_01', ref('node')->domElementAttributeValue('items_attribute_01')->cast(type_int()))
+            ->withEntry('parent_attribute_02', ref('node')->domElementAttributeValue('items_attribute_02')->cast(type_int()))
+            ->withEntry('items', ref('node')->xpath('/*/item'))
+            ->withEntry('item', ref('items')->expand())
+            ->withEntry('item_attribute_01', ref('item')->domElementAttributeValue('item_attribute_01')->cast(type_int()))
+            ->withEntry('value', ref('item')->cast(type_int()))
+            ->withEntry('date', ref('date')->cast('date'))
+            ->sortBy(ref('date')->asc())
+            ->drop('node', 'items', 'item')
+            ->fetch();
+
+        self::assertEquals(
+            [
+                ['parent_attribute_01' => 1, 'parent_attribute_02' => 2, 'item_attribute_01' => 1, 'value' => 1, 'date' => new \DateTimeImmutable('2024-08-01')],
+                ['parent_attribute_01' => 1, 'parent_attribute_02' => 2, 'item_attribute_01' => 2, 'value' => 2, 'date' => new \DateTimeImmutable('2024-08-01')],
+                ['parent_attribute_01' => 1, 'parent_attribute_02' => 2, 'item_attribute_01' => 3, 'value' => 3, 'date' => new \DateTimeImmutable('2024-08-01')],
+                ['parent_attribute_01' => 1, 'parent_attribute_02' => 2, 'item_attribute_01' => 4, 'value' => 4, 'date' => new \DateTimeImmutable('2024-08-01')],
+                ['parent_attribute_01' => 1, 'parent_attribute_02' => 2, 'item_attribute_01' => 5, 'value' => 5, 'date' => new \DateTimeImmutable('2024-08-01')],
+                ['parent_attribute_01' => 1, 'parent_attribute_02' => 2, 'item_attribute_01' => 6, 'value' => 6, 'date' => new \DateTimeImmutable('2024-08-02')],
+                ['parent_attribute_01' => 1, 'parent_attribute_02' => 2, 'item_attribute_01' => 7, 'value' => 7, 'date' => new \DateTimeImmutable('2024-08-03')],
+                ['parent_attribute_01' => 1, 'parent_attribute_02' => 2, 'item_attribute_01' => 8, 'value' => 8, 'date' => new \DateTimeImmutable('2024-08-03')],
+            ],
+            $rows->toArray()
+        );
+
+        self::assertEquals(
+            schema(
+                int_schema('parent_attribute_01'),
+                int_schema('parent_attribute_02'),
+                int_schema('item_attribute_01'),
+                int_schema('value'),
+                datetime_schema('date')
             ),
             $rows->schema()
         );

--- a/src/core/etl/src/Flow/ETL/Function/XPath.php
+++ b/src/core/etl/src/Flow/ETL/Function/XPath.php
@@ -12,9 +12,6 @@ final class XPath extends ScalarFunctionChain
     {
     }
 
-    /**
-     * @psalm-suppress InvalidReturnStatement
-     */
     public function eval(Row $row) : \DOMNode|array|null
     {
         $value = $this->ref->eval($row);
@@ -39,10 +36,6 @@ final class XPath extends ScalarFunctionChain
 
         if ($result->length === 0) {
             return null;
-        }
-
-        if ($result->length === 1) {
-            return $result->item(0);
         }
 
         $nodes = [];

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Function/XPathTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Function/XPathTest.php
@@ -17,7 +17,7 @@ final class XPathTest extends TestCase
         $xml->loadXML('<root><foo baz="buz">bar</foo></root>');
 
         self::assertEquals(
-            $xml->documentElement->firstChild,
+            [$xml->documentElement->firstChild],
             ref('value')->xpath('/root/foo')->eval(Row::create((new NativeEntryFactory())->create('value', $xml)))
         );
     }


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <li>XMLParserExtractor implementation of XMLExtractor</li>
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>XMLReaderExtractor is now deprecated as it can't read from remote files</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

I'm not sure what to do with XMLReaderExtractor, for now I'm gonna leave it deprecated but I think it should be removed since it brings zero added value compared to XMLParserExtractor. 
