### PR TITLE
Json Loader - allow to write each node in a new line

### DIFF
--- a/src/adapter/etl-adapter-json/src/Flow/ETL/Adapter/JSON/functions.php
+++ b/src/adapter/etl-adapter-json/src/Flow/ETL/Adapter/JSON/functions.php
@@ -47,7 +47,11 @@ function from_json(
  *
  * @return Loader
  */
-function to_json(string|Path $path, string $date_time_format = \DateTimeInterface::ATOM) : Loader
-{
-    return new JsonLoader(\is_string($path) ? Path::realpath($path) : $path, $date_time_format);
+function to_json(
+    string|Path $path,
+    int $flags = JSON_THROW_ON_ERROR,
+    string $date_time_format = \DateTimeInterface::ATOM,
+    bool $put_rows_in_new_lines = false
+) : Loader {
+    return new JsonLoader(\is_string($path) ? Path::realpath($path) : $path, $flags, $date_time_format, $put_rows_in_new_lines);
 }

--- a/src/adapter/etl-adapter-json/tests/Flow/ETL/Adapter/JSON/Tests/Integration/JsonTest.php
+++ b/src/adapter/etl-adapter-json/tests/Flow/ETL/Adapter/JSON/Tests/Integration/JsonTest.php
@@ -6,7 +6,7 @@ namespace Flow\ETL\Adapter\JSON\Tests\Integration;
 
 use function Flow\ETL\Adapter\JSON\from_json;
 use function Flow\ETL\Adapter\Json\to_json;
-use function Flow\ETL\DSL\{df, overwrite};
+use function Flow\ETL\DSL\{df, from_array, overwrite};
 use function Flow\Filesystem\DSL\path;
 use Flow\ETL\Adapter\JSON\JsonLoader;
 use Flow\ETL\Tests\Double\FakeExtractor;
@@ -79,5 +79,55 @@ JSON,
         if (\file_exists($path)) {
             \unlink($path);
         }
+    }
+
+    public function test_putting_each_row_in_a_new_line() : void
+    {
+        df()
+            ->read(from_array([
+                ['name' => 'John', 'age' => 30],
+                ['name' => 'Jane', 'age' => 25],
+            ]))
+            ->saveMode(overwrite())
+            ->write(to_json($path = __DIR__ . '/var/test_putting_each_row_in_a_new_line.json', put_rows_in_new_lines: true))
+            ->run();
+
+        self::assertStringContainsString(
+            <<<'JSON'
+[
+{"name":"John","age":30},
+{"name":"Jane","age":25}
+]
+JSON,
+            \file_get_contents($path)
+        );
+    }
+
+    public function test_putting_each_row_in_a_new_line_with_json_pretty_print_flag() : void
+    {
+        df()
+            ->read(from_array([
+                ['name' => 'John', 'age' => 30],
+                ['name' => 'Jane', 'age' => 25],
+            ]))
+            ->saveMode(overwrite())
+            ->write(to_json($path = __DIR__ . '/var/test_putting_each_row_in_a_new_line.json', flags: JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT, put_rows_in_new_lines: true))
+            ->run();
+
+        self::assertStringContainsString(
+            <<<'JSON'
+[
+{
+    "name": "John",
+    "age": 30
+},
+{
+    "name": "Jane",
+    "age": 25
+}
+]
+JSON,
+            \file_get_contents($path)
+        );
     }
 }


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <li>JsonLoader parameter that defines if each row should be a single line in the output file</li>
    <li>JsonLoader int $flags parameter that is passed later to internal json_encode function</li>
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

<!-- Please provide a short description of changes in this section, feel free to use markdown syntax -->

Resolves: #1180 
