### PR TITLE
Added description to landing page examples

### DIFF
--- a/examples/topics/data_source/array/description.md
+++ b/examples/topics/data_source/array/description.md
@@ -1,0 +1,1 @@
+Read data directly from a php associative array.  Relays on `array_to_rows` DSL function.

--- a/examples/topics/data_source/csv/description.md
+++ b/examples/topics/data_source/csv/description.md
@@ -1,0 +1,22 @@
+Read data from a csv file.
+
+```php
+function from_csv(
+    string|Path|array $path,
+    bool $with_header = true,
+    bool $empty_to_null = true,
+    ?string $delimiter = null,
+    ?string $enclosure = null,
+    ?string $escape = null,
+    int $characters_read_in_line = 1000,
+    ?Schema $schema = null
+):
+``` 
+
+* `with_header` - default true, if false, the first row will be treated as data
+* `empty_to_null` - default false, if true, empty string will be treated as null
+* `delimiter` - the delimiter of the csv file, when not set, it will be auto detected
+* `enclosure` - the enclosure of the csv file, when not set, it will be auto detected
+* `escape` - default `\`, the escape character of the csv file
+* `characters_in_line` - default `1000`, size of chunk used to read lines from the file
+* `schema` - the schema of the csv file, when not set, it will be auto detected

--- a/examples/topics/data_source/json/description.md
+++ b/examples/topics/data_source/json/description.md
@@ -1,0 +1,12 @@
+Read data from a json file.
+
+```php
+function from_json(
+    string|Path|array $path,
+    ?string $pointer = null,
+    ?Schema $schema = null,
+);
+```
+
+* `pointer` - default null, used to iterate only results of a subtree, read more about [pointers](https://github.com/halaxa/json-machine#parsing-a-subtree)
+* `schema` - the schema of the csv file, when not set, it will be auto detected

--- a/examples/topics/data_source/parquet/description.md
+++ b/examples/topics/data_source/parquet/description.md
@@ -1,0 +1,16 @@
+Read data from a json file.
+
+```php
+function from_parquet(
+    string|Path|array $uri,
+    array $columns = [],
+    Options $options = new Options(),
+    ByteOrder $byte_order = ByteOrder::LITTLE_ENDIAN,
+    ?int $offset = null,
+);
+```
+
+* `columns` - default [], list of columns to read, when empty, all columns will be read
+* `options` - custom Parquet Reader [Options](https://github.com/flow-php/flow/blob/1.x/src/lib/parquet/src/Flow/Parquet/Options.php)
+* `byte_order` - default `ByteOrder::LITTLE_ENDIAN`, the byte order of the parquet file
+* `offset` - default null, rows to skip from the beginning of the file 

--- a/examples/topics/data_source/xml/description.md
+++ b/examples/topics/data_source/xml/description.md
@@ -1,0 +1,10 @@
+Read data from a json file.
+
+```php
+function from_xml(
+    string|Path|array $path,
+    string $xml_node_path = ''
+);
+```
+
+* `xml_node_path` - default '', the path to the node to read, when empty, the root node will be read. It's not xpath, it is just a sequence of node names separated with slash.

--- a/examples/topics/schema/inferring/description.md
+++ b/examples/topics/schema/inferring/description.md
@@ -1,0 +1,2 @@
+Schema inferring is a process of generating a schema from a whole or part of the dataset.   
+Once schema is inferred, it can be saved and used to speed up next dataset processing.

--- a/src/adapter/etl-adapter-parquet/src/Flow/ETL/Adapter/Parquet/functions.php
+++ b/src/adapter/etl-adapter-parquet/src/Flow/ETL/Adapter/Parquet/functions.php
@@ -13,26 +13,26 @@ use Flow\Parquet\ParquetFile\Compressions;
 use Flow\Parquet\{ByteOrder, Options};
 
 /**
- * @param array<Path>|Path|string $uri
+ * @param array<Path>|Path|string $path
  * @param array<string> $columns
  *
  * @return Extractor
  */
 function from_parquet(
-    string|Path|array $uri,
+    string|Path|array $path,
     array $columns = [],
     Options $options = new Options(),
     ByteOrder $byte_order = ByteOrder::LITTLE_ENDIAN,
     ?int $offset = null,
 ) : Extractor {
-    if (\is_array($uri)) {
+    if (\is_array($path)) {
         $extractors = [];
 
         if ($offset !== null) {
             throw new InvalidArgumentException('Offset can be used only with single file path, not with pattern');
         }
 
-        foreach ($uri as $filePath) {
+        foreach ($path as $filePath) {
             $extractors[] = new ParquetExtractor(
                 $filePath,
                 $options,
@@ -45,7 +45,7 @@ function from_parquet(
     }
 
     return new ParquetExtractor(
-        \is_string($uri) ? Path::realpath($uri) : $uri,
+        \is_string($path) ? Path::realpath($path) : $path,
         $options,
         $byte_order,
         $columns,

--- a/web/landing/assets/controllers/all_links_external_controller.js
+++ b/web/landing/assets/controllers/all_links_external_controller.js
@@ -1,0 +1,13 @@
+import {Controller} from '@hotwired/stimulus';
+
+/* stimulusFetch: 'lazy' */
+export default class extends Controller
+{
+    connect()
+    {
+        this.element.querySelectorAll('a').forEach(link => {
+                link.target = '_blank';
+                link.rel = 'noopener';
+        });
+    }
+}

--- a/web/landing/assets/styles/app.css
+++ b/web/landing/assets/styles/app.css
@@ -60,3 +60,27 @@ code {
 #blog-post hr {
     @apply text-blue-100 my-4 border-t-2 rounded;
 }
+
+#example-description h1 {
+    @apply font-bold text-2xl;
+}
+
+#example-description h2 {
+    @apply font-bold text-xl mt-4;
+}
+
+#example-description h1, h2, ul, hr, p {
+    @apply mb-3;
+}
+
+#example-description ul {
+    @apply list-disc pl-6;
+}
+
+#example-description hr {
+    @apply text-blue-100 my-4 border-t-2 rounded;
+}
+
+#example-description code {
+    @apply text-orange-100;
+}

--- a/web/landing/composer.json
+++ b/web/landing/composer.json
@@ -23,7 +23,7 @@
         "monolog/monolog": "^3.5",
         "symfony/monolog-bundle": "^3.10",
         "coduo/php-humanizer": "^4.0",
-        "twig/markdown-extra": "^3.8",
+        "twig/markdown-extra": "^3.11",
         "twig/extra-bundle": "^3.8",
         "league/commonmark": "^2.4"
     },

--- a/web/landing/composer.lock
+++ b/web/landing/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7ffce47f5ec3692a4516ce30fbcb265b",
+    "content-hash": "cad381dd9d02ae735d21b00ab3ac728a",
     "packages": [
         {
             "name": "aeon-php/calendar",
@@ -5206,16 +5206,16 @@
         },
         {
             "name": "twig/markdown-extra",
-            "version": "v3.10.0",
+            "version": "v3.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/markdown-extra.git",
-                "reference": "e4bf2419df819dcf9dc7a0b25dd8cd1092cbd86d"
+                "reference": "504557d60d80478260ebd2221a2b3332a480865d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/markdown-extra/zipball/e4bf2419df819dcf9dc7a0b25dd8cd1092cbd86d",
-                "reference": "e4bf2419df819dcf9dc7a0b25dd8cd1092cbd86d",
+                "url": "https://api.github.com/repos/twigphp/markdown-extra/zipball/504557d60d80478260ebd2221a2b3332a480865d",
+                "reference": "504557d60d80478260ebd2221a2b3332a480865d",
                 "shasum": ""
             },
             "require": {
@@ -5262,7 +5262,7 @@
                 "twig"
             ],
             "support": {
-                "source": "https://github.com/twigphp/markdown-extra/tree/v3.10.0"
+                "source": "https://github.com/twigphp/markdown-extra/tree/v3.11.0"
             },
             "funding": [
                 {
@@ -5274,7 +5274,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-05-11T07:35:57+00:00"
+            "time": "2024-08-07T17:34:09+00:00"
         },
         {
             "name": "twig/twig",

--- a/web/landing/src/Flow/Website/Controller/ExamplesController.php
+++ b/web/landing/src/Flow/Website/Controller/ExamplesController.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Flow\Website\Controller;
 
-use Flow\Website\Service\{Examples};
+use Flow\Website\Service\Examples;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 
-final class DefaultController extends AbstractController
+final class ExamplesController extends AbstractController
 {
     public function __construct(
         private readonly Examples $examples,
@@ -30,16 +30,9 @@ final class DefaultController extends AbstractController
             'examples' => $examples,
             'currentTopic' => $topic,
             'currentExample' => $example,
+            'description' => $this->examples->description($currentTopic, $currentExample),
             'code' => $this->examples->code($currentTopic, $currentExample),
             'output' => $this->examples->output($currentTopic, $currentExample),
-        ]);
-    }
-
-    #[Route('/', name: 'main')]
-    public function main() : Response
-    {
-        return $this->render('main/index.html.twig', [
-            'topics' => $this->examples->topics(),
         ]);
     }
 
@@ -57,6 +50,7 @@ final class DefaultController extends AbstractController
             'examples' => $examples,
             'currentTopic' => $currentTopic,
             'currentExample' => $currentExample,
+            'description' => $this->examples->description($currentTopic, $currentExample),
             'code' => $this->examples->code($currentTopic, $currentExample),
             'output' => $this->examples->output($currentTopic, $currentExample),
         ]);

--- a/web/landing/src/Flow/Website/Controller/HomeController.php
+++ b/web/landing/src/Flow/Website/Controller/HomeController.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\Website\Controller;
+
+use Flow\Website\Service\{Examples};
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+final class HomeController extends AbstractController
+{
+    public function __construct(
+        private readonly Examples $examples,
+    ) {
+    }
+
+    #[Route('/', name: 'home')]
+    public function home() : Response
+    {
+        return $this->render('main/index.html.twig', [
+            'topics' => $this->examples->topics(),
+        ]);
+    }
+}

--- a/web/landing/src/Flow/Website/Service/Examples.php
+++ b/web/landing/src/Flow/Website/Service/Examples.php
@@ -21,6 +21,17 @@ final class Examples
         return \file_get_contents($path);
     }
 
+    public function description(string $topic, string $example) : ?string
+    {
+        $path = \sprintf('%s/topics/%s/%s/description.md', \realpath($this->examplesPath), $topic, $example);
+
+        if (false === \file_exists($path)) {
+            return null;
+        }
+
+        return \file_get_contents($path);
+    }
+
     /**
      * @return string[]
      */

--- a/web/landing/templates/base.html.twig
+++ b/web/landing/templates/base.html.twig
@@ -51,7 +51,7 @@
 <body class="scroll-smooth bg-black text-white">
     <header class="py-2 text-white bg-blue-200">
         <div class="mx-auto max-w-screen-xl px-4 flex items-center justify-between">
-            <a href="{{ path('main') }}">
+            <a href="{{ path('home') }}">
                 <img src="{{ asset('images/logo.svg') }}" alt="flow php" width="176" height="48">
             </a>
 

--- a/web/landing/templates/example/index.html.twig
+++ b/web/landing/templates/example/index.html.twig
@@ -39,6 +39,7 @@
 
             <div id="example" class="-mt-36 pt-36">
                 {% if description %}
+                    <h2 class="text-xl mt-5 mb-5">Description</h2>
                     <article id="example-description"
                              class="rounded px-4 pt-4 overflow-auto shadow-2xl shadow-gray rounded border-gray border-2 relative mb-10"
                             {{ stimulus_controller('all_links_external') }}
@@ -48,6 +49,7 @@
                 {% endif %}
 
                 {% apply spaceless %}
+                    <h2 class="text-xl mt-5 mb-5">Code</h2>
                     <pre class="rounded p-4 overflow-auto shadow-2xl shadow-gray rounded border-gray border-2 relative">
                         <button class="absolute top-0 right-0 bg-orange-100 rounded px-4 leading-9 [&.copied]:before:content-['Copied!'] before:absolute before:-translate-x-24" title="copy code" data-clipboard-target="#code" {{ stimulus_controller('clipboard') }}>
                             <img src="{{ asset('images/icons/copy.svg') }}" alt="copy code" width="20" height="20" class="inline">

--- a/web/landing/templates/example/index.html.twig
+++ b/web/landing/templates/example/index.html.twig
@@ -10,6 +10,7 @@
 
 {% block main %}
     <div class="py-10 px-2 sm:px-4 mx-auto max-w-screen-xl" data-hx-boost="true">
+        <h2 class="mb-4 text-2xl font-semibold tracking-wide">Examples:</h2>
         <nav class="font-medium text-center bg-orange-100 rounded">
             <ul class="flex whitespace-nowrap overflow-auto justify-between">
                 {% for topic in topics %}
@@ -37,6 +38,15 @@
             </nav>
 
             <div id="example" class="-mt-36 pt-36">
+                {% if description %}
+                    <article id="example-description"
+                             class="rounded px-4 pt-4 overflow-auto shadow-2xl shadow-gray rounded border-gray border-2 relative mb-10"
+                            {{ stimulus_controller('all_links_external') }}
+                    >
+                        {{ description|markdown_to_html }}
+                    </article>
+                {% endif %}
+
                 {% apply spaceless %}
                     <pre class="rounded p-4 overflow-auto shadow-2xl shadow-gray rounded border-gray border-2 relative">
                         <button class="absolute top-0 right-0 bg-orange-100 rounded px-4 leading-9 [&.copied]:before:content-['Copied!'] before:absolute before:-translate-x-24" title="copy code" data-clipboard-target="#code" {{ stimulus_controller('clipboard') }}>


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <li>Description to landing page examples</li>
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

<!-- Please provide a short description of changes in this section, feel free to use markdown syntax -->

Based on some questions from discord server I think we should add some description to examples, especially when things are not super obvious from the code. 

<img width="1388" alt="image" src="https://github.com/user-attachments/assets/6ef152a3-b912-4273-b5a7-26d0130a7804">

