### PR TITLE
Duplicate Module/Type enums in website to avoid dependencies and keep boundaries clean

### DIFF
--- a/src/adapter/etl-adapter-chartjs/src/Flow/ETL/Adapter/ChartJS/functions.php
+++ b/src/adapter/etl-adapter-chartjs/src/Flow/ETL/Adapter/ChartJS/functions.php
@@ -9,25 +9,25 @@ use Flow\ETL\Attribute\{DocumentationDSL, Module, Type};
 use Flow\ETL\Row\{EntryReference, References};
 use Flow\Filesystem\Path;
 
-#[DocumentationDSL(module: Module::CHARTJS, type: Type::HELPER)]
+#[DocumentationDSL(module: Module::CHART_JS, type: Type::HELPER)]
 function bar_chart(EntryReference $label, References $datasets) : BarChart
 {
     return new BarChart($label, $datasets);
 }
 
-#[DocumentationDSL(module: Module::CHARTJS, type: Type::HELPER)]
+#[DocumentationDSL(module: Module::CHART_JS, type: Type::HELPER)]
 function line_chart(EntryReference $label, References $datasets) : LineChart
 {
     return new LineChart($label, $datasets);
 }
 
-#[DocumentationDSL(module: Module::CHARTJS, type: Type::HELPER)]
+#[DocumentationDSL(module: Module::CHART_JS, type: Type::HELPER)]
 function pie_chart(EntryReference $label, References $datasets) : PieChart
 {
     return new PieChart($label, $datasets);
 }
 
-#[DocumentationDSL(module: Module::CHARTJS, type: Type::LOADER)]
+#[DocumentationDSL(module: Module::CHART_JS, type: Type::LOADER)]
 function to_chartjs_file(Chart $type, Path|string|null $output = null, Path|string|null $template = null) : ChartJSLoader
 {
     if (\is_string($output)) {
@@ -45,7 +45,7 @@ function to_chartjs_file(Chart $type, Path|string|null $output = null, Path|stri
     return new ChartJSLoader($type, output: $output, template: $template);
 }
 
-#[DocumentationDSL(module: Module::CHARTJS, type: Type::LOADER)]
+#[DocumentationDSL(module: Module::CHART_JS, type: Type::LOADER)]
 function to_chartjs_var(Chart $type, array &$output) : ChartJSLoader
 {
     /** @psalm-suppress ReferenceConstraintViolation */

--- a/src/adapter/etl-adapter-elasticsearch/src/Flow/ETL/Adapter/Elasticsearch/functions.php
+++ b/src/adapter/etl-adapter-elasticsearch/src/Flow/ETL/Adapter/Elasticsearch/functions.php
@@ -27,7 +27,7 @@ use Flow\ETL\Attribute\{DocumentationDSL, Module, Type};
  * @param IdFactory $id_factory
  * @param array<mixed> $parameters - https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-bulk.html
  */
-#[DocumentationDSL(module: Module::ELASTICSEARCH, type: Type::LOADER)]
+#[DocumentationDSL(module: Module::ELASTIC_SEARCH, type: Type::LOADER)]
 function to_es_bulk_index(
     array $config,
     string $index,
@@ -57,7 +57,7 @@ function to_es_bulk_index(
  * @param IdFactory $id_factory
  * @param array<mixed> $parameters - https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-bulk.html
  */
-#[DocumentationDSL(module: Module::ELASTICSEARCH, type: Type::LOADER)]
+#[DocumentationDSL(module: Module::ELASTIC_SEARCH, type: Type::LOADER)]
 function to_es_bulk_update(
     array $config,
     string $index,
@@ -72,7 +72,7 @@ function to_es_bulk_update(
  *
  * @return HitsIntoRowsTransformer
  */
-#[DocumentationDSL(module: Module::ELASTICSEARCH, type: Type::HELPER)]
+#[DocumentationDSL(module: Module::ELASTIC_SEARCH, type: Type::HELPER)]
 function es_hits_to_rows(DocumentDataSource $source = DocumentDataSource::source) : HitsIntoRowsTransformer
 {
     return new HitsIntoRowsTransformer($source);
@@ -100,7 +100,7 @@ function es_hits_to_rows(DocumentDataSource $source = DocumentDataSource::source
  * @param array<mixed> $params - https://www.elastic.co/guide/en/elasticsearch/reference/master/search-search.html
  * @param ?array<mixed> $pit_params - when used extractor will create point in time to stabilize search results. Point in time is automatically closed when last element is extracted. https://www.elastic.co/guide/en/elasticsearch/reference/master/point-in-time-api.html
  */
-#[DocumentationDSL(module: Module::ELASTICSEARCH, type: Type::EXTRACTOR)]
+#[DocumentationDSL(module: Module::ELASTIC_SEARCH, type: Type::EXTRACTOR)]
 function from_es(array $config, array $params, ?array $pit_params = null) : ElasticsearchExtractor
 {
     return new ElasticsearchExtractor(

--- a/src/core/etl/src/Flow/ETL/Attribute/Module.php
+++ b/src/core/etl/src/Flow/ETL/Attribute/Module.php
@@ -6,18 +6,18 @@ namespace Flow\ETL\Attribute;
 
 enum Module : string
 {
-    case AZURE_FILESYSTEM = 'Azure Filesystem';
-    case AZURE_SDK = 'Azure SDK';
-    case CHARTJS = 'ChartJS';
-    case CORE = 'Core';
+    case AZURE_FILESYSTEM = 'AZURE_FILESYSTEM';
+    case AZURE_SDK = 'AZURE_SDK';
+    case CHART_JS = 'CHART_JS';
+    case CORE = 'CORE';
     case CSV = 'CSV';
-    case DOCTRINE = 'Doctrine';
-    case ELASTICSEARCH = 'Elastic Search';
-    case FILESYSTEM = 'Filesystem';
-    case GOOGLE_SHEET = 'Google Sheet';
+    case DOCTRINE = 'DOCTRINE';
+    case ELASTIC_SEARCH = 'ELASTIC_SEARCH';
+    case FILESYSTEM = 'FILESYSTEM';
+    case GOOGLE_SHEET = 'GOOGLE_SHEET';
     case JSON = 'JSON';
-    case MEILI_SEARCH = 'MeiliSearch';
-    case PARQUET = 'Parquet';
-    case TEXT = 'Text';
+    case MEILI_SEARCH = 'MEILI_SEARCH';
+    case PARQUET = 'PARQUET';
+    case TEXT = 'TEXT';
     case XML = 'XML';
 }

--- a/src/core/etl/src/Flow/ETL/Attribute/Type.php
+++ b/src/core/etl/src/Flow/ETL/Attribute/Type.php
@@ -6,16 +6,16 @@ namespace Flow\ETL\Attribute;
 
 enum Type : string
 {
-    case AGGREGATING_FUNCTION = 'aggregating functions';
-    case COMPARISON = 'comparisons';
-    case DATA_FRAME = 'data frame';
-    case ENTRY = 'entries';
-    case EXTRACTOR = 'extractors';
-    case HELPER = 'helpers';
-    case LOADER = 'loaders';
-    case SCALAR_FUNCTION = 'scalar functions';
-    case SCHEMA = 'schema';
-    case TRANSFORMER = 'transformers';
-    case TYPE = 'types';
-    case WINDOW_FUNCTION = 'window functions';
+    case AGGREGATING_FUNCTION = 'AGGREGATING_FUNCTION';
+    case COMPARISON = 'COMPARISON';
+    case DATA_FRAME = 'DATA_FRAME';
+    case ENTRY = 'ENTRY';
+    case EXTRACTOR = 'EXTRACTOR';
+    case HELPER = 'HELPER';
+    case LOADER = 'LOADER';
+    case SCALAR_FUNCTION = 'SCALAR_FUNCTION';
+    case SCHEMA = 'SCHEMA';
+    case TRANSFORMER = 'TRANSFORMER';
+    case TYPE = 'TYPE';
+    case WINDOW_FUNCTION = 'WINDOW_FUNCTION';
 }

--- a/web/landing/resources/dsl.json
+++ b/web/landing/resources/dsl.json
@@ -1,1 +1,14632 @@
-[{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":132,"slug":"df","name":"df","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"config","type":[{"name":"Config","namespace":"Flow\\ETL","is_nullable":false,"is_variadic":false},{"name":"ConfigBuilder","namespace":"Flow\\ETL\\Config","is_nullable":false,"is_variadic":false},{"name":"null","namespace":null,"is_nullable":true,"is_variadic":false}],"has_default_value":true,"is_nullable":true,"is_variadic":false}],"return_type":[{"name":"Flow","namespace":"Flow\\ETL","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"data frame"}}],"doc_comment":"LyoqCiAqIEFsaWFzIGZvciBkYXRhX2ZyYW1lKCkgOiBGbG93LgogKi8="},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":138,"slug":"data-frame","name":"data_frame","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"config","type":[{"name":"Config","namespace":"Flow\\ETL","is_nullable":false,"is_variadic":false},{"name":"ConfigBuilder","namespace":"Flow\\ETL\\Config","is_nullable":false,"is_variadic":false},{"name":"null","namespace":null,"is_nullable":true,"is_variadic":false}],"has_default_value":true,"is_nullable":true,"is_variadic":false}],"return_type":[{"name":"Flow","namespace":"Flow\\ETL","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"data frame"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":144,"slug":"from-rows","name":"from_rows","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"rows","type":[{"name":"Rows","namespace":"Flow\\ETL","is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":true}],"return_type":[{"name":"RowsExtractor","namespace":"Flow\\ETL\\Extractor","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"extractors"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":150,"slug":"from-path-partitions","name":"from_path_partitions","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"path","type":[{"name":"Path","namespace":"Flow\\Filesystem","is_nullable":false,"is_variadic":false},{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"PathPartitionsExtractor","namespace":"Flow\\ETL\\Extractor","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"extractors"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":156,"slug":"from-array","name":"from_array","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"array","type":[{"name":"iterable","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"schema","type":[{"name":"Schema","namespace":"Flow\\ETL\\Row","is_nullable":true,"is_variadic":false}],"has_default_value":true,"is_nullable":true,"is_variadic":false}],"return_type":[{"name":"ArrayExtractor","namespace":"Flow\\ETL\\Extractor","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"extractors"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":162,"slug":"from-cache","name":"from_cache","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"id","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"fallback_extractor","type":[{"name":"Extractor","namespace":"Flow\\ETL","is_nullable":true,"is_variadic":false}],"has_default_value":true,"is_nullable":true,"is_variadic":false},{"name":"clear","type":[{"name":"bool","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"CacheExtractor","namespace":"Flow\\ETL\\Extractor","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"extractors"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":168,"slug":"from-all","name":"from_all","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"extractors","type":[{"name":"Extractor","namespace":"Flow\\ETL","is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":true}],"return_type":[{"name":"ChainExtractor","namespace":"Flow\\ETL\\Extractor","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"extractors"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":174,"slug":"from-memory","name":"from_memory","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"memory","type":[{"name":"Memory","namespace":"Flow\\ETL\\Memory","is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"MemoryExtractor","namespace":"Flow\\ETL\\Extractor","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"extractors"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":180,"slug":"files","name":"files","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"directory","type":[{"name":"Path","namespace":"Flow\\Filesystem","is_nullable":false,"is_variadic":false},{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"FilesExtractor","namespace":"Flow\\ETL\\Extractor","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"extractors"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":186,"slug":"filesystem-cache","name":"filesystem_cache","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"cache_dir","type":[{"name":"Path","namespace":"Flow\\Filesystem","is_nullable":false,"is_variadic":false},{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false},{"name":"null","namespace":null,"is_nullable":true,"is_variadic":false}],"has_default_value":true,"is_nullable":true,"is_variadic":false},{"name":"filesystem","type":[{"name":"Filesystem","namespace":"Flow\\Filesystem","is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false},{"name":"serializer","type":[{"name":"Serializer","namespace":"Flow\\Serializer","is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"FilesystemCache","namespace":"Flow\\ETL\\Cache\\Implementation","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"data frame"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":195,"slug":"chunks-from","name":"chunks_from","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"extractor","type":[{"name":"Extractor","namespace":"Flow\\ETL","is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"chunk_size","type":[{"name":"int","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"ChunkExtractor","namespace":"Flow\\ETL\\Extractor","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"extractors"}}],"doc_comment":"LyoqCiAqIEBwYXJhbSBpbnQ8MSwgbWF4PiAkY2h1bmtfc2l6ZQogKi8="},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":200,"slug":"from-pipeline","name":"from_pipeline","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"pipeline","type":[{"name":"Pipeline","namespace":"Flow\\ETL","is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"PipelineExtractor","namespace":"Flow\\ETL\\Extractor","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"extractors"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":206,"slug":"from-data-frame","name":"from_data_frame","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"data_frame","type":[{"name":"DataFrame","namespace":"Flow\\ETL","is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"DataFrameExtractor","namespace":"Flow\\ETL\\Extractor","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"extractors"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":212,"slug":"from-sequence-date-period","name":"from_sequence_date_period","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"entry_name","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"start","type":[{"name":"DateTimeInterface","namespace":"","is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"interval","type":[{"name":"DateInterval","namespace":"","is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"end","type":[{"name":"DateTimeInterface","namespace":"","is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"options","type":[{"name":"int","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"SequenceExtractor","namespace":"Flow\\ETL\\Extractor","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"extractors"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":221,"slug":"from-sequence-date-period-recurrences","name":"from_sequence_date_period_recurrences","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"entry_name","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"start","type":[{"name":"DateTimeInterface","namespace":"","is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"interval","type":[{"name":"DateInterval","namespace":"","is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"recurrences","type":[{"name":"int","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"options","type":[{"name":"int","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"SequenceExtractor","namespace":"Flow\\ETL\\Extractor","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"extractors"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":230,"slug":"from-sequence-number","name":"from_sequence_number","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"entry_name","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"start","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false},{"name":"int","namespace":null,"is_nullable":false,"is_variadic":false},{"name":"float","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"end","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false},{"name":"int","namespace":null,"is_nullable":false,"is_variadic":false},{"name":"float","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"step","type":[{"name":"int","namespace":null,"is_nullable":false,"is_variadic":false},{"name":"float","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"SequenceExtractor","namespace":"Flow\\ETL\\Extractor","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"extractors"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":239,"slug":"to-callable","name":"to_callable","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"callable","type":[{"name":"callable","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"CallbackLoader","namespace":"Flow\\ETL\\Loader","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"loaders"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":245,"slug":"to-memory","name":"to_memory","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"memory","type":[{"name":"Memory","namespace":"Flow\\ETL\\Memory","is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"MemoryLoader","namespace":"Flow\\ETL\\Loader","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"loaders"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":251,"slug":"to-output","name":"to_output","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"truncate","type":[{"name":"int","namespace":null,"is_nullable":false,"is_variadic":false},{"name":"bool","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false},{"name":"output","type":[{"name":"Output","namespace":"Flow\\ETL\\Loader\\StreamLoader","is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false},{"name":"formatter","type":[{"name":"Formatter","namespace":"Flow\\ETL","is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false},{"name":"schemaFormatter","type":[{"name":"SchemaFormatter","namespace":"Flow\\ETL\\Row\\Schema","is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"StreamLoader","namespace":"Flow\\ETL\\Loader","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"loaders"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":257,"slug":"to-stderr","name":"to_stderr","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"truncate","type":[{"name":"int","namespace":null,"is_nullable":false,"is_variadic":false},{"name":"bool","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false},{"name":"output","type":[{"name":"Output","namespace":"Flow\\ETL\\Loader\\StreamLoader","is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false},{"name":"formatter","type":[{"name":"Formatter","namespace":"Flow\\ETL","is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false},{"name":"schemaFormatter","type":[{"name":"SchemaFormatter","namespace":"Flow\\ETL\\Row\\Schema","is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"StreamLoader","namespace":"Flow\\ETL\\Loader","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"loaders"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":263,"slug":"to-stdout","name":"to_stdout","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"truncate","type":[{"name":"int","namespace":null,"is_nullable":false,"is_variadic":false},{"name":"bool","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false},{"name":"output","type":[{"name":"Output","namespace":"Flow\\ETL\\Loader\\StreamLoader","is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false},{"name":"formatter","type":[{"name":"Formatter","namespace":"Flow\\ETL","is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false},{"name":"schemaFormatter","type":[{"name":"SchemaFormatter","namespace":"Flow\\ETL\\Row\\Schema","is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"StreamLoader","namespace":"Flow\\ETL\\Loader","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"loaders"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":269,"slug":"to-stream","name":"to_stream","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"uri","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"truncate","type":[{"name":"int","namespace":null,"is_nullable":false,"is_variadic":false},{"name":"bool","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false},{"name":"output","type":[{"name":"Output","namespace":"Flow\\ETL\\Loader\\StreamLoader","is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false},{"name":"mode","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false},{"name":"formatter","type":[{"name":"Formatter","namespace":"Flow\\ETL","is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false},{"name":"schemaFormatter","type":[{"name":"SchemaFormatter","namespace":"Flow\\ETL\\Row\\Schema","is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"StreamLoader","namespace":"Flow\\ETL\\Loader","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"loaders"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":275,"slug":"to-transformation","name":"to_transformation","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"transformer","type":[{"name":"Transformer","namespace":"Flow\\ETL","is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"loader","type":[{"name":"Loader","namespace":"Flow\\ETL","is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"TransformerLoader","namespace":"Flow\\ETL\\Loader","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"loaders"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":281,"slug":"to-branch","name":"to_branch","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"condition","type":[{"name":"ScalarFunction","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"loader","type":[{"name":"Loader","namespace":"Flow\\ETL","is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"Loader","namespace":"Flow\\ETL","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"loaders"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":290,"slug":"array-entry","name":"array_entry","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"array","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"data","type":[{"name":"array","namespace":null,"is_nullable":true,"is_variadic":false}],"has_default_value":false,"is_nullable":true,"is_variadic":false}],"return_type":[{"name":"ArrayEntry","namespace":"Flow\\ETL\\Row\\Entry","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"entries"}}],"doc_comment":"LyoqCiAqIEBwYXJhbSBhcnJheTxtaXhlZD4gJGRhdGEKICov"},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":296,"slug":"bool-entry","name":"bool_entry","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"name","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"value","type":[{"name":"bool","namespace":null,"is_nullable":true,"is_variadic":false}],"has_default_value":false,"is_nullable":true,"is_variadic":false}],"return_type":[{"name":"BooleanEntry","namespace":"Flow\\ETL\\Row\\Entry","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"entries"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":302,"slug":"boolean-entry","name":"boolean_entry","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"name","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"value","type":[{"name":"bool","namespace":null,"is_nullable":true,"is_variadic":false}],"has_default_value":false,"is_nullable":true,"is_variadic":false}],"return_type":[{"name":"BooleanEntry","namespace":"Flow\\ETL\\Row\\Entry","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"entries"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":308,"slug":"datetime-entry","name":"datetime_entry","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"name","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"value","type":[{"name":"DateTimeInterface","namespace":"","is_nullable":false,"is_variadic":false},{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false},{"name":"null","namespace":null,"is_nullable":true,"is_variadic":false}],"has_default_value":false,"is_nullable":true,"is_variadic":false}],"return_type":[{"name":"DateTimeEntry","namespace":"Flow\\ETL\\Row\\Entry","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"entries"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":314,"slug":"int-entry","name":"int_entry","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"name","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"value","type":[{"name":"int","namespace":null,"is_nullable":true,"is_variadic":false}],"has_default_value":false,"is_nullable":true,"is_variadic":false}],"return_type":[{"name":"IntegerEntry","namespace":"Flow\\ETL\\Row\\Entry","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"entries"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":320,"slug":"integer-entry","name":"integer_entry","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"name","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"value","type":[{"name":"int","namespace":null,"is_nullable":true,"is_variadic":false}],"has_default_value":false,"is_nullable":true,"is_variadic":false}],"return_type":[{"name":"IntegerEntry","namespace":"Flow\\ETL\\Row\\Entry","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"entries"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":326,"slug":"enum-entry","name":"enum_entry","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"name","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"enum","type":[{"name":"UnitEnum","namespace":"","is_nullable":true,"is_variadic":false}],"has_default_value":false,"is_nullable":true,"is_variadic":false}],"return_type":[{"name":"EnumEntry","namespace":"Flow\\ETL\\Row\\Entry","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"entries"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":332,"slug":"float-entry","name":"float_entry","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"name","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"value","type":[{"name":"float","namespace":null,"is_nullable":true,"is_variadic":false}],"has_default_value":false,"is_nullable":true,"is_variadic":false}],"return_type":[{"name":"FloatEntry","namespace":"Flow\\ETL\\Row\\Entry","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"entries"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":338,"slug":"json-entry","name":"json_entry","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"name","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"data","type":[{"name":"array","namespace":null,"is_nullable":false,"is_variadic":false},{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false},{"name":"null","namespace":null,"is_nullable":true,"is_variadic":false}],"has_default_value":false,"is_nullable":true,"is_variadic":false}],"return_type":[{"name":"JsonEntry","namespace":"Flow\\ETL\\Row\\Entry","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"entries"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":347,"slug":"json-object-entry","name":"json_object_entry","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"name","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"data","type":[{"name":"array","namespace":null,"is_nullable":false,"is_variadic":false},{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false},{"name":"null","namespace":null,"is_nullable":true,"is_variadic":false}],"has_default_value":false,"is_nullable":true,"is_variadic":false}],"return_type":[{"name":"JsonEntry","namespace":"Flow\\ETL\\Row\\Entry","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"entries"}}],"doc_comment":"LyoqCiAqIEB0aHJvd3MgSW52YWxpZEFyZ3VtZW50RXhjZXB0aW9uCiAqLw=="},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":357,"slug":"object-entry","name":"object_entry","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"name","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"data","type":[{"name":"object","namespace":null,"is_nullable":true,"is_variadic":false}],"has_default_value":false,"is_nullable":true,"is_variadic":false}],"return_type":[{"name":"ObjectEntry","namespace":"Flow\\ETL\\Row\\Entry","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"entries"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":363,"slug":"obj-entry","name":"obj_entry","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"name","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"data","type":[{"name":"object","namespace":null,"is_nullable":true,"is_variadic":false}],"has_default_value":false,"is_nullable":true,"is_variadic":false}],"return_type":[{"name":"ObjectEntry","namespace":"Flow\\ETL\\Row\\Entry","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"entries"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":369,"slug":"str-entry","name":"str_entry","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"name","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"value","type":[{"name":"string","namespace":null,"is_nullable":true,"is_variadic":false}],"has_default_value":false,"is_nullable":true,"is_variadic":false}],"return_type":[{"name":"StringEntry","namespace":"Flow\\ETL\\Row\\Entry","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"entries"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":375,"slug":"string-entry","name":"string_entry","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"name","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"value","type":[{"name":"string","namespace":null,"is_nullable":true,"is_variadic":false}],"has_default_value":false,"is_nullable":true,"is_variadic":false}],"return_type":[{"name":"StringEntry","namespace":"Flow\\ETL\\Row\\Entry","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"entries"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":381,"slug":"uuid-entry","name":"uuid_entry","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"name","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"value","type":[{"name":"Uuid","namespace":"Flow\\ETL\\PHP\\Value","is_nullable":false,"is_variadic":false},{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false},{"name":"null","namespace":null,"is_nullable":true,"is_variadic":false}],"has_default_value":false,"is_nullable":true,"is_variadic":false}],"return_type":[{"name":"UuidEntry","namespace":"Flow\\ETL\\Row\\Entry","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"entries"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":387,"slug":"xml-entry","name":"xml_entry","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"name","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"value","type":[{"name":"DOMDocument","namespace":"","is_nullable":false,"is_variadic":false},{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false},{"name":"null","namespace":null,"is_nullable":true,"is_variadic":false}],"has_default_value":false,"is_nullable":true,"is_variadic":false}],"return_type":[{"name":"XMLEntry","namespace":"Flow\\ETL\\Row\\Entry","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"entries"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":393,"slug":"xml-element-entry","name":"xml_element_entry","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"name","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"value","type":[{"name":"DOMElement","namespace":"","is_nullable":false,"is_variadic":false},{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false},{"name":"null","namespace":null,"is_nullable":true,"is_variadic":false}],"has_default_value":false,"is_nullable":true,"is_variadic":false}],"return_type":[{"name":"XMLElementEntry","namespace":"Flow\\ETL\\Row\\Entry","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"entries"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":399,"slug":"entries","name":"entries","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"entries","type":[{"name":"Entry","namespace":"Flow\\ETL\\Row","is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":true}],"return_type":[{"name":"Entries","namespace":"Flow\\ETL\\Row","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"data frame"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":405,"slug":"struct-entry","name":"struct_entry","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"name","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"value","type":[{"name":"array","namespace":null,"is_nullable":true,"is_variadic":false}],"has_default_value":false,"is_nullable":true,"is_variadic":false},{"name":"type","type":[{"name":"StructureType","namespace":"Flow\\ETL\\PHP\\Type\\Logical","is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"StructureEntry","namespace":"Flow\\ETL\\Row\\Entry","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"entries"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":411,"slug":"structure-entry","name":"structure_entry","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"name","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"value","type":[{"name":"array","namespace":null,"is_nullable":true,"is_variadic":false}],"has_default_value":false,"is_nullable":true,"is_variadic":false},{"name":"type","type":[{"name":"StructureType","namespace":"Flow\\ETL\\PHP\\Type\\Logical","is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"StructureEntry","namespace":"Flow\\ETL\\Row\\Entry","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"entries"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":420,"slug":"struct-type","name":"struct_type","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"elements","type":[{"name":"array","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"nullable","type":[{"name":"bool","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"StructureType","namespace":"Flow\\ETL\\PHP\\Type\\Logical","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"types"}}],"doc_comment":"LyoqCiAqIEBwYXJhbSBhcnJheTxTdHJ1Y3R1cmVFbGVtZW50PiAkZWxlbWVudHMKICov"},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":429,"slug":"structure-type","name":"structure_type","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"elements","type":[{"name":"array","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"nullable","type":[{"name":"bool","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"StructureType","namespace":"Flow\\ETL\\PHP\\Type\\Logical","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"types"}}],"doc_comment":"LyoqCiAqIEBwYXJhbSBhcnJheTxTdHJ1Y3R1cmVFbGVtZW50PiAkZWxlbWVudHMKICov"},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":438,"slug":"type-structure","name":"type_structure","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"elements","type":[{"name":"array","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"nullable","type":[{"name":"bool","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"StructureType","namespace":"Flow\\ETL\\PHP\\Type\\Logical","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"types"}}],"doc_comment":"LyoqCiAqIEBwYXJhbSBhcnJheTxTdHJ1Y3R1cmVFbGVtZW50PiAkZWxlbWVudHMKICov"},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":444,"slug":"struct-element","name":"struct_element","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"name","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"type","type":[{"name":"Type","namespace":"Flow\\ETL\\PHP\\Type","is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"StructureElement","namespace":"Flow\\ETL\\PHP\\Type\\Logical\\Structure","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"types"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":450,"slug":"structure-element","name":"structure_element","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"name","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"type","type":[{"name":"Type","namespace":"Flow\\ETL\\PHP\\Type","is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"StructureElement","namespace":"Flow\\ETL\\PHP\\Type\\Logical\\Structure","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"types"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":456,"slug":"list-entry","name":"list_entry","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"name","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"value","type":[{"name":"array","namespace":null,"is_nullable":true,"is_variadic":false}],"has_default_value":false,"is_nullable":true,"is_variadic":false},{"name":"type","type":[{"name":"ListType","namespace":"Flow\\ETL\\PHP\\Type\\Logical","is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"ListEntry","namespace":"Flow\\ETL\\Row\\Entry","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"entries"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":462,"slug":"type-list","name":"type_list","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"element","type":[{"name":"Type","namespace":"Flow\\ETL\\PHP\\Type","is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"nullable","type":[{"name":"bool","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"ListType","namespace":"Flow\\ETL\\PHP\\Type\\Logical","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"types"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":468,"slug":"type-map","name":"type_map","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"key_type","type":[{"name":"ScalarType","namespace":"Flow\\ETL\\PHP\\Type\\Native","is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"value_type","type":[{"name":"Type","namespace":"Flow\\ETL\\PHP\\Type","is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"nullable","type":[{"name":"bool","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"MapType","namespace":"Flow\\ETL\\PHP\\Type\\Logical","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"types"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":474,"slug":"map-entry","name":"map_entry","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"name","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"value","type":[{"name":"array","namespace":null,"is_nullable":true,"is_variadic":false}],"has_default_value":false,"is_nullable":true,"is_variadic":false},{"name":"mapType","type":[{"name":"MapType","namespace":"Flow\\ETL\\PHP\\Type\\Logical","is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"MapEntry","namespace":"Flow\\ETL\\Row\\Entry","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"entries"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":480,"slug":"type-json","name":"type_json","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"nullable","type":[{"name":"bool","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"JsonType","namespace":"Flow\\ETL\\PHP\\Type\\Logical","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"types"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":486,"slug":"type-datetime","name":"type_datetime","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"nullable","type":[{"name":"bool","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"DateTimeType","namespace":"Flow\\ETL\\PHP\\Type\\Logical","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"types"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":492,"slug":"type-xml","name":"type_xml","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"nullable","type":[{"name":"bool","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"XMLType","namespace":"Flow\\ETL\\PHP\\Type\\Logical","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"types"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":498,"slug":"type-xml-element","name":"type_xml_element","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"nullable","type":[{"name":"bool","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"XMLElementType","namespace":"Flow\\ETL\\PHP\\Type\\Logical","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"types"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":504,"slug":"type-uuid","name":"type_uuid","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"nullable","type":[{"name":"bool","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"UuidType","namespace":"Flow\\ETL\\PHP\\Type\\Logical","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"types"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":510,"slug":"type-int","name":"type_int","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"nullable","type":[{"name":"bool","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"ScalarType","namespace":"Flow\\ETL\\PHP\\Type\\Native","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"types"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":516,"slug":"type-integer","name":"type_integer","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"nullable","type":[{"name":"bool","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"ScalarType","namespace":"Flow\\ETL\\PHP\\Type\\Native","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"types"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":522,"slug":"type-string","name":"type_string","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"nullable","type":[{"name":"bool","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"ScalarType","namespace":"Flow\\ETL\\PHP\\Type\\Native","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"types"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":528,"slug":"type-float","name":"type_float","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"nullable","type":[{"name":"bool","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"ScalarType","namespace":"Flow\\ETL\\PHP\\Type\\Native","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"types"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":534,"slug":"type-boolean","name":"type_boolean","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"nullable","type":[{"name":"bool","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"ScalarType","namespace":"Flow\\ETL\\PHP\\Type\\Native","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"types"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":543,"slug":"type-object","name":"type_object","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"class","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"nullable","type":[{"name":"bool","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"ObjectType","namespace":"Flow\\ETL\\PHP\\Type\\Native","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"types"}}],"doc_comment":"LyoqCiAqIEBwYXJhbSBjbGFzcy1zdHJpbmcgJGNsYXNzCiAqLw=="},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":549,"slug":"type-resource","name":"type_resource","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"nullable","type":[{"name":"bool","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"ResourceType","namespace":"Flow\\ETL\\PHP\\Type\\Native","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"types"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":555,"slug":"type-array","name":"type_array","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"empty","type":[{"name":"bool","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false},{"name":"nullable","type":[{"name":"bool","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"ArrayType","namespace":"Flow\\ETL\\PHP\\Type\\Native","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"types"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":561,"slug":"type-callable","name":"type_callable","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"nullable","type":[{"name":"bool","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"CallableType","namespace":"Flow\\ETL\\PHP\\Type\\Native","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"types"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":567,"slug":"type-null","name":"type_null","namespace":"Flow\\ETL\\DSL","parameters":[],"return_type":[{"name":"NullType","namespace":"Flow\\ETL\\PHP\\Type\\Native","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"types"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":576,"slug":"type-enum","name":"type_enum","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"class","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"nullable","type":[{"name":"bool","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"EnumType","namespace":"Flow\\ETL\\PHP\\Type\\Native","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"types"}}],"doc_comment":"LyoqCiAqIEBwYXJhbSBjbGFzcy1zdHJpbmc8XFVuaXRFbnVtPiAkY2xhc3MKICov"},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":582,"slug":"row","name":"row","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"entry","type":[{"name":"Entry","namespace":"Flow\\ETL\\Row","is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":true}],"return_type":[{"name":"Row","namespace":"Flow\\ETL","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"data frame"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":588,"slug":"rows","name":"rows","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"row","type":[{"name":"Row","namespace":"Flow\\ETL","is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":true}],"return_type":[{"name":"Rows","namespace":"Flow\\ETL","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"data frame"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":594,"slug":"rows-partitioned","name":"rows_partitioned","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"rows","type":[{"name":"array","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"partitions","type":[{"name":"Partitions","namespace":"Flow\\Filesystem","is_nullable":false,"is_variadic":false},{"name":"array","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"Rows","namespace":"Flow\\ETL","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"data frame"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":603,"slug":"col","name":"col","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"entry","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"EntryReference","namespace":"Flow\\ETL\\Row","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"data frame"}}],"doc_comment":"LyoqCiAqIEFuIGFsaWFzIGZvciBgcmVmYC4KICov"},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":612,"slug":"entry","name":"entry","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"entry","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"EntryReference","namespace":"Flow\\ETL\\Row","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"scalar functions"}}],"doc_comment":"LyoqCiAqIEFuIGFsaWFzIGZvciBgcmVmYC4KICov"},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":618,"slug":"ref","name":"ref","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"entry","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"EntryReference","namespace":"Flow\\ETL\\Row","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"scalar functions"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":624,"slug":"structure-ref","name":"structure_ref","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"entry","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"StructureFunctions","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"scalar functions"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":630,"slug":"list-ref","name":"list_ref","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"entry","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"ListFunctions","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"scalar functions"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":636,"slug":"refs","name":"refs","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"entries","type":[{"name":"Reference","namespace":"Flow\\ETL\\Row","is_nullable":false,"is_variadic":false},{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":true}],"return_type":[{"name":"References","namespace":"Flow\\ETL\\Row","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"scalar functions"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":642,"slug":"optional","name":"optional","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"function","type":[{"name":"ScalarFunction","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"Optional","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"scalar functions"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":648,"slug":"lit","name":"lit","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"value","type":[{"name":"mixed","namespace":null,"is_nullable":true,"is_variadic":false}],"has_default_value":false,"is_nullable":true,"is_variadic":false}],"return_type":[{"name":"Literal","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"scalar functions"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":654,"slug":"exists","name":"exists","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"ref","type":[{"name":"ScalarFunction","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"Exists","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"scalar functions"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":660,"slug":"when","name":"when","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"condition","type":[{"name":"mixed","namespace":null,"is_nullable":true,"is_variadic":false}],"has_default_value":false,"is_nullable":true,"is_variadic":false},{"name":"then","type":[{"name":"mixed","namespace":null,"is_nullable":true,"is_variadic":false}],"has_default_value":false,"is_nullable":true,"is_variadic":false},{"name":"else","type":[{"name":"mixed","namespace":null,"is_nullable":true,"is_variadic":false}],"has_default_value":true,"is_nullable":true,"is_variadic":false}],"return_type":[{"name":"When","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"scalar functions"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":666,"slug":"array-get","name":"array_get","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"ref","type":[{"name":"ScalarFunction","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"path","type":[{"name":"ScalarFunction","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false},{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"ArrayGet","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"scalar functions"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":672,"slug":"array-get-collection","name":"array_get_collection","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"ref","type":[{"name":"ScalarFunction","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"keys","type":[{"name":"ScalarFunction","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false},{"name":"array","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"ArrayGetCollection","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"scalar functions"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":678,"slug":"array-get-collection-first","name":"array_get_collection_first","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"ref","type":[{"name":"ScalarFunction","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"keys","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":true}],"return_type":[{"name":"ArrayGetCollection","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"scalar functions"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":684,"slug":"array-exists","name":"array_exists","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"ref","type":[{"name":"ScalarFunction","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false},{"name":"array","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"path","type":[{"name":"ScalarFunction","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false},{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"ArrayPathExists","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"scalar functions"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":690,"slug":"array-merge","name":"array_merge","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"left","type":[{"name":"ScalarFunction","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false},{"name":"array","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"right","type":[{"name":"ScalarFunction","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false},{"name":"array","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"ArrayMerge","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"scalar functions"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":696,"slug":"array-merge-collection","name":"array_merge_collection","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"array","type":[{"name":"ScalarFunction","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false},{"name":"array","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"ArrayMergeCollection","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"scalar functions"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":702,"slug":"array-key-rename","name":"array_key_rename","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"ref","type":[{"name":"ScalarFunction","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"path","type":[{"name":"ScalarFunction","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false},{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"newName","type":[{"name":"ScalarFunction","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false},{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"ArrayKeyRename","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"scalar functions"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":708,"slug":"array-keys-style-convert","name":"array_keys_style_convert","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"ref","type":[{"name":"ScalarFunction","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"style","type":[{"name":"StringStyles","namespace":"Flow\\ETL\\Function\\StyleConverter","is_nullable":false,"is_variadic":false},{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"ArrayKeysStyleConvert","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"scalar functions"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":714,"slug":"array-sort","name":"array_sort","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"function","type":[{"name":"ScalarFunction","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"sort_function","type":[{"name":"ScalarFunction","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false},{"name":"Sort","namespace":"Flow\\ETL\\Function\\ArraySort","is_nullable":false,"is_variadic":false},{"name":"null","namespace":null,"is_nullable":true,"is_variadic":false}],"has_default_value":true,"is_nullable":true,"is_variadic":false},{"name":"flags","type":[{"name":"ScalarFunction","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false},{"name":"int","namespace":null,"is_nullable":false,"is_variadic":false},{"name":"null","namespace":null,"is_nullable":true,"is_variadic":false}],"has_default_value":true,"is_nullable":true,"is_variadic":false},{"name":"recursive","type":[{"name":"ScalarFunction","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false},{"name":"bool","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"ArraySort","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"scalar functions"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":724,"slug":"array-reverse","name":"array_reverse","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"function","type":[{"name":"ScalarFunction","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false},{"name":"array","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"preserveKeys","type":[{"name":"ScalarFunction","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false},{"name":"bool","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"ArrayReverse","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"scalar functions"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":730,"slug":"now","name":"now","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"time_zone","type":[{"name":"DateTimeZone","namespace":"","is_nullable":false,"is_variadic":false},{"name":"ScalarFunction","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"Now","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"scalar functions"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":736,"slug":"between","name":"between","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"value","type":[{"name":"mixed","namespace":null,"is_nullable":true,"is_variadic":false}],"has_default_value":false,"is_nullable":true,"is_variadic":false},{"name":"lower_bound","type":[{"name":"mixed","namespace":null,"is_nullable":true,"is_variadic":false}],"has_default_value":false,"is_nullable":true,"is_variadic":false},{"name":"upper_bound","type":[{"name":"mixed","namespace":null,"is_nullable":true,"is_variadic":false}],"has_default_value":false,"is_nullable":true,"is_variadic":false},{"name":"boundary","type":[{"name":"ScalarFunction","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false},{"name":"Boundary","namespace":"Flow\\ETL\\Function\\Between","is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"Between","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"scalar functions"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":742,"slug":"to-date-time","name":"to_date_time","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"ref","type":[{"name":"mixed","namespace":null,"is_nullable":true,"is_variadic":false}],"has_default_value":false,"is_nullable":true,"is_variadic":false},{"name":"format","type":[{"name":"ScalarFunction","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false},{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false},{"name":"timeZone","type":[{"name":"ScalarFunction","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false},{"name":"DateTimeZone","namespace":"","is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"ToDateTime","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"scalar functions"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":748,"slug":"to-date","name":"to_date","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"ref","type":[{"name":"mixed","namespace":null,"is_nullable":true,"is_variadic":false}],"has_default_value":false,"is_nullable":true,"is_variadic":false},{"name":"format","type":[{"name":"ScalarFunction","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false},{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false},{"name":"timeZone","type":[{"name":"ScalarFunction","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false},{"name":"DateTimeZone","namespace":"","is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"ToDate","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"scalar functions"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":754,"slug":"date-time-format","name":"date_time_format","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"ref","type":[{"name":"ScalarFunction","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"format","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"DateTimeFormat","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"scalar functions"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":760,"slug":"split","name":"split","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"value","type":[{"name":"ScalarFunction","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false},{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"separator","type":[{"name":"ScalarFunction","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false},{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"limit","type":[{"name":"ScalarFunction","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false},{"name":"int","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"Split","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"scalar functions"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":766,"slug":"combine","name":"combine","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"keys","type":[{"name":"ScalarFunction","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false},{"name":"array","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"values","type":[{"name":"ScalarFunction","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false},{"name":"array","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"Combine","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"scalar functions"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":772,"slug":"concat","name":"concat","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"functions","type":[{"name":"ScalarFunction","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false},{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":true}],"return_type":[{"name":"Concat","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"scalar functions"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":778,"slug":"hash","name":"hash","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"value","type":[{"name":"mixed","namespace":null,"is_nullable":true,"is_variadic":false}],"has_default_value":false,"is_nullable":true,"is_variadic":false},{"name":"algorithm","type":[{"name":"Algorithm","namespace":"Flow\\ETL\\Hash","is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"Hash","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"scalar functions"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":784,"slug":"cast","name":"cast","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"value","type":[{"name":"mixed","namespace":null,"is_nullable":true,"is_variadic":false}],"has_default_value":false,"is_nullable":true,"is_variadic":false},{"name":"type","type":[{"name":"ScalarFunction","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false},{"name":"Type","namespace":"Flow\\ETL\\PHP\\Type","is_nullable":false,"is_variadic":false},{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"Cast","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"scalar functions"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":790,"slug":"count","name":"count","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"function","type":[{"name":"Reference","namespace":"Flow\\ETL\\Row","is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"Count","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"aggregating functions"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":815,"slug":"array-unpack","name":"array_unpack","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"array","type":[{"name":"ScalarFunction","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false},{"name":"array","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"skip_keys","type":[{"name":"ScalarFunction","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false},{"name":"array","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false},{"name":"entry_prefix","type":[{"name":"ScalarFunction","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false},{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false},{"name":"null","namespace":null,"is_nullable":true,"is_variadic":false}],"has_default_value":true,"is_nullable":true,"is_variadic":false}],"return_type":[{"name":"ArrayUnpack","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"scalar functions"}}],"doc_comment":"LyoqCiAqIFVucGFja3MgZWFjaCBlbGVtZW50IG9mIGFuIGFycmF5IGludG8gYSBuZXcgZW50cnksIHVzaW5nIHRoZSBhcnJheSBrZXkgYXMgdGhlIGVudHJ5IG5hbWUuCiAqCiAqIEJlZm9yZToKICogKy0tKy0tLS0tLS0tLS0tLS0tLS0tLS0rCiAqIHxpZHwgICAgICAgICAgICAgIGFycmF5fAogKiArLS0rLS0tLS0tLS0tLS0tLS0tLS0tLSsKICogfCAxfHsiYSI6MSwiYiI6MiwiYyI6M318CiAqIHwgMnx7ImQiOjQsImUiOjUsImYiOjZ9fAogKiArLS0rLS0tLS0tLS0tLS0tLS0tLS0tLSsKICoKICogQWZ0ZXI6CiAqICstLSstLS0tLSstLS0tLSstLS0tLSstLS0tLSstLS0tLSsKICogfGlkfGFyci5ifGFyci5jfGFyci5kfGFyci5lfGFyci5mfAogKiArLS0rLS0tLS0rLS0tLS0rLS0tLS0rLS0tLS0rLS0tLS0rCiAqIHwgMXwgICAgMnwgICAgM3wgICAgIHwgICAgIHwgICAgIHwKICogfCAyfCAgICAgfCAgICAgfCAgICA0fCAgICA1fCAgICA2fAogKiArLS0rLS0tLS0rLS0tLS0rLS0tLS0rLS0tLS0rLS0tLS0rCiAqLw=="},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":841,"slug":"array-expand","name":"array_expand","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"function","type":[{"name":"ScalarFunction","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"expand","type":[{"name":"ArrayExpand","namespace":"Flow\\ETL\\Function\\ArrayExpand","is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"ArrayExpand","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"scalar functions"}}],"doc_comment":"LyoqCiAqIEV4cGFuZHMgZWFjaCB2YWx1ZSBpbnRvIGVudHJ5LCBpZiB0aGVyZSBhcmUgbW9yZSB0aGFuIG9uZSB2YWx1ZSwgbXVsdGlwbGUgcm93cyB3aWxsIGJlIGNyZWF0ZWQuCiAqIEFycmF5IGtleXMgYXJlIGlnbm9yZWQsIG9ubHkgdmFsdWVzIGFyZSB1c2VkIHRvIGNyZWF0ZSBuZXcgcm93cy4KICoKICogQmVmb3JlOgogKiAgICstLSstLS0tLS0tLS0tLS0tLS0tLS0tKwogKiAgIHxpZHwgICAgICAgICAgICAgIGFycmF5fAogKiAgICstLSstLS0tLS0tLS0tLS0tLS0tLS0tKwogKiAgIHwgMXx7ImEiOjEsImIiOjIsImMiOjN9fAogKiAgICstLSstLS0tLS0tLS0tLS0tLS0tLS0tKwogKgogKiBBZnRlcjoKICogICArLS0rLS0tLS0tLS0rCiAqICAgfGlkfGV4cGFuZGVkfAogKiAgICstLSstLS0tLS0tLSsKICogICB8IDF8ICAgICAgIDF8CiAqICAgfCAxfCAgICAgICAyfAogKiAgIHwgMXwgICAgICAgM3wKICogICArLS0rLS0tLS0tLS0rCiAqLw=="},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":847,"slug":"size","name":"size","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"value","type":[{"name":"mixed","namespace":null,"is_nullable":true,"is_variadic":false}],"has_default_value":false,"is_nullable":true,"is_variadic":false}],"return_type":[{"name":"Size","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"scalar functions"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":853,"slug":"uuid-v4","name":"uuid_v4","namespace":"Flow\\ETL\\DSL","parameters":[],"return_type":[{"name":"Uuid","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"scalar functions"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":859,"slug":"uuid-v7","name":"uuid_v7","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"value","type":[{"name":"ScalarFunction","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false},{"name":"DateTimeInterface","namespace":"","is_nullable":false,"is_variadic":false},{"name":"null","namespace":null,"is_nullable":true,"is_variadic":false}],"has_default_value":true,"is_nullable":true,"is_variadic":false}],"return_type":[{"name":"Uuid","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"scalar functions"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":865,"slug":"ulid","name":"ulid","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"value","type":[{"name":"ScalarFunction","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false},{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false},{"name":"null","namespace":null,"is_nullable":true,"is_variadic":false}],"has_default_value":true,"is_nullable":true,"is_variadic":false}],"return_type":[{"name":"Ulid","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"scalar functions"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":871,"slug":"lower","name":"lower","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"value","type":[{"name":"ScalarFunction","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false},{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"ToLower","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"scalar functions"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":877,"slug":"capitalize","name":"capitalize","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"value","type":[{"name":"ScalarFunction","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false},{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"Capitalize","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"scalar functions"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":883,"slug":"upper","name":"upper","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"value","type":[{"name":"ScalarFunction","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false},{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"ToUpper","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"scalar functions"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":892,"slug":"call-method","name":"call_method","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"object","type":[{"name":"object","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"method","type":[{"name":"ScalarFunction","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false},{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"params","type":[{"name":"array","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"CallMethod","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"scalar functions"}}],"doc_comment":"LyoqCiAqIEBwYXJhbSBhcnJheTxtaXhlZD4gJHBhcmFtcwogKi8="},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":898,"slug":"all","name":"all","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"functions","type":[{"name":"ScalarFunction","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":true}],"return_type":[{"name":"All","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"scalar functions"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":904,"slug":"any","name":"any","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"values","type":[{"name":"ScalarFunction","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":true}],"return_type":[{"name":"Any","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"scalar functions"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":910,"slug":"not","name":"not","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"value","type":[{"name":"ScalarFunction","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"Not","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"scalar functions"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":916,"slug":"to-timezone","name":"to_timezone","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"value","type":[{"name":"ScalarFunction","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false},{"name":"DateTimeInterface","namespace":"","is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"timeZone","type":[{"name":"ScalarFunction","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false},{"name":"DateTimeZone","namespace":"","is_nullable":false,"is_variadic":false},{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"ToTimeZone","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"scalar functions"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":922,"slug":"ignore-error-handler","name":"ignore_error_handler","namespace":"Flow\\ETL\\DSL","parameters":[],"return_type":[{"name":"IgnoreError","namespace":"Flow\\ETL\\ErrorHandler","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"data frame"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":928,"slug":"skip-rows-handler","name":"skip_rows_handler","namespace":"Flow\\ETL\\DSL","parameters":[],"return_type":[{"name":"SkipRows","namespace":"Flow\\ETL\\ErrorHandler","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"data frame"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":934,"slug":"throw-error-handler","name":"throw_error_handler","namespace":"Flow\\ETL\\DSL","parameters":[],"return_type":[{"name":"ThrowError","namespace":"Flow\\ETL\\ErrorHandler","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"data frame"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":940,"slug":"regex-replace","name":"regex_replace","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"pattern","type":[{"name":"ScalarFunction","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false},{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"replacement","type":[{"name":"ScalarFunction","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false},{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"subject","type":[{"name":"ScalarFunction","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false},{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"limit","type":[{"name":"ScalarFunction","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false},{"name":"int","namespace":null,"is_nullable":false,"is_variadic":false},{"name":"null","namespace":null,"is_nullable":true,"is_variadic":false}],"has_default_value":true,"is_nullable":true,"is_variadic":false}],"return_type":[{"name":"RegexReplace","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"scalar functions"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":946,"slug":"regex-match-all","name":"regex_match_all","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"pattern","type":[{"name":"ScalarFunction","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false},{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"subject","type":[{"name":"ScalarFunction","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false},{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"flags","type":[{"name":"ScalarFunction","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false},{"name":"int","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false},{"name":"offset","type":[{"name":"ScalarFunction","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false},{"name":"int","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"RegexMatchAll","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"scalar functions"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":952,"slug":"regex-match","name":"regex_match","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"pattern","type":[{"name":"ScalarFunction","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false},{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"subject","type":[{"name":"ScalarFunction","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false},{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"flags","type":[{"name":"ScalarFunction","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false},{"name":"int","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false},{"name":"offset","type":[{"name":"ScalarFunction","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false},{"name":"int","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"RegexMatch","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"scalar functions"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":958,"slug":"regex","name":"regex","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"pattern","type":[{"name":"ScalarFunction","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false},{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"subject","type":[{"name":"ScalarFunction","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false},{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"flags","type":[{"name":"ScalarFunction","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false},{"name":"int","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false},{"name":"offset","type":[{"name":"ScalarFunction","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false},{"name":"int","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"Regex","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"scalar functions"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":964,"slug":"regex-all","name":"regex_all","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"pattern","type":[{"name":"ScalarFunction","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false},{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"subject","type":[{"name":"ScalarFunction","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false},{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"flags","type":[{"name":"ScalarFunction","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false},{"name":"int","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false},{"name":"offset","type":[{"name":"ScalarFunction","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false},{"name":"int","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"RegexAll","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"scalar functions"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":970,"slug":"sprintf","name":"sprintf","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"format","type":[{"name":"ScalarFunction","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false},{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"args","type":[{"name":"ScalarFunction","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false},{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false},{"name":"int","namespace":null,"is_nullable":false,"is_variadic":false},{"name":"float","namespace":null,"is_nullable":false,"is_variadic":false},{"name":"null","namespace":null,"is_nullable":true,"is_variadic":false}],"has_default_value":false,"is_nullable":true,"is_variadic":true}],"return_type":[{"name":"Sprintf","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"scalar functions"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":976,"slug":"sanitize","name":"sanitize","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"value","type":[{"name":"ScalarFunction","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false},{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"placeholder","type":[{"name":"ScalarFunction","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false},{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false},{"name":"skipCharacters","type":[{"name":"ScalarFunction","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false},{"name":"int","namespace":null,"is_nullable":false,"is_variadic":false},{"name":"null","namespace":null,"is_nullable":true,"is_variadic":false}],"has_default_value":true,"is_nullable":true,"is_variadic":false}],"return_type":[{"name":"Sanitize","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"scalar functions"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":982,"slug":"round","name":"round","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"value","type":[{"name":"ScalarFunction","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false},{"name":"int","namespace":null,"is_nullable":false,"is_variadic":false},{"name":"float","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"precision","type":[{"name":"ScalarFunction","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false},{"name":"int","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false},{"name":"mode","type":[{"name":"ScalarFunction","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false},{"name":"int","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"Round","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"scalar functions"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":988,"slug":"number-format","name":"number_format","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"value","type":[{"name":"ScalarFunction","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false},{"name":"int","namespace":null,"is_nullable":false,"is_variadic":false},{"name":"float","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"decimals","type":[{"name":"ScalarFunction","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false},{"name":"int","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false},{"name":"decimal_separator","type":[{"name":"ScalarFunction","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false},{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false},{"name":"thousands_separator","type":[{"name":"ScalarFunction","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false},{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"NumberFormat","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"scalar functions"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":998,"slug":"array-to-row","name":"array_to_row","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"data","type":[{"name":"array","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"entryFactory","type":[{"name":"EntryFactory","namespace":"Flow\\ETL\\Row","is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false},{"name":"partitions","type":[{"name":"Partitions","namespace":"Flow\\Filesystem","is_nullable":false,"is_variadic":false},{"name":"array","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false},{"name":"schema","type":[{"name":"Schema","namespace":"Flow\\ETL\\Row","is_nullable":true,"is_variadic":false}],"has_default_value":true,"is_nullable":true,"is_variadic":false}],"return_type":[{"name":"Row","namespace":"Flow\\ETL","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"data frame"}}],"doc_comment":"LyoqCiAqIEBwYXJhbSBhcnJheTxhcnJheTxtaXhlZD4+fGFycmF5PG1peGVkfHN0cmluZz4gJGRhdGEKICogQHBhcmFtIGFycmF5PFBhcnRpdGlvbj58UGFydGl0aW9ucyAkcGFydGl0aW9ucwogKi8="},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":1048,"slug":"array-to-rows","name":"array_to_rows","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"data","type":[{"name":"array","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"entryFactory","type":[{"name":"EntryFactory","namespace":"Flow\\ETL\\Row","is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false},{"name":"partitions","type":[{"name":"Partitions","namespace":"Flow\\Filesystem","is_nullable":false,"is_variadic":false},{"name":"array","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false},{"name":"schema","type":[{"name":"Schema","namespace":"Flow\\ETL\\Row","is_nullable":true,"is_variadic":false}],"has_default_value":true,"is_nullable":true,"is_variadic":false}],"return_type":[{"name":"Rows","namespace":"Flow\\ETL","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"data frame"}}],"doc_comment":"LyoqCiAqIEBwYXJhbSBhcnJheTxhcnJheTxtaXhlZD4+fGFycmF5PG1peGVkfHN0cmluZz4gJGRhdGEKICogQHBhcmFtIGFycmF5PFBhcnRpdGlvbj58UGFydGl0aW9ucyAkcGFydGl0aW9ucwogKi8="},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":1076,"slug":"rank","name":"rank","namespace":"Flow\\ETL\\DSL","parameters":[],"return_type":[{"name":"Rank","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"window functions"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":1082,"slug":"dens-rank","name":"dens_rank","namespace":"Flow\\ETL\\DSL","parameters":[],"return_type":[{"name":"DenseRank","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"window functions"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":1088,"slug":"dense-rank","name":"dense_rank","namespace":"Flow\\ETL\\DSL","parameters":[],"return_type":[{"name":"DenseRank","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"window functions"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":1094,"slug":"average","name":"average","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"ref","type":[{"name":"Reference","namespace":"Flow\\ETL\\Row","is_nullable":false,"is_variadic":false},{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"Average","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"aggregating functions"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":1100,"slug":"collect","name":"collect","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"ref","type":[{"name":"Reference","namespace":"Flow\\ETL\\Row","is_nullable":false,"is_variadic":false},{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"Collect","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"aggregating functions"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":1106,"slug":"collect-unique","name":"collect_unique","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"ref","type":[{"name":"Reference","namespace":"Flow\\ETL\\Row","is_nullable":false,"is_variadic":false},{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"CollectUnique","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"aggregating functions"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":1112,"slug":"window","name":"window","namespace":"Flow\\ETL\\DSL","parameters":[],"return_type":[{"name":"Window","namespace":"Flow\\ETL","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"data frame"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":1118,"slug":"sum","name":"sum","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"ref","type":[{"name":"Reference","namespace":"Flow\\ETL\\Row","is_nullable":false,"is_variadic":false},{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"Sum","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"aggregating functions"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":1124,"slug":"first","name":"first","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"ref","type":[{"name":"Reference","namespace":"Flow\\ETL\\Row","is_nullable":false,"is_variadic":false},{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"First","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"aggregating functions"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":1130,"slug":"last","name":"last","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"ref","type":[{"name":"Reference","namespace":"Flow\\ETL\\Row","is_nullable":false,"is_variadic":false},{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"Last","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"aggregating functions"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":1136,"slug":"max","name":"max","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"ref","type":[{"name":"Reference","namespace":"Flow\\ETL\\Row","is_nullable":false,"is_variadic":false},{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"Max","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"aggregating functions"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":1142,"slug":"min","name":"min","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"ref","type":[{"name":"Reference","namespace":"Flow\\ETL\\Row","is_nullable":false,"is_variadic":false},{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"Min","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"aggregating functions"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":1148,"slug":"row-number","name":"row_number","namespace":"Flow\\ETL\\DSL","parameters":[],"return_type":[{"name":"RowNumber","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"data frame"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":1154,"slug":"schema","name":"schema","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"definitions","type":[{"name":"Definition","namespace":"Flow\\ETL\\Row\\Schema","is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":true}],"return_type":[{"name":"Schema","namespace":"Flow\\ETL\\Row","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"schema"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":1160,"slug":"schema-to-json","name":"schema_to_json","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"schema","type":[{"name":"Schema","namespace":"Flow\\ETL\\Row","is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"schema"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":1166,"slug":"schema-from-json","name":"schema_from_json","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"schema","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"Schema","namespace":"Flow\\ETL\\Row","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"schema"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":1172,"slug":"schema-strict-matcher","name":"schema_strict_matcher","namespace":"Flow\\ETL\\DSL","parameters":[],"return_type":[{"name":"StrictSchemaMatcher","namespace":"Flow\\ETL\\Row\\Schema\\Matcher","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"schema"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":1178,"slug":"schema-evolving-matcher","name":"schema_evolving_matcher","namespace":"Flow\\ETL\\DSL","parameters":[],"return_type":[{"name":"EvolvingSchemaMatcher","namespace":"Flow\\ETL\\Row\\Schema\\Matcher","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"schema"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":1184,"slug":"int-schema","name":"int_schema","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"name","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"nullable","type":[{"name":"bool","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false},{"name":"metadata","type":[{"name":"Metadata","namespace":"Flow\\ETL\\Row\\Schema","is_nullable":true,"is_variadic":false}],"has_default_value":true,"is_nullable":true,"is_variadic":false}],"return_type":[{"name":"Definition","namespace":"Flow\\ETL\\Row\\Schema","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"schema"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":1190,"slug":"str-schema","name":"str_schema","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"name","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"nullable","type":[{"name":"bool","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false},{"name":"metadata","type":[{"name":"Metadata","namespace":"Flow\\ETL\\Row\\Schema","is_nullable":true,"is_variadic":false}],"has_default_value":true,"is_nullable":true,"is_variadic":false}],"return_type":[{"name":"Definition","namespace":"Flow\\ETL\\Row\\Schema","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"schema"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":1196,"slug":"bool-schema","name":"bool_schema","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"name","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"nullable","type":[{"name":"bool","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false},{"name":"metadata","type":[{"name":"Metadata","namespace":"Flow\\ETL\\Row\\Schema","is_nullable":true,"is_variadic":false}],"has_default_value":true,"is_nullable":true,"is_variadic":false}],"return_type":[{"name":"Definition","namespace":"Flow\\ETL\\Row\\Schema","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"schema"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":1202,"slug":"float-schema","name":"float_schema","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"name","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"nullable","type":[{"name":"bool","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false},{"name":"metadata","type":[{"name":"Metadata","namespace":"Flow\\ETL\\Row\\Schema","is_nullable":true,"is_variadic":false}],"has_default_value":true,"is_nullable":true,"is_variadic":false}],"return_type":[{"name":"Definition","namespace":"Flow\\ETL\\Row\\Schema","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"schema"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":1208,"slug":"array-schema","name":"array_schema","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"name","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"empty","type":[{"name":"bool","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false},{"name":"nullable","type":[{"name":"bool","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false},{"name":"metadata","type":[{"name":"Metadata","namespace":"Flow\\ETL\\Row\\Schema","is_nullable":true,"is_variadic":false}],"has_default_value":true,"is_nullable":true,"is_variadic":false}],"return_type":[{"name":"Definition","namespace":"Flow\\ETL\\Row\\Schema","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"schema"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":1214,"slug":"object-schema","name":"object_schema","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"name","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"type","type":[{"name":"ObjectType","namespace":"Flow\\ETL\\PHP\\Type\\Native","is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"metadata","type":[{"name":"Metadata","namespace":"Flow\\ETL\\Row\\Schema","is_nullable":true,"is_variadic":false}],"has_default_value":true,"is_nullable":true,"is_variadic":false}],"return_type":[{"name":"Definition","namespace":"Flow\\ETL\\Row\\Schema","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"schema"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":1220,"slug":"map-schema","name":"map_schema","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"name","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"type","type":[{"name":"MapType","namespace":"Flow\\ETL\\PHP\\Type\\Logical","is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"metadata","type":[{"name":"Metadata","namespace":"Flow\\ETL\\Row\\Schema","is_nullable":true,"is_variadic":false}],"has_default_value":true,"is_nullable":true,"is_variadic":false}],"return_type":[{"name":"Definition","namespace":"Flow\\ETL\\Row\\Schema","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"schema"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":1226,"slug":"list-schema","name":"list_schema","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"name","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"type","type":[{"name":"ListType","namespace":"Flow\\ETL\\PHP\\Type\\Logical","is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"metadata","type":[{"name":"Metadata","namespace":"Flow\\ETL\\Row\\Schema","is_nullable":true,"is_variadic":false}],"has_default_value":true,"is_nullable":true,"is_variadic":false}],"return_type":[{"name":"Definition","namespace":"Flow\\ETL\\Row\\Schema","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"schema"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":1235,"slug":"enum-schema","name":"enum_schema","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"name","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"type","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"nullable","type":[{"name":"bool","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false},{"name":"metadata","type":[{"name":"Metadata","namespace":"Flow\\ETL\\Row\\Schema","is_nullable":true,"is_variadic":false}],"has_default_value":true,"is_nullable":true,"is_variadic":false}],"return_type":[{"name":"Definition","namespace":"Flow\\ETL\\Row\\Schema","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"schema"}}],"doc_comment":"LyoqCiAqIEBwYXJhbSBjbGFzcy1zdHJpbmc8XFVuaXRFbnVtPiAkdHlwZQogKi8="},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":1241,"slug":"null-schema","name":"null_schema","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"name","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"metadata","type":[{"name":"Metadata","namespace":"Flow\\ETL\\Row\\Schema","is_nullable":true,"is_variadic":false}],"has_default_value":true,"is_nullable":true,"is_variadic":false}],"return_type":[{"name":"Definition","namespace":"Flow\\ETL\\Row\\Schema","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"schema"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":1247,"slug":"datetime-schema","name":"datetime_schema","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"name","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"nullable","type":[{"name":"bool","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false},{"name":"metadata","type":[{"name":"Metadata","namespace":"Flow\\ETL\\Row\\Schema","is_nullable":true,"is_variadic":false}],"has_default_value":true,"is_nullable":true,"is_variadic":false}],"return_type":[{"name":"Definition","namespace":"Flow\\ETL\\Row\\Schema","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"schema"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":1253,"slug":"json-schema","name":"json_schema","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"name","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"nullable","type":[{"name":"bool","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false},{"name":"metadata","type":[{"name":"Metadata","namespace":"Flow\\ETL\\Row\\Schema","is_nullable":true,"is_variadic":false}],"has_default_value":true,"is_nullable":true,"is_variadic":false}],"return_type":[{"name":"Definition","namespace":"Flow\\ETL\\Row\\Schema","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"schema"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":1259,"slug":"xml-schema","name":"xml_schema","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"name","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"nullable","type":[{"name":"bool","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false},{"name":"metadata","type":[{"name":"Metadata","namespace":"Flow\\ETL\\Row\\Schema","is_nullable":true,"is_variadic":false}],"has_default_value":true,"is_nullable":true,"is_variadic":false}],"return_type":[{"name":"Definition","namespace":"Flow\\ETL\\Row\\Schema","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"schema"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":1265,"slug":"xml-element-schema","name":"xml_element_schema","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"name","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"nullable","type":[{"name":"bool","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false},{"name":"metadata","type":[{"name":"Metadata","namespace":"Flow\\ETL\\Row\\Schema","is_nullable":true,"is_variadic":false}],"has_default_value":true,"is_nullable":true,"is_variadic":false}],"return_type":[{"name":"Definition","namespace":"Flow\\ETL\\Row\\Schema","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"schema"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":1271,"slug":"struct-schema","name":"struct_schema","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"name","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"type","type":[{"name":"StructureType","namespace":"Flow\\ETL\\PHP\\Type\\Logical","is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"metadata","type":[{"name":"Metadata","namespace":"Flow\\ETL\\Row\\Schema","is_nullable":true,"is_variadic":false}],"has_default_value":true,"is_nullable":true,"is_variadic":false}],"return_type":[{"name":"Definition","namespace":"Flow\\ETL\\Row\\Schema","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"schema"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":1277,"slug":"structure-schema","name":"structure_schema","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"name","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"type","type":[{"name":"StructureType","namespace":"Flow\\ETL\\PHP\\Type\\Logical","is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"metadata","type":[{"name":"Metadata","namespace":"Flow\\ETL\\Row\\Schema","is_nullable":true,"is_variadic":false}],"has_default_value":true,"is_nullable":true,"is_variadic":false}],"return_type":[{"name":"Definition","namespace":"Flow\\ETL\\Row\\Schema","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"schema"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":1283,"slug":"uuid-schema","name":"uuid_schema","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"name","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"nullable","type":[{"name":"bool","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false},{"name":"metadata","type":[{"name":"Metadata","namespace":"Flow\\ETL\\Row\\Schema","is_nullable":true,"is_variadic":false}],"has_default_value":true,"is_nullable":true,"is_variadic":false}],"return_type":[{"name":"Definition","namespace":"Flow\\ETL\\Row\\Schema","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"schema"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":1289,"slug":"execution-context","name":"execution_context","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"config","type":[{"name":"Config","namespace":"Flow\\ETL","is_nullable":true,"is_variadic":false}],"has_default_value":true,"is_nullable":true,"is_variadic":false}],"return_type":[{"name":"FlowContext","namespace":"Flow\\ETL","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"data frame"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":1295,"slug":"flow-context","name":"flow_context","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"config","type":[{"name":"Config","namespace":"Flow\\ETL","is_nullable":true,"is_variadic":false}],"has_default_value":true,"is_nullable":true,"is_variadic":false}],"return_type":[{"name":"FlowContext","namespace":"Flow\\ETL","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"data frame"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":1301,"slug":"config","name":"config","namespace":"Flow\\ETL\\DSL","parameters":[],"return_type":[{"name":"Config","namespace":"Flow\\ETL","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"data frame"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":1307,"slug":"config-builder","name":"config_builder","namespace":"Flow\\ETL\\DSL","parameters":[],"return_type":[{"name":"ConfigBuilder","namespace":"Flow\\ETL\\Config","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"data frame"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":1313,"slug":"overwrite","name":"overwrite","namespace":"Flow\\ETL\\DSL","parameters":[],"return_type":[{"name":"SaveMode","namespace":"Flow\\ETL\\Filesystem","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"data frame"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":1319,"slug":"ignore","name":"ignore","namespace":"Flow\\ETL\\DSL","parameters":[],"return_type":[{"name":"SaveMode","namespace":"Flow\\ETL\\Filesystem","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"data frame"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":1325,"slug":"exception-if-exists","name":"exception_if_exists","namespace":"Flow\\ETL\\DSL","parameters":[],"return_type":[{"name":"SaveMode","namespace":"Flow\\ETL\\Filesystem","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"data frame"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":1331,"slug":"append","name":"append","namespace":"Flow\\ETL\\DSL","parameters":[],"return_type":[{"name":"SaveMode","namespace":"Flow\\ETL\\Filesystem","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"data frame"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":1337,"slug":"get-type","name":"get_type","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"value","type":[{"name":"mixed","namespace":null,"is_nullable":true,"is_variadic":false}],"has_default_value":false,"is_nullable":true,"is_variadic":false}],"return_type":[{"name":"Type","namespace":"Flow\\ETL\\PHP\\Type","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"data frame"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":1343,"slug":"print-schema","name":"print_schema","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"schema","type":[{"name":"Schema","namespace":"Flow\\ETL\\Row","is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"formatter","type":[{"name":"SchemaFormatter","namespace":"Flow\\ETL\\Row\\Schema","is_nullable":true,"is_variadic":false}],"has_default_value":true,"is_nullable":true,"is_variadic":false}],"return_type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"schema"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":1349,"slug":"print-rows","name":"print_rows","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"rows","type":[{"name":"Rows","namespace":"Flow\\ETL","is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"truncate","type":[{"name":"int","namespace":null,"is_nullable":false,"is_variadic":false},{"name":"bool","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false},{"name":"formatter","type":[{"name":"Formatter","namespace":"Flow\\ETL","is_nullable":true,"is_variadic":false}],"has_default_value":true,"is_nullable":true,"is_variadic":false}],"return_type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"data frame"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":1355,"slug":"identical","name":"identical","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"left","type":[{"name":"Reference","namespace":"Flow\\ETL\\Row","is_nullable":false,"is_variadic":false},{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"right","type":[{"name":"Reference","namespace":"Flow\\ETL\\Row","is_nullable":false,"is_variadic":false},{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"Identical","namespace":"Flow\\ETL\\Join\\Comparison","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"comparisons"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":1361,"slug":"equal","name":"equal","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"left","type":[{"name":"Reference","namespace":"Flow\\ETL\\Row","is_nullable":false,"is_variadic":false},{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"right","type":[{"name":"Reference","namespace":"Flow\\ETL\\Row","is_nullable":false,"is_variadic":false},{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"Equal","namespace":"Flow\\ETL\\Join\\Comparison","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"comparisons"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":1367,"slug":"compare-all","name":"compare_all","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"comparisons","type":[{"name":"Comparison","namespace":"Flow\\ETL\\Join","is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":true}],"return_type":[{"name":"All","namespace":"Flow\\ETL\\Join\\Comparison","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"comparisons"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":1373,"slug":"compare-any","name":"compare_any","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"comparisons","type":[{"name":"Comparison","namespace":"Flow\\ETL\\Join","is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":true}],"return_type":[{"name":"Any","namespace":"Flow\\ETL\\Join\\Comparison","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"comparisons"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":1379,"slug":"join-on","name":"join_on","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"comparisons","type":[{"name":"Comparison","namespace":"Flow\\ETL\\Join","is_nullable":false,"is_variadic":false},{"name":"array","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"joinPrefix","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"Expression","namespace":"Flow\\ETL\\Join","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"data frame"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":1385,"slug":"compare-entries-by-name","name":"compare_entries_by_name","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"order","type":[{"name":"Order","namespace":"Flow\\ETL\\Transformer\\OrderEntries","is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"Comparator","namespace":"Flow\\ETL\\Transformer\\OrderEntries","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"data frame"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":1391,"slug":"compare-entries-by-name-desc","name":"compare_entries_by_name_desc","namespace":"Flow\\ETL\\DSL","parameters":[],"return_type":[{"name":"Comparator","namespace":"Flow\\ETL\\Transformer\\OrderEntries","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"data frame"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":1400,"slug":"compare-entries-by-type","name":"compare_entries_by_type","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"priorities","type":[{"name":"array","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false},{"name":"order","type":[{"name":"Order","namespace":"Flow\\ETL\\Transformer\\OrderEntries","is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"Comparator","namespace":"Flow\\ETL\\Transformer\\OrderEntries","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"data frame"}}],"doc_comment":"LyoqCiAqIEBwYXJhbSBhcnJheTxjbGFzcy1zdHJpbmc8RW50cnk+LCBpbnQ+ICRwcmlvcml0aWVzCiAqLw=="},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":1409,"slug":"compare-entries-by-type-desc","name":"compare_entries_by_type_desc","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"priorities","type":[{"name":"array","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"Comparator","namespace":"Flow\\ETL\\Transformer\\OrderEntries","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"data frame"}}],"doc_comment":"LyoqCiAqIEBwYXJhbSBhcnJheTxjbGFzcy1zdHJpbmc8RW50cnk+LCBpbnQ+ICRwcmlvcml0aWVzCiAqLw=="},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":1418,"slug":"compare-entries-by-type-and-name","name":"compare_entries_by_type_and_name","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"priorities","type":[{"name":"array","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false},{"name":"order","type":[{"name":"Order","namespace":"Flow\\ETL\\Transformer\\OrderEntries","is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"Comparator","namespace":"Flow\\ETL\\Transformer\\OrderEntries","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"data frame"}}],"doc_comment":"LyoqCiAqIEBwYXJhbSBhcnJheTxjbGFzcy1zdHJpbmc8RW50cnk+LCBpbnQ+ICRwcmlvcml0aWVzCiAqLw=="},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":1431,"slug":"is-type","name":"is_type","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"types","type":[{"name":"array","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"value","type":[{"name":"mixed","namespace":null,"is_nullable":true,"is_variadic":false}],"has_default_value":false,"is_nullable":true,"is_variadic":false}],"return_type":[{"name":"bool","namespace":null,"is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"data frame"}}],"doc_comment":"LyoqCiAqIEBwYXJhbSBhcnJheTxzdHJpbmd8VHlwZT4gJHR5cGVzCiAqIEBwYXJhbSBtaXhlZCAkdmFsdWUKICov"},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":1461,"slug":"generate-random-string","name":"generate_random_string","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"length","type":[{"name":"int","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false},{"name":"generator","type":[{"name":"NativePHPRandomValueGenerator","namespace":"Flow\\ETL","is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"data frame"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":1467,"slug":"generate-random-int","name":"generate_random_int","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"start","type":[{"name":"int","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false},{"name":"end","type":[{"name":"int","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false},{"name":"generator","type":[{"name":"NativePHPRandomValueGenerator","namespace":"Flow\\ETL","is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"int","namespace":null,"is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"data frame"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":1473,"slug":"random-string","name":"random_string","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"length","type":[{"name":"ScalarFunction","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false},{"name":"int","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"generator","type":[{"name":"RandomValueGenerator","namespace":"Flow\\ETL","is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"RandomString","namespace":"Flow\\ETL\\Function","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"data frame"}}],"doc_comment":null},{"repository_path":"src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php","start_line_in_file":1481,"slug":"dom-element-to-string","name":"dom_element_to_string","namespace":"Flow\\ETL\\DSL","parameters":[{"name":"element","type":[{"name":"DOMElement","namespace":"","is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"format_output","type":[{"name":"bool","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false},{"name":"preserver_white_space","type":[{"name":"bool","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false},{"name":"false","namespace":null,"is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Core","type":"data frame"}}],"doc_comment":null},{"repository_path":"src\/adapter\/etl-adapter-chartjs\/src\/Flow\/ETL\/Adapter\/ChartJS\/functions.php","start_line_in_file":13,"slug":"bar-chart","name":"bar_chart","namespace":"Flow\\ETL\\Adapter\\ChartJS","parameters":[{"name":"label","type":[{"name":"EntryReference","namespace":"Flow\\ETL\\Row","is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"datasets","type":[{"name":"References","namespace":"Flow\\ETL\\Row","is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"BarChart","namespace":"Flow\\ETL\\Adapter\\ChartJS\\Chart","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"ChartJS","type":"helpers"}}],"doc_comment":null},{"repository_path":"src\/adapter\/etl-adapter-chartjs\/src\/Flow\/ETL\/Adapter\/ChartJS\/functions.php","start_line_in_file":19,"slug":"line-chart","name":"line_chart","namespace":"Flow\\ETL\\Adapter\\ChartJS","parameters":[{"name":"label","type":[{"name":"EntryReference","namespace":"Flow\\ETL\\Row","is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"datasets","type":[{"name":"References","namespace":"Flow\\ETL\\Row","is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"LineChart","namespace":"Flow\\ETL\\Adapter\\ChartJS\\Chart","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"ChartJS","type":"helpers"}}],"doc_comment":null},{"repository_path":"src\/adapter\/etl-adapter-chartjs\/src\/Flow\/ETL\/Adapter\/ChartJS\/functions.php","start_line_in_file":25,"slug":"pie-chart","name":"pie_chart","namespace":"Flow\\ETL\\Adapter\\ChartJS","parameters":[{"name":"label","type":[{"name":"EntryReference","namespace":"Flow\\ETL\\Row","is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"datasets","type":[{"name":"References","namespace":"Flow\\ETL\\Row","is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"PieChart","namespace":"Flow\\ETL\\Adapter\\ChartJS\\Chart","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"ChartJS","type":"helpers"}}],"doc_comment":null},{"repository_path":"src\/adapter\/etl-adapter-chartjs\/src\/Flow\/ETL\/Adapter\/ChartJS\/functions.php","start_line_in_file":31,"slug":"to-chartjs-file","name":"to_chartjs_file","namespace":"Flow\\ETL\\Adapter\\ChartJS","parameters":[{"name":"type","type":[{"name":"Chart","namespace":"Flow\\ETL\\Adapter\\ChartJS","is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"output","type":[{"name":"Path","namespace":"Flow\\Filesystem","is_nullable":false,"is_variadic":false},{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false},{"name":"null","namespace":null,"is_nullable":true,"is_variadic":false}],"has_default_value":true,"is_nullable":true,"is_variadic":false},{"name":"template","type":[{"name":"Path","namespace":"Flow\\Filesystem","is_nullable":false,"is_variadic":false},{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false},{"name":"null","namespace":null,"is_nullable":true,"is_variadic":false}],"has_default_value":true,"is_nullable":true,"is_variadic":false}],"return_type":[{"name":"ChartJSLoader","namespace":"Flow\\ETL\\Adapter\\ChartJS","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"ChartJS","type":"loaders"}}],"doc_comment":null},{"repository_path":"src\/adapter\/etl-adapter-chartjs\/src\/Flow\/ETL\/Adapter\/ChartJS\/functions.php","start_line_in_file":49,"slug":"to-chartjs-var","name":"to_chartjs_var","namespace":"Flow\\ETL\\Adapter\\ChartJS","parameters":[{"name":"type","type":[{"name":"Chart","namespace":"Flow\\ETL\\Adapter\\ChartJS","is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"output","type":[{"name":"array","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"ChartJSLoader","namespace":"Flow\\ETL\\Adapter\\ChartJS","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"ChartJS","type":"loaders"}}],"doc_comment":null},{"repository_path":"src\/adapter\/etl-adapter-csv\/src\/Flow\/ETL\/Adapter\/CSV\/functions.php","start_line_in_file":17,"slug":"from-csv","name":"from_csv","namespace":"Flow\\ETL\\Adapter\\CSV","parameters":[{"name":"path","type":[{"name":"Path","namespace":"Flow\\Filesystem","is_nullable":false,"is_variadic":false},{"name":"array","namespace":null,"is_nullable":false,"is_variadic":false},{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"with_header","type":[{"name":"bool","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false},{"name":"empty_to_null","type":[{"name":"bool","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false},{"name":"delimiter","type":[{"name":"string","namespace":null,"is_nullable":true,"is_variadic":false}],"has_default_value":true,"is_nullable":true,"is_variadic":false},{"name":"enclosure","type":[{"name":"string","namespace":null,"is_nullable":true,"is_variadic":false}],"has_default_value":true,"is_nullable":true,"is_variadic":false},{"name":"escape","type":[{"name":"string","namespace":null,"is_nullable":true,"is_variadic":false}],"has_default_value":true,"is_nullable":true,"is_variadic":false},{"name":"characters_read_in_line","type":[{"name":"int","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false},{"name":"schema","type":[{"name":"Schema","namespace":"Flow\\ETL\\Row","is_nullable":true,"is_variadic":false}],"has_default_value":true,"is_nullable":true,"is_variadic":false}],"return_type":[{"name":"Extractor","namespace":"Flow\\ETL","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"CSV","type":"extractors"}}],"doc_comment":"LyoqCiAqIEBwYXJhbSBpbnQ8MSwgbWF4PiAkY2hhcmFjdGVyc19yZWFkX2luX2xpbmUKICov"},{"repository_path":"src\/adapter\/etl-adapter-csv\/src\/Flow\/ETL\/Adapter\/CSV\/functions.php","start_line_in_file":59,"slug":"to-csv","name":"to_csv","namespace":"Flow\\ETL\\Adapter\\CSV","parameters":[{"name":"uri","type":[{"name":"Path","namespace":"Flow\\Filesystem","is_nullable":false,"is_variadic":false},{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"with_header","type":[{"name":"bool","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false},{"name":"separator","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false},{"name":"enclosure","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false},{"name":"escape","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false},{"name":"new_line_separator","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false},{"name":"datetime_format","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"Loader","namespace":"Flow\\ETL","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"CSV","type":"loaders"}}],"doc_comment":null},{"repository_path":"src\/adapter\/etl-adapter-csv\/src\/Flow\/ETL\/Adapter\/CSV\/functions.php","start_line_in_file":86,"slug":"csv-detect-separator","name":"csv_detect_separator","namespace":"Flow\\ETL\\Adapter\\CSV","parameters":[{"name":"stream","type":[{"name":"SourceStream","namespace":"Flow\\Filesystem","is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"lines","type":[{"name":"int","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false},{"name":"fallback","type":[{"name":"Option","namespace":"Flow\\ETL\\Adapter\\CSV\\Detector","is_nullable":true,"is_variadic":false}],"has_default_value":true,"is_nullable":true,"is_variadic":false},{"name":"options","type":[{"name":"Options","namespace":"Flow\\ETL\\Adapter\\CSV\\Detector","is_nullable":true,"is_variadic":false}],"has_default_value":true,"is_nullable":true,"is_variadic":false}],"return_type":[{"name":"Option","namespace":"Flow\\ETL\\Adapter\\CSV\\Detector","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"CSV","type":"helpers"}}],"doc_comment":"LyoqCiAqIEBwYXJhbSBTb3VyY2VTdHJlYW0gJHN0cmVhbSAtIHZhbGlkIHJlc291cmNlIHRvIENTViBmaWxlCiAqIEBwYXJhbSBpbnQ8MSwgbWF4PiAkbGluZXMgLSBudW1iZXIgb2YgbGluZXMgdG8gcmVhZCBmcm9tIENTViBmaWxlLCBkZWZhdWx0IDUsIG1vcmUgbGluZXMgbWVhbnMgbW9yZSBhY2N1cmF0ZSBkZXRlY3Rpb24gYnV0IHNsb3dlciBkZXRlY3Rpb24KICogQHBhcmFtIG51bGx8T3B0aW9uICRmYWxsYmFjayAtIGZhbGxiYWNrIG9wdGlvbiB0byB1c2Ugd2hlbiBubyBiZXN0IG9wdGlvbiBjYW4gYmUgZGV0ZWN0ZWQsIGRlZmF1bHQgaXMgT3B0aW9uKCcsJywgJyInLCAnXFwnKQogKiBAcGFyYW0gbnVsbHxPcHRpb25zICRvcHRpb25zIC0gb3B0aW9ucyB0byB1c2UgZm9yIGRldGVjdGlvbiwgZGVmYXVsdCBpcyBPcHRpb25zOjphbGwoKQogKi8="},{"repository_path":"src\/adapter\/etl-adapter-doctrine\/src\/Flow\/ETL\/Adapter\/Doctrine\/functions.php","start_line_in_file":22,"slug":"dbal-dataframe-factory","name":"dbal_dataframe_factory","namespace":"Flow\\ETL\\Adapter\\Doctrine","parameters":[{"name":"connection","type":[{"name":"Connection","namespace":"Doctrine\\DBAL","is_nullable":false,"is_variadic":false},{"name":"array","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"query","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"parameters","type":[{"name":"QueryParameter","namespace":"Flow\\ETL\\Adapter\\Doctrine","is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":true}],"return_type":[{"name":"DbalDataFrameFactory","namespace":"Flow\\ETL\\Adapter\\Doctrine","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Doctrine","type":"helpers"}}],"doc_comment":"LyoqCiAqIEBwYXJhbSBhcnJheTxzdHJpbmcsIG1peGVkPnxDb25uZWN0aW9uICRjb25uZWN0aW9uCiAqIEBwYXJhbSBzdHJpbmcgJHF1ZXJ5CiAqIEBwYXJhbSBRdWVyeVBhcmFtZXRlciAuLi4kcGFyYW1ldGVycwogKi8="},{"repository_path":"src\/adapter\/etl-adapter-doctrine\/src\/Flow\/ETL\/Adapter\/Doctrine\/functions.php","start_line_in_file":42,"slug":"from-dbal-limit-offset","name":"from_dbal_limit_offset","namespace":"Flow\\ETL\\Adapter\\Doctrine","parameters":[{"name":"connection","type":[{"name":"Connection","namespace":"Doctrine\\DBAL","is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"table","type":[{"name":"Table","namespace":"Flow\\ETL\\Adapter\\Doctrine","is_nullable":false,"is_variadic":false},{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"order_by","type":[{"name":"OrderBy","namespace":"Flow\\ETL\\Adapter\\Doctrine","is_nullable":false,"is_variadic":false},{"name":"array","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"page_size","type":[{"name":"int","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false},{"name":"maximum","type":[{"name":"int","namespace":null,"is_nullable":true,"is_variadic":false}],"has_default_value":true,"is_nullable":true,"is_variadic":false}],"return_type":[{"name":"DbalLimitOffsetExtractor","namespace":"Flow\\ETL\\Adapter\\Doctrine","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Doctrine","type":"extractors"}}],"doc_comment":"LyoqCiAqIEBwYXJhbSBDb25uZWN0aW9uICRjb25uZWN0aW9uCiAqIEBwYXJhbSBzdHJpbmd8VGFibGUgJHRhYmxlCiAqIEBwYXJhbSBhcnJheTxPcmRlckJ5PnxPcmRlckJ5ICRvcmRlcl9ieQogKiBAcGFyYW0gaW50ICRwYWdlX3NpemUKICogQHBhcmFtIG51bGx8aW50ICRtYXhpbXVtCiAqCiAqIEB0aHJvd3MgSW52YWxpZEFyZ3VtZW50RXhjZXB0aW9uCiAqLw=="},{"repository_path":"src\/adapter\/etl-adapter-doctrine\/src\/Flow\/ETL\/Adapter\/Doctrine\/functions.php","start_line_in_file":64,"slug":"from-dbal-limit-offset-qb","name":"from_dbal_limit_offset_qb","namespace":"Flow\\ETL\\Adapter\\Doctrine","parameters":[{"name":"connection","type":[{"name":"Connection","namespace":"Doctrine\\DBAL","is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"queryBuilder","type":[{"name":"QueryBuilder","namespace":"Doctrine\\DBAL\\Query","is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"page_size","type":[{"name":"int","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false},{"name":"maximum","type":[{"name":"int","namespace":null,"is_nullable":true,"is_variadic":false}],"has_default_value":true,"is_nullable":true,"is_variadic":false}],"return_type":[{"name":"DbalLimitOffsetExtractor","namespace":"Flow\\ETL\\Adapter\\Doctrine","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Doctrine","type":"extractors"}}],"doc_comment":"LyoqCiAqIEBwYXJhbSBDb25uZWN0aW9uICRjb25uZWN0aW9uCiAqIEBwYXJhbSBpbnQgJHBhZ2Vfc2l6ZQogKiBAcGFyYW0gbnVsbHxpbnQgJG1heGltdW0KICov"},{"repository_path":"src\/adapter\/etl-adapter-doctrine\/src\/Flow\/ETL\/Adapter\/Doctrine\/functions.php","start_line_in_file":83,"slug":"dbal-from-queries","name":"dbal_from_queries","namespace":"Flow\\ETL\\Adapter\\Doctrine","parameters":[{"name":"connection","type":[{"name":"Connection","namespace":"Doctrine\\DBAL","is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"query","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"parameters_set","type":[{"name":"ParametersSet","namespace":"Flow\\ETL\\Adapter\\Doctrine","is_nullable":true,"is_variadic":false}],"has_default_value":true,"is_nullable":true,"is_variadic":false},{"name":"types","type":[{"name":"array","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"DbalQueryExtractor","namespace":"Flow\\ETL\\Adapter\\Doctrine","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Doctrine","type":"extractors"}}],"doc_comment":"LyoqCiAqIEBwYXJhbSBudWxsfFBhcmFtZXRlcnNTZXQgJHBhcmFtZXRlcnNfc2V0IC0gZWFjaCBvbmUgcGFyYW1ldGVycyBhcnJheSB3aWxsIGJlIGV2YWx1YXRlZCBhcyBuZXcgcXVlcnkKICogQHBhcmFtIGFycmF5PGludHxzdHJpbmcsIERiYWxBcnJheVR5cGV8RGJhbFBhcmFtZXRlclR5cGV8RGJhbFR5cGV8aW50fHN0cmluZz4gJHR5cGVzCiAqLw=="},{"repository_path":"src\/adapter\/etl-adapter-doctrine\/src\/Flow\/ETL\/Adapter\/Doctrine\/functions.php","start_line_in_file":102,"slug":"dbal-from-query","name":"dbal_from_query","namespace":"Flow\\ETL\\Adapter\\Doctrine","parameters":[{"name":"connection","type":[{"name":"Connection","namespace":"Doctrine\\DBAL","is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"query","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"parameters","type":[{"name":"array","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false},{"name":"types","type":[{"name":"array","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"DbalQueryExtractor","namespace":"Flow\\ETL\\Adapter\\Doctrine","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Doctrine","type":"extractors"}}],"doc_comment":"LyoqCiAqIEBwYXJhbSBhcnJheTxzdHJpbmcsIG1peGVkPnxsaXN0PG1peGVkPiAkcGFyYW1ldGVycwogKiBAcGFyYW0gYXJyYXk8aW50fHN0cmluZywgRGJhbEFycmF5VHlwZXxEYmFsUGFyYW1ldGVyVHlwZXxEYmFsVHlwZXxpbnR8c3RyaW5nPiAkdHlwZXMKICov"},{"repository_path":"src\/adapter\/etl-adapter-doctrine\/src\/Flow\/ETL\/Adapter\/Doctrine\/functions.php","start_line_in_file":131,"slug":"to-dbal-table-insert","name":"to_dbal_table_insert","namespace":"Flow\\ETL\\Adapter\\Doctrine","parameters":[{"name":"connection","type":[{"name":"Connection","namespace":"Doctrine\\DBAL","is_nullable":false,"is_variadic":false},{"name":"array","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"table","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"options","type":[{"name":"array","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"DbalLoader","namespace":"Flow\\ETL\\Adapter\\Doctrine","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Doctrine","type":"loaders"}}],"doc_comment":"LyoqCiAqIEluIG9yZGVyIHRvIGNvbnRyb2wgdGhlIHNpemUgb2YgdGhlIHNpbmdsZSBpbnNlcnQsIHVzZSBEYXRhRnJhbWU6OmNodW5rU2l6ZSgpIG1ldGhvZCBqdXN0IGJlZm9yZSBjYWxsaW5nIERhdGFGcmFtZTo6bG9hZCgpLgogKgogKiBAcGFyYW0gYXJyYXk8c3RyaW5nLCBtaXhlZD58Q29ubmVjdGlvbiAkY29ubmVjdGlvbgogKiBAcGFyYW0gYXJyYXl7CiAqICBza2lwX2NvbmZsaWN0cz86IGJvb2xlYW4sCiAqICBjb25zdHJhaW50Pzogc3RyaW5nLAogKiAgY29uZmxpY3RfY29sdW1ucz86IGFycmF5PHN0cmluZz4sCiAqICB1cGRhdGVfY29sdW1ucz86IGFycmF5PHN0cmluZz4sCiAqICBwcmltYXJ5X2tleV9jb2x1bW5zPzogYXJyYXk8c3RyaW5nPgogKiB9ICRvcHRpb25zCiAqCiAqIEB0aHJvd3MgSW52YWxpZEFyZ3VtZW50RXhjZXB0aW9uCiAqLw=="},{"repository_path":"src\/adapter\/etl-adapter-doctrine\/src\/Flow\/ETL\/Adapter\/Doctrine\/functions.php","start_line_in_file":156,"slug":"to-dbal-table-update","name":"to_dbal_table_update","namespace":"Flow\\ETL\\Adapter\\Doctrine","parameters":[{"name":"connection","type":[{"name":"Connection","namespace":"Doctrine\\DBAL","is_nullable":false,"is_variadic":false},{"name":"array","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"table","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"options","type":[{"name":"array","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"DbalLoader","namespace":"Flow\\ETL\\Adapter\\Doctrine","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Doctrine","type":"loaders"}}],"doc_comment":"LyoqCiAqICBJbiBvcmRlciB0byBjb250cm9sIHRoZSBzaXplIG9mIHRoZSBzaW5nbGUgcmVxdWVzdCwgdXNlIERhdGFGcmFtZTo6Y2h1bmtTaXplKCkgbWV0aG9kIGp1c3QgYmVmb3JlIGNhbGxpbmcgRGF0YUZyYW1lOjpsb2FkKCkuCiAqCiAqIEBwYXJhbSBhcnJheTxzdHJpbmcsIG1peGVkPnxDb25uZWN0aW9uICRjb25uZWN0aW9uCiAqIEBwYXJhbSBhcnJheXsKICogIHNraXBfY29uZmxpY3RzPzogYm9vbGVhbiwKICogIGNvbnN0cmFpbnQ\/OiBzdHJpbmcsCiAqICBjb25mbGljdF9jb2x1bW5zPzogYXJyYXk8c3RyaW5nPiwKICogIHVwZGF0ZV9jb2x1bW5zPzogYXJyYXk8c3RyaW5nPiwKICogIHByaW1hcnlfa2V5X2NvbHVtbnM\/OiBhcnJheTxzdHJpbmc+CiAqIH0gJG9wdGlvbnMKICoKICogQHRocm93cyBJbnZhbGlkQXJndW1lbnRFeGNlcHRpb24KICov"},{"repository_path":"src\/adapter\/etl-adapter-elasticsearch\/src\/Flow\/ETL\/Adapter\/Elasticsearch\/functions.php","start_line_in_file":31,"slug":"to-es-bulk-index","name":"to_es_bulk_index","namespace":"Flow\\ETL\\Adapter\\Elasticsearch","parameters":[{"name":"config","type":[{"name":"array","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"index","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"id_factory","type":[{"name":"IdFactory","namespace":"Flow\\ETL\\Adapter\\Elasticsearch","is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"parameters","type":[{"name":"array","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"ElasticsearchLoader","namespace":"Flow\\ETL\\Adapter\\Elasticsearch\\ElasticsearchPHP","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Elastic Search","type":"loaders"}}],"doc_comment":"LyoqCiAqIGh0dHBzOi8vd3d3LmVsYXN0aWMuY28vZ3VpZGUvZW4vZWxhc3RpY3NlYXJjaC9yZWZlcmVuY2UvbWFzdGVyL2RvY3MtYnVsay5odG1sLgogKgogKiBJbiBvcmRlciB0byBjb250cm9sIHRoZSBzaXplIG9mIHRoZSBzaW5nbGUgcmVxdWVzdCwgdXNlIERhdGFGcmFtZTo6Y2h1bmtTaXplKCkgbWV0aG9kIGp1c3QgYmVmb3JlIGNhbGxpbmcgRGF0YUZyYW1lOjpsb2FkKCkuCiAqCiAqIEBwYXJhbSBhcnJheXsKICogIGhvc3RzPzogYXJyYXk8c3RyaW5nPiwKICogIGNvbm5lY3Rpb25QYXJhbXM\/OiBhcnJheTxtaXhlZD4sCiAqICByZXRyaWVzPzogaW50LAogKiAgc25pZmZPblN0YXJ0PzogYm9vbGVhbiwKICogIHNzbENlcnQ\/OiBhcnJheTxzdHJpbmc+LAogKiAgc3NsS2V5PzogYXJyYXk8c3RyaW5nPiwKICogIHNzbFZlcmlmaWNhdGlvbj86IGJvb2xlYW58c3RyaW5nLAogKiAgZWxhc3RpY01ldGFIZWFkZXI\/OiBib29sZWFuLAogKiAgaW5jbHVkZVBvcnRJbkhvc3RIZWFkZXI\/OiBib29sZWFuCiAqIH0gJGNvbmZpZwogKiBAcGFyYW0gc3RyaW5nICRpbmRleAogKiBAcGFyYW0gSWRGYWN0b3J5ICRpZF9mYWN0b3J5CiAqIEBwYXJhbSBhcnJheTxtaXhlZD4gJHBhcmFtZXRlcnMgLSBodHRwczovL3d3dy5lbGFzdGljLmNvL2d1aWRlL2VuL2VsYXN0aWNzZWFyY2gvcmVmZXJlbmNlL21hc3Rlci9kb2NzLWJ1bGsuaHRtbAogKi8="},{"repository_path":"src\/adapter\/etl-adapter-elasticsearch\/src\/Flow\/ETL\/Adapter\/Elasticsearch\/functions.php","start_line_in_file":61,"slug":"to-es-bulk-update","name":"to_es_bulk_update","namespace":"Flow\\ETL\\Adapter\\Elasticsearch","parameters":[{"name":"config","type":[{"name":"array","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"index","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"id_factory","type":[{"name":"IdFactory","namespace":"Flow\\ETL\\Adapter\\Elasticsearch","is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"parameters","type":[{"name":"array","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"ElasticsearchLoader","namespace":"Flow\\ETL\\Adapter\\Elasticsearch\\ElasticsearchPHP","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Elastic Search","type":"loaders"}}],"doc_comment":"LyoqCiAqICBodHRwczovL3d3dy5lbGFzdGljLmNvL2d1aWRlL2VuL2VsYXN0aWNzZWFyY2gvcmVmZXJlbmNlL21hc3Rlci9kb2NzLWJ1bGsuaHRtbC4KICoKICogSW4gb3JkZXIgdG8gY29udHJvbCB0aGUgc2l6ZSBvZiB0aGUgc2luZ2xlIHJlcXVlc3QsIHVzZSBEYXRhRnJhbWU6OmNodW5rU2l6ZSgpIG1ldGhvZCBqdXN0IGJlZm9yZSBjYWxsaW5nIERhdGFGcmFtZTo6bG9hZCgpLgogKgogKiBAcGFyYW0gYXJyYXl7CiAqICBob3N0cz86IGFycmF5PHN0cmluZz4sCiAqICBjb25uZWN0aW9uUGFyYW1zPzogYXJyYXk8bWl4ZWQ+LAogKiAgcmV0cmllcz86IGludCwKICogIHNuaWZmT25TdGFydD86IGJvb2xlYW4sCiAqICBzc2xDZXJ0PzogYXJyYXk8c3RyaW5nPiwKICogIHNzbEtleT86IGFycmF5PHN0cmluZz4sCiAqICBzc2xWZXJpZmljYXRpb24\/OiBib29sZWFufHN0cmluZywKICogIGVsYXN0aWNNZXRhSGVhZGVyPzogYm9vbGVhbiwKICogIGluY2x1ZGVQb3J0SW5Ib3N0SGVhZGVyPzogYm9vbGVhbgogKiB9ICRjb25maWcKICogQHBhcmFtIHN0cmluZyAkaW5kZXgKICogQHBhcmFtIElkRmFjdG9yeSAkaWRfZmFjdG9yeQogKiBAcGFyYW0gYXJyYXk8bWl4ZWQ+ICRwYXJhbWV0ZXJzIC0gaHR0cHM6Ly93d3cuZWxhc3RpYy5jby9ndWlkZS9lbi9lbGFzdGljc2VhcmNoL3JlZmVyZW5jZS9tYXN0ZXIvZG9jcy1idWxrLmh0bWwKICov"},{"repository_path":"src\/adapter\/etl-adapter-elasticsearch\/src\/Flow\/ETL\/Adapter\/Elasticsearch\/functions.php","start_line_in_file":76,"slug":"es-hits-to-rows","name":"es_hits_to_rows","namespace":"Flow\\ETL\\Adapter\\Elasticsearch","parameters":[{"name":"source","type":[{"name":"DocumentDataSource","namespace":"Flow\\ETL\\Adapter\\Elasticsearch\\ElasticsearchPHP","is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"HitsIntoRowsTransformer","namespace":"Flow\\ETL\\Adapter\\Elasticsearch\\ElasticsearchPHP","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Elastic Search","type":"helpers"}}],"doc_comment":"LyoqCiAqIFRyYW5zZm9ybXMgZWxhc3RpY3NlYXJjaCByZXN1bHRzIGludG8gY2xlYXIgRmxvdyBSb3dzIHVzaW5nIFsnaGl0cyddWydoaXRzJ11beF1bJ19zb3VyY2UnXS4KICoKICogQHJldHVybiBIaXRzSW50b1Jvd3NUcmFuc2Zvcm1lcgogKi8="},{"repository_path":"src\/adapter\/etl-adapter-elasticsearch\/src\/Flow\/ETL\/Adapter\/Elasticsearch\/functions.php","start_line_in_file":104,"slug":"from-es","name":"from_es","namespace":"Flow\\ETL\\Adapter\\Elasticsearch","parameters":[{"name":"config","type":[{"name":"array","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"params","type":[{"name":"array","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"pit_params","type":[{"name":"array","namespace":null,"is_nullable":true,"is_variadic":false}],"has_default_value":true,"is_nullable":true,"is_variadic":false}],"return_type":[{"name":"ElasticsearchExtractor","namespace":"Flow\\ETL\\Adapter\\Elasticsearch\\ElasticsearchPHP","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Elastic Search","type":"extractors"}}],"doc_comment":"LyoqCiAqIEV4dHJhY3RvciB3aWxsIGF1dG9tYXRpY2FsbHkgdHJ5IHRvIGl0ZXJhdGUgb3ZlciB3aG9sZSBpbmRleCB1c2luZyBvbmUgb2YgdGhlIHR3byBpdGVyYXRpb24gbWV0aG9kczouCiAqCiAqIC0gZnJvbS9zaXplCiAqIC0gc2VhcmNoX2FmdGVyCiAqCiAqIFNlYXJjaCBhZnRlciBpcyBzZWxlY3RlZCB3aGVuIHlvdSBwcm92aWRlIGRlZmluZSBzb3J0IHBhcmFtZXRlcnMgaW4gcXVlcnksIG90aGVyd2lzZSBpdCB3aWxsIGZhbGxiYWNrIHRvIGZyb20vc2l6ZS4KICoKICogQHBhcmFtIGFycmF5ewogKiAgaG9zdHM\/OiBhcnJheTxzdHJpbmc+LAogKiAgY29ubmVjdGlvblBhcmFtcz86IGFycmF5PG1peGVkPiwKICogIHJldHJpZXM\/OiBpbnQsCiAqICBzbmlmZk9uU3RhcnQ\/OiBib29sZWFuLAogKiAgc3NsQ2VydD86IGFycmF5PHN0cmluZz4sCiAqICBzc2xLZXk\/OiBhcnJheTxzdHJpbmc+LAogKiAgc3NsVmVyaWZpY2F0aW9uPzogYm9vbGVhbnxzdHJpbmcsCiAqICBlbGFzdGljTWV0YUhlYWRlcj86IGJvb2xlYW4sCiAqICBpbmNsdWRlUG9ydEluSG9zdEhlYWRlcj86IGJvb2xlYW4KICogfSAkY29uZmlnCiAqIEBwYXJhbSBhcnJheTxtaXhlZD4gJHBhcmFtcyAtIGh0dHBzOi8vd3d3LmVsYXN0aWMuY28vZ3VpZGUvZW4vZWxhc3RpY3NlYXJjaC9yZWZlcmVuY2UvbWFzdGVyL3NlYXJjaC1zZWFyY2guaHRtbAogKiBAcGFyYW0gP2FycmF5PG1peGVkPiAkcGl0X3BhcmFtcyAtIHdoZW4gdXNlZCBleHRyYWN0b3Igd2lsbCBjcmVhdGUgcG9pbnQgaW4gdGltZSB0byBzdGFiaWxpemUgc2VhcmNoIHJlc3VsdHMuIFBvaW50IGluIHRpbWUgaXMgYXV0b21hdGljYWxseSBjbG9zZWQgd2hlbiBsYXN0IGVsZW1lbnQgaXMgZXh0cmFjdGVkLiBodHRwczovL3d3dy5lbGFzdGljLmNvL2d1aWRlL2VuL2VsYXN0aWNzZWFyY2gvcmVmZXJlbmNlL21hc3Rlci9wb2ludC1pbi10aW1lLWFwaS5odG1sCiAqLw=="},{"repository_path":"src\/adapter\/etl-adapter-google-sheet\/src\/Flow\/ETL\/Adapter\/GoogleSheet\/functions.php","start_line_in_file":21,"slug":"from-google-sheet","name":"from_google_sheet","namespace":"Flow\\ETL\\Adapter\\GoogleSheet","parameters":[{"name":"auth_config","type":[{"name":"Sheets","namespace":"Google\\Service","is_nullable":false,"is_variadic":false},{"name":"array","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"spreadsheet_id","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"sheet_name","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"with_header","type":[{"name":"bool","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false},{"name":"rows_per_page","type":[{"name":"int","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false},{"name":"options","type":[{"name":"array","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"Extractor","namespace":"Flow\\ETL","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Google Sheet","type":"extractors"}}],"doc_comment":"LyoqCiAqIEBwYXJhbSBhcnJheXt0eXBlOiBzdHJpbmcsIHByb2plY3RfaWQ6IHN0cmluZywgcHJpdmF0ZV9rZXlfaWQ6IHN0cmluZywgcHJpdmF0ZV9rZXk6IHN0cmluZywgY2xpZW50X2VtYWlsOiBzdHJpbmcsIGNsaWVudF9pZDogc3RyaW5nLCBhdXRoX3VyaTogc3RyaW5nLCB0b2tlbl91cmk6IHN0cmluZywgYXV0aF9wcm92aWRlcl94NTA5X2NlcnRfdXJsOiBzdHJpbmcsIGNsaWVudF94NTA5X2NlcnRfdXJsOiBzdHJpbmd9fFNoZWV0cyAkYXV0aF9jb25maWcKICogQHBhcmFtIHN0cmluZyAkc3ByZWFkc2hlZXRfaWQKICogQHBhcmFtIHN0cmluZyAkc2hlZXRfbmFtZQogKiBAcGFyYW0gYm9vbCAkd2l0aF9oZWFkZXIKICogQHBhcmFtIGludCAkcm93c19wZXJfcGFnZSAtIGhvdyBtYW55IHJvd3MgcGVyIHBhZ2UgdG8gZmV0Y2ggZnJvbSBHb29nbGUgU2hlZXRzIEFQSQogKiBAcGFyYW0gYXJyYXl7ZGF0ZVRpbWVSZW5kZXJPcHRpb24\/OiBzdHJpbmcsIG1ham9yRGltZW5zaW9uPzogc3RyaW5nLCB2YWx1ZVJlbmRlck9wdGlvbj86IHN0cmluZ30gJG9wdGlvbnMKICov"},{"repository_path":"src\/adapter\/etl-adapter-google-sheet\/src\/Flow\/ETL\/Adapter\/GoogleSheet\/functions.php","start_line_in_file":59,"slug":"from-google-sheet-columns","name":"from_google_sheet_columns","namespace":"Flow\\ETL\\Adapter\\GoogleSheet","parameters":[{"name":"auth_config","type":[{"name":"Sheets","namespace":"Google\\Service","is_nullable":false,"is_variadic":false},{"name":"array","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"spreadsheet_id","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"sheet_name","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"start_range_column","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"end_range_column","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"with_header","type":[{"name":"bool","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false},{"name":"rows_per_page","type":[{"name":"int","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false},{"name":"options","type":[{"name":"array","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"Extractor","namespace":"Flow\\ETL","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Google Sheet","type":"extractors"}}],"doc_comment":"LyoqCiAqIEBwYXJhbSBhcnJheXt0eXBlOiBzdHJpbmcsIHByb2plY3RfaWQ6IHN0cmluZywgcHJpdmF0ZV9rZXlfaWQ6IHN0cmluZywgcHJpdmF0ZV9rZXk6IHN0cmluZywgY2xpZW50X2VtYWlsOiBzdHJpbmcsIGNsaWVudF9pZDogc3RyaW5nLCBhdXRoX3VyaTogc3RyaW5nLCB0b2tlbl91cmk6IHN0cmluZywgYXV0aF9wcm92aWRlcl94NTA5X2NlcnRfdXJsOiBzdHJpbmcsIGNsaWVudF94NTA5X2NlcnRfdXJsOiBzdHJpbmd9fFNoZWV0cyAkYXV0aF9jb25maWcKICogQHBhcmFtIHN0cmluZyAkc3ByZWFkc2hlZXRfaWQKICogQHBhcmFtIHN0cmluZyAkc2hlZXRfbmFtZQogKiBAcGFyYW0gc3RyaW5nICRzdGFydF9yYW5nZV9jb2x1bW4KICogQHBhcmFtIHN0cmluZyAkZW5kX3JhbmdlX2NvbHVtbgogKiBAcGFyYW0gYm9vbCAkd2l0aF9oZWFkZXIKICogQHBhcmFtIGludCAkcm93c19wZXJfcGFnZSAtIGhvdyBtYW55IHJvd3MgcGVyIHBhZ2UgdG8gZmV0Y2ggZnJvbSBHb29nbGUgU2hlZXRzIEFQSQogKiBAcGFyYW0gYXJyYXl7ZGF0ZVRpbWVSZW5kZXJPcHRpb24\/OiBzdHJpbmcsIG1ham9yRGltZW5zaW9uPzogc3RyaW5nLCB2YWx1ZVJlbmRlck9wdGlvbj86IHN0cmluZ30gJG9wdGlvbnMKICov"},{"repository_path":"src\/adapter\/etl-adapter-json\/src\/Flow\/ETL\/Adapter\/JSON\/functions.php","start_line_in_file":18,"slug":"from-json","name":"from_json","namespace":"Flow\\ETL\\Adapter\\JSON","parameters":[{"name":"path","type":[{"name":"Path","namespace":"Flow\\Filesystem","is_nullable":false,"is_variadic":false},{"name":"array","namespace":null,"is_nullable":false,"is_variadic":false},{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"pointer","type":[{"name":"string","namespace":null,"is_nullable":true,"is_variadic":false}],"has_default_value":true,"is_nullable":true,"is_variadic":false},{"name":"schema","type":[{"name":"Schema","namespace":"Flow\\ETL\\Row","is_nullable":true,"is_variadic":false}],"has_default_value":true,"is_nullable":true,"is_variadic":false}],"return_type":[{"name":"Extractor","namespace":"Flow\\ETL","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"JSON","type":"extractors"}}],"doc_comment":"LyoqCiAqIEBwYXJhbSBhcnJheTxQYXRofHN0cmluZz58UGF0aHxzdHJpbmcgJHBhdGggLSBzdHJpbmcgaXMgaW50ZXJuYWxseSB0dXJuZWQgaW50byBzdHJlYW0KICogQHBhcmFtID9zdHJpbmcgJHBvaW50ZXIgLSBpZiB5b3Ugd2FudCB0byBpdGVyYXRlIG9ubHkgcmVzdWx0cyBvZiBhIHN1YnRyZWUsIHVzZSBhIHBvaW50ZXIsIHJlYWQgbW9yZSBhdCBodHRwczovL2dpdGh1Yi5jb20vaGFsYXhhL2pzb24tbWFjaGluZSNwYXJzaW5nLWEtc3VidHJlZQogKi8="},{"repository_path":"src\/adapter\/etl-adapter-json\/src\/Flow\/ETL\/Adapter\/JSON\/functions.php","start_line_in_file":50,"slug":"to-json","name":"to_json","namespace":"Flow\\ETL\\Adapter\\JSON","parameters":[{"name":"path","type":[{"name":"Path","namespace":"Flow\\Filesystem","is_nullable":false,"is_variadic":false},{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"flags","type":[{"name":"int","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false},{"name":"date_time_format","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false},{"name":"put_rows_in_new_lines","type":[{"name":"bool","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"Loader","namespace":"Flow\\ETL","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"JSON","type":"loaders"}}],"doc_comment":"LyoqCiAqIEBwYXJhbSBQYXRofHN0cmluZyAkcGF0aAogKgogKiBAcmV0dXJuIExvYWRlcgogKi8="},{"repository_path":"src\/adapter\/etl-adapter-meilisearch\/src\/Flow\/ETL\/Adapter\/Meilisearch\/functions.php","start_line_in_file":16,"slug":"to-meilisearch-bulk-index","name":"to_meilisearch_bulk_index","namespace":"Flow\\ETL\\Adapter\\Meilisearch","parameters":[{"name":"config","type":[{"name":"array","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"index","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"Loader","namespace":"Flow\\ETL","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"MeiliSearch","type":"loaders"}}],"doc_comment":"LyoqCiAqIEBwYXJhbSBhcnJheXt1cmw6IHN0cmluZywgYXBpS2V5OiBzdHJpbmcsIGh0dHBDbGllbnQ6ID9DbGllbnRJbnRlcmZhY2V9ICRjb25maWcKICov"},{"repository_path":"src\/adapter\/etl-adapter-meilisearch\/src\/Flow\/ETL\/Adapter\/Meilisearch\/functions.php","start_line_in_file":27,"slug":"to-meilisearch-bulk-update","name":"to_meilisearch_bulk_update","namespace":"Flow\\ETL\\Adapter\\Meilisearch","parameters":[{"name":"config","type":[{"name":"array","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"index","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"Loader","namespace":"Flow\\ETL","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"MeiliSearch","type":"loaders"}}],"doc_comment":"LyoqCiAqIEBwYXJhbSBhcnJheXt1cmw6IHN0cmluZywgYXBpS2V5OiBzdHJpbmcsIGh0dHBDbGllbnQ6ID9DbGllbnRJbnRlcmZhY2V9ICRjb25maWcKICov"},{"repository_path":"src\/adapter\/etl-adapter-meilisearch\/src\/Flow\/ETL\/Adapter\/Meilisearch\/functions.php","start_line_in_file":38,"slug":"meilisearch-hits-to-rows","name":"meilisearch_hits_to_rows","namespace":"Flow\\ETL\\Adapter\\Meilisearch","parameters":[],"return_type":[{"name":"HitsIntoRowsTransformer","namespace":"Flow\\ETL\\Adapter\\Meilisearch\\MeilisearchPHP","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"MeiliSearch","type":"helpers"}}],"doc_comment":"LyoqCiAqIFRyYW5zZm9ybXMgTWVpbGlzZWFyY2ggcmVzdWx0cyBpbnRvIGNsZWFyIEZsb3cgUm93cy4KICov"},{"repository_path":"src\/adapter\/etl-adapter-meilisearch\/src\/Flow\/ETL\/Adapter\/Meilisearch\/functions.php","start_line_in_file":48,"slug":"from-meilisearch","name":"from_meilisearch","namespace":"Flow\\ETL\\Adapter\\Meilisearch","parameters":[{"name":"config","type":[{"name":"array","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"params","type":[{"name":"array","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"index","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"MeilisearchExtractor","namespace":"Flow\\ETL\\Adapter\\Meilisearch\\MeilisearchPHP","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"MeiliSearch","type":"extractors"}}],"doc_comment":"LyoqCiAqIEBwYXJhbSBhcnJheXt1cmw6IHN0cmluZywgYXBpS2V5OiBzdHJpbmd9ICRjb25maWcKICogQHBhcmFtIGFycmF5e3E6IHN0cmluZywgbGltaXQ6ID9pbnQsIG9mZnNldDogP2ludCwgYXR0cmlidXRlc1RvUmV0cmlldmU6ID9hcnJheTxzdHJpbmc+LCBzb3J0OiA\/YXJyYXk8c3RyaW5nPn0gJHBhcmFtcwogKi8="},{"repository_path":"src\/adapter\/etl-adapter-parquet\/src\/Flow\/ETL\/Adapter\/Parquet\/functions.php","start_line_in_file":22,"slug":"from-parquet","name":"from_parquet","namespace":"Flow\\ETL\\Adapter\\Parquet","parameters":[{"name":"path","type":[{"name":"Path","namespace":"Flow\\Filesystem","is_nullable":false,"is_variadic":false},{"name":"array","namespace":null,"is_nullable":false,"is_variadic":false},{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"columns","type":[{"name":"array","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false},{"name":"options","type":[{"name":"Options","namespace":"Flow\\Parquet","is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false},{"name":"byte_order","type":[{"name":"ByteOrder","namespace":"Flow\\Parquet","is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false},{"name":"offset","type":[{"name":"int","namespace":null,"is_nullable":true,"is_variadic":false}],"has_default_value":true,"is_nullable":true,"is_variadic":false}],"return_type":[{"name":"Extractor","namespace":"Flow\\ETL","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Parquet","type":"extractors"}}],"doc_comment":"LyoqCiAqIEBwYXJhbSBhcnJheTxQYXRoPnxQYXRofHN0cmluZyAkcGF0aAogKiBAcGFyYW0gYXJyYXk8c3RyaW5nPiAkY29sdW1ucwogKgogKiBAcmV0dXJuIEV4dHJhY3RvcgogKi8="},{"repository_path":"src\/adapter\/etl-adapter-parquet\/src\/Flow\/ETL\/Adapter\/Parquet\/functions.php","start_line_in_file":64,"slug":"to-parquet","name":"to_parquet","namespace":"Flow\\ETL\\Adapter\\Parquet","parameters":[{"name":"path","type":[{"name":"Path","namespace":"Flow\\Filesystem","is_nullable":false,"is_variadic":false},{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"options","type":[{"name":"Options","namespace":"Flow\\Parquet","is_nullable":true,"is_variadic":false}],"has_default_value":true,"is_nullable":true,"is_variadic":false},{"name":"compressions","type":[{"name":"Compressions","namespace":"Flow\\Parquet\\ParquetFile","is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false},{"name":"schema","type":[{"name":"Schema","namespace":"Flow\\ETL\\Row","is_nullable":true,"is_variadic":false}],"has_default_value":true,"is_nullable":true,"is_variadic":false}],"return_type":[{"name":"Loader","namespace":"Flow\\ETL","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Parquet","type":"loaders"}}],"doc_comment":"LyoqCiAqIEBwYXJhbSBQYXRofHN0cmluZyAkcGF0aAogKiBAcGFyYW0gbnVsbHxTY2hlbWEgJHNjaGVtYQogKgogKiBAcmV0dXJuIExvYWRlcgogKi8="},{"repository_path":"src\/adapter\/etl-adapter-text\/src\/Flow\/ETL\/Adapter\/Text\/functions.php","start_line_in_file":16,"slug":"from-text","name":"from_text","namespace":"Flow\\ETL\\Adapter\\Text","parameters":[{"name":"path","type":[{"name":"Path","namespace":"Flow\\Filesystem","is_nullable":false,"is_variadic":false},{"name":"array","namespace":null,"is_nullable":false,"is_variadic":false},{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"Extractor","namespace":"Flow\\ETL","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Text","type":"extractors"}}],"doc_comment":"LyoqCiAqIEBwYXJhbSBhcnJheTxQYXRofHN0cmluZz58UGF0aHxzdHJpbmcgJHBhdGgKICoKICogQHJldHVybiBFeHRyYWN0b3IKICov"},{"repository_path":"src\/adapter\/etl-adapter-text\/src\/Flow\/ETL\/Adapter\/Text\/functions.php","start_line_in_file":43,"slug":"to-text","name":"to_text","namespace":"Flow\\ETL\\Adapter\\Text","parameters":[{"name":"path","type":[{"name":"Path","namespace":"Flow\\Filesystem","is_nullable":false,"is_variadic":false},{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"new_line_separator","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"Loader","namespace":"Flow\\ETL","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Text","type":"loaders"}}],"doc_comment":"LyoqCiAqIEBwYXJhbSBQYXRofHN0cmluZyAkcGF0aAogKiBAcGFyYW0gc3RyaW5nICRuZXdfbGluZV9zZXBhcmF0b3IKICoKICogQHJldHVybiBMb2FkZXIKICov"},{"repository_path":"src\/adapter\/etl-adapter-xml\/src\/Flow\/ETL\/Adapter\/XML\/functions.php","start_line_in_file":21,"slug":"from-xml","name":"from_xml","namespace":"Flow\\ETL\\Adapter\\XML","parameters":[{"name":"path","type":[{"name":"Path","namespace":"Flow\\Filesystem","is_nullable":false,"is_variadic":false},{"name":"array","namespace":null,"is_nullable":false,"is_variadic":false},{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"xml_node_path","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"Extractor","namespace":"Flow\\ETL","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"XML","type":"extractors"}}],"doc_comment":"LyoqCiAqIEBwYXJhbSBhcnJheTxQYXRofHN0cmluZz58UGF0aHxzdHJpbmcgJHBhdGgKICov"},{"repository_path":"src\/adapter\/etl-adapter-xml\/src\/Flow\/ETL\/Adapter\/XML\/functions.php","start_line_in_file":46,"slug":"to-xml","name":"to_xml","namespace":"Flow\\ETL\\Adapter\\XML","parameters":[{"name":"path","type":[{"name":"Path","namespace":"Flow\\Filesystem","is_nullable":false,"is_variadic":false},{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"root_element_name","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false},{"name":"row_element_name","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false},{"name":"attribute_prefix","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false},{"name":"date_time_format","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false},{"name":"xml_writer","type":[{"name":"XMLWriter","namespace":"Flow\\ETL\\Adapter\\XML","is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"XMLLoader","namespace":"Flow\\ETL\\Adapter\\XML\\Loader","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"XML","type":"loaders"}}],"doc_comment":null},{"repository_path":"src\/lib\/filesystem\/src\/Flow\/Filesystem\/DSL\/functions.php","start_line_in_file":12,"slug":"protocol","name":"protocol","namespace":"Flow\\Filesystem\\DSL","parameters":[{"name":"protocol","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"Protocol","namespace":"Flow\\Filesystem","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Filesystem","type":"helpers"}}],"doc_comment":null},{"repository_path":"src\/lib\/filesystem\/src\/Flow\/Filesystem\/DSL\/functions.php","start_line_in_file":18,"slug":"partition","name":"partition","namespace":"Flow\\Filesystem\\DSL","parameters":[{"name":"name","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"value","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"Partition","namespace":"Flow\\Filesystem","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Filesystem","type":"helpers"}}],"doc_comment":null},{"repository_path":"src\/lib\/filesystem\/src\/Flow\/Filesystem\/DSL\/functions.php","start_line_in_file":24,"slug":"partitions","name":"partitions","namespace":"Flow\\Filesystem\\DSL","parameters":[{"name":"partition","type":[{"name":"Partition","namespace":"Flow\\Filesystem","is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":true}],"return_type":[{"name":"Partitions","namespace":"Flow\\Filesystem","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Filesystem","type":"helpers"}}],"doc_comment":null},{"repository_path":"src\/lib\/filesystem\/src\/Flow\/Filesystem\/DSL\/functions.php","start_line_in_file":43,"slug":"path","name":"path","namespace":"Flow\\Filesystem\\DSL","parameters":[{"name":"path","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"options","type":[{"name":"array","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"Path","namespace":"Flow\\Filesystem","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Filesystem","type":"helpers"}}],"doc_comment":"LyoqCiAqIFBhdGggc3VwcG9ydHMgZ2xvYiBwYXR0ZXJucy4KICogRXhhbXBsZXM6CiAqICAtIHBhdGgoJyouY3N2JykgLSBhbnkgY3N2IGZpbGUgaW4gY3VycmVudCBkaXJlY3RvcnkKICogIC0gcGF0aCgnLyoqIC8gKi5jc3YnKSAtIGFueSBjc3YgZmlsZSBpbiBhbnkgc3ViZGlyZWN0b3J5IChyZW1vdmUgZW1wdHkgc3BhY2VzKQogKiAgLSBwYXRoKCcvZGlyL3BhcnRpdGlvbj0qIC8qLnBhcnF1ZXQnKSAtIGFueSBwYXJxdWV0IGZpbGUgaW4gZ2l2ZW4gcGFydGl0aW9uIGRpcmVjdG9yeS4KICoKICogR2xvYiBwYXR0ZXJuIGlzIGFsc28gc3VwcG9ydGVkIGJ5IHJlbW90ZSBmaWxlc3lzdGVtcyBsaWtlIEF6dXJlCiAqCiAqICAtIHBhdGgoJ2F6dXJlLWJsb2I6Ly9kaXJlY3RvcnkvKi5jc3YnKSAtIGFueSBjc3YgZmlsZSBpbiBnaXZlbiBkaXJlY3RvcnkKICoKICogQHBhcmFtIGFycmF5PHN0cmluZywgbWl4ZWQ+ICRvcHRpb25zCiAqLw=="},{"repository_path":"src\/lib\/filesystem\/src\/Flow\/Filesystem\/DSL\/functions.php","start_line_in_file":54,"slug":"path-real","name":"path_real","namespace":"Flow\\Filesystem\\DSL","parameters":[{"name":"path","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"options","type":[{"name":"array","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"Path","namespace":"Flow\\Filesystem","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Filesystem","type":"helpers"}}],"doc_comment":"LyoqCiAqIFJlc29sdmUgcmVhbCBwYXRoIGZyb20gZ2l2ZW4gcGF0aC4KICoKICogQHBhcmFtIGFycmF5PHN0cmluZywgbWl4ZWQ+ICRvcHRpb25zCiAqLw=="},{"repository_path":"src\/lib\/filesystem\/src\/Flow\/Filesystem\/DSL\/functions.php","start_line_in_file":60,"slug":"native-local-filesystem","name":"native_local_filesystem","namespace":"Flow\\Filesystem\\DSL","parameters":[],"return_type":[{"name":"NativeLocalFilesystem","namespace":"Flow\\Filesystem\\Local","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Filesystem","type":"helpers"}}],"doc_comment":null},{"repository_path":"src\/lib\/filesystem\/src\/Flow\/Filesystem\/DSL\/functions.php","start_line_in_file":71,"slug":"fstab","name":"fstab","namespace":"Flow\\Filesystem\\DSL","parameters":[{"name":"filesystems","type":[{"name":"Filesystem","namespace":"Flow\\Filesystem","is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":true}],"return_type":[{"name":"FilesystemTable","namespace":"Flow\\Filesystem","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Filesystem","type":"helpers"}}],"doc_comment":"LyoqCiAqIENyZWF0ZSBhIG5ldyBmaWxlc3lzdGVtIHRhYmxlIHdpdGggZ2l2ZW4gZmlsZXN5c3RlbXMuCiAqIEZpbGVzeXN0ZW1zIGNhbiBiZSBhbHNvIG1vdW50ZWQgbGF0ZXIuCiAqIElmIG5vIGZpbGVzeXN0ZW1zIGFyZSBwcm92aWRlZCwgbG9jYWwgZmlsZXN5c3RlbSBpcyBtb3VudGVkLgogKi8="},{"repository_path":"src\/bridge\/filesystem\/azure\/src\/Flow\/Filesystem\/Bridge\/Azure\/DSL\/functions.php","start_line_in_file":12,"slug":"azure-filesystem-options","name":"azure_filesystem_options","namespace":"Flow\\Filesystem\\Bridge\\Azure\\DSL","parameters":[],"return_type":[{"name":"Options","namespace":"Flow\\Filesystem\\Bridge\\Azure","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Azure Filesystem","type":"helpers"}}],"doc_comment":null},{"repository_path":"src\/bridge\/filesystem\/azure\/src\/Flow\/Filesystem\/Bridge\/Azure\/DSL\/functions.php","start_line_in_file":18,"slug":"azure-filesystem","name":"azure_filesystem","namespace":"Flow\\Filesystem\\Bridge\\Azure\\DSL","parameters":[{"name":"blob_service","type":[{"name":"BlobServiceInterface","namespace":"Flow\\Azure\\SDK","is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"options","type":[{"name":"Options","namespace":"Flow\\Filesystem\\Bridge\\Azure","is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"AzureBlobFilesystem","namespace":"Flow\\Filesystem\\Bridge\\Azure","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Azure Filesystem","type":"helpers"}}],"doc_comment":null},{"repository_path":"src\/lib\/azure-sdk\/src\/Flow\/Azure\/SDK\/DSL\/functions.php","start_line_in_file":18,"slug":"azurite-url-factory","name":"azurite_url_factory","namespace":"Flow\\Azure\\SDK\\DSL","parameters":[{"name":"host","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false},{"name":"port","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false},{"name":"secure","type":[{"name":"bool","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"AzuriteURLFactory","namespace":"Flow\\Azure\\SDK\\BlobService\\URLFactory","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Azure SDK","type":"helpers"}}],"doc_comment":null},{"repository_path":"src\/lib\/azure-sdk\/src\/Flow\/Azure\/SDK\/DSL\/functions.php","start_line_in_file":24,"slug":"azure-shared-key-authorization-factory","name":"azure_shared_key_authorization_factory","namespace":"Flow\\Azure\\SDK\\DSL","parameters":[{"name":"account","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"key","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"SharedKeyFactory","namespace":"Flow\\Azure\\SDK\\AuthorizationFactory","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Azure SDK","type":"helpers"}}],"doc_comment":null},{"repository_path":"src\/lib\/azure-sdk\/src\/Flow\/Azure\/SDK\/DSL\/functions.php","start_line_in_file":30,"slug":"azure-blob-service-config","name":"azure_blob_service_config","namespace":"Flow\\Azure\\SDK\\DSL","parameters":[{"name":"account","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"container","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"Configuration","namespace":"Flow\\Azure\\SDK\\BlobService","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Azure SDK","type":"helpers"}}],"doc_comment":null},{"repository_path":"src\/lib\/azure-sdk\/src\/Flow\/Azure\/SDK\/DSL\/functions.php","start_line_in_file":36,"slug":"azure-url-factory","name":"azure_url_factory","namespace":"Flow\\Azure\\SDK\\DSL","parameters":[{"name":"host","type":[{"name":"string","namespace":null,"is_nullable":false,"is_variadic":false}],"has_default_value":true,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"AzureURLFactory","namespace":"Flow\\Azure\\SDK\\BlobService\\URLFactory","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Azure SDK","type":"helpers"}}],"doc_comment":null},{"repository_path":"src\/lib\/azure-sdk\/src\/Flow\/Azure\/SDK\/DSL\/functions.php","start_line_in_file":42,"slug":"azure-http-factory","name":"azure_http_factory","namespace":"Flow\\Azure\\SDK\\DSL","parameters":[{"name":"request_factory","type":[{"name":"RequestFactoryInterface","namespace":"Psr\\Http\\Message","is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"stream_factory","type":[{"name":"StreamFactoryInterface","namespace":"Psr\\Http\\Message","is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false}],"return_type":[{"name":"HttpFactory","namespace":"Flow\\Azure\\SDK","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Azure SDK","type":"helpers"}}],"doc_comment":null},{"repository_path":"src\/lib\/azure-sdk\/src\/Flow\/Azure\/SDK\/DSL\/functions.php","start_line_in_file":48,"slug":"azure-blob-service","name":"azure_blob_service","namespace":"Flow\\Azure\\SDK\\DSL","parameters":[{"name":"configuration","type":[{"name":"Configuration","namespace":"Flow\\Azure\\SDK\\BlobService","is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"azure_authorization_factory","type":[{"name":"AuthorizationFactory","namespace":"Flow\\Azure\\SDK","is_nullable":false,"is_variadic":false}],"has_default_value":false,"is_nullable":false,"is_variadic":false},{"name":"client","type":[{"name":"ClientInterface","namespace":"Psr\\Http\\Client","is_nullable":true,"is_variadic":false}],"has_default_value":true,"is_nullable":true,"is_variadic":false},{"name":"azure_http_factory","type":[{"name":"HttpFactory","namespace":"Flow\\Azure\\SDK","is_nullable":true,"is_variadic":false}],"has_default_value":true,"is_nullable":true,"is_variadic":false},{"name":"azure_url_factory","type":[{"name":"URLFactory","namespace":"Flow\\Azure\\SDK","is_nullable":true,"is_variadic":false}],"has_default_value":true,"is_nullable":true,"is_variadic":false},{"name":"logger","type":[{"name":"LoggerInterface","namespace":"Psr\\Log","is_nullable":true,"is_variadic":false}],"has_default_value":true,"is_nullable":true,"is_variadic":false}],"return_type":[{"name":"BlobServiceInterface","namespace":"Flow\\Azure\\SDK","is_nullable":false,"is_variadic":false}],"attributes":[{"name":"DocumentationDSL","namespace":"Flow\\ETL\\Attribute","arguments":{"module":"Azure SDK","type":"helpers"}}],"doc_comment":null}]
+[
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 132,
+    "slug": "df",
+    "name": "df",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "config",
+        "type": [
+          {
+            "name": "Config",
+            "namespace": "Flow\\ETL",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "ConfigBuilder",
+            "namespace": "Flow\\ETL\\Config",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "null",
+            "namespace": null,
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": true,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "Flow",
+        "namespace": "Flow\\ETL",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "DATA_FRAME"
+        }
+      }
+    ],
+    "doc_comment": "LyoqCiAqIEFsaWFzIGZvciBkYXRhX2ZyYW1lKCkgOiBGbG93LgogKi8="
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 138,
+    "slug": "data-frame",
+    "name": "data_frame",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "config",
+        "type": [
+          {
+            "name": "Config",
+            "namespace": "Flow\\ETL",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "ConfigBuilder",
+            "namespace": "Flow\\ETL\\Config",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "null",
+            "namespace": null,
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": true,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "Flow",
+        "namespace": "Flow\\ETL",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "DATA_FRAME"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 144,
+    "slug": "from-rows",
+    "name": "from_rows",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "rows",
+        "type": [
+          {
+            "name": "Rows",
+            "namespace": "Flow\\ETL",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": true
+      }
+    ],
+    "return_type": [
+      {
+        "name": "RowsExtractor",
+        "namespace": "Flow\\ETL\\Extractor",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "EXTRACTOR"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 150,
+    "slug": "from-path-partitions",
+    "name": "from_path_partitions",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "path",
+        "type": [
+          {
+            "name": "Path",
+            "namespace": "Flow\\Filesystem",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "PathPartitionsExtractor",
+        "namespace": "Flow\\ETL\\Extractor",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "EXTRACTOR"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 156,
+    "slug": "from-array",
+    "name": "from_array",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "array",
+        "type": [
+          {
+            "name": "iterable",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "schema",
+        "type": [
+          {
+            "name": "Schema",
+            "namespace": "Flow\\ETL\\Row",
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": true,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "ArrayExtractor",
+        "namespace": "Flow\\ETL\\Extractor",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "EXTRACTOR"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 162,
+    "slug": "from-cache",
+    "name": "from_cache",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "id",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "fallback_extractor",
+        "type": [
+          {
+            "name": "Extractor",
+            "namespace": "Flow\\ETL",
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": true,
+        "is_variadic": false
+      },
+      {
+        "name": "clear",
+        "type": [
+          {
+            "name": "bool",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "CacheExtractor",
+        "namespace": "Flow\\ETL\\Extractor",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "EXTRACTOR"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 168,
+    "slug": "from-all",
+    "name": "from_all",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "extractors",
+        "type": [
+          {
+            "name": "Extractor",
+            "namespace": "Flow\\ETL",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": true
+      }
+    ],
+    "return_type": [
+      {
+        "name": "ChainExtractor",
+        "namespace": "Flow\\ETL\\Extractor",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "EXTRACTOR"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 174,
+    "slug": "from-memory",
+    "name": "from_memory",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "memory",
+        "type": [
+          {
+            "name": "Memory",
+            "namespace": "Flow\\ETL\\Memory",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "MemoryExtractor",
+        "namespace": "Flow\\ETL\\Extractor",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "EXTRACTOR"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 180,
+    "slug": "files",
+    "name": "files",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "directory",
+        "type": [
+          {
+            "name": "Path",
+            "namespace": "Flow\\Filesystem",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "FilesExtractor",
+        "namespace": "Flow\\ETL\\Extractor",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "EXTRACTOR"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 186,
+    "slug": "filesystem-cache",
+    "name": "filesystem_cache",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "cache_dir",
+        "type": [
+          {
+            "name": "Path",
+            "namespace": "Flow\\Filesystem",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "null",
+            "namespace": null,
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": true,
+        "is_variadic": false
+      },
+      {
+        "name": "filesystem",
+        "type": [
+          {
+            "name": "Filesystem",
+            "namespace": "Flow\\Filesystem",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "serializer",
+        "type": [
+          {
+            "name": "Serializer",
+            "namespace": "Flow\\Serializer",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "FilesystemCache",
+        "namespace": "Flow\\ETL\\Cache\\Implementation",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "DATA_FRAME"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 195,
+    "slug": "chunks-from",
+    "name": "chunks_from",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "extractor",
+        "type": [
+          {
+            "name": "Extractor",
+            "namespace": "Flow\\ETL",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "chunk_size",
+        "type": [
+          {
+            "name": "int",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "ChunkExtractor",
+        "namespace": "Flow\\ETL\\Extractor",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "EXTRACTOR"
+        }
+      }
+    ],
+    "doc_comment": "LyoqCiAqIEBwYXJhbSBpbnQ8MSwgbWF4PiAkY2h1bmtfc2l6ZQogKi8="
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 200,
+    "slug": "from-pipeline",
+    "name": "from_pipeline",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "pipeline",
+        "type": [
+          {
+            "name": "Pipeline",
+            "namespace": "Flow\\ETL",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "PipelineExtractor",
+        "namespace": "Flow\\ETL\\Extractor",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "EXTRACTOR"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 206,
+    "slug": "from-data-frame",
+    "name": "from_data_frame",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "data_frame",
+        "type": [
+          {
+            "name": "DataFrame",
+            "namespace": "Flow\\ETL",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "DataFrameExtractor",
+        "namespace": "Flow\\ETL\\Extractor",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "EXTRACTOR"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 212,
+    "slug": "from-sequence-date-period",
+    "name": "from_sequence_date_period",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "entry_name",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "start",
+        "type": [
+          {
+            "name": "DateTimeInterface",
+            "namespace": "",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "interval",
+        "type": [
+          {
+            "name": "DateInterval",
+            "namespace": "",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "end",
+        "type": [
+          {
+            "name": "DateTimeInterface",
+            "namespace": "",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "options",
+        "type": [
+          {
+            "name": "int",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "SequenceExtractor",
+        "namespace": "Flow\\ETL\\Extractor",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "EXTRACTOR"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 221,
+    "slug": "from-sequence-date-period-recurrences",
+    "name": "from_sequence_date_period_recurrences",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "entry_name",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "start",
+        "type": [
+          {
+            "name": "DateTimeInterface",
+            "namespace": "",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "interval",
+        "type": [
+          {
+            "name": "DateInterval",
+            "namespace": "",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "recurrences",
+        "type": [
+          {
+            "name": "int",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "options",
+        "type": [
+          {
+            "name": "int",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "SequenceExtractor",
+        "namespace": "Flow\\ETL\\Extractor",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "EXTRACTOR"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 230,
+    "slug": "from-sequence-number",
+    "name": "from_sequence_number",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "entry_name",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "start",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "int",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "float",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "end",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "int",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "float",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "step",
+        "type": [
+          {
+            "name": "int",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "float",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "SequenceExtractor",
+        "namespace": "Flow\\ETL\\Extractor",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "EXTRACTOR"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 239,
+    "slug": "to-callable",
+    "name": "to_callable",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "callable",
+        "type": [
+          {
+            "name": "callable",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "CallbackLoader",
+        "namespace": "Flow\\ETL\\Loader",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "LOADER"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 245,
+    "slug": "to-memory",
+    "name": "to_memory",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "memory",
+        "type": [
+          {
+            "name": "Memory",
+            "namespace": "Flow\\ETL\\Memory",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "MemoryLoader",
+        "namespace": "Flow\\ETL\\Loader",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "LOADER"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 251,
+    "slug": "to-output",
+    "name": "to_output",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "truncate",
+        "type": [
+          {
+            "name": "int",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "bool",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "output",
+        "type": [
+          {
+            "name": "Output",
+            "namespace": "Flow\\ETL\\Loader\\StreamLoader",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "formatter",
+        "type": [
+          {
+            "name": "Formatter",
+            "namespace": "Flow\\ETL",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "schemaFormatter",
+        "type": [
+          {
+            "name": "SchemaFormatter",
+            "namespace": "Flow\\ETL\\Row\\Schema",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "StreamLoader",
+        "namespace": "Flow\\ETL\\Loader",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "LOADER"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 257,
+    "slug": "to-stderr",
+    "name": "to_stderr",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "truncate",
+        "type": [
+          {
+            "name": "int",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "bool",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "output",
+        "type": [
+          {
+            "name": "Output",
+            "namespace": "Flow\\ETL\\Loader\\StreamLoader",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "formatter",
+        "type": [
+          {
+            "name": "Formatter",
+            "namespace": "Flow\\ETL",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "schemaFormatter",
+        "type": [
+          {
+            "name": "SchemaFormatter",
+            "namespace": "Flow\\ETL\\Row\\Schema",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "StreamLoader",
+        "namespace": "Flow\\ETL\\Loader",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "LOADER"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 263,
+    "slug": "to-stdout",
+    "name": "to_stdout",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "truncate",
+        "type": [
+          {
+            "name": "int",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "bool",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "output",
+        "type": [
+          {
+            "name": "Output",
+            "namespace": "Flow\\ETL\\Loader\\StreamLoader",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "formatter",
+        "type": [
+          {
+            "name": "Formatter",
+            "namespace": "Flow\\ETL",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "schemaFormatter",
+        "type": [
+          {
+            "name": "SchemaFormatter",
+            "namespace": "Flow\\ETL\\Row\\Schema",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "StreamLoader",
+        "namespace": "Flow\\ETL\\Loader",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "LOADER"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 269,
+    "slug": "to-stream",
+    "name": "to_stream",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "uri",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "truncate",
+        "type": [
+          {
+            "name": "int",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "bool",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "output",
+        "type": [
+          {
+            "name": "Output",
+            "namespace": "Flow\\ETL\\Loader\\StreamLoader",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "mode",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "formatter",
+        "type": [
+          {
+            "name": "Formatter",
+            "namespace": "Flow\\ETL",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "schemaFormatter",
+        "type": [
+          {
+            "name": "SchemaFormatter",
+            "namespace": "Flow\\ETL\\Row\\Schema",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "StreamLoader",
+        "namespace": "Flow\\ETL\\Loader",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "LOADER"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 275,
+    "slug": "to-transformation",
+    "name": "to_transformation",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "transformer",
+        "type": [
+          {
+            "name": "Transformer",
+            "namespace": "Flow\\ETL",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "loader",
+        "type": [
+          {
+            "name": "Loader",
+            "namespace": "Flow\\ETL",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "TransformerLoader",
+        "namespace": "Flow\\ETL\\Loader",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "LOADER"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 281,
+    "slug": "to-branch",
+    "name": "to_branch",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "condition",
+        "type": [
+          {
+            "name": "ScalarFunction",
+            "namespace": "Flow\\ETL\\Function",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "loader",
+        "type": [
+          {
+            "name": "Loader",
+            "namespace": "Flow\\ETL",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "Loader",
+        "namespace": "Flow\\ETL",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "LOADER"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 290,
+    "slug": "array-entry",
+    "name": "array_entry",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "array",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "data",
+        "type": [
+          {
+            "name": "array",
+            "namespace": null,
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": true,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "ArrayEntry",
+        "namespace": "Flow\\ETL\\Row\\Entry",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "ENTRY"
+        }
+      }
+    ],
+    "doc_comment": "LyoqCiAqIEBwYXJhbSBhcnJheTxtaXhlZD4gJGRhdGEKICov"
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 296,
+    "slug": "bool-entry",
+    "name": "bool_entry",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "name",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "value",
+        "type": [
+          {
+            "name": "bool",
+            "namespace": null,
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": true,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "BooleanEntry",
+        "namespace": "Flow\\ETL\\Row\\Entry",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "ENTRY"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 302,
+    "slug": "boolean-entry",
+    "name": "boolean_entry",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "name",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "value",
+        "type": [
+          {
+            "name": "bool",
+            "namespace": null,
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": true,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "BooleanEntry",
+        "namespace": "Flow\\ETL\\Row\\Entry",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "ENTRY"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 308,
+    "slug": "datetime-entry",
+    "name": "datetime_entry",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "name",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "value",
+        "type": [
+          {
+            "name": "DateTimeInterface",
+            "namespace": "",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "null",
+            "namespace": null,
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": true,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "DateTimeEntry",
+        "namespace": "Flow\\ETL\\Row\\Entry",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "ENTRY"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 314,
+    "slug": "int-entry",
+    "name": "int_entry",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "name",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "value",
+        "type": [
+          {
+            "name": "int",
+            "namespace": null,
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": true,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "IntegerEntry",
+        "namespace": "Flow\\ETL\\Row\\Entry",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "ENTRY"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 320,
+    "slug": "integer-entry",
+    "name": "integer_entry",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "name",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "value",
+        "type": [
+          {
+            "name": "int",
+            "namespace": null,
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": true,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "IntegerEntry",
+        "namespace": "Flow\\ETL\\Row\\Entry",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "ENTRY"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 326,
+    "slug": "enum-entry",
+    "name": "enum_entry",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "name",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "enum",
+        "type": [
+          {
+            "name": "UnitEnum",
+            "namespace": "",
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": true,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "EnumEntry",
+        "namespace": "Flow\\ETL\\Row\\Entry",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "ENTRY"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 332,
+    "slug": "float-entry",
+    "name": "float_entry",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "name",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "value",
+        "type": [
+          {
+            "name": "float",
+            "namespace": null,
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": true,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "FloatEntry",
+        "namespace": "Flow\\ETL\\Row\\Entry",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "ENTRY"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 338,
+    "slug": "json-entry",
+    "name": "json_entry",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "name",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "data",
+        "type": [
+          {
+            "name": "array",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "null",
+            "namespace": null,
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": true,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "JsonEntry",
+        "namespace": "Flow\\ETL\\Row\\Entry",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "ENTRY"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 347,
+    "slug": "json-object-entry",
+    "name": "json_object_entry",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "name",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "data",
+        "type": [
+          {
+            "name": "array",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "null",
+            "namespace": null,
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": true,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "JsonEntry",
+        "namespace": "Flow\\ETL\\Row\\Entry",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "ENTRY"
+        }
+      }
+    ],
+    "doc_comment": "LyoqCiAqIEB0aHJvd3MgSW52YWxpZEFyZ3VtZW50RXhjZXB0aW9uCiAqLw=="
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 357,
+    "slug": "object-entry",
+    "name": "object_entry",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "name",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "data",
+        "type": [
+          {
+            "name": "object",
+            "namespace": null,
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": true,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "ObjectEntry",
+        "namespace": "Flow\\ETL\\Row\\Entry",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "ENTRY"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 363,
+    "slug": "obj-entry",
+    "name": "obj_entry",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "name",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "data",
+        "type": [
+          {
+            "name": "object",
+            "namespace": null,
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": true,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "ObjectEntry",
+        "namespace": "Flow\\ETL\\Row\\Entry",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "ENTRY"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 369,
+    "slug": "str-entry",
+    "name": "str_entry",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "name",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "value",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": true,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "StringEntry",
+        "namespace": "Flow\\ETL\\Row\\Entry",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "ENTRY"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 375,
+    "slug": "string-entry",
+    "name": "string_entry",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "name",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "value",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": true,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "StringEntry",
+        "namespace": "Flow\\ETL\\Row\\Entry",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "ENTRY"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 381,
+    "slug": "uuid-entry",
+    "name": "uuid_entry",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "name",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "value",
+        "type": [
+          {
+            "name": "Uuid",
+            "namespace": "Flow\\ETL\\PHP\\Value",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "null",
+            "namespace": null,
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": true,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "UuidEntry",
+        "namespace": "Flow\\ETL\\Row\\Entry",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "ENTRY"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 387,
+    "slug": "xml-entry",
+    "name": "xml_entry",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "name",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "value",
+        "type": [
+          {
+            "name": "DOMDocument",
+            "namespace": "",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "null",
+            "namespace": null,
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": true,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "XMLEntry",
+        "namespace": "Flow\\ETL\\Row\\Entry",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "ENTRY"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 393,
+    "slug": "xml-element-entry",
+    "name": "xml_element_entry",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "name",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "value",
+        "type": [
+          {
+            "name": "DOMElement",
+            "namespace": "",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "null",
+            "namespace": null,
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": true,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "XMLElementEntry",
+        "namespace": "Flow\\ETL\\Row\\Entry",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "ENTRY"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 399,
+    "slug": "entries",
+    "name": "entries",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "entries",
+        "type": [
+          {
+            "name": "Entry",
+            "namespace": "Flow\\ETL\\Row",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": true
+      }
+    ],
+    "return_type": [
+      {
+        "name": "Entries",
+        "namespace": "Flow\\ETL\\Row",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "DATA_FRAME"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 405,
+    "slug": "struct-entry",
+    "name": "struct_entry",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "name",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "value",
+        "type": [
+          {
+            "name": "array",
+            "namespace": null,
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": true,
+        "is_variadic": false
+      },
+      {
+        "name": "type",
+        "type": [
+          {
+            "name": "StructureType",
+            "namespace": "Flow\\ETL\\PHP\\Type\\Logical",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "StructureEntry",
+        "namespace": "Flow\\ETL\\Row\\Entry",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "ENTRY"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 411,
+    "slug": "structure-entry",
+    "name": "structure_entry",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "name",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "value",
+        "type": [
+          {
+            "name": "array",
+            "namespace": null,
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": true,
+        "is_variadic": false
+      },
+      {
+        "name": "type",
+        "type": [
+          {
+            "name": "StructureType",
+            "namespace": "Flow\\ETL\\PHP\\Type\\Logical",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "StructureEntry",
+        "namespace": "Flow\\ETL\\Row\\Entry",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "ENTRY"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 420,
+    "slug": "struct-type",
+    "name": "struct_type",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "elements",
+        "type": [
+          {
+            "name": "array",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "nullable",
+        "type": [
+          {
+            "name": "bool",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "StructureType",
+        "namespace": "Flow\\ETL\\PHP\\Type\\Logical",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "TYPE"
+        }
+      }
+    ],
+    "doc_comment": "LyoqCiAqIEBwYXJhbSBhcnJheTxTdHJ1Y3R1cmVFbGVtZW50PiAkZWxlbWVudHMKICov"
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 429,
+    "slug": "structure-type",
+    "name": "structure_type",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "elements",
+        "type": [
+          {
+            "name": "array",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "nullable",
+        "type": [
+          {
+            "name": "bool",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "StructureType",
+        "namespace": "Flow\\ETL\\PHP\\Type\\Logical",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "TYPE"
+        }
+      }
+    ],
+    "doc_comment": "LyoqCiAqIEBwYXJhbSBhcnJheTxTdHJ1Y3R1cmVFbGVtZW50PiAkZWxlbWVudHMKICov"
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 438,
+    "slug": "type-structure",
+    "name": "type_structure",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "elements",
+        "type": [
+          {
+            "name": "array",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "nullable",
+        "type": [
+          {
+            "name": "bool",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "StructureType",
+        "namespace": "Flow\\ETL\\PHP\\Type\\Logical",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "TYPE"
+        }
+      }
+    ],
+    "doc_comment": "LyoqCiAqIEBwYXJhbSBhcnJheTxTdHJ1Y3R1cmVFbGVtZW50PiAkZWxlbWVudHMKICov"
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 444,
+    "slug": "struct-element",
+    "name": "struct_element",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "name",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "type",
+        "type": [
+          {
+            "name": "Type",
+            "namespace": "Flow\\ETL\\PHP\\Type",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "StructureElement",
+        "namespace": "Flow\\ETL\\PHP\\Type\\Logical\\Structure",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "TYPE"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 450,
+    "slug": "structure-element",
+    "name": "structure_element",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "name",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "type",
+        "type": [
+          {
+            "name": "Type",
+            "namespace": "Flow\\ETL\\PHP\\Type",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "StructureElement",
+        "namespace": "Flow\\ETL\\PHP\\Type\\Logical\\Structure",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "TYPE"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 456,
+    "slug": "list-entry",
+    "name": "list_entry",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "name",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "value",
+        "type": [
+          {
+            "name": "array",
+            "namespace": null,
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": true,
+        "is_variadic": false
+      },
+      {
+        "name": "type",
+        "type": [
+          {
+            "name": "ListType",
+            "namespace": "Flow\\ETL\\PHP\\Type\\Logical",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "ListEntry",
+        "namespace": "Flow\\ETL\\Row\\Entry",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "ENTRY"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 462,
+    "slug": "type-list",
+    "name": "type_list",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "element",
+        "type": [
+          {
+            "name": "Type",
+            "namespace": "Flow\\ETL\\PHP\\Type",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "nullable",
+        "type": [
+          {
+            "name": "bool",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "ListType",
+        "namespace": "Flow\\ETL\\PHP\\Type\\Logical",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "TYPE"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 468,
+    "slug": "type-map",
+    "name": "type_map",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "key_type",
+        "type": [
+          {
+            "name": "ScalarType",
+            "namespace": "Flow\\ETL\\PHP\\Type\\Native",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "value_type",
+        "type": [
+          {
+            "name": "Type",
+            "namespace": "Flow\\ETL\\PHP\\Type",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "nullable",
+        "type": [
+          {
+            "name": "bool",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "MapType",
+        "namespace": "Flow\\ETL\\PHP\\Type\\Logical",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "TYPE"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 474,
+    "slug": "map-entry",
+    "name": "map_entry",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "name",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "value",
+        "type": [
+          {
+            "name": "array",
+            "namespace": null,
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": true,
+        "is_variadic": false
+      },
+      {
+        "name": "mapType",
+        "type": [
+          {
+            "name": "MapType",
+            "namespace": "Flow\\ETL\\PHP\\Type\\Logical",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "MapEntry",
+        "namespace": "Flow\\ETL\\Row\\Entry",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "ENTRY"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 480,
+    "slug": "type-json",
+    "name": "type_json",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "nullable",
+        "type": [
+          {
+            "name": "bool",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "JsonType",
+        "namespace": "Flow\\ETL\\PHP\\Type\\Logical",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "TYPE"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 486,
+    "slug": "type-datetime",
+    "name": "type_datetime",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "nullable",
+        "type": [
+          {
+            "name": "bool",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "DateTimeType",
+        "namespace": "Flow\\ETL\\PHP\\Type\\Logical",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "TYPE"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 492,
+    "slug": "type-xml",
+    "name": "type_xml",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "nullable",
+        "type": [
+          {
+            "name": "bool",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "XMLType",
+        "namespace": "Flow\\ETL\\PHP\\Type\\Logical",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "TYPE"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 498,
+    "slug": "type-xml-element",
+    "name": "type_xml_element",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "nullable",
+        "type": [
+          {
+            "name": "bool",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "XMLElementType",
+        "namespace": "Flow\\ETL\\PHP\\Type\\Logical",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "TYPE"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 504,
+    "slug": "type-uuid",
+    "name": "type_uuid",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "nullable",
+        "type": [
+          {
+            "name": "bool",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "UuidType",
+        "namespace": "Flow\\ETL\\PHP\\Type\\Logical",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "TYPE"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 510,
+    "slug": "type-int",
+    "name": "type_int",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "nullable",
+        "type": [
+          {
+            "name": "bool",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "ScalarType",
+        "namespace": "Flow\\ETL\\PHP\\Type\\Native",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "TYPE"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 516,
+    "slug": "type-integer",
+    "name": "type_integer",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "nullable",
+        "type": [
+          {
+            "name": "bool",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "ScalarType",
+        "namespace": "Flow\\ETL\\PHP\\Type\\Native",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "TYPE"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 522,
+    "slug": "type-string",
+    "name": "type_string",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "nullable",
+        "type": [
+          {
+            "name": "bool",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "ScalarType",
+        "namespace": "Flow\\ETL\\PHP\\Type\\Native",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "TYPE"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 528,
+    "slug": "type-float",
+    "name": "type_float",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "nullable",
+        "type": [
+          {
+            "name": "bool",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "ScalarType",
+        "namespace": "Flow\\ETL\\PHP\\Type\\Native",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "TYPE"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 534,
+    "slug": "type-boolean",
+    "name": "type_boolean",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "nullable",
+        "type": [
+          {
+            "name": "bool",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "ScalarType",
+        "namespace": "Flow\\ETL\\PHP\\Type\\Native",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "TYPE"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 543,
+    "slug": "type-object",
+    "name": "type_object",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "class",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "nullable",
+        "type": [
+          {
+            "name": "bool",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "ObjectType",
+        "namespace": "Flow\\ETL\\PHP\\Type\\Native",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "TYPE"
+        }
+      }
+    ],
+    "doc_comment": "LyoqCiAqIEBwYXJhbSBjbGFzcy1zdHJpbmcgJGNsYXNzCiAqLw=="
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 549,
+    "slug": "type-resource",
+    "name": "type_resource",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "nullable",
+        "type": [
+          {
+            "name": "bool",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "ResourceType",
+        "namespace": "Flow\\ETL\\PHP\\Type\\Native",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "TYPE"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 555,
+    "slug": "type-array",
+    "name": "type_array",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "empty",
+        "type": [
+          {
+            "name": "bool",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "nullable",
+        "type": [
+          {
+            "name": "bool",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "ArrayType",
+        "namespace": "Flow\\ETL\\PHP\\Type\\Native",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "TYPE"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 561,
+    "slug": "type-callable",
+    "name": "type_callable",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "nullable",
+        "type": [
+          {
+            "name": "bool",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "CallableType",
+        "namespace": "Flow\\ETL\\PHP\\Type\\Native",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "TYPE"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 567,
+    "slug": "type-null",
+    "name": "type_null",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [],
+    "return_type": [
+      {
+        "name": "NullType",
+        "namespace": "Flow\\ETL\\PHP\\Type\\Native",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "TYPE"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 576,
+    "slug": "type-enum",
+    "name": "type_enum",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "class",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "nullable",
+        "type": [
+          {
+            "name": "bool",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "EnumType",
+        "namespace": "Flow\\ETL\\PHP\\Type\\Native",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "TYPE"
+        }
+      }
+    ],
+    "doc_comment": "LyoqCiAqIEBwYXJhbSBjbGFzcy1zdHJpbmc8XFVuaXRFbnVtPiAkY2xhc3MKICov"
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 582,
+    "slug": "row",
+    "name": "row",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "entry",
+        "type": [
+          {
+            "name": "Entry",
+            "namespace": "Flow\\ETL\\Row",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": true
+      }
+    ],
+    "return_type": [
+      {
+        "name": "Row",
+        "namespace": "Flow\\ETL",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "DATA_FRAME"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 588,
+    "slug": "rows",
+    "name": "rows",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "row",
+        "type": [
+          {
+            "name": "Row",
+            "namespace": "Flow\\ETL",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": true
+      }
+    ],
+    "return_type": [
+      {
+        "name": "Rows",
+        "namespace": "Flow\\ETL",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "DATA_FRAME"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 594,
+    "slug": "rows-partitioned",
+    "name": "rows_partitioned",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "rows",
+        "type": [
+          {
+            "name": "array",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "partitions",
+        "type": [
+          {
+            "name": "Partitions",
+            "namespace": "Flow\\Filesystem",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "array",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "Rows",
+        "namespace": "Flow\\ETL",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "DATA_FRAME"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 603,
+    "slug": "col",
+    "name": "col",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "entry",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "EntryReference",
+        "namespace": "Flow\\ETL\\Row",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "DATA_FRAME"
+        }
+      }
+    ],
+    "doc_comment": "LyoqCiAqIEFuIGFsaWFzIGZvciBgcmVmYC4KICov"
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 612,
+    "slug": "entry",
+    "name": "entry",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "entry",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "EntryReference",
+        "namespace": "Flow\\ETL\\Row",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "SCALAR_FUNCTION"
+        }
+      }
+    ],
+    "doc_comment": "LyoqCiAqIEFuIGFsaWFzIGZvciBgcmVmYC4KICov"
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 618,
+    "slug": "ref",
+    "name": "ref",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "entry",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "EntryReference",
+        "namespace": "Flow\\ETL\\Row",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "SCALAR_FUNCTION"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 624,
+    "slug": "structure-ref",
+    "name": "structure_ref",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "entry",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "StructureFunctions",
+        "namespace": "Flow\\ETL\\Function",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "SCALAR_FUNCTION"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 630,
+    "slug": "list-ref",
+    "name": "list_ref",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "entry",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "ListFunctions",
+        "namespace": "Flow\\ETL\\Function",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "SCALAR_FUNCTION"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 636,
+    "slug": "refs",
+    "name": "refs",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "entries",
+        "type": [
+          {
+            "name": "Reference",
+            "namespace": "Flow\\ETL\\Row",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": true
+      }
+    ],
+    "return_type": [
+      {
+        "name": "References",
+        "namespace": "Flow\\ETL\\Row",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "SCALAR_FUNCTION"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 642,
+    "slug": "optional",
+    "name": "optional",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "function",
+        "type": [
+          {
+            "name": "ScalarFunction",
+            "namespace": "Flow\\ETL\\Function",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "Optional",
+        "namespace": "Flow\\ETL\\Function",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "SCALAR_FUNCTION"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 648,
+    "slug": "lit",
+    "name": "lit",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "value",
+        "type": [
+          {
+            "name": "mixed",
+            "namespace": null,
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": true,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "Literal",
+        "namespace": "Flow\\ETL\\Function",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "SCALAR_FUNCTION"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 654,
+    "slug": "exists",
+    "name": "exists",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "ref",
+        "type": [
+          {
+            "name": "ScalarFunction",
+            "namespace": "Flow\\ETL\\Function",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "Exists",
+        "namespace": "Flow\\ETL\\Function",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "SCALAR_FUNCTION"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 660,
+    "slug": "when",
+    "name": "when",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "condition",
+        "type": [
+          {
+            "name": "mixed",
+            "namespace": null,
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": true,
+        "is_variadic": false
+      },
+      {
+        "name": "then",
+        "type": [
+          {
+            "name": "mixed",
+            "namespace": null,
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": true,
+        "is_variadic": false
+      },
+      {
+        "name": "else",
+        "type": [
+          {
+            "name": "mixed",
+            "namespace": null,
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": true,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "When",
+        "namespace": "Flow\\ETL\\Function",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "SCALAR_FUNCTION"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 666,
+    "slug": "array-get",
+    "name": "array_get",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "ref",
+        "type": [
+          {
+            "name": "ScalarFunction",
+            "namespace": "Flow\\ETL\\Function",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "path",
+        "type": [
+          {
+            "name": "ScalarFunction",
+            "namespace": "Flow\\ETL\\Function",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "ArrayGet",
+        "namespace": "Flow\\ETL\\Function",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "SCALAR_FUNCTION"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 672,
+    "slug": "array-get-collection",
+    "name": "array_get_collection",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "ref",
+        "type": [
+          {
+            "name": "ScalarFunction",
+            "namespace": "Flow\\ETL\\Function",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "keys",
+        "type": [
+          {
+            "name": "ScalarFunction",
+            "namespace": "Flow\\ETL\\Function",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "array",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "ArrayGetCollection",
+        "namespace": "Flow\\ETL\\Function",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "SCALAR_FUNCTION"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 678,
+    "slug": "array-get-collection-first",
+    "name": "array_get_collection_first",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "ref",
+        "type": [
+          {
+            "name": "ScalarFunction",
+            "namespace": "Flow\\ETL\\Function",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "keys",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": true
+      }
+    ],
+    "return_type": [
+      {
+        "name": "ArrayGetCollection",
+        "namespace": "Flow\\ETL\\Function",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "SCALAR_FUNCTION"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 684,
+    "slug": "array-exists",
+    "name": "array_exists",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "ref",
+        "type": [
+          {
+            "name": "ScalarFunction",
+            "namespace": "Flow\\ETL\\Function",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "array",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "path",
+        "type": [
+          {
+            "name": "ScalarFunction",
+            "namespace": "Flow\\ETL\\Function",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "ArrayPathExists",
+        "namespace": "Flow\\ETL\\Function",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "SCALAR_FUNCTION"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 690,
+    "slug": "array-merge",
+    "name": "array_merge",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "left",
+        "type": [
+          {
+            "name": "ScalarFunction",
+            "namespace": "Flow\\ETL\\Function",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "array",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "right",
+        "type": [
+          {
+            "name": "ScalarFunction",
+            "namespace": "Flow\\ETL\\Function",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "array",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "ArrayMerge",
+        "namespace": "Flow\\ETL\\Function",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "SCALAR_FUNCTION"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 696,
+    "slug": "array-merge-collection",
+    "name": "array_merge_collection",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "array",
+        "type": [
+          {
+            "name": "ScalarFunction",
+            "namespace": "Flow\\ETL\\Function",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "array",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "ArrayMergeCollection",
+        "namespace": "Flow\\ETL\\Function",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "SCALAR_FUNCTION"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 702,
+    "slug": "array-key-rename",
+    "name": "array_key_rename",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "ref",
+        "type": [
+          {
+            "name": "ScalarFunction",
+            "namespace": "Flow\\ETL\\Function",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "path",
+        "type": [
+          {
+            "name": "ScalarFunction",
+            "namespace": "Flow\\ETL\\Function",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "newName",
+        "type": [
+          {
+            "name": "ScalarFunction",
+            "namespace": "Flow\\ETL\\Function",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "ArrayKeyRename",
+        "namespace": "Flow\\ETL\\Function",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "SCALAR_FUNCTION"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 708,
+    "slug": "array-keys-style-convert",
+    "name": "array_keys_style_convert",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "ref",
+        "type": [
+          {
+            "name": "ScalarFunction",
+            "namespace": "Flow\\ETL\\Function",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "style",
+        "type": [
+          {
+            "name": "StringStyles",
+            "namespace": "Flow\\ETL\\Function\\StyleConverter",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "ArrayKeysStyleConvert",
+        "namespace": "Flow\\ETL\\Function",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "SCALAR_FUNCTION"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 714,
+    "slug": "array-sort",
+    "name": "array_sort",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "function",
+        "type": [
+          {
+            "name": "ScalarFunction",
+            "namespace": "Flow\\ETL\\Function",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "sort_function",
+        "type": [
+          {
+            "name": "ScalarFunction",
+            "namespace": "Flow\\ETL\\Function",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "Sort",
+            "namespace": "Flow\\ETL\\Function\\ArraySort",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "null",
+            "namespace": null,
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": true,
+        "is_variadic": false
+      },
+      {
+        "name": "flags",
+        "type": [
+          {
+            "name": "ScalarFunction",
+            "namespace": "Flow\\ETL\\Function",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "int",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "null",
+            "namespace": null,
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": true,
+        "is_variadic": false
+      },
+      {
+        "name": "recursive",
+        "type": [
+          {
+            "name": "ScalarFunction",
+            "namespace": "Flow\\ETL\\Function",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "bool",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "ArraySort",
+        "namespace": "Flow\\ETL\\Function",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "SCALAR_FUNCTION"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 724,
+    "slug": "array-reverse",
+    "name": "array_reverse",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "function",
+        "type": [
+          {
+            "name": "ScalarFunction",
+            "namespace": "Flow\\ETL\\Function",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "array",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "preserveKeys",
+        "type": [
+          {
+            "name": "ScalarFunction",
+            "namespace": "Flow\\ETL\\Function",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "bool",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "ArrayReverse",
+        "namespace": "Flow\\ETL\\Function",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "SCALAR_FUNCTION"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 730,
+    "slug": "now",
+    "name": "now",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "time_zone",
+        "type": [
+          {
+            "name": "DateTimeZone",
+            "namespace": "",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "ScalarFunction",
+            "namespace": "Flow\\ETL\\Function",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "Now",
+        "namespace": "Flow\\ETL\\Function",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "SCALAR_FUNCTION"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 736,
+    "slug": "between",
+    "name": "between",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "value",
+        "type": [
+          {
+            "name": "mixed",
+            "namespace": null,
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": true,
+        "is_variadic": false
+      },
+      {
+        "name": "lower_bound",
+        "type": [
+          {
+            "name": "mixed",
+            "namespace": null,
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": true,
+        "is_variadic": false
+      },
+      {
+        "name": "upper_bound",
+        "type": [
+          {
+            "name": "mixed",
+            "namespace": null,
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": true,
+        "is_variadic": false
+      },
+      {
+        "name": "boundary",
+        "type": [
+          {
+            "name": "ScalarFunction",
+            "namespace": "Flow\\ETL\\Function",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "Boundary",
+            "namespace": "Flow\\ETL\\Function\\Between",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "Between",
+        "namespace": "Flow\\ETL\\Function",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "SCALAR_FUNCTION"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 742,
+    "slug": "to-date-time",
+    "name": "to_date_time",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "ref",
+        "type": [
+          {
+            "name": "mixed",
+            "namespace": null,
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": true,
+        "is_variadic": false
+      },
+      {
+        "name": "format",
+        "type": [
+          {
+            "name": "ScalarFunction",
+            "namespace": "Flow\\ETL\\Function",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "timeZone",
+        "type": [
+          {
+            "name": "ScalarFunction",
+            "namespace": "Flow\\ETL\\Function",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "DateTimeZone",
+            "namespace": "",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "ToDateTime",
+        "namespace": "Flow\\ETL\\Function",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "SCALAR_FUNCTION"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 748,
+    "slug": "to-date",
+    "name": "to_date",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "ref",
+        "type": [
+          {
+            "name": "mixed",
+            "namespace": null,
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": true,
+        "is_variadic": false
+      },
+      {
+        "name": "format",
+        "type": [
+          {
+            "name": "ScalarFunction",
+            "namespace": "Flow\\ETL\\Function",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "timeZone",
+        "type": [
+          {
+            "name": "ScalarFunction",
+            "namespace": "Flow\\ETL\\Function",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "DateTimeZone",
+            "namespace": "",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "ToDate",
+        "namespace": "Flow\\ETL\\Function",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "SCALAR_FUNCTION"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 754,
+    "slug": "date-time-format",
+    "name": "date_time_format",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "ref",
+        "type": [
+          {
+            "name": "ScalarFunction",
+            "namespace": "Flow\\ETL\\Function",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "format",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "DateTimeFormat",
+        "namespace": "Flow\\ETL\\Function",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "SCALAR_FUNCTION"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 760,
+    "slug": "split",
+    "name": "split",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "value",
+        "type": [
+          {
+            "name": "ScalarFunction",
+            "namespace": "Flow\\ETL\\Function",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "separator",
+        "type": [
+          {
+            "name": "ScalarFunction",
+            "namespace": "Flow\\ETL\\Function",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "limit",
+        "type": [
+          {
+            "name": "ScalarFunction",
+            "namespace": "Flow\\ETL\\Function",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "int",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "Split",
+        "namespace": "Flow\\ETL\\Function",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "SCALAR_FUNCTION"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 766,
+    "slug": "combine",
+    "name": "combine",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "keys",
+        "type": [
+          {
+            "name": "ScalarFunction",
+            "namespace": "Flow\\ETL\\Function",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "array",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "values",
+        "type": [
+          {
+            "name": "ScalarFunction",
+            "namespace": "Flow\\ETL\\Function",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "array",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "Combine",
+        "namespace": "Flow\\ETL\\Function",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "SCALAR_FUNCTION"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 772,
+    "slug": "concat",
+    "name": "concat",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "functions",
+        "type": [
+          {
+            "name": "ScalarFunction",
+            "namespace": "Flow\\ETL\\Function",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": true
+      }
+    ],
+    "return_type": [
+      {
+        "name": "Concat",
+        "namespace": "Flow\\ETL\\Function",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "SCALAR_FUNCTION"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 778,
+    "slug": "hash",
+    "name": "hash",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "value",
+        "type": [
+          {
+            "name": "mixed",
+            "namespace": null,
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": true,
+        "is_variadic": false
+      },
+      {
+        "name": "algorithm",
+        "type": [
+          {
+            "name": "Algorithm",
+            "namespace": "Flow\\ETL\\Hash",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "Hash",
+        "namespace": "Flow\\ETL\\Function",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "SCALAR_FUNCTION"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 784,
+    "slug": "cast",
+    "name": "cast",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "value",
+        "type": [
+          {
+            "name": "mixed",
+            "namespace": null,
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": true,
+        "is_variadic": false
+      },
+      {
+        "name": "type",
+        "type": [
+          {
+            "name": "ScalarFunction",
+            "namespace": "Flow\\ETL\\Function",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "Type",
+            "namespace": "Flow\\ETL\\PHP\\Type",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "Cast",
+        "namespace": "Flow\\ETL\\Function",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "SCALAR_FUNCTION"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 790,
+    "slug": "count",
+    "name": "count",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "function",
+        "type": [
+          {
+            "name": "Reference",
+            "namespace": "Flow\\ETL\\Row",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "Count",
+        "namespace": "Flow\\ETL\\Function",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "AGGREGATING_FUNCTION"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 815,
+    "slug": "array-unpack",
+    "name": "array_unpack",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "array",
+        "type": [
+          {
+            "name": "ScalarFunction",
+            "namespace": "Flow\\ETL\\Function",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "array",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "skip_keys",
+        "type": [
+          {
+            "name": "ScalarFunction",
+            "namespace": "Flow\\ETL\\Function",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "array",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "entry_prefix",
+        "type": [
+          {
+            "name": "ScalarFunction",
+            "namespace": "Flow\\ETL\\Function",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "null",
+            "namespace": null,
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": true,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "ArrayUnpack",
+        "namespace": "Flow\\ETL\\Function",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "SCALAR_FUNCTION"
+        }
+      }
+    ],
+    "doc_comment": "LyoqCiAqIFVucGFja3MgZWFjaCBlbGVtZW50IG9mIGFuIGFycmF5IGludG8gYSBuZXcgZW50cnksIHVzaW5nIHRoZSBhcnJheSBrZXkgYXMgdGhlIGVudHJ5IG5hbWUuCiAqCiAqIEJlZm9yZToKICogKy0tKy0tLS0tLS0tLS0tLS0tLS0tLS0rCiAqIHxpZHwgICAgICAgICAgICAgIGFycmF5fAogKiArLS0rLS0tLS0tLS0tLS0tLS0tLS0tLSsKICogfCAxfHsiYSI6MSwiYiI6MiwiYyI6M318CiAqIHwgMnx7ImQiOjQsImUiOjUsImYiOjZ9fAogKiArLS0rLS0tLS0tLS0tLS0tLS0tLS0tLSsKICoKICogQWZ0ZXI6CiAqICstLSstLS0tLSstLS0tLSstLS0tLSstLS0tLSstLS0tLSsKICogfGlkfGFyci5ifGFyci5jfGFyci5kfGFyci5lfGFyci5mfAogKiArLS0rLS0tLS0rLS0tLS0rLS0tLS0rLS0tLS0rLS0tLS0rCiAqIHwgMXwgICAgMnwgICAgM3wgICAgIHwgICAgIHwgICAgIHwKICogfCAyfCAgICAgfCAgICAgfCAgICA0fCAgICA1fCAgICA2fAogKiArLS0rLS0tLS0rLS0tLS0rLS0tLS0rLS0tLS0rLS0tLS0rCiAqLw=="
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 841,
+    "slug": "array-expand",
+    "name": "array_expand",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "function",
+        "type": [
+          {
+            "name": "ScalarFunction",
+            "namespace": "Flow\\ETL\\Function",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "expand",
+        "type": [
+          {
+            "name": "ArrayExpand",
+            "namespace": "Flow\\ETL\\Function\\ArrayExpand",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "ArrayExpand",
+        "namespace": "Flow\\ETL\\Function",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "SCALAR_FUNCTION"
+        }
+      }
+    ],
+    "doc_comment": "LyoqCiAqIEV4cGFuZHMgZWFjaCB2YWx1ZSBpbnRvIGVudHJ5LCBpZiB0aGVyZSBhcmUgbW9yZSB0aGFuIG9uZSB2YWx1ZSwgbXVsdGlwbGUgcm93cyB3aWxsIGJlIGNyZWF0ZWQuCiAqIEFycmF5IGtleXMgYXJlIGlnbm9yZWQsIG9ubHkgdmFsdWVzIGFyZSB1c2VkIHRvIGNyZWF0ZSBuZXcgcm93cy4KICoKICogQmVmb3JlOgogKiAgICstLSstLS0tLS0tLS0tLS0tLS0tLS0tKwogKiAgIHxpZHwgICAgICAgICAgICAgIGFycmF5fAogKiAgICstLSstLS0tLS0tLS0tLS0tLS0tLS0tKwogKiAgIHwgMXx7ImEiOjEsImIiOjIsImMiOjN9fAogKiAgICstLSstLS0tLS0tLS0tLS0tLS0tLS0tKwogKgogKiBBZnRlcjoKICogICArLS0rLS0tLS0tLS0rCiAqICAgfGlkfGV4cGFuZGVkfAogKiAgICstLSstLS0tLS0tLSsKICogICB8IDF8ICAgICAgIDF8CiAqICAgfCAxfCAgICAgICAyfAogKiAgIHwgMXwgICAgICAgM3wKICogICArLS0rLS0tLS0tLS0rCiAqLw=="
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 847,
+    "slug": "size",
+    "name": "size",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "value",
+        "type": [
+          {
+            "name": "mixed",
+            "namespace": null,
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": true,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "Size",
+        "namespace": "Flow\\ETL\\Function",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "SCALAR_FUNCTION"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 853,
+    "slug": "uuid-v4",
+    "name": "uuid_v4",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [],
+    "return_type": [
+      {
+        "name": "Uuid",
+        "namespace": "Flow\\ETL\\Function",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "SCALAR_FUNCTION"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 859,
+    "slug": "uuid-v7",
+    "name": "uuid_v7",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "value",
+        "type": [
+          {
+            "name": "ScalarFunction",
+            "namespace": "Flow\\ETL\\Function",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "DateTimeInterface",
+            "namespace": "",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "null",
+            "namespace": null,
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": true,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "Uuid",
+        "namespace": "Flow\\ETL\\Function",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "SCALAR_FUNCTION"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 865,
+    "slug": "ulid",
+    "name": "ulid",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "value",
+        "type": [
+          {
+            "name": "ScalarFunction",
+            "namespace": "Flow\\ETL\\Function",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "null",
+            "namespace": null,
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": true,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "Ulid",
+        "namespace": "Flow\\ETL\\Function",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "SCALAR_FUNCTION"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 871,
+    "slug": "lower",
+    "name": "lower",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "value",
+        "type": [
+          {
+            "name": "ScalarFunction",
+            "namespace": "Flow\\ETL\\Function",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "ToLower",
+        "namespace": "Flow\\ETL\\Function",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "SCALAR_FUNCTION"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 877,
+    "slug": "capitalize",
+    "name": "capitalize",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "value",
+        "type": [
+          {
+            "name": "ScalarFunction",
+            "namespace": "Flow\\ETL\\Function",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "Capitalize",
+        "namespace": "Flow\\ETL\\Function",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "SCALAR_FUNCTION"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 883,
+    "slug": "upper",
+    "name": "upper",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "value",
+        "type": [
+          {
+            "name": "ScalarFunction",
+            "namespace": "Flow\\ETL\\Function",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "ToUpper",
+        "namespace": "Flow\\ETL\\Function",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "SCALAR_FUNCTION"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 892,
+    "slug": "call-method",
+    "name": "call_method",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "object",
+        "type": [
+          {
+            "name": "object",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "method",
+        "type": [
+          {
+            "name": "ScalarFunction",
+            "namespace": "Flow\\ETL\\Function",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "params",
+        "type": [
+          {
+            "name": "array",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "CallMethod",
+        "namespace": "Flow\\ETL\\Function",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "SCALAR_FUNCTION"
+        }
+      }
+    ],
+    "doc_comment": "LyoqCiAqIEBwYXJhbSBhcnJheTxtaXhlZD4gJHBhcmFtcwogKi8="
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 898,
+    "slug": "all",
+    "name": "all",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "functions",
+        "type": [
+          {
+            "name": "ScalarFunction",
+            "namespace": "Flow\\ETL\\Function",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": true
+      }
+    ],
+    "return_type": [
+      {
+        "name": "All",
+        "namespace": "Flow\\ETL\\Function",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "SCALAR_FUNCTION"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 904,
+    "slug": "any",
+    "name": "any",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "values",
+        "type": [
+          {
+            "name": "ScalarFunction",
+            "namespace": "Flow\\ETL\\Function",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": true
+      }
+    ],
+    "return_type": [
+      {
+        "name": "Any",
+        "namespace": "Flow\\ETL\\Function",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "SCALAR_FUNCTION"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 910,
+    "slug": "not",
+    "name": "not",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "value",
+        "type": [
+          {
+            "name": "ScalarFunction",
+            "namespace": "Flow\\ETL\\Function",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "Not",
+        "namespace": "Flow\\ETL\\Function",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "SCALAR_FUNCTION"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 916,
+    "slug": "to-timezone",
+    "name": "to_timezone",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "value",
+        "type": [
+          {
+            "name": "ScalarFunction",
+            "namespace": "Flow\\ETL\\Function",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "DateTimeInterface",
+            "namespace": "",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "timeZone",
+        "type": [
+          {
+            "name": "ScalarFunction",
+            "namespace": "Flow\\ETL\\Function",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "DateTimeZone",
+            "namespace": "",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "ToTimeZone",
+        "namespace": "Flow\\ETL\\Function",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "SCALAR_FUNCTION"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 922,
+    "slug": "ignore-error-handler",
+    "name": "ignore_error_handler",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [],
+    "return_type": [
+      {
+        "name": "IgnoreError",
+        "namespace": "Flow\\ETL\\ErrorHandler",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "DATA_FRAME"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 928,
+    "slug": "skip-rows-handler",
+    "name": "skip_rows_handler",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [],
+    "return_type": [
+      {
+        "name": "SkipRows",
+        "namespace": "Flow\\ETL\\ErrorHandler",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "DATA_FRAME"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 934,
+    "slug": "throw-error-handler",
+    "name": "throw_error_handler",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [],
+    "return_type": [
+      {
+        "name": "ThrowError",
+        "namespace": "Flow\\ETL\\ErrorHandler",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "DATA_FRAME"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 940,
+    "slug": "regex-replace",
+    "name": "regex_replace",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "pattern",
+        "type": [
+          {
+            "name": "ScalarFunction",
+            "namespace": "Flow\\ETL\\Function",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "replacement",
+        "type": [
+          {
+            "name": "ScalarFunction",
+            "namespace": "Flow\\ETL\\Function",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "subject",
+        "type": [
+          {
+            "name": "ScalarFunction",
+            "namespace": "Flow\\ETL\\Function",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "limit",
+        "type": [
+          {
+            "name": "ScalarFunction",
+            "namespace": "Flow\\ETL\\Function",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "int",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "null",
+            "namespace": null,
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": true,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "RegexReplace",
+        "namespace": "Flow\\ETL\\Function",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "SCALAR_FUNCTION"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 946,
+    "slug": "regex-match-all",
+    "name": "regex_match_all",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "pattern",
+        "type": [
+          {
+            "name": "ScalarFunction",
+            "namespace": "Flow\\ETL\\Function",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "subject",
+        "type": [
+          {
+            "name": "ScalarFunction",
+            "namespace": "Flow\\ETL\\Function",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "flags",
+        "type": [
+          {
+            "name": "ScalarFunction",
+            "namespace": "Flow\\ETL\\Function",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "int",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "offset",
+        "type": [
+          {
+            "name": "ScalarFunction",
+            "namespace": "Flow\\ETL\\Function",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "int",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "RegexMatchAll",
+        "namespace": "Flow\\ETL\\Function",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "SCALAR_FUNCTION"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 952,
+    "slug": "regex-match",
+    "name": "regex_match",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "pattern",
+        "type": [
+          {
+            "name": "ScalarFunction",
+            "namespace": "Flow\\ETL\\Function",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "subject",
+        "type": [
+          {
+            "name": "ScalarFunction",
+            "namespace": "Flow\\ETL\\Function",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "flags",
+        "type": [
+          {
+            "name": "ScalarFunction",
+            "namespace": "Flow\\ETL\\Function",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "int",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "offset",
+        "type": [
+          {
+            "name": "ScalarFunction",
+            "namespace": "Flow\\ETL\\Function",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "int",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "RegexMatch",
+        "namespace": "Flow\\ETL\\Function",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "SCALAR_FUNCTION"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 958,
+    "slug": "regex",
+    "name": "regex",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "pattern",
+        "type": [
+          {
+            "name": "ScalarFunction",
+            "namespace": "Flow\\ETL\\Function",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "subject",
+        "type": [
+          {
+            "name": "ScalarFunction",
+            "namespace": "Flow\\ETL\\Function",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "flags",
+        "type": [
+          {
+            "name": "ScalarFunction",
+            "namespace": "Flow\\ETL\\Function",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "int",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "offset",
+        "type": [
+          {
+            "name": "ScalarFunction",
+            "namespace": "Flow\\ETL\\Function",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "int",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "Regex",
+        "namespace": "Flow\\ETL\\Function",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "SCALAR_FUNCTION"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 964,
+    "slug": "regex-all",
+    "name": "regex_all",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "pattern",
+        "type": [
+          {
+            "name": "ScalarFunction",
+            "namespace": "Flow\\ETL\\Function",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "subject",
+        "type": [
+          {
+            "name": "ScalarFunction",
+            "namespace": "Flow\\ETL\\Function",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "flags",
+        "type": [
+          {
+            "name": "ScalarFunction",
+            "namespace": "Flow\\ETL\\Function",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "int",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "offset",
+        "type": [
+          {
+            "name": "ScalarFunction",
+            "namespace": "Flow\\ETL\\Function",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "int",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "RegexAll",
+        "namespace": "Flow\\ETL\\Function",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "SCALAR_FUNCTION"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 970,
+    "slug": "sprintf",
+    "name": "sprintf",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "format",
+        "type": [
+          {
+            "name": "ScalarFunction",
+            "namespace": "Flow\\ETL\\Function",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "args",
+        "type": [
+          {
+            "name": "ScalarFunction",
+            "namespace": "Flow\\ETL\\Function",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "int",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "float",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "null",
+            "namespace": null,
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": true,
+        "is_variadic": true
+      }
+    ],
+    "return_type": [
+      {
+        "name": "Sprintf",
+        "namespace": "Flow\\ETL\\Function",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "SCALAR_FUNCTION"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 976,
+    "slug": "sanitize",
+    "name": "sanitize",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "value",
+        "type": [
+          {
+            "name": "ScalarFunction",
+            "namespace": "Flow\\ETL\\Function",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "placeholder",
+        "type": [
+          {
+            "name": "ScalarFunction",
+            "namespace": "Flow\\ETL\\Function",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "skipCharacters",
+        "type": [
+          {
+            "name": "ScalarFunction",
+            "namespace": "Flow\\ETL\\Function",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "int",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "null",
+            "namespace": null,
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": true,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "Sanitize",
+        "namespace": "Flow\\ETL\\Function",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "SCALAR_FUNCTION"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 982,
+    "slug": "round",
+    "name": "round",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "value",
+        "type": [
+          {
+            "name": "ScalarFunction",
+            "namespace": "Flow\\ETL\\Function",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "int",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "float",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "precision",
+        "type": [
+          {
+            "name": "ScalarFunction",
+            "namespace": "Flow\\ETL\\Function",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "int",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "mode",
+        "type": [
+          {
+            "name": "ScalarFunction",
+            "namespace": "Flow\\ETL\\Function",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "int",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "Round",
+        "namespace": "Flow\\ETL\\Function",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "SCALAR_FUNCTION"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 988,
+    "slug": "number-format",
+    "name": "number_format",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "value",
+        "type": [
+          {
+            "name": "ScalarFunction",
+            "namespace": "Flow\\ETL\\Function",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "int",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "float",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "decimals",
+        "type": [
+          {
+            "name": "ScalarFunction",
+            "namespace": "Flow\\ETL\\Function",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "int",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "decimal_separator",
+        "type": [
+          {
+            "name": "ScalarFunction",
+            "namespace": "Flow\\ETL\\Function",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "thousands_separator",
+        "type": [
+          {
+            "name": "ScalarFunction",
+            "namespace": "Flow\\ETL\\Function",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "NumberFormat",
+        "namespace": "Flow\\ETL\\Function",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "SCALAR_FUNCTION"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 998,
+    "slug": "array-to-row",
+    "name": "array_to_row",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "data",
+        "type": [
+          {
+            "name": "array",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "entryFactory",
+        "type": [
+          {
+            "name": "EntryFactory",
+            "namespace": "Flow\\ETL\\Row",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "partitions",
+        "type": [
+          {
+            "name": "Partitions",
+            "namespace": "Flow\\Filesystem",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "array",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "schema",
+        "type": [
+          {
+            "name": "Schema",
+            "namespace": "Flow\\ETL\\Row",
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": true,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "Row",
+        "namespace": "Flow\\ETL",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "DATA_FRAME"
+        }
+      }
+    ],
+    "doc_comment": "LyoqCiAqIEBwYXJhbSBhcnJheTxhcnJheTxtaXhlZD4+fGFycmF5PG1peGVkfHN0cmluZz4gJGRhdGEKICogQHBhcmFtIGFycmF5PFBhcnRpdGlvbj58UGFydGl0aW9ucyAkcGFydGl0aW9ucwogKi8="
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 1048,
+    "slug": "array-to-rows",
+    "name": "array_to_rows",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "data",
+        "type": [
+          {
+            "name": "array",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "entryFactory",
+        "type": [
+          {
+            "name": "EntryFactory",
+            "namespace": "Flow\\ETL\\Row",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "partitions",
+        "type": [
+          {
+            "name": "Partitions",
+            "namespace": "Flow\\Filesystem",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "array",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "schema",
+        "type": [
+          {
+            "name": "Schema",
+            "namespace": "Flow\\ETL\\Row",
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": true,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "Rows",
+        "namespace": "Flow\\ETL",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "DATA_FRAME"
+        }
+      }
+    ],
+    "doc_comment": "LyoqCiAqIEBwYXJhbSBhcnJheTxhcnJheTxtaXhlZD4+fGFycmF5PG1peGVkfHN0cmluZz4gJGRhdGEKICogQHBhcmFtIGFycmF5PFBhcnRpdGlvbj58UGFydGl0aW9ucyAkcGFydGl0aW9ucwogKi8="
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 1076,
+    "slug": "rank",
+    "name": "rank",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [],
+    "return_type": [
+      {
+        "name": "Rank",
+        "namespace": "Flow\\ETL\\Function",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "WINDOW_FUNCTION"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 1082,
+    "slug": "dens-rank",
+    "name": "dens_rank",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [],
+    "return_type": [
+      {
+        "name": "DenseRank",
+        "namespace": "Flow\\ETL\\Function",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "WINDOW_FUNCTION"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 1088,
+    "slug": "dense-rank",
+    "name": "dense_rank",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [],
+    "return_type": [
+      {
+        "name": "DenseRank",
+        "namespace": "Flow\\ETL\\Function",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "WINDOW_FUNCTION"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 1094,
+    "slug": "average",
+    "name": "average",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "ref",
+        "type": [
+          {
+            "name": "Reference",
+            "namespace": "Flow\\ETL\\Row",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "Average",
+        "namespace": "Flow\\ETL\\Function",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "AGGREGATING_FUNCTION"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 1100,
+    "slug": "collect",
+    "name": "collect",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "ref",
+        "type": [
+          {
+            "name": "Reference",
+            "namespace": "Flow\\ETL\\Row",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "Collect",
+        "namespace": "Flow\\ETL\\Function",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "AGGREGATING_FUNCTION"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 1106,
+    "slug": "collect-unique",
+    "name": "collect_unique",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "ref",
+        "type": [
+          {
+            "name": "Reference",
+            "namespace": "Flow\\ETL\\Row",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "CollectUnique",
+        "namespace": "Flow\\ETL\\Function",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "AGGREGATING_FUNCTION"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 1112,
+    "slug": "window",
+    "name": "window",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [],
+    "return_type": [
+      {
+        "name": "Window",
+        "namespace": "Flow\\ETL",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "DATA_FRAME"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 1118,
+    "slug": "sum",
+    "name": "sum",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "ref",
+        "type": [
+          {
+            "name": "Reference",
+            "namespace": "Flow\\ETL\\Row",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "Sum",
+        "namespace": "Flow\\ETL\\Function",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "AGGREGATING_FUNCTION"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 1124,
+    "slug": "first",
+    "name": "first",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "ref",
+        "type": [
+          {
+            "name": "Reference",
+            "namespace": "Flow\\ETL\\Row",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "First",
+        "namespace": "Flow\\ETL\\Function",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "AGGREGATING_FUNCTION"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 1130,
+    "slug": "last",
+    "name": "last",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "ref",
+        "type": [
+          {
+            "name": "Reference",
+            "namespace": "Flow\\ETL\\Row",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "Last",
+        "namespace": "Flow\\ETL\\Function",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "AGGREGATING_FUNCTION"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 1136,
+    "slug": "max",
+    "name": "max",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "ref",
+        "type": [
+          {
+            "name": "Reference",
+            "namespace": "Flow\\ETL\\Row",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "Max",
+        "namespace": "Flow\\ETL\\Function",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "AGGREGATING_FUNCTION"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 1142,
+    "slug": "min",
+    "name": "min",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "ref",
+        "type": [
+          {
+            "name": "Reference",
+            "namespace": "Flow\\ETL\\Row",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "Min",
+        "namespace": "Flow\\ETL\\Function",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "AGGREGATING_FUNCTION"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 1148,
+    "slug": "row-number",
+    "name": "row_number",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [],
+    "return_type": [
+      {
+        "name": "RowNumber",
+        "namespace": "Flow\\ETL\\Function",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "DATA_FRAME"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 1154,
+    "slug": "schema",
+    "name": "schema",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "definitions",
+        "type": [
+          {
+            "name": "Definition",
+            "namespace": "Flow\\ETL\\Row\\Schema",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": true
+      }
+    ],
+    "return_type": [
+      {
+        "name": "Schema",
+        "namespace": "Flow\\ETL\\Row",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "SCHEMA"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 1160,
+    "slug": "schema-to-json",
+    "name": "schema_to_json",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "schema",
+        "type": [
+          {
+            "name": "Schema",
+            "namespace": "Flow\\ETL\\Row",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "string",
+        "namespace": null,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "SCHEMA"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 1166,
+    "slug": "schema-from-json",
+    "name": "schema_from_json",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "schema",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "Schema",
+        "namespace": "Flow\\ETL\\Row",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "SCHEMA"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 1172,
+    "slug": "schema-strict-matcher",
+    "name": "schema_strict_matcher",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [],
+    "return_type": [
+      {
+        "name": "StrictSchemaMatcher",
+        "namespace": "Flow\\ETL\\Row\\Schema\\Matcher",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "SCHEMA"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 1178,
+    "slug": "schema-evolving-matcher",
+    "name": "schema_evolving_matcher",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [],
+    "return_type": [
+      {
+        "name": "EvolvingSchemaMatcher",
+        "namespace": "Flow\\ETL\\Row\\Schema\\Matcher",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "SCHEMA"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 1184,
+    "slug": "int-schema",
+    "name": "int_schema",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "name",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "nullable",
+        "type": [
+          {
+            "name": "bool",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "metadata",
+        "type": [
+          {
+            "name": "Metadata",
+            "namespace": "Flow\\ETL\\Row\\Schema",
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": true,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "Definition",
+        "namespace": "Flow\\ETL\\Row\\Schema",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "SCHEMA"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 1190,
+    "slug": "str-schema",
+    "name": "str_schema",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "name",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "nullable",
+        "type": [
+          {
+            "name": "bool",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "metadata",
+        "type": [
+          {
+            "name": "Metadata",
+            "namespace": "Flow\\ETL\\Row\\Schema",
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": true,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "Definition",
+        "namespace": "Flow\\ETL\\Row\\Schema",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "SCHEMA"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 1196,
+    "slug": "bool-schema",
+    "name": "bool_schema",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "name",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "nullable",
+        "type": [
+          {
+            "name": "bool",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "metadata",
+        "type": [
+          {
+            "name": "Metadata",
+            "namespace": "Flow\\ETL\\Row\\Schema",
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": true,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "Definition",
+        "namespace": "Flow\\ETL\\Row\\Schema",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "SCHEMA"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 1202,
+    "slug": "float-schema",
+    "name": "float_schema",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "name",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "nullable",
+        "type": [
+          {
+            "name": "bool",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "metadata",
+        "type": [
+          {
+            "name": "Metadata",
+            "namespace": "Flow\\ETL\\Row\\Schema",
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": true,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "Definition",
+        "namespace": "Flow\\ETL\\Row\\Schema",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "SCHEMA"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 1208,
+    "slug": "array-schema",
+    "name": "array_schema",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "name",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "empty",
+        "type": [
+          {
+            "name": "bool",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "nullable",
+        "type": [
+          {
+            "name": "bool",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "metadata",
+        "type": [
+          {
+            "name": "Metadata",
+            "namespace": "Flow\\ETL\\Row\\Schema",
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": true,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "Definition",
+        "namespace": "Flow\\ETL\\Row\\Schema",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "SCHEMA"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 1214,
+    "slug": "object-schema",
+    "name": "object_schema",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "name",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "type",
+        "type": [
+          {
+            "name": "ObjectType",
+            "namespace": "Flow\\ETL\\PHP\\Type\\Native",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "metadata",
+        "type": [
+          {
+            "name": "Metadata",
+            "namespace": "Flow\\ETL\\Row\\Schema",
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": true,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "Definition",
+        "namespace": "Flow\\ETL\\Row\\Schema",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "SCHEMA"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 1220,
+    "slug": "map-schema",
+    "name": "map_schema",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "name",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "type",
+        "type": [
+          {
+            "name": "MapType",
+            "namespace": "Flow\\ETL\\PHP\\Type\\Logical",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "metadata",
+        "type": [
+          {
+            "name": "Metadata",
+            "namespace": "Flow\\ETL\\Row\\Schema",
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": true,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "Definition",
+        "namespace": "Flow\\ETL\\Row\\Schema",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "SCHEMA"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 1226,
+    "slug": "list-schema",
+    "name": "list_schema",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "name",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "type",
+        "type": [
+          {
+            "name": "ListType",
+            "namespace": "Flow\\ETL\\PHP\\Type\\Logical",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "metadata",
+        "type": [
+          {
+            "name": "Metadata",
+            "namespace": "Flow\\ETL\\Row\\Schema",
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": true,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "Definition",
+        "namespace": "Flow\\ETL\\Row\\Schema",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "SCHEMA"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 1235,
+    "slug": "enum-schema",
+    "name": "enum_schema",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "name",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "type",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "nullable",
+        "type": [
+          {
+            "name": "bool",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "metadata",
+        "type": [
+          {
+            "name": "Metadata",
+            "namespace": "Flow\\ETL\\Row\\Schema",
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": true,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "Definition",
+        "namespace": "Flow\\ETL\\Row\\Schema",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "SCHEMA"
+        }
+      }
+    ],
+    "doc_comment": "LyoqCiAqIEBwYXJhbSBjbGFzcy1zdHJpbmc8XFVuaXRFbnVtPiAkdHlwZQogKi8="
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 1241,
+    "slug": "null-schema",
+    "name": "null_schema",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "name",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "metadata",
+        "type": [
+          {
+            "name": "Metadata",
+            "namespace": "Flow\\ETL\\Row\\Schema",
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": true,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "Definition",
+        "namespace": "Flow\\ETL\\Row\\Schema",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "SCHEMA"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 1247,
+    "slug": "datetime-schema",
+    "name": "datetime_schema",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "name",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "nullable",
+        "type": [
+          {
+            "name": "bool",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "metadata",
+        "type": [
+          {
+            "name": "Metadata",
+            "namespace": "Flow\\ETL\\Row\\Schema",
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": true,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "Definition",
+        "namespace": "Flow\\ETL\\Row\\Schema",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "SCHEMA"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 1253,
+    "slug": "json-schema",
+    "name": "json_schema",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "name",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "nullable",
+        "type": [
+          {
+            "name": "bool",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "metadata",
+        "type": [
+          {
+            "name": "Metadata",
+            "namespace": "Flow\\ETL\\Row\\Schema",
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": true,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "Definition",
+        "namespace": "Flow\\ETL\\Row\\Schema",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "SCHEMA"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 1259,
+    "slug": "xml-schema",
+    "name": "xml_schema",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "name",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "nullable",
+        "type": [
+          {
+            "name": "bool",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "metadata",
+        "type": [
+          {
+            "name": "Metadata",
+            "namespace": "Flow\\ETL\\Row\\Schema",
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": true,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "Definition",
+        "namespace": "Flow\\ETL\\Row\\Schema",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "SCHEMA"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 1265,
+    "slug": "xml-element-schema",
+    "name": "xml_element_schema",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "name",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "nullable",
+        "type": [
+          {
+            "name": "bool",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "metadata",
+        "type": [
+          {
+            "name": "Metadata",
+            "namespace": "Flow\\ETL\\Row\\Schema",
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": true,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "Definition",
+        "namespace": "Flow\\ETL\\Row\\Schema",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "SCHEMA"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 1271,
+    "slug": "struct-schema",
+    "name": "struct_schema",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "name",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "type",
+        "type": [
+          {
+            "name": "StructureType",
+            "namespace": "Flow\\ETL\\PHP\\Type\\Logical",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "metadata",
+        "type": [
+          {
+            "name": "Metadata",
+            "namespace": "Flow\\ETL\\Row\\Schema",
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": true,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "Definition",
+        "namespace": "Flow\\ETL\\Row\\Schema",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "SCHEMA"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 1277,
+    "slug": "structure-schema",
+    "name": "structure_schema",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "name",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "type",
+        "type": [
+          {
+            "name": "StructureType",
+            "namespace": "Flow\\ETL\\PHP\\Type\\Logical",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "metadata",
+        "type": [
+          {
+            "name": "Metadata",
+            "namespace": "Flow\\ETL\\Row\\Schema",
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": true,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "Definition",
+        "namespace": "Flow\\ETL\\Row\\Schema",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "SCHEMA"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 1283,
+    "slug": "uuid-schema",
+    "name": "uuid_schema",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "name",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "nullable",
+        "type": [
+          {
+            "name": "bool",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "metadata",
+        "type": [
+          {
+            "name": "Metadata",
+            "namespace": "Flow\\ETL\\Row\\Schema",
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": true,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "Definition",
+        "namespace": "Flow\\ETL\\Row\\Schema",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "SCHEMA"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 1289,
+    "slug": "execution-context",
+    "name": "execution_context",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "config",
+        "type": [
+          {
+            "name": "Config",
+            "namespace": "Flow\\ETL",
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": true,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "FlowContext",
+        "namespace": "Flow\\ETL",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "DATA_FRAME"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 1295,
+    "slug": "flow-context",
+    "name": "flow_context",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "config",
+        "type": [
+          {
+            "name": "Config",
+            "namespace": "Flow\\ETL",
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": true,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "FlowContext",
+        "namespace": "Flow\\ETL",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "DATA_FRAME"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 1301,
+    "slug": "config",
+    "name": "config",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [],
+    "return_type": [
+      {
+        "name": "Config",
+        "namespace": "Flow\\ETL",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "DATA_FRAME"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 1307,
+    "slug": "config-builder",
+    "name": "config_builder",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [],
+    "return_type": [
+      {
+        "name": "ConfigBuilder",
+        "namespace": "Flow\\ETL\\Config",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "DATA_FRAME"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 1313,
+    "slug": "overwrite",
+    "name": "overwrite",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [],
+    "return_type": [
+      {
+        "name": "SaveMode",
+        "namespace": "Flow\\ETL\\Filesystem",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "DATA_FRAME"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 1319,
+    "slug": "ignore",
+    "name": "ignore",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [],
+    "return_type": [
+      {
+        "name": "SaveMode",
+        "namespace": "Flow\\ETL\\Filesystem",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "DATA_FRAME"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 1325,
+    "slug": "exception-if-exists",
+    "name": "exception_if_exists",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [],
+    "return_type": [
+      {
+        "name": "SaveMode",
+        "namespace": "Flow\\ETL\\Filesystem",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "DATA_FRAME"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 1331,
+    "slug": "append",
+    "name": "append",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [],
+    "return_type": [
+      {
+        "name": "SaveMode",
+        "namespace": "Flow\\ETL\\Filesystem",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "DATA_FRAME"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 1337,
+    "slug": "get-type",
+    "name": "get_type",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "value",
+        "type": [
+          {
+            "name": "mixed",
+            "namespace": null,
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": true,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "Type",
+        "namespace": "Flow\\ETL\\PHP\\Type",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "DATA_FRAME"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 1343,
+    "slug": "print-schema",
+    "name": "print_schema",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "schema",
+        "type": [
+          {
+            "name": "Schema",
+            "namespace": "Flow\\ETL\\Row",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "formatter",
+        "type": [
+          {
+            "name": "SchemaFormatter",
+            "namespace": "Flow\\ETL\\Row\\Schema",
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": true,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "string",
+        "namespace": null,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "SCHEMA"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 1349,
+    "slug": "print-rows",
+    "name": "print_rows",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "rows",
+        "type": [
+          {
+            "name": "Rows",
+            "namespace": "Flow\\ETL",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "truncate",
+        "type": [
+          {
+            "name": "int",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "bool",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "formatter",
+        "type": [
+          {
+            "name": "Formatter",
+            "namespace": "Flow\\ETL",
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": true,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "string",
+        "namespace": null,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "DATA_FRAME"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 1355,
+    "slug": "identical",
+    "name": "identical",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "left",
+        "type": [
+          {
+            "name": "Reference",
+            "namespace": "Flow\\ETL\\Row",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "right",
+        "type": [
+          {
+            "name": "Reference",
+            "namespace": "Flow\\ETL\\Row",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "Identical",
+        "namespace": "Flow\\ETL\\Join\\Comparison",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "COMPARISON"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 1361,
+    "slug": "equal",
+    "name": "equal",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "left",
+        "type": [
+          {
+            "name": "Reference",
+            "namespace": "Flow\\ETL\\Row",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "right",
+        "type": [
+          {
+            "name": "Reference",
+            "namespace": "Flow\\ETL\\Row",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "Equal",
+        "namespace": "Flow\\ETL\\Join\\Comparison",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "COMPARISON"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 1367,
+    "slug": "compare-all",
+    "name": "compare_all",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "comparisons",
+        "type": [
+          {
+            "name": "Comparison",
+            "namespace": "Flow\\ETL\\Join",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": true
+      }
+    ],
+    "return_type": [
+      {
+        "name": "All",
+        "namespace": "Flow\\ETL\\Join\\Comparison",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "COMPARISON"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 1373,
+    "slug": "compare-any",
+    "name": "compare_any",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "comparisons",
+        "type": [
+          {
+            "name": "Comparison",
+            "namespace": "Flow\\ETL\\Join",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": true
+      }
+    ],
+    "return_type": [
+      {
+        "name": "Any",
+        "namespace": "Flow\\ETL\\Join\\Comparison",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "COMPARISON"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 1379,
+    "slug": "join-on",
+    "name": "join_on",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "comparisons",
+        "type": [
+          {
+            "name": "Comparison",
+            "namespace": "Flow\\ETL\\Join",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "array",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "joinPrefix",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "Expression",
+        "namespace": "Flow\\ETL\\Join",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "DATA_FRAME"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 1385,
+    "slug": "compare-entries-by-name",
+    "name": "compare_entries_by_name",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "order",
+        "type": [
+          {
+            "name": "Order",
+            "namespace": "Flow\\ETL\\Transformer\\OrderEntries",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "Comparator",
+        "namespace": "Flow\\ETL\\Transformer\\OrderEntries",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "DATA_FRAME"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 1391,
+    "slug": "compare-entries-by-name-desc",
+    "name": "compare_entries_by_name_desc",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [],
+    "return_type": [
+      {
+        "name": "Comparator",
+        "namespace": "Flow\\ETL\\Transformer\\OrderEntries",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "DATA_FRAME"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 1400,
+    "slug": "compare-entries-by-type",
+    "name": "compare_entries_by_type",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "priorities",
+        "type": [
+          {
+            "name": "array",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "order",
+        "type": [
+          {
+            "name": "Order",
+            "namespace": "Flow\\ETL\\Transformer\\OrderEntries",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "Comparator",
+        "namespace": "Flow\\ETL\\Transformer\\OrderEntries",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "DATA_FRAME"
+        }
+      }
+    ],
+    "doc_comment": "LyoqCiAqIEBwYXJhbSBhcnJheTxjbGFzcy1zdHJpbmc8RW50cnk+LCBpbnQ+ICRwcmlvcml0aWVzCiAqLw=="
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 1409,
+    "slug": "compare-entries-by-type-desc",
+    "name": "compare_entries_by_type_desc",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "priorities",
+        "type": [
+          {
+            "name": "array",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "Comparator",
+        "namespace": "Flow\\ETL\\Transformer\\OrderEntries",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "DATA_FRAME"
+        }
+      }
+    ],
+    "doc_comment": "LyoqCiAqIEBwYXJhbSBhcnJheTxjbGFzcy1zdHJpbmc8RW50cnk+LCBpbnQ+ICRwcmlvcml0aWVzCiAqLw=="
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 1418,
+    "slug": "compare-entries-by-type-and-name",
+    "name": "compare_entries_by_type_and_name",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "priorities",
+        "type": [
+          {
+            "name": "array",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "order",
+        "type": [
+          {
+            "name": "Order",
+            "namespace": "Flow\\ETL\\Transformer\\OrderEntries",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "Comparator",
+        "namespace": "Flow\\ETL\\Transformer\\OrderEntries",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "DATA_FRAME"
+        }
+      }
+    ],
+    "doc_comment": "LyoqCiAqIEBwYXJhbSBhcnJheTxjbGFzcy1zdHJpbmc8RW50cnk+LCBpbnQ+ICRwcmlvcml0aWVzCiAqLw=="
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 1431,
+    "slug": "is-type",
+    "name": "is_type",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "types",
+        "type": [
+          {
+            "name": "array",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "value",
+        "type": [
+          {
+            "name": "mixed",
+            "namespace": null,
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": true,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "bool",
+        "namespace": null,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "DATA_FRAME"
+        }
+      }
+    ],
+    "doc_comment": "LyoqCiAqIEBwYXJhbSBhcnJheTxzdHJpbmd8VHlwZT4gJHR5cGVzCiAqIEBwYXJhbSBtaXhlZCAkdmFsdWUKICov"
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 1461,
+    "slug": "generate-random-string",
+    "name": "generate_random_string",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "length",
+        "type": [
+          {
+            "name": "int",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "generator",
+        "type": [
+          {
+            "name": "NativePHPRandomValueGenerator",
+            "namespace": "Flow\\ETL",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "string",
+        "namespace": null,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "DATA_FRAME"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 1467,
+    "slug": "generate-random-int",
+    "name": "generate_random_int",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "start",
+        "type": [
+          {
+            "name": "int",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "end",
+        "type": [
+          {
+            "name": "int",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "generator",
+        "type": [
+          {
+            "name": "NativePHPRandomValueGenerator",
+            "namespace": "Flow\\ETL",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "int",
+        "namespace": null,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "DATA_FRAME"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 1473,
+    "slug": "random-string",
+    "name": "random_string",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "length",
+        "type": [
+          {
+            "name": "ScalarFunction",
+            "namespace": "Flow\\ETL\\Function",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "int",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "generator",
+        "type": [
+          {
+            "name": "RandomValueGenerator",
+            "namespace": "Flow\\ETL",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "RandomString",
+        "namespace": "Flow\\ETL\\Function",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "DATA_FRAME"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/core\/etl\/src\/Flow\/ETL\/DSL\/functions.php",
+    "start_line_in_file": 1481,
+    "slug": "dom-element-to-string",
+    "name": "dom_element_to_string",
+    "namespace": "Flow\\ETL\\DSL",
+    "parameters": [
+      {
+        "name": "element",
+        "type": [
+          {
+            "name": "DOMElement",
+            "namespace": "",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "format_output",
+        "type": [
+          {
+            "name": "bool",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "preserver_white_space",
+        "type": [
+          {
+            "name": "bool",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "string",
+        "namespace": null,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "false",
+        "namespace": null,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CORE",
+          "type": "DATA_FRAME"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/adapter\/etl-adapter-chartjs\/src\/Flow\/ETL\/Adapter\/ChartJS\/functions.php",
+    "start_line_in_file": 13,
+    "slug": "bar-chart",
+    "name": "bar_chart",
+    "namespace": "Flow\\ETL\\Adapter\\ChartJS",
+    "parameters": [
+      {
+        "name": "label",
+        "type": [
+          {
+            "name": "EntryReference",
+            "namespace": "Flow\\ETL\\Row",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "datasets",
+        "type": [
+          {
+            "name": "References",
+            "namespace": "Flow\\ETL\\Row",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "BarChart",
+        "namespace": "Flow\\ETL\\Adapter\\ChartJS\\Chart",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CHART_JS",
+          "type": "HELPER"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/adapter\/etl-adapter-chartjs\/src\/Flow\/ETL\/Adapter\/ChartJS\/functions.php",
+    "start_line_in_file": 19,
+    "slug": "line-chart",
+    "name": "line_chart",
+    "namespace": "Flow\\ETL\\Adapter\\ChartJS",
+    "parameters": [
+      {
+        "name": "label",
+        "type": [
+          {
+            "name": "EntryReference",
+            "namespace": "Flow\\ETL\\Row",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "datasets",
+        "type": [
+          {
+            "name": "References",
+            "namespace": "Flow\\ETL\\Row",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "LineChart",
+        "namespace": "Flow\\ETL\\Adapter\\ChartJS\\Chart",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CHART_JS",
+          "type": "HELPER"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/adapter\/etl-adapter-chartjs\/src\/Flow\/ETL\/Adapter\/ChartJS\/functions.php",
+    "start_line_in_file": 25,
+    "slug": "pie-chart",
+    "name": "pie_chart",
+    "namespace": "Flow\\ETL\\Adapter\\ChartJS",
+    "parameters": [
+      {
+        "name": "label",
+        "type": [
+          {
+            "name": "EntryReference",
+            "namespace": "Flow\\ETL\\Row",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "datasets",
+        "type": [
+          {
+            "name": "References",
+            "namespace": "Flow\\ETL\\Row",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "PieChart",
+        "namespace": "Flow\\ETL\\Adapter\\ChartJS\\Chart",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CHART_JS",
+          "type": "HELPER"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/adapter\/etl-adapter-chartjs\/src\/Flow\/ETL\/Adapter\/ChartJS\/functions.php",
+    "start_line_in_file": 31,
+    "slug": "to-chartjs-file",
+    "name": "to_chartjs_file",
+    "namespace": "Flow\\ETL\\Adapter\\ChartJS",
+    "parameters": [
+      {
+        "name": "type",
+        "type": [
+          {
+            "name": "Chart",
+            "namespace": "Flow\\ETL\\Adapter\\ChartJS",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "output",
+        "type": [
+          {
+            "name": "Path",
+            "namespace": "Flow\\Filesystem",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "null",
+            "namespace": null,
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": true,
+        "is_variadic": false
+      },
+      {
+        "name": "template",
+        "type": [
+          {
+            "name": "Path",
+            "namespace": "Flow\\Filesystem",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "null",
+            "namespace": null,
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": true,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "ChartJSLoader",
+        "namespace": "Flow\\ETL\\Adapter\\ChartJS",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CHART_JS",
+          "type": "LOADER"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/adapter\/etl-adapter-chartjs\/src\/Flow\/ETL\/Adapter\/ChartJS\/functions.php",
+    "start_line_in_file": 49,
+    "slug": "to-chartjs-var",
+    "name": "to_chartjs_var",
+    "namespace": "Flow\\ETL\\Adapter\\ChartJS",
+    "parameters": [
+      {
+        "name": "type",
+        "type": [
+          {
+            "name": "Chart",
+            "namespace": "Flow\\ETL\\Adapter\\ChartJS",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "output",
+        "type": [
+          {
+            "name": "array",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "ChartJSLoader",
+        "namespace": "Flow\\ETL\\Adapter\\ChartJS",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CHART_JS",
+          "type": "LOADER"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/adapter\/etl-adapter-csv\/src\/Flow\/ETL\/Adapter\/CSV\/functions.php",
+    "start_line_in_file": 17,
+    "slug": "from-csv",
+    "name": "from_csv",
+    "namespace": "Flow\\ETL\\Adapter\\CSV",
+    "parameters": [
+      {
+        "name": "path",
+        "type": [
+          {
+            "name": "Path",
+            "namespace": "Flow\\Filesystem",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "array",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "with_header",
+        "type": [
+          {
+            "name": "bool",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "empty_to_null",
+        "type": [
+          {
+            "name": "bool",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "delimiter",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": true,
+        "is_variadic": false
+      },
+      {
+        "name": "enclosure",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": true,
+        "is_variadic": false
+      },
+      {
+        "name": "escape",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": true,
+        "is_variadic": false
+      },
+      {
+        "name": "characters_read_in_line",
+        "type": [
+          {
+            "name": "int",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "schema",
+        "type": [
+          {
+            "name": "Schema",
+            "namespace": "Flow\\ETL\\Row",
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": true,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "Extractor",
+        "namespace": "Flow\\ETL",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CSV",
+          "type": "EXTRACTOR"
+        }
+      }
+    ],
+    "doc_comment": "LyoqCiAqIEBwYXJhbSBpbnQ8MSwgbWF4PiAkY2hhcmFjdGVyc19yZWFkX2luX2xpbmUKICov"
+  },
+  {
+    "repository_path": "src\/adapter\/etl-adapter-csv\/src\/Flow\/ETL\/Adapter\/CSV\/functions.php",
+    "start_line_in_file": 59,
+    "slug": "to-csv",
+    "name": "to_csv",
+    "namespace": "Flow\\ETL\\Adapter\\CSV",
+    "parameters": [
+      {
+        "name": "uri",
+        "type": [
+          {
+            "name": "Path",
+            "namespace": "Flow\\Filesystem",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "with_header",
+        "type": [
+          {
+            "name": "bool",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "separator",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "enclosure",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "escape",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "new_line_separator",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "datetime_format",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "Loader",
+        "namespace": "Flow\\ETL",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CSV",
+          "type": "LOADER"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/adapter\/etl-adapter-csv\/src\/Flow\/ETL\/Adapter\/CSV\/functions.php",
+    "start_line_in_file": 86,
+    "slug": "csv-detect-separator",
+    "name": "csv_detect_separator",
+    "namespace": "Flow\\ETL\\Adapter\\CSV",
+    "parameters": [
+      {
+        "name": "stream",
+        "type": [
+          {
+            "name": "SourceStream",
+            "namespace": "Flow\\Filesystem",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "lines",
+        "type": [
+          {
+            "name": "int",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "fallback",
+        "type": [
+          {
+            "name": "Option",
+            "namespace": "Flow\\ETL\\Adapter\\CSV\\Detector",
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": true,
+        "is_variadic": false
+      },
+      {
+        "name": "options",
+        "type": [
+          {
+            "name": "Options",
+            "namespace": "Flow\\ETL\\Adapter\\CSV\\Detector",
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": true,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "Option",
+        "namespace": "Flow\\ETL\\Adapter\\CSV\\Detector",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "CSV",
+          "type": "HELPER"
+        }
+      }
+    ],
+    "doc_comment": "LyoqCiAqIEBwYXJhbSBTb3VyY2VTdHJlYW0gJHN0cmVhbSAtIHZhbGlkIHJlc291cmNlIHRvIENTViBmaWxlCiAqIEBwYXJhbSBpbnQ8MSwgbWF4PiAkbGluZXMgLSBudW1iZXIgb2YgbGluZXMgdG8gcmVhZCBmcm9tIENTViBmaWxlLCBkZWZhdWx0IDUsIG1vcmUgbGluZXMgbWVhbnMgbW9yZSBhY2N1cmF0ZSBkZXRlY3Rpb24gYnV0IHNsb3dlciBkZXRlY3Rpb24KICogQHBhcmFtIG51bGx8T3B0aW9uICRmYWxsYmFjayAtIGZhbGxiYWNrIG9wdGlvbiB0byB1c2Ugd2hlbiBubyBiZXN0IG9wdGlvbiBjYW4gYmUgZGV0ZWN0ZWQsIGRlZmF1bHQgaXMgT3B0aW9uKCcsJywgJyInLCAnXFwnKQogKiBAcGFyYW0gbnVsbHxPcHRpb25zICRvcHRpb25zIC0gb3B0aW9ucyB0byB1c2UgZm9yIGRldGVjdGlvbiwgZGVmYXVsdCBpcyBPcHRpb25zOjphbGwoKQogKi8="
+  },
+  {
+    "repository_path": "src\/adapter\/etl-adapter-doctrine\/src\/Flow\/ETL\/Adapter\/Doctrine\/functions.php",
+    "start_line_in_file": 22,
+    "slug": "dbal-dataframe-factory",
+    "name": "dbal_dataframe_factory",
+    "namespace": "Flow\\ETL\\Adapter\\Doctrine",
+    "parameters": [
+      {
+        "name": "connection",
+        "type": [
+          {
+            "name": "Connection",
+            "namespace": "Doctrine\\DBAL",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "array",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "query",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "parameters",
+        "type": [
+          {
+            "name": "QueryParameter",
+            "namespace": "Flow\\ETL\\Adapter\\Doctrine",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": true
+      }
+    ],
+    "return_type": [
+      {
+        "name": "DbalDataFrameFactory",
+        "namespace": "Flow\\ETL\\Adapter\\Doctrine",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "DOCTRINE",
+          "type": "HELPER"
+        }
+      }
+    ],
+    "doc_comment": "LyoqCiAqIEBwYXJhbSBhcnJheTxzdHJpbmcsIG1peGVkPnxDb25uZWN0aW9uICRjb25uZWN0aW9uCiAqIEBwYXJhbSBzdHJpbmcgJHF1ZXJ5CiAqIEBwYXJhbSBRdWVyeVBhcmFtZXRlciAuLi4kcGFyYW1ldGVycwogKi8="
+  },
+  {
+    "repository_path": "src\/adapter\/etl-adapter-doctrine\/src\/Flow\/ETL\/Adapter\/Doctrine\/functions.php",
+    "start_line_in_file": 42,
+    "slug": "from-dbal-limit-offset",
+    "name": "from_dbal_limit_offset",
+    "namespace": "Flow\\ETL\\Adapter\\Doctrine",
+    "parameters": [
+      {
+        "name": "connection",
+        "type": [
+          {
+            "name": "Connection",
+            "namespace": "Doctrine\\DBAL",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "table",
+        "type": [
+          {
+            "name": "Table",
+            "namespace": "Flow\\ETL\\Adapter\\Doctrine",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "order_by",
+        "type": [
+          {
+            "name": "OrderBy",
+            "namespace": "Flow\\ETL\\Adapter\\Doctrine",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "array",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "page_size",
+        "type": [
+          {
+            "name": "int",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "maximum",
+        "type": [
+          {
+            "name": "int",
+            "namespace": null,
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": true,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "DbalLimitOffsetExtractor",
+        "namespace": "Flow\\ETL\\Adapter\\Doctrine",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "DOCTRINE",
+          "type": "EXTRACTOR"
+        }
+      }
+    ],
+    "doc_comment": "LyoqCiAqIEBwYXJhbSBDb25uZWN0aW9uICRjb25uZWN0aW9uCiAqIEBwYXJhbSBzdHJpbmd8VGFibGUgJHRhYmxlCiAqIEBwYXJhbSBhcnJheTxPcmRlckJ5PnxPcmRlckJ5ICRvcmRlcl9ieQogKiBAcGFyYW0gaW50ICRwYWdlX3NpemUKICogQHBhcmFtIG51bGx8aW50ICRtYXhpbXVtCiAqCiAqIEB0aHJvd3MgSW52YWxpZEFyZ3VtZW50RXhjZXB0aW9uCiAqLw=="
+  },
+  {
+    "repository_path": "src\/adapter\/etl-adapter-doctrine\/src\/Flow\/ETL\/Adapter\/Doctrine\/functions.php",
+    "start_line_in_file": 64,
+    "slug": "from-dbal-limit-offset-qb",
+    "name": "from_dbal_limit_offset_qb",
+    "namespace": "Flow\\ETL\\Adapter\\Doctrine",
+    "parameters": [
+      {
+        "name": "connection",
+        "type": [
+          {
+            "name": "Connection",
+            "namespace": "Doctrine\\DBAL",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "queryBuilder",
+        "type": [
+          {
+            "name": "QueryBuilder",
+            "namespace": "Doctrine\\DBAL\\Query",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "page_size",
+        "type": [
+          {
+            "name": "int",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "maximum",
+        "type": [
+          {
+            "name": "int",
+            "namespace": null,
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": true,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "DbalLimitOffsetExtractor",
+        "namespace": "Flow\\ETL\\Adapter\\Doctrine",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "DOCTRINE",
+          "type": "EXTRACTOR"
+        }
+      }
+    ],
+    "doc_comment": "LyoqCiAqIEBwYXJhbSBDb25uZWN0aW9uICRjb25uZWN0aW9uCiAqIEBwYXJhbSBpbnQgJHBhZ2Vfc2l6ZQogKiBAcGFyYW0gbnVsbHxpbnQgJG1heGltdW0KICov"
+  },
+  {
+    "repository_path": "src\/adapter\/etl-adapter-doctrine\/src\/Flow\/ETL\/Adapter\/Doctrine\/functions.php",
+    "start_line_in_file": 83,
+    "slug": "dbal-from-queries",
+    "name": "dbal_from_queries",
+    "namespace": "Flow\\ETL\\Adapter\\Doctrine",
+    "parameters": [
+      {
+        "name": "connection",
+        "type": [
+          {
+            "name": "Connection",
+            "namespace": "Doctrine\\DBAL",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "query",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "parameters_set",
+        "type": [
+          {
+            "name": "ParametersSet",
+            "namespace": "Flow\\ETL\\Adapter\\Doctrine",
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": true,
+        "is_variadic": false
+      },
+      {
+        "name": "types",
+        "type": [
+          {
+            "name": "array",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "DbalQueryExtractor",
+        "namespace": "Flow\\ETL\\Adapter\\Doctrine",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "DOCTRINE",
+          "type": "EXTRACTOR"
+        }
+      }
+    ],
+    "doc_comment": "LyoqCiAqIEBwYXJhbSBudWxsfFBhcmFtZXRlcnNTZXQgJHBhcmFtZXRlcnNfc2V0IC0gZWFjaCBvbmUgcGFyYW1ldGVycyBhcnJheSB3aWxsIGJlIGV2YWx1YXRlZCBhcyBuZXcgcXVlcnkKICogQHBhcmFtIGFycmF5PGludHxzdHJpbmcsIERiYWxBcnJheVR5cGV8RGJhbFBhcmFtZXRlclR5cGV8RGJhbFR5cGV8aW50fHN0cmluZz4gJHR5cGVzCiAqLw=="
+  },
+  {
+    "repository_path": "src\/adapter\/etl-adapter-doctrine\/src\/Flow\/ETL\/Adapter\/Doctrine\/functions.php",
+    "start_line_in_file": 102,
+    "slug": "dbal-from-query",
+    "name": "dbal_from_query",
+    "namespace": "Flow\\ETL\\Adapter\\Doctrine",
+    "parameters": [
+      {
+        "name": "connection",
+        "type": [
+          {
+            "name": "Connection",
+            "namespace": "Doctrine\\DBAL",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "query",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "parameters",
+        "type": [
+          {
+            "name": "array",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "types",
+        "type": [
+          {
+            "name": "array",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "DbalQueryExtractor",
+        "namespace": "Flow\\ETL\\Adapter\\Doctrine",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "DOCTRINE",
+          "type": "EXTRACTOR"
+        }
+      }
+    ],
+    "doc_comment": "LyoqCiAqIEBwYXJhbSBhcnJheTxzdHJpbmcsIG1peGVkPnxsaXN0PG1peGVkPiAkcGFyYW1ldGVycwogKiBAcGFyYW0gYXJyYXk8aW50fHN0cmluZywgRGJhbEFycmF5VHlwZXxEYmFsUGFyYW1ldGVyVHlwZXxEYmFsVHlwZXxpbnR8c3RyaW5nPiAkdHlwZXMKICov"
+  },
+  {
+    "repository_path": "src\/adapter\/etl-adapter-doctrine\/src\/Flow\/ETL\/Adapter\/Doctrine\/functions.php",
+    "start_line_in_file": 131,
+    "slug": "to-dbal-table-insert",
+    "name": "to_dbal_table_insert",
+    "namespace": "Flow\\ETL\\Adapter\\Doctrine",
+    "parameters": [
+      {
+        "name": "connection",
+        "type": [
+          {
+            "name": "Connection",
+            "namespace": "Doctrine\\DBAL",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "array",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "table",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "options",
+        "type": [
+          {
+            "name": "array",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "DbalLoader",
+        "namespace": "Flow\\ETL\\Adapter\\Doctrine",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "DOCTRINE",
+          "type": "LOADER"
+        }
+      }
+    ],
+    "doc_comment": "LyoqCiAqIEluIG9yZGVyIHRvIGNvbnRyb2wgdGhlIHNpemUgb2YgdGhlIHNpbmdsZSBpbnNlcnQsIHVzZSBEYXRhRnJhbWU6OmNodW5rU2l6ZSgpIG1ldGhvZCBqdXN0IGJlZm9yZSBjYWxsaW5nIERhdGFGcmFtZTo6bG9hZCgpLgogKgogKiBAcGFyYW0gYXJyYXk8c3RyaW5nLCBtaXhlZD58Q29ubmVjdGlvbiAkY29ubmVjdGlvbgogKiBAcGFyYW0gYXJyYXl7CiAqICBza2lwX2NvbmZsaWN0cz86IGJvb2xlYW4sCiAqICBjb25zdHJhaW50Pzogc3RyaW5nLAogKiAgY29uZmxpY3RfY29sdW1ucz86IGFycmF5PHN0cmluZz4sCiAqICB1cGRhdGVfY29sdW1ucz86IGFycmF5PHN0cmluZz4sCiAqICBwcmltYXJ5X2tleV9jb2x1bW5zPzogYXJyYXk8c3RyaW5nPgogKiB9ICRvcHRpb25zCiAqCiAqIEB0aHJvd3MgSW52YWxpZEFyZ3VtZW50RXhjZXB0aW9uCiAqLw=="
+  },
+  {
+    "repository_path": "src\/adapter\/etl-adapter-doctrine\/src\/Flow\/ETL\/Adapter\/Doctrine\/functions.php",
+    "start_line_in_file": 156,
+    "slug": "to-dbal-table-update",
+    "name": "to_dbal_table_update",
+    "namespace": "Flow\\ETL\\Adapter\\Doctrine",
+    "parameters": [
+      {
+        "name": "connection",
+        "type": [
+          {
+            "name": "Connection",
+            "namespace": "Doctrine\\DBAL",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "array",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "table",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "options",
+        "type": [
+          {
+            "name": "array",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "DbalLoader",
+        "namespace": "Flow\\ETL\\Adapter\\Doctrine",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "DOCTRINE",
+          "type": "LOADER"
+        }
+      }
+    ],
+    "doc_comment": "LyoqCiAqICBJbiBvcmRlciB0byBjb250cm9sIHRoZSBzaXplIG9mIHRoZSBzaW5nbGUgcmVxdWVzdCwgdXNlIERhdGFGcmFtZTo6Y2h1bmtTaXplKCkgbWV0aG9kIGp1c3QgYmVmb3JlIGNhbGxpbmcgRGF0YUZyYW1lOjpsb2FkKCkuCiAqCiAqIEBwYXJhbSBhcnJheTxzdHJpbmcsIG1peGVkPnxDb25uZWN0aW9uICRjb25uZWN0aW9uCiAqIEBwYXJhbSBhcnJheXsKICogIHNraXBfY29uZmxpY3RzPzogYm9vbGVhbiwKICogIGNvbnN0cmFpbnQ\/OiBzdHJpbmcsCiAqICBjb25mbGljdF9jb2x1bW5zPzogYXJyYXk8c3RyaW5nPiwKICogIHVwZGF0ZV9jb2x1bW5zPzogYXJyYXk8c3RyaW5nPiwKICogIHByaW1hcnlfa2V5X2NvbHVtbnM\/OiBhcnJheTxzdHJpbmc+CiAqIH0gJG9wdGlvbnMKICoKICogQHRocm93cyBJbnZhbGlkQXJndW1lbnRFeGNlcHRpb24KICov"
+  },
+  {
+    "repository_path": "src\/adapter\/etl-adapter-elasticsearch\/src\/Flow\/ETL\/Adapter\/Elasticsearch\/functions.php",
+    "start_line_in_file": 31,
+    "slug": "to-es-bulk-index",
+    "name": "to_es_bulk_index",
+    "namespace": "Flow\\ETL\\Adapter\\Elasticsearch",
+    "parameters": [
+      {
+        "name": "config",
+        "type": [
+          {
+            "name": "array",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "index",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "id_factory",
+        "type": [
+          {
+            "name": "IdFactory",
+            "namespace": "Flow\\ETL\\Adapter\\Elasticsearch",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "parameters",
+        "type": [
+          {
+            "name": "array",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "ElasticsearchLoader",
+        "namespace": "Flow\\ETL\\Adapter\\Elasticsearch\\ElasticsearchPHP",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "ELASTIC_SEARCH",
+          "type": "LOADER"
+        }
+      }
+    ],
+    "doc_comment": "LyoqCiAqIGh0dHBzOi8vd3d3LmVsYXN0aWMuY28vZ3VpZGUvZW4vZWxhc3RpY3NlYXJjaC9yZWZlcmVuY2UvbWFzdGVyL2RvY3MtYnVsay5odG1sLgogKgogKiBJbiBvcmRlciB0byBjb250cm9sIHRoZSBzaXplIG9mIHRoZSBzaW5nbGUgcmVxdWVzdCwgdXNlIERhdGFGcmFtZTo6Y2h1bmtTaXplKCkgbWV0aG9kIGp1c3QgYmVmb3JlIGNhbGxpbmcgRGF0YUZyYW1lOjpsb2FkKCkuCiAqCiAqIEBwYXJhbSBhcnJheXsKICogIGhvc3RzPzogYXJyYXk8c3RyaW5nPiwKICogIGNvbm5lY3Rpb25QYXJhbXM\/OiBhcnJheTxtaXhlZD4sCiAqICByZXRyaWVzPzogaW50LAogKiAgc25pZmZPblN0YXJ0PzogYm9vbGVhbiwKICogIHNzbENlcnQ\/OiBhcnJheTxzdHJpbmc+LAogKiAgc3NsS2V5PzogYXJyYXk8c3RyaW5nPiwKICogIHNzbFZlcmlmaWNhdGlvbj86IGJvb2xlYW58c3RyaW5nLAogKiAgZWxhc3RpY01ldGFIZWFkZXI\/OiBib29sZWFuLAogKiAgaW5jbHVkZVBvcnRJbkhvc3RIZWFkZXI\/OiBib29sZWFuCiAqIH0gJGNvbmZpZwogKiBAcGFyYW0gc3RyaW5nICRpbmRleAogKiBAcGFyYW0gSWRGYWN0b3J5ICRpZF9mYWN0b3J5CiAqIEBwYXJhbSBhcnJheTxtaXhlZD4gJHBhcmFtZXRlcnMgLSBodHRwczovL3d3dy5lbGFzdGljLmNvL2d1aWRlL2VuL2VsYXN0aWNzZWFyY2gvcmVmZXJlbmNlL21hc3Rlci9kb2NzLWJ1bGsuaHRtbAogKi8="
+  },
+  {
+    "repository_path": "src\/adapter\/etl-adapter-elasticsearch\/src\/Flow\/ETL\/Adapter\/Elasticsearch\/functions.php",
+    "start_line_in_file": 61,
+    "slug": "to-es-bulk-update",
+    "name": "to_es_bulk_update",
+    "namespace": "Flow\\ETL\\Adapter\\Elasticsearch",
+    "parameters": [
+      {
+        "name": "config",
+        "type": [
+          {
+            "name": "array",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "index",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "id_factory",
+        "type": [
+          {
+            "name": "IdFactory",
+            "namespace": "Flow\\ETL\\Adapter\\Elasticsearch",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "parameters",
+        "type": [
+          {
+            "name": "array",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "ElasticsearchLoader",
+        "namespace": "Flow\\ETL\\Adapter\\Elasticsearch\\ElasticsearchPHP",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "ELASTIC_SEARCH",
+          "type": "LOADER"
+        }
+      }
+    ],
+    "doc_comment": "LyoqCiAqICBodHRwczovL3d3dy5lbGFzdGljLmNvL2d1aWRlL2VuL2VsYXN0aWNzZWFyY2gvcmVmZXJlbmNlL21hc3Rlci9kb2NzLWJ1bGsuaHRtbC4KICoKICogSW4gb3JkZXIgdG8gY29udHJvbCB0aGUgc2l6ZSBvZiB0aGUgc2luZ2xlIHJlcXVlc3QsIHVzZSBEYXRhRnJhbWU6OmNodW5rU2l6ZSgpIG1ldGhvZCBqdXN0IGJlZm9yZSBjYWxsaW5nIERhdGFGcmFtZTo6bG9hZCgpLgogKgogKiBAcGFyYW0gYXJyYXl7CiAqICBob3N0cz86IGFycmF5PHN0cmluZz4sCiAqICBjb25uZWN0aW9uUGFyYW1zPzogYXJyYXk8bWl4ZWQ+LAogKiAgcmV0cmllcz86IGludCwKICogIHNuaWZmT25TdGFydD86IGJvb2xlYW4sCiAqICBzc2xDZXJ0PzogYXJyYXk8c3RyaW5nPiwKICogIHNzbEtleT86IGFycmF5PHN0cmluZz4sCiAqICBzc2xWZXJpZmljYXRpb24\/OiBib29sZWFufHN0cmluZywKICogIGVsYXN0aWNNZXRhSGVhZGVyPzogYm9vbGVhbiwKICogIGluY2x1ZGVQb3J0SW5Ib3N0SGVhZGVyPzogYm9vbGVhbgogKiB9ICRjb25maWcKICogQHBhcmFtIHN0cmluZyAkaW5kZXgKICogQHBhcmFtIElkRmFjdG9yeSAkaWRfZmFjdG9yeQogKiBAcGFyYW0gYXJyYXk8bWl4ZWQ+ICRwYXJhbWV0ZXJzIC0gaHR0cHM6Ly93d3cuZWxhc3RpYy5jby9ndWlkZS9lbi9lbGFzdGljc2VhcmNoL3JlZmVyZW5jZS9tYXN0ZXIvZG9jcy1idWxrLmh0bWwKICov"
+  },
+  {
+    "repository_path": "src\/adapter\/etl-adapter-elasticsearch\/src\/Flow\/ETL\/Adapter\/Elasticsearch\/functions.php",
+    "start_line_in_file": 76,
+    "slug": "es-hits-to-rows",
+    "name": "es_hits_to_rows",
+    "namespace": "Flow\\ETL\\Adapter\\Elasticsearch",
+    "parameters": [
+      {
+        "name": "source",
+        "type": [
+          {
+            "name": "DocumentDataSource",
+            "namespace": "Flow\\ETL\\Adapter\\Elasticsearch\\ElasticsearchPHP",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "HitsIntoRowsTransformer",
+        "namespace": "Flow\\ETL\\Adapter\\Elasticsearch\\ElasticsearchPHP",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "ELASTIC_SEARCH",
+          "type": "HELPER"
+        }
+      }
+    ],
+    "doc_comment": "LyoqCiAqIFRyYW5zZm9ybXMgZWxhc3RpY3NlYXJjaCByZXN1bHRzIGludG8gY2xlYXIgRmxvdyBSb3dzIHVzaW5nIFsnaGl0cyddWydoaXRzJ11beF1bJ19zb3VyY2UnXS4KICoKICogQHJldHVybiBIaXRzSW50b1Jvd3NUcmFuc2Zvcm1lcgogKi8="
+  },
+  {
+    "repository_path": "src\/adapter\/etl-adapter-elasticsearch\/src\/Flow\/ETL\/Adapter\/Elasticsearch\/functions.php",
+    "start_line_in_file": 104,
+    "slug": "from-es",
+    "name": "from_es",
+    "namespace": "Flow\\ETL\\Adapter\\Elasticsearch",
+    "parameters": [
+      {
+        "name": "config",
+        "type": [
+          {
+            "name": "array",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "params",
+        "type": [
+          {
+            "name": "array",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "pit_params",
+        "type": [
+          {
+            "name": "array",
+            "namespace": null,
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": true,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "ElasticsearchExtractor",
+        "namespace": "Flow\\ETL\\Adapter\\Elasticsearch\\ElasticsearchPHP",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "ELASTIC_SEARCH",
+          "type": "EXTRACTOR"
+        }
+      }
+    ],
+    "doc_comment": "LyoqCiAqIEV4dHJhY3RvciB3aWxsIGF1dG9tYXRpY2FsbHkgdHJ5IHRvIGl0ZXJhdGUgb3ZlciB3aG9sZSBpbmRleCB1c2luZyBvbmUgb2YgdGhlIHR3byBpdGVyYXRpb24gbWV0aG9kczouCiAqCiAqIC0gZnJvbS9zaXplCiAqIC0gc2VhcmNoX2FmdGVyCiAqCiAqIFNlYXJjaCBhZnRlciBpcyBzZWxlY3RlZCB3aGVuIHlvdSBwcm92aWRlIGRlZmluZSBzb3J0IHBhcmFtZXRlcnMgaW4gcXVlcnksIG90aGVyd2lzZSBpdCB3aWxsIGZhbGxiYWNrIHRvIGZyb20vc2l6ZS4KICoKICogQHBhcmFtIGFycmF5ewogKiAgaG9zdHM\/OiBhcnJheTxzdHJpbmc+LAogKiAgY29ubmVjdGlvblBhcmFtcz86IGFycmF5PG1peGVkPiwKICogIHJldHJpZXM\/OiBpbnQsCiAqICBzbmlmZk9uU3RhcnQ\/OiBib29sZWFuLAogKiAgc3NsQ2VydD86IGFycmF5PHN0cmluZz4sCiAqICBzc2xLZXk\/OiBhcnJheTxzdHJpbmc+LAogKiAgc3NsVmVyaWZpY2F0aW9uPzogYm9vbGVhbnxzdHJpbmcsCiAqICBlbGFzdGljTWV0YUhlYWRlcj86IGJvb2xlYW4sCiAqICBpbmNsdWRlUG9ydEluSG9zdEhlYWRlcj86IGJvb2xlYW4KICogfSAkY29uZmlnCiAqIEBwYXJhbSBhcnJheTxtaXhlZD4gJHBhcmFtcyAtIGh0dHBzOi8vd3d3LmVsYXN0aWMuY28vZ3VpZGUvZW4vZWxhc3RpY3NlYXJjaC9yZWZlcmVuY2UvbWFzdGVyL3NlYXJjaC1zZWFyY2guaHRtbAogKiBAcGFyYW0gP2FycmF5PG1peGVkPiAkcGl0X3BhcmFtcyAtIHdoZW4gdXNlZCBleHRyYWN0b3Igd2lsbCBjcmVhdGUgcG9pbnQgaW4gdGltZSB0byBzdGFiaWxpemUgc2VhcmNoIHJlc3VsdHMuIFBvaW50IGluIHRpbWUgaXMgYXV0b21hdGljYWxseSBjbG9zZWQgd2hlbiBsYXN0IGVsZW1lbnQgaXMgZXh0cmFjdGVkLiBodHRwczovL3d3dy5lbGFzdGljLmNvL2d1aWRlL2VuL2VsYXN0aWNzZWFyY2gvcmVmZXJlbmNlL21hc3Rlci9wb2ludC1pbi10aW1lLWFwaS5odG1sCiAqLw=="
+  },
+  {
+    "repository_path": "src\/adapter\/etl-adapter-google-sheet\/src\/Flow\/ETL\/Adapter\/GoogleSheet\/functions.php",
+    "start_line_in_file": 21,
+    "slug": "from-google-sheet",
+    "name": "from_google_sheet",
+    "namespace": "Flow\\ETL\\Adapter\\GoogleSheet",
+    "parameters": [
+      {
+        "name": "auth_config",
+        "type": [
+          {
+            "name": "Sheets",
+            "namespace": "Google\\Service",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "array",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "spreadsheet_id",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "sheet_name",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "with_header",
+        "type": [
+          {
+            "name": "bool",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "rows_per_page",
+        "type": [
+          {
+            "name": "int",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "options",
+        "type": [
+          {
+            "name": "array",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "Extractor",
+        "namespace": "Flow\\ETL",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "GOOGLE_SHEET",
+          "type": "EXTRACTOR"
+        }
+      }
+    ],
+    "doc_comment": "LyoqCiAqIEBwYXJhbSBhcnJheXt0eXBlOiBzdHJpbmcsIHByb2plY3RfaWQ6IHN0cmluZywgcHJpdmF0ZV9rZXlfaWQ6IHN0cmluZywgcHJpdmF0ZV9rZXk6IHN0cmluZywgY2xpZW50X2VtYWlsOiBzdHJpbmcsIGNsaWVudF9pZDogc3RyaW5nLCBhdXRoX3VyaTogc3RyaW5nLCB0b2tlbl91cmk6IHN0cmluZywgYXV0aF9wcm92aWRlcl94NTA5X2NlcnRfdXJsOiBzdHJpbmcsIGNsaWVudF94NTA5X2NlcnRfdXJsOiBzdHJpbmd9fFNoZWV0cyAkYXV0aF9jb25maWcKICogQHBhcmFtIHN0cmluZyAkc3ByZWFkc2hlZXRfaWQKICogQHBhcmFtIHN0cmluZyAkc2hlZXRfbmFtZQogKiBAcGFyYW0gYm9vbCAkd2l0aF9oZWFkZXIKICogQHBhcmFtIGludCAkcm93c19wZXJfcGFnZSAtIGhvdyBtYW55IHJvd3MgcGVyIHBhZ2UgdG8gZmV0Y2ggZnJvbSBHb29nbGUgU2hlZXRzIEFQSQogKiBAcGFyYW0gYXJyYXl7ZGF0ZVRpbWVSZW5kZXJPcHRpb24\/OiBzdHJpbmcsIG1ham9yRGltZW5zaW9uPzogc3RyaW5nLCB2YWx1ZVJlbmRlck9wdGlvbj86IHN0cmluZ30gJG9wdGlvbnMKICov"
+  },
+  {
+    "repository_path": "src\/adapter\/etl-adapter-google-sheet\/src\/Flow\/ETL\/Adapter\/GoogleSheet\/functions.php",
+    "start_line_in_file": 59,
+    "slug": "from-google-sheet-columns",
+    "name": "from_google_sheet_columns",
+    "namespace": "Flow\\ETL\\Adapter\\GoogleSheet",
+    "parameters": [
+      {
+        "name": "auth_config",
+        "type": [
+          {
+            "name": "Sheets",
+            "namespace": "Google\\Service",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "array",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "spreadsheet_id",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "sheet_name",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "start_range_column",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "end_range_column",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "with_header",
+        "type": [
+          {
+            "name": "bool",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "rows_per_page",
+        "type": [
+          {
+            "name": "int",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "options",
+        "type": [
+          {
+            "name": "array",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "Extractor",
+        "namespace": "Flow\\ETL",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "GOOGLE_SHEET",
+          "type": "EXTRACTOR"
+        }
+      }
+    ],
+    "doc_comment": "LyoqCiAqIEBwYXJhbSBhcnJheXt0eXBlOiBzdHJpbmcsIHByb2plY3RfaWQ6IHN0cmluZywgcHJpdmF0ZV9rZXlfaWQ6IHN0cmluZywgcHJpdmF0ZV9rZXk6IHN0cmluZywgY2xpZW50X2VtYWlsOiBzdHJpbmcsIGNsaWVudF9pZDogc3RyaW5nLCBhdXRoX3VyaTogc3RyaW5nLCB0b2tlbl91cmk6IHN0cmluZywgYXV0aF9wcm92aWRlcl94NTA5X2NlcnRfdXJsOiBzdHJpbmcsIGNsaWVudF94NTA5X2NlcnRfdXJsOiBzdHJpbmd9fFNoZWV0cyAkYXV0aF9jb25maWcKICogQHBhcmFtIHN0cmluZyAkc3ByZWFkc2hlZXRfaWQKICogQHBhcmFtIHN0cmluZyAkc2hlZXRfbmFtZQogKiBAcGFyYW0gc3RyaW5nICRzdGFydF9yYW5nZV9jb2x1bW4KICogQHBhcmFtIHN0cmluZyAkZW5kX3JhbmdlX2NvbHVtbgogKiBAcGFyYW0gYm9vbCAkd2l0aF9oZWFkZXIKICogQHBhcmFtIGludCAkcm93c19wZXJfcGFnZSAtIGhvdyBtYW55IHJvd3MgcGVyIHBhZ2UgdG8gZmV0Y2ggZnJvbSBHb29nbGUgU2hlZXRzIEFQSQogKiBAcGFyYW0gYXJyYXl7ZGF0ZVRpbWVSZW5kZXJPcHRpb24\/OiBzdHJpbmcsIG1ham9yRGltZW5zaW9uPzogc3RyaW5nLCB2YWx1ZVJlbmRlck9wdGlvbj86IHN0cmluZ30gJG9wdGlvbnMKICov"
+  },
+  {
+    "repository_path": "src\/adapter\/etl-adapter-json\/src\/Flow\/ETL\/Adapter\/JSON\/functions.php",
+    "start_line_in_file": 18,
+    "slug": "from-json",
+    "name": "from_json",
+    "namespace": "Flow\\ETL\\Adapter\\JSON",
+    "parameters": [
+      {
+        "name": "path",
+        "type": [
+          {
+            "name": "Path",
+            "namespace": "Flow\\Filesystem",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "array",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "pointer",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": true,
+        "is_variadic": false
+      },
+      {
+        "name": "schema",
+        "type": [
+          {
+            "name": "Schema",
+            "namespace": "Flow\\ETL\\Row",
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": true,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "Extractor",
+        "namespace": "Flow\\ETL",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "JSON",
+          "type": "EXTRACTOR"
+        }
+      }
+    ],
+    "doc_comment": "LyoqCiAqIEBwYXJhbSBhcnJheTxQYXRofHN0cmluZz58UGF0aHxzdHJpbmcgJHBhdGggLSBzdHJpbmcgaXMgaW50ZXJuYWxseSB0dXJuZWQgaW50byBzdHJlYW0KICogQHBhcmFtID9zdHJpbmcgJHBvaW50ZXIgLSBpZiB5b3Ugd2FudCB0byBpdGVyYXRlIG9ubHkgcmVzdWx0cyBvZiBhIHN1YnRyZWUsIHVzZSBhIHBvaW50ZXIsIHJlYWQgbW9yZSBhdCBodHRwczovL2dpdGh1Yi5jb20vaGFsYXhhL2pzb24tbWFjaGluZSNwYXJzaW5nLWEtc3VidHJlZQogKi8="
+  },
+  {
+    "repository_path": "src\/adapter\/etl-adapter-json\/src\/Flow\/ETL\/Adapter\/JSON\/functions.php",
+    "start_line_in_file": 50,
+    "slug": "to-json",
+    "name": "to_json",
+    "namespace": "Flow\\ETL\\Adapter\\JSON",
+    "parameters": [
+      {
+        "name": "path",
+        "type": [
+          {
+            "name": "Path",
+            "namespace": "Flow\\Filesystem",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "flags",
+        "type": [
+          {
+            "name": "int",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "date_time_format",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "put_rows_in_new_lines",
+        "type": [
+          {
+            "name": "bool",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "Loader",
+        "namespace": "Flow\\ETL",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "JSON",
+          "type": "LOADER"
+        }
+      }
+    ],
+    "doc_comment": "LyoqCiAqIEBwYXJhbSBQYXRofHN0cmluZyAkcGF0aAogKgogKiBAcmV0dXJuIExvYWRlcgogKi8="
+  },
+  {
+    "repository_path": "src\/adapter\/etl-adapter-meilisearch\/src\/Flow\/ETL\/Adapter\/Meilisearch\/functions.php",
+    "start_line_in_file": 16,
+    "slug": "to-meilisearch-bulk-index",
+    "name": "to_meilisearch_bulk_index",
+    "namespace": "Flow\\ETL\\Adapter\\Meilisearch",
+    "parameters": [
+      {
+        "name": "config",
+        "type": [
+          {
+            "name": "array",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "index",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "Loader",
+        "namespace": "Flow\\ETL",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "MEILI_SEARCH",
+          "type": "LOADER"
+        }
+      }
+    ],
+    "doc_comment": "LyoqCiAqIEBwYXJhbSBhcnJheXt1cmw6IHN0cmluZywgYXBpS2V5OiBzdHJpbmcsIGh0dHBDbGllbnQ6ID9DbGllbnRJbnRlcmZhY2V9ICRjb25maWcKICov"
+  },
+  {
+    "repository_path": "src\/adapter\/etl-adapter-meilisearch\/src\/Flow\/ETL\/Adapter\/Meilisearch\/functions.php",
+    "start_line_in_file": 27,
+    "slug": "to-meilisearch-bulk-update",
+    "name": "to_meilisearch_bulk_update",
+    "namespace": "Flow\\ETL\\Adapter\\Meilisearch",
+    "parameters": [
+      {
+        "name": "config",
+        "type": [
+          {
+            "name": "array",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "index",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "Loader",
+        "namespace": "Flow\\ETL",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "MEILI_SEARCH",
+          "type": "LOADER"
+        }
+      }
+    ],
+    "doc_comment": "LyoqCiAqIEBwYXJhbSBhcnJheXt1cmw6IHN0cmluZywgYXBpS2V5OiBzdHJpbmcsIGh0dHBDbGllbnQ6ID9DbGllbnRJbnRlcmZhY2V9ICRjb25maWcKICov"
+  },
+  {
+    "repository_path": "src\/adapter\/etl-adapter-meilisearch\/src\/Flow\/ETL\/Adapter\/Meilisearch\/functions.php",
+    "start_line_in_file": 38,
+    "slug": "meilisearch-hits-to-rows",
+    "name": "meilisearch_hits_to_rows",
+    "namespace": "Flow\\ETL\\Adapter\\Meilisearch",
+    "parameters": [],
+    "return_type": [
+      {
+        "name": "HitsIntoRowsTransformer",
+        "namespace": "Flow\\ETL\\Adapter\\Meilisearch\\MeilisearchPHP",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "MEILI_SEARCH",
+          "type": "HELPER"
+        }
+      }
+    ],
+    "doc_comment": "LyoqCiAqIFRyYW5zZm9ybXMgTWVpbGlzZWFyY2ggcmVzdWx0cyBpbnRvIGNsZWFyIEZsb3cgUm93cy4KICov"
+  },
+  {
+    "repository_path": "src\/adapter\/etl-adapter-meilisearch\/src\/Flow\/ETL\/Adapter\/Meilisearch\/functions.php",
+    "start_line_in_file": 48,
+    "slug": "from-meilisearch",
+    "name": "from_meilisearch",
+    "namespace": "Flow\\ETL\\Adapter\\Meilisearch",
+    "parameters": [
+      {
+        "name": "config",
+        "type": [
+          {
+            "name": "array",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "params",
+        "type": [
+          {
+            "name": "array",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "index",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "MeilisearchExtractor",
+        "namespace": "Flow\\ETL\\Adapter\\Meilisearch\\MeilisearchPHP",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "MEILI_SEARCH",
+          "type": "EXTRACTOR"
+        }
+      }
+    ],
+    "doc_comment": "LyoqCiAqIEBwYXJhbSBhcnJheXt1cmw6IHN0cmluZywgYXBpS2V5OiBzdHJpbmd9ICRjb25maWcKICogQHBhcmFtIGFycmF5e3E6IHN0cmluZywgbGltaXQ6ID9pbnQsIG9mZnNldDogP2ludCwgYXR0cmlidXRlc1RvUmV0cmlldmU6ID9hcnJheTxzdHJpbmc+LCBzb3J0OiA\/YXJyYXk8c3RyaW5nPn0gJHBhcmFtcwogKi8="
+  },
+  {
+    "repository_path": "src\/adapter\/etl-adapter-parquet\/src\/Flow\/ETL\/Adapter\/Parquet\/functions.php",
+    "start_line_in_file": 22,
+    "slug": "from-parquet",
+    "name": "from_parquet",
+    "namespace": "Flow\\ETL\\Adapter\\Parquet",
+    "parameters": [
+      {
+        "name": "path",
+        "type": [
+          {
+            "name": "Path",
+            "namespace": "Flow\\Filesystem",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "array",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "columns",
+        "type": [
+          {
+            "name": "array",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "options",
+        "type": [
+          {
+            "name": "Options",
+            "namespace": "Flow\\Parquet",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "byte_order",
+        "type": [
+          {
+            "name": "ByteOrder",
+            "namespace": "Flow\\Parquet",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "offset",
+        "type": [
+          {
+            "name": "int",
+            "namespace": null,
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": true,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "Extractor",
+        "namespace": "Flow\\ETL",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "PARQUET",
+          "type": "EXTRACTOR"
+        }
+      }
+    ],
+    "doc_comment": "LyoqCiAqIEBwYXJhbSBhcnJheTxQYXRoPnxQYXRofHN0cmluZyAkcGF0aAogKiBAcGFyYW0gYXJyYXk8c3RyaW5nPiAkY29sdW1ucwogKgogKiBAcmV0dXJuIEV4dHJhY3RvcgogKi8="
+  },
+  {
+    "repository_path": "src\/adapter\/etl-adapter-parquet\/src\/Flow\/ETL\/Adapter\/Parquet\/functions.php",
+    "start_line_in_file": 64,
+    "slug": "to-parquet",
+    "name": "to_parquet",
+    "namespace": "Flow\\ETL\\Adapter\\Parquet",
+    "parameters": [
+      {
+        "name": "path",
+        "type": [
+          {
+            "name": "Path",
+            "namespace": "Flow\\Filesystem",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "options",
+        "type": [
+          {
+            "name": "Options",
+            "namespace": "Flow\\Parquet",
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": true,
+        "is_variadic": false
+      },
+      {
+        "name": "compressions",
+        "type": [
+          {
+            "name": "Compressions",
+            "namespace": "Flow\\Parquet\\ParquetFile",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "schema",
+        "type": [
+          {
+            "name": "Schema",
+            "namespace": "Flow\\ETL\\Row",
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": true,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "Loader",
+        "namespace": "Flow\\ETL",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "PARQUET",
+          "type": "LOADER"
+        }
+      }
+    ],
+    "doc_comment": "LyoqCiAqIEBwYXJhbSBQYXRofHN0cmluZyAkcGF0aAogKiBAcGFyYW0gbnVsbHxTY2hlbWEgJHNjaGVtYQogKgogKiBAcmV0dXJuIExvYWRlcgogKi8="
+  },
+  {
+    "repository_path": "src\/adapter\/etl-adapter-text\/src\/Flow\/ETL\/Adapter\/Text\/functions.php",
+    "start_line_in_file": 16,
+    "slug": "from-text",
+    "name": "from_text",
+    "namespace": "Flow\\ETL\\Adapter\\Text",
+    "parameters": [
+      {
+        "name": "path",
+        "type": [
+          {
+            "name": "Path",
+            "namespace": "Flow\\Filesystem",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "array",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "Extractor",
+        "namespace": "Flow\\ETL",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "TEXT",
+          "type": "EXTRACTOR"
+        }
+      }
+    ],
+    "doc_comment": "LyoqCiAqIEBwYXJhbSBhcnJheTxQYXRofHN0cmluZz58UGF0aHxzdHJpbmcgJHBhdGgKICoKICogQHJldHVybiBFeHRyYWN0b3IKICov"
+  },
+  {
+    "repository_path": "src\/adapter\/etl-adapter-text\/src\/Flow\/ETL\/Adapter\/Text\/functions.php",
+    "start_line_in_file": 43,
+    "slug": "to-text",
+    "name": "to_text",
+    "namespace": "Flow\\ETL\\Adapter\\Text",
+    "parameters": [
+      {
+        "name": "path",
+        "type": [
+          {
+            "name": "Path",
+            "namespace": "Flow\\Filesystem",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "new_line_separator",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "Loader",
+        "namespace": "Flow\\ETL",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "TEXT",
+          "type": "LOADER"
+        }
+      }
+    ],
+    "doc_comment": "LyoqCiAqIEBwYXJhbSBQYXRofHN0cmluZyAkcGF0aAogKiBAcGFyYW0gc3RyaW5nICRuZXdfbGluZV9zZXBhcmF0b3IKICoKICogQHJldHVybiBMb2FkZXIKICov"
+  },
+  {
+    "repository_path": "src\/adapter\/etl-adapter-xml\/src\/Flow\/ETL\/Adapter\/XML\/functions.php",
+    "start_line_in_file": 21,
+    "slug": "from-xml",
+    "name": "from_xml",
+    "namespace": "Flow\\ETL\\Adapter\\XML",
+    "parameters": [
+      {
+        "name": "path",
+        "type": [
+          {
+            "name": "Path",
+            "namespace": "Flow\\Filesystem",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "array",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "xml_node_path",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "Extractor",
+        "namespace": "Flow\\ETL",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "XML",
+          "type": "EXTRACTOR"
+        }
+      }
+    ],
+    "doc_comment": "LyoqCiAqIEBwYXJhbSBhcnJheTxQYXRofHN0cmluZz58UGF0aHxzdHJpbmcgJHBhdGgKICov"
+  },
+  {
+    "repository_path": "src\/adapter\/etl-adapter-xml\/src\/Flow\/ETL\/Adapter\/XML\/functions.php",
+    "start_line_in_file": 46,
+    "slug": "to-xml",
+    "name": "to_xml",
+    "namespace": "Flow\\ETL\\Adapter\\XML",
+    "parameters": [
+      {
+        "name": "path",
+        "type": [
+          {
+            "name": "Path",
+            "namespace": "Flow\\Filesystem",
+            "is_nullable": false,
+            "is_variadic": false
+          },
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "root_element_name",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "row_element_name",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "attribute_prefix",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "date_time_format",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "xml_writer",
+        "type": [
+          {
+            "name": "XMLWriter",
+            "namespace": "Flow\\ETL\\Adapter\\XML",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "XMLLoader",
+        "namespace": "Flow\\ETL\\Adapter\\XML\\Loader",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "XML",
+          "type": "LOADER"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/lib\/filesystem\/src\/Flow\/Filesystem\/DSL\/functions.php",
+    "start_line_in_file": 12,
+    "slug": "protocol",
+    "name": "protocol",
+    "namespace": "Flow\\Filesystem\\DSL",
+    "parameters": [
+      {
+        "name": "protocol",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "Protocol",
+        "namespace": "Flow\\Filesystem",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "FILESYSTEM",
+          "type": "HELPER"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/lib\/filesystem\/src\/Flow\/Filesystem\/DSL\/functions.php",
+    "start_line_in_file": 18,
+    "slug": "partition",
+    "name": "partition",
+    "namespace": "Flow\\Filesystem\\DSL",
+    "parameters": [
+      {
+        "name": "name",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "value",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "Partition",
+        "namespace": "Flow\\Filesystem",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "FILESYSTEM",
+          "type": "HELPER"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/lib\/filesystem\/src\/Flow\/Filesystem\/DSL\/functions.php",
+    "start_line_in_file": 24,
+    "slug": "partitions",
+    "name": "partitions",
+    "namespace": "Flow\\Filesystem\\DSL",
+    "parameters": [
+      {
+        "name": "partition",
+        "type": [
+          {
+            "name": "Partition",
+            "namespace": "Flow\\Filesystem",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": true
+      }
+    ],
+    "return_type": [
+      {
+        "name": "Partitions",
+        "namespace": "Flow\\Filesystem",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "FILESYSTEM",
+          "type": "HELPER"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/lib\/filesystem\/src\/Flow\/Filesystem\/DSL\/functions.php",
+    "start_line_in_file": 43,
+    "slug": "path",
+    "name": "path",
+    "namespace": "Flow\\Filesystem\\DSL",
+    "parameters": [
+      {
+        "name": "path",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "options",
+        "type": [
+          {
+            "name": "array",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "Path",
+        "namespace": "Flow\\Filesystem",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "FILESYSTEM",
+          "type": "HELPER"
+        }
+      }
+    ],
+    "doc_comment": "LyoqCiAqIFBhdGggc3VwcG9ydHMgZ2xvYiBwYXR0ZXJucy4KICogRXhhbXBsZXM6CiAqICAtIHBhdGgoJyouY3N2JykgLSBhbnkgY3N2IGZpbGUgaW4gY3VycmVudCBkaXJlY3RvcnkKICogIC0gcGF0aCgnLyoqIC8gKi5jc3YnKSAtIGFueSBjc3YgZmlsZSBpbiBhbnkgc3ViZGlyZWN0b3J5IChyZW1vdmUgZW1wdHkgc3BhY2VzKQogKiAgLSBwYXRoKCcvZGlyL3BhcnRpdGlvbj0qIC8qLnBhcnF1ZXQnKSAtIGFueSBwYXJxdWV0IGZpbGUgaW4gZ2l2ZW4gcGFydGl0aW9uIGRpcmVjdG9yeS4KICoKICogR2xvYiBwYXR0ZXJuIGlzIGFsc28gc3VwcG9ydGVkIGJ5IHJlbW90ZSBmaWxlc3lzdGVtcyBsaWtlIEF6dXJlCiAqCiAqICAtIHBhdGgoJ2F6dXJlLWJsb2I6Ly9kaXJlY3RvcnkvKi5jc3YnKSAtIGFueSBjc3YgZmlsZSBpbiBnaXZlbiBkaXJlY3RvcnkKICoKICogQHBhcmFtIGFycmF5PHN0cmluZywgbWl4ZWQ+ICRvcHRpb25zCiAqLw=="
+  },
+  {
+    "repository_path": "src\/lib\/filesystem\/src\/Flow\/Filesystem\/DSL\/functions.php",
+    "start_line_in_file": 54,
+    "slug": "path-real",
+    "name": "path_real",
+    "namespace": "Flow\\Filesystem\\DSL",
+    "parameters": [
+      {
+        "name": "path",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "options",
+        "type": [
+          {
+            "name": "array",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "Path",
+        "namespace": "Flow\\Filesystem",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "FILESYSTEM",
+          "type": "HELPER"
+        }
+      }
+    ],
+    "doc_comment": "LyoqCiAqIFJlc29sdmUgcmVhbCBwYXRoIGZyb20gZ2l2ZW4gcGF0aC4KICoKICogQHBhcmFtIGFycmF5PHN0cmluZywgbWl4ZWQ+ICRvcHRpb25zCiAqLw=="
+  },
+  {
+    "repository_path": "src\/lib\/filesystem\/src\/Flow\/Filesystem\/DSL\/functions.php",
+    "start_line_in_file": 60,
+    "slug": "native-local-filesystem",
+    "name": "native_local_filesystem",
+    "namespace": "Flow\\Filesystem\\DSL",
+    "parameters": [],
+    "return_type": [
+      {
+        "name": "NativeLocalFilesystem",
+        "namespace": "Flow\\Filesystem\\Local",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "FILESYSTEM",
+          "type": "HELPER"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/lib\/filesystem\/src\/Flow\/Filesystem\/DSL\/functions.php",
+    "start_line_in_file": 71,
+    "slug": "fstab",
+    "name": "fstab",
+    "namespace": "Flow\\Filesystem\\DSL",
+    "parameters": [
+      {
+        "name": "filesystems",
+        "type": [
+          {
+            "name": "Filesystem",
+            "namespace": "Flow\\Filesystem",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": true
+      }
+    ],
+    "return_type": [
+      {
+        "name": "FilesystemTable",
+        "namespace": "Flow\\Filesystem",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "FILESYSTEM",
+          "type": "HELPER"
+        }
+      }
+    ],
+    "doc_comment": "LyoqCiAqIENyZWF0ZSBhIG5ldyBmaWxlc3lzdGVtIHRhYmxlIHdpdGggZ2l2ZW4gZmlsZXN5c3RlbXMuCiAqIEZpbGVzeXN0ZW1zIGNhbiBiZSBhbHNvIG1vdW50ZWQgbGF0ZXIuCiAqIElmIG5vIGZpbGVzeXN0ZW1zIGFyZSBwcm92aWRlZCwgbG9jYWwgZmlsZXN5c3RlbSBpcyBtb3VudGVkLgogKi8="
+  },
+  {
+    "repository_path": "src\/bridge\/filesystem\/azure\/src\/Flow\/Filesystem\/Bridge\/Azure\/DSL\/functions.php",
+    "start_line_in_file": 12,
+    "slug": "azure-filesystem-options",
+    "name": "azure_filesystem_options",
+    "namespace": "Flow\\Filesystem\\Bridge\\Azure\\DSL",
+    "parameters": [],
+    "return_type": [
+      {
+        "name": "Options",
+        "namespace": "Flow\\Filesystem\\Bridge\\Azure",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "AZURE_FILESYSTEM",
+          "type": "HELPER"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/bridge\/filesystem\/azure\/src\/Flow\/Filesystem\/Bridge\/Azure\/DSL\/functions.php",
+    "start_line_in_file": 18,
+    "slug": "azure-filesystem",
+    "name": "azure_filesystem",
+    "namespace": "Flow\\Filesystem\\Bridge\\Azure\\DSL",
+    "parameters": [
+      {
+        "name": "blob_service",
+        "type": [
+          {
+            "name": "BlobServiceInterface",
+            "namespace": "Flow\\Azure\\SDK",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "options",
+        "type": [
+          {
+            "name": "Options",
+            "namespace": "Flow\\Filesystem\\Bridge\\Azure",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "AzureBlobFilesystem",
+        "namespace": "Flow\\Filesystem\\Bridge\\Azure",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "AZURE_FILESYSTEM",
+          "type": "HELPER"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/lib\/azure-sdk\/src\/Flow\/Azure\/SDK\/DSL\/functions.php",
+    "start_line_in_file": 18,
+    "slug": "azurite-url-factory",
+    "name": "azurite_url_factory",
+    "namespace": "Flow\\Azure\\SDK\\DSL",
+    "parameters": [
+      {
+        "name": "host",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "port",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "secure",
+        "type": [
+          {
+            "name": "bool",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "AzuriteURLFactory",
+        "namespace": "Flow\\Azure\\SDK\\BlobService\\URLFactory",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "AZURE_SDK",
+          "type": "HELPER"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/lib\/azure-sdk\/src\/Flow\/Azure\/SDK\/DSL\/functions.php",
+    "start_line_in_file": 24,
+    "slug": "azure-shared-key-authorization-factory",
+    "name": "azure_shared_key_authorization_factory",
+    "namespace": "Flow\\Azure\\SDK\\DSL",
+    "parameters": [
+      {
+        "name": "account",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "key",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "SharedKeyFactory",
+        "namespace": "Flow\\Azure\\SDK\\AuthorizationFactory",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "AZURE_SDK",
+          "type": "HELPER"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/lib\/azure-sdk\/src\/Flow\/Azure\/SDK\/DSL\/functions.php",
+    "start_line_in_file": 30,
+    "slug": "azure-blob-service-config",
+    "name": "azure_blob_service_config",
+    "namespace": "Flow\\Azure\\SDK\\DSL",
+    "parameters": [
+      {
+        "name": "account",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "container",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "Configuration",
+        "namespace": "Flow\\Azure\\SDK\\BlobService",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "AZURE_SDK",
+          "type": "HELPER"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/lib\/azure-sdk\/src\/Flow\/Azure\/SDK\/DSL\/functions.php",
+    "start_line_in_file": 36,
+    "slug": "azure-url-factory",
+    "name": "azure_url_factory",
+    "namespace": "Flow\\Azure\\SDK\\DSL",
+    "parameters": [
+      {
+        "name": "host",
+        "type": [
+          {
+            "name": "string",
+            "namespace": null,
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "AzureURLFactory",
+        "namespace": "Flow\\Azure\\SDK\\BlobService\\URLFactory",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "AZURE_SDK",
+          "type": "HELPER"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/lib\/azure-sdk\/src\/Flow\/Azure\/SDK\/DSL\/functions.php",
+    "start_line_in_file": 42,
+    "slug": "azure-http-factory",
+    "name": "azure_http_factory",
+    "namespace": "Flow\\Azure\\SDK\\DSL",
+    "parameters": [
+      {
+        "name": "request_factory",
+        "type": [
+          {
+            "name": "RequestFactoryInterface",
+            "namespace": "Psr\\Http\\Message",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "stream_factory",
+        "type": [
+          {
+            "name": "StreamFactoryInterface",
+            "namespace": "Psr\\Http\\Message",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "HttpFactory",
+        "namespace": "Flow\\Azure\\SDK",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "AZURE_SDK",
+          "type": "HELPER"
+        }
+      }
+    ],
+    "doc_comment": null
+  },
+  {
+    "repository_path": "src\/lib\/azure-sdk\/src\/Flow\/Azure\/SDK\/DSL\/functions.php",
+    "start_line_in_file": 48,
+    "slug": "azure-blob-service",
+    "name": "azure_blob_service",
+    "namespace": "Flow\\Azure\\SDK\\DSL",
+    "parameters": [
+      {
+        "name": "configuration",
+        "type": [
+          {
+            "name": "Configuration",
+            "namespace": "Flow\\Azure\\SDK\\BlobService",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "azure_authorization_factory",
+        "type": [
+          {
+            "name": "AuthorizationFactory",
+            "namespace": "Flow\\Azure\\SDK",
+            "is_nullable": false,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": false,
+        "is_nullable": false,
+        "is_variadic": false
+      },
+      {
+        "name": "client",
+        "type": [
+          {
+            "name": "ClientInterface",
+            "namespace": "Psr\\Http\\Client",
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": true,
+        "is_variadic": false
+      },
+      {
+        "name": "azure_http_factory",
+        "type": [
+          {
+            "name": "HttpFactory",
+            "namespace": "Flow\\Azure\\SDK",
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": true,
+        "is_variadic": false
+      },
+      {
+        "name": "azure_url_factory",
+        "type": [
+          {
+            "name": "URLFactory",
+            "namespace": "Flow\\Azure\\SDK",
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": true,
+        "is_variadic": false
+      },
+      {
+        "name": "logger",
+        "type": [
+          {
+            "name": "LoggerInterface",
+            "namespace": "Psr\\Log",
+            "is_nullable": true,
+            "is_variadic": false
+          }
+        ],
+        "has_default_value": true,
+        "is_nullable": true,
+        "is_variadic": false
+      }
+    ],
+    "return_type": [
+      {
+        "name": "BlobServiceInterface",
+        "namespace": "Flow\\Azure\\SDK",
+        "is_nullable": false,
+        "is_variadic": false
+      }
+    ],
+    "attributes": [
+      {
+        "name": "DocumentationDSL",
+        "namespace": "Flow\\ETL\\Attribute",
+        "arguments": {
+          "module": "AZURE_SDK",
+          "type": "HELPER"
+        }
+      }
+    ],
+    "doc_comment": null
+  }
+]

--- a/web/landing/src/Flow/Website/Controller/DocumentationController.php
+++ b/web/landing/src/Flow/Website/Controller/DocumentationController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Flow\Website\Controller;
 
+use Flow\Website\Model\Documentation\Module;
 use Flow\Website\Service\Documentation\DSLDefinitions;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
@@ -24,7 +25,7 @@ final class DocumentationController extends AbstractController
         return $this->render('documentation/dsl.html.twig', [
             'module_name' => $module,
             'modules' => $modules,
-            'definitions' => $this->dslDefinitions->fromModule($module),
+            'definitions' => $this->dslDefinitions->fromModule(Module::fromName($module)),
             'types' => $this->dslDefinitions->types(),
         ]);
     }
@@ -37,7 +38,7 @@ final class DocumentationController extends AbstractController
         return $this->render('documentation/dsl/function.html.twig', [
             'module_name' => $module,
             'modules' => $modules,
-            'definition' => $this->dslDefinitions->fromModule($module)->get($function),
+            'definition' => $this->dslDefinitions->fromModule(Module::fromName($module))->get($function),
             'types' => $this->dslDefinitions->types(),
         ]);
     }

--- a/web/landing/src/Flow/Website/Model/Documentation/DSLDefinition.php
+++ b/web/landing/src/Flow/Website/Model/Documentation/DSLDefinition.php
@@ -45,13 +45,13 @@ final class DSLDefinition
         return $this->data['doc_comment'] !== null;
     }
 
-    public function module() : ?string
+    public function module() : ?Module
     {
         foreach ($this->data['attributes'] as $attribute) {
             if ($attribute['name'] === 'DocumentationDSL') {
                 foreach ($attribute['arguments'] as $name => $argument) {
                     if ($name === 'module') {
-                        return $argument;
+                        return Module::fromName($argument);
                     }
                 }
             }
@@ -102,13 +102,13 @@ final class DSLDefinition
         return $output;
     }
 
-    public function type() : ?string
+    public function type() : ?Type
     {
         foreach ($this->data['attributes'] as $attribute) {
             if ($attribute['name'] === 'DocumentationDSL') {
                 foreach ($attribute['arguments'] as $name => $argument) {
                     if ($name === 'type') {
-                        return $argument;
+                        return Type::fromName($argument);
                     }
                 }
             }

--- a/web/landing/src/Flow/Website/Model/Documentation/Module.php
+++ b/web/landing/src/Flow/Website/Model/Documentation/Module.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\Website\Model\Documentation;
+
+enum Module : string
+{
+    case AZURE_FILESYSTEM = 'Azure Filesystem';
+    case AZURE_SDK = 'Azure SDK';
+    case CHART_JS = 'Chart.js';
+    case CORE = 'Core';
+    case CSV = 'CSV';
+    case DOCTRINE = 'Doctrine';
+    case ELASTIC_SEARCH = 'Elastic Search';
+    case FILESYSTEM = 'Filesystem';
+    case GOOGLE_SHEET = 'Google Sheet';
+    case JSON = 'JSON';
+    case MEILI_SEARCH = 'Meili Search';
+    case PARQUET = 'Parquet';
+    case TEXT = 'Text';
+    case XML = 'XML';
+
+    public static function fromName(string $name) : self
+    {
+        $name = \mb_strtoupper(\str_replace([' ', '-'], '_', $name));
+
+        return constant("self::{$name}");
+    }
+
+    public function priority() : int
+    {
+        return match ($this) {
+            self::CORE => 1,
+            self::CSV => 2,
+            self::DOCTRINE => 3,
+            self::ELASTIC_SEARCH => 4,
+            self::GOOGLE_SHEET => 5,
+            self::CHART_JS => 6,
+            self::JSON => 7,
+            self::MEILI_SEARCH => 8,
+            self::PARQUET => 9,
+            self::TEXT => 10,
+            self::XML => 11,
+            self::FILESYSTEM => 12,
+            self::AZURE_FILESYSTEM => 13,
+            self::AZURE_SDK => 14,
+            default => 99,
+        };
+    }
+}

--- a/web/landing/src/Flow/Website/Model/Documentation/Type.php
+++ b/web/landing/src/Flow/Website/Model/Documentation/Type.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\Website\Model\Documentation;
+
+enum Type : string
+{
+    case AGGREGATING_FUNCTION = 'Aggregating Functions';
+    case COMPARISON = 'Comparisons';
+    case DATA_FRAME = 'Data Frame';
+    case ENTRY = 'Entries';
+    case EXTRACTOR = 'Extractors';
+    case HELPER = 'Helpers';
+    case LOADER = 'Loaders';
+    case SCALAR_FUNCTION = 'Scalar Functions';
+    case SCHEMA = 'Schema';
+    case TRANSFORMER = 'Transformers';
+    case TYPE = 'Type';
+    case WINDOW_FUNCTION = 'Window Functions';
+
+    public static function fromName(string $name) : self
+    {
+        $name = \mb_strtoupper(\str_replace([' ', '-'], '_', $name));
+
+        return constant("self::{$name}");
+    }
+
+    public function priority() : int
+    {
+        return match ($this) {
+            self::SCHEMA => 1,
+            self::TYPE => 2,
+            self::ENTRY => 3,
+            self::DATA_FRAME => 4,
+            self::EXTRACTOR => 5,
+            self::TRANSFORMER => 6,
+            self::AGGREGATING_FUNCTION => 7,
+            self::SCALAR_FUNCTION => 8,
+            self::WINDOW_FUNCTION => 9,
+            self::COMPARISON => 10,
+            self::HELPER => 11,
+            self::LOADER => 12,
+            default => 99,
+        };
+    }
+}

--- a/web/landing/src/Flow/Website/Service/Documentation/DSLDefinitions.php
+++ b/web/landing/src/Flow/Website/Service/Documentation/DSLDefinitions.php
@@ -66,7 +66,7 @@ final class DSLDefinitions
     }
 
     /**
-     * @return array<string>
+     * @return array<Module>
      */
     public function modules() : array
     {

--- a/web/landing/src/Flow/Website/StaticSourceProvider/DSLProvider.php
+++ b/web/landing/src/Flow/Website/StaticSourceProvider/DSLProvider.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Flow\Website\StaticSourceProvider;
 
-use Cocur\Slugify\Slugify;
 use Flow\Website\Service\Documentation\DSLDefinitions;
 use NorbertTech\StaticContentGeneratorBundle\Content\{Source, SourceProvider};
 
@@ -19,7 +18,7 @@ final class DSLProvider implements SourceProvider
         $sources = [];
 
         foreach ($this->dslDefinitions->modules() as $module) {
-            $sources[] = new Source('documentation_dsl', ['module' => (new Slugify())->slugify($module)]);
+            $sources[] = new Source('documentation_dsl', ['module' => $module->name]);
         }
 
         foreach ($this->dslDefinitions->all() as $definition) {
@@ -27,7 +26,7 @@ final class DSLProvider implements SourceProvider
                 throw new \RuntimeException('Module is required for DSL definition, non given for: ' . $definition->path());
             }
 
-            $sources[] = new Source('documentation_dsl_function', ['module' => (new Slugify())->slugify($definition->module()), 'function' => $definition->slug()]);
+            $sources[] = new Source('documentation_dsl_function', ['module' => $definition->module()->name, 'function' => $definition->slug()]);
         }
 
         return $sources;

--- a/web/landing/templates/documentation/dsl.html.twig
+++ b/web/landing/templates/documentation/dsl.html.twig
@@ -18,16 +18,16 @@
                 {% for module in modules %}
                     <li class="mb-1" data-dsl-module="{{ module_name | slugify | lower }}">
                         <a
-                            href="{{ path('documentation_dsl', {module: module|lower, _fragment:"dsl-functions"}) }}"
-                            class="{% if module | slugify | lower == module_name | slugify |lower  %}text-white {% endif %}"
+                            href="{{ path('documentation_dsl', {module: module.name | lower, _fragment:"dsl-functions"}) }}"
+                            class="{% if module.name | lower == module_name  %}text-white {% endif %}"
 
-                        >{{ module }}</a>
-                        {% if module | slugify |lower == module_name | slugify |lower %}
+                        >{{ module.value }}</a>
+                        {% if module.name | lower == module_name | lower %}
                         <ul class="list-disc pl-6 mt-2">
                             {% for type in types %}
                                 {% if definitions.onlyType(type).count %}
                                     <li class="text-sm">
-                                        <a href="#type-{{ type }}">{{ type|humanize }}</a>
+                                        <a href="#type-{{ type.name }}">{{ type.value }}</a>
                                     </li>
                                 {% endif %}
                             {% endfor %}
@@ -47,9 +47,9 @@
             </p>
             {% for type in types %}
                 {% if definitions.onlyType(type).count %}
-                    <h2 id="type-{{ type }}" class="font-bold text-2xl mb-2" data-dsl-type="{{ type }}">
-                        <a href="#type-{{ type }}" class="text-white">
-                            {{ type|humanize }}
+                    <h2 id="type-{{ type.value }}" class="font-bold text-2xl mb-2" data-dsl-type="{{ type.value }}">
+                        <a href="#type-{{ type.value }}" class="text-white">
+                            {{ type.name }}
                         </a>
                     </h2>
                     <hr class="text-blue-100 my-4 border-t-2 rounded" />
@@ -58,7 +58,7 @@
                             <div class="grid grid-cols-2 mb-2">
                                 <div class="text-left">
                                     <h4 class="mb-2 inline" id="dsl-{{ definition.name }}">
-                                        <a href="{{ path('documentation_dsl_function', {module: definition.module | slugify | lower, function: definition.name | slugify | lower, _fragment: "dsl-function"}) }}" class="text-white">
+                                        <a href="{{ path('documentation_dsl_function', {module: definition.module.name | lower, function: definition.name | slugify | lower, _fragment: "dsl-function"}) }}" class="text-white">
                                             <img src="{{ asset('images/icons/link.svg') }}" width="16" height="16" alt="feature" class="inline">
                                             {{ definition.name }}
                                         </a>

--- a/web/landing/templates/documentation/dsl/function.html.twig
+++ b/web/landing/templates/documentation/dsl/function.html.twig
@@ -17,10 +17,10 @@
                     {% for module in modules %}
                         <li class="mb-1">
                             <a
-                                href="{{ path('documentation_dsl', {module: module|lower, _fragment:"dsl-functions"}) }}"
-                                class="{% if module| slugify |lower == module_name | slugify |lower  %}text-white {% endif %}"
+                                href="{{ path('documentation_dsl', {module: module.name | lower, _fragment:"dsl-functions"}) }}"
+                                class="{% if module.name |lower == module_name |lower  %}text-white {% endif %}"
 
-                            >{{ module }}</a>
+                            >{{ module.value }}</a>
                         </li>
                     {% endfor %}
                 </ul>


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Duplicate Module/Type enums in website to avoid dependencies and keep boundaries clean</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

<!-- Please provide a short description of changes in this section, feel free to use markdown syntax -->
