### PR TITLE
Restored original behavior of DOMElementValue function combined with XPath

### DIFF
--- a/examples/topics/data_source/xml/output.txt
+++ b/examples/topics/data_source/xml/output.txt
@@ -1,15 +1,15 @@
-+----+------+--------+-------+
-| id | name | active | email |
-+----+------+--------+-------+
-|  1 |      |        |       |
-|  2 |      |        |       |
-|  3 |      |        |       |
-|  4 |      |        |       |
-|  5 |      |        |       |
-|  6 |      |        |       |
-|  7 |      |        |       |
-|  8 |      |        |       |
-|  9 |      |        |       |
-| 10 |      |        |       |
-+----+------+--------+-------+
++----+---------+--------+---------------------+
+| id |    name | active |               email |
++----+---------+--------+---------------------+
+|  1 |   Alice |   true |   alice@example.com |
+|  2 |     Bob |  false |     bob@example.com |
+|  3 | Charlie |   true | charlie@example.com |
+|  4 |   David |  false |   david@example.com |
+|  5 |    Emma |   true |    emma@example.com |
+|  6 |   Frank |  false |   frank@example.com |
+|  7 |   Grace |   true |   grace@example.com |
+|  8 |   Harry |  false |   harry@example.com |
+|  9 |    Isla |   true |    isla@example.com |
+| 10 |   James |  false |   james@example.com |
++----+---------+--------+---------------------+
 10 rows

--- a/src/core/etl/src/Flow/ETL/Function/DOMElementAttributeValue.php
+++ b/src/core/etl/src/Flow/ETL/Function/DOMElementAttributeValue.php
@@ -16,7 +16,20 @@ final class DOMElementAttributeValue extends ScalarFunctionChain
 
     public function eval(Row $row) : ?string
     {
-        $domElement = (new Parameter($this->domElement))->asInstanceOf($row, \DOMElement::class);
+        $domElement = Parameter::oneOf(
+            (new Parameter($this->domElement))->asInstanceOf($row, \DOMElement::class),
+            (new Parameter($this->domElement))->asInstanceOf($row, \DOMDocument::class),
+            (new Parameter($this->domElement))->asListOfObjects($row, \DOMElement::class),
+        );
+
+        if ($domElement instanceof \DOMDocument) {
+            $domElement = $domElement->documentElement;
+        }
+
+        if (\is_array($domElement) && \count($domElement)) {
+            $domElement = \reset($domElement);
+        }
+
         $attributeName = (new Parameter($this->attribute))->asString($row);
 
         if ($domElement === null || $attributeName === null) {

--- a/src/core/etl/src/Flow/ETL/Function/DOMElementValue.php
+++ b/src/core/etl/src/Flow/ETL/Function/DOMElementValue.php
@@ -14,7 +14,19 @@ final class DOMElementValue extends ScalarFunctionChain
 
     public function eval(Row $row) : mixed
     {
-        $domElement = (new Parameter($this->domElement))->asInstanceOf($row, \DOMElement::class);
+        $domElement = Parameter::oneOf(
+            (new Parameter($this->domElement))->asInstanceOf($row, \DOMElement::class),
+            (new Parameter($this->domElement))->asInstanceOf($row, \DOMDocument::class),
+            (new Parameter($this->domElement))->asListOfObjects($row, \DOMElement::class),
+        );
+
+        if (\is_array($domElement) && \count($domElement)) {
+            $domElement = \reset($domElement);
+        }
+
+        if ($domElement instanceof \DOMDocument) {
+            $domElement = $domElement->documentElement;
+        }
 
         if (!$domElement instanceof \DOMElement) {
             return null;

--- a/src/core/etl/src/Flow/ETL/Function/Parameter.php
+++ b/src/core/etl/src/Flow/ETL/Function/Parameter.php
@@ -97,6 +97,23 @@ final class Parameter
         return \is_int($result) ? $result : null;
     }
 
+    public function asListOfObjects(Row $row, string $class) : ?array
+    {
+        $result = $this->function->eval($row);
+
+        if (!\is_array($result)) {
+            return null;
+        }
+
+        foreach ($result as $item) {
+            if (!\is_object($item) || !\is_a($item, $class)) {
+                return null;
+            }
+        }
+
+        return $result;
+    }
+
     /**
      * @psalm-suppress InvalidReturnType
      * @psalm-suppress InvalidReturnStatement

--- a/src/core/etl/tests/Flow/ETL/Tests/Integration/Function/DOMElementAttributeValueTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Integration/Function/DOMElementAttributeValueTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Tests\Integration\Function;
+
+use function Flow\ETL\DSL\{df, from_rows, ref, row, rows, xml_element_entry, xml_entry};
+use Flow\ETL\Adapter\Elasticsearch\Tests\Integration\TestCase;
+
+final class DOMElementAttributeValueTest extends TestCase
+{
+    public function test_dom_element_attribute_value() : void
+    {
+        $rows = df()
+            ->read(from_rows(
+                rows(
+                    row(
+                        xml_element_entry('node', '<name id="1">User Name 01</name>')
+                    )
+                )
+            ))
+            ->withEntry('user_id', ref('node')->domElementAttributeValue('id'))
+            ->drop('node')
+            ->fetch();
+
+        self::assertSame(
+            [
+                ['user_id' => '1'],
+            ],
+            $rows->toArray()
+        );
+    }
+
+    public function test_dom_element_attribute_value_from_dom_document() : void
+    {
+        $rows = df()
+            ->read(from_rows(
+                rows(
+                    row(
+                        xml_entry('node', '<name id="1">User Name 01</name>')
+                    )
+                )
+            ))
+            ->withEntry('user_id', ref('node')->domElementAttributeValue('id'))
+            ->drop('node')
+            ->fetch();
+
+        self::assertSame(
+            [
+                ['user_id' => '1'],
+            ],
+            $rows->toArray()
+        );
+    }
+
+    public function test_dom_element_attribute_value_on_xpath_result() : void
+    {
+        $rows = df()
+            ->read(from_rows(
+                rows(
+                    row(
+                        xml_entry('node', '<user><name id="1">User Name 01</name></user>')
+                    )
+                )
+            ))
+            ->withEntry('user_id', ref('node')->xpath('name')->domElementAttributeValue('id'))
+            ->drop('node')
+            ->fetch();
+
+        self::assertSame(
+            [
+                ['user_id' => '1'],
+            ],
+            $rows->toArray()
+        );
+    }
+}

--- a/src/core/etl/tests/Flow/ETL/Tests/Integration/Function/DOMElementValueTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Integration/Function/DOMElementValueTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Tests\Integration\Function;
+
+use function Flow\ETL\DSL\{df, from_rows, ref, row, rows, xml_element_entry, xml_entry};
+use Flow\ETL\Adapter\Elasticsearch\Tests\Integration\TestCase;
+
+final class DOMElementValueTest extends TestCase
+{
+    public function test_dom_element_value() : void
+    {
+        $rows = df()
+            ->read(from_rows(
+                rows(
+                    row(
+                        xml_element_entry('node', '<name>User Name 01</name>')
+                    )
+                )
+            ))
+            ->withEntry('user_name', ref('node')->domElementValue())
+            ->drop('node')
+            ->fetch();
+
+        self::assertSame(
+            [
+                ['user_name' => 'User Name 01'],
+            ],
+            $rows->toArray()
+        );
+    }
+
+    public function test_dom_element_value_from_dom_document() : void
+    {
+        $rows = df()
+            ->read(from_rows(
+                rows(
+                    row(
+                        xml_entry('node', '<name>User Name 01</name>')
+                    )
+                )
+            ))
+            ->withEntry('user_name', ref('node')->domElementValue())
+            ->drop('node')
+            ->fetch();
+
+        self::assertSame(
+            [
+                ['user_name' => 'User Name 01'],
+            ],
+            $rows->toArray()
+        );
+    }
+
+    public function test_dom_element_value_on_xpath_result() : void
+    {
+        $rows = df()
+            ->read(from_rows(
+                rows(
+                    row(
+                        xml_entry('node', '<user><name>User Name 01</name></user>')
+                    )
+                )
+            ))
+            ->withEntry('user_name', ref('node')->xpath('name')->domElementValue())
+            ->drop('node')
+            ->fetch();
+
+        self::assertSame(
+            [
+                ['user_name' => 'User Name 01'],
+            ],
+            $rows->toArray()
+        );
+    }
+}


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>DOMElementValue behavior when used on a XPath scalar function result</li>
    <li>DOMElementAttributeValue behavior when used on a XPath scalar function result</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

Long story short this PR is a fix for a bug I introduced when I changed the result of XPath. 
In general XPath should always return an array, and it used to return single node when it array had one element. 
Since DOMElementValue and DOMElementAttributeValue expects DOMElement it would require to add some kind of `->first()` function on `xpath` results. 
Instead, DOMElementValue and DOMElementAttributeValue will now try to check if value is an array of DOMElement's and take the first one when available which restores the original behavior. 

