### PR TITLE
Return DOMDocument instead of DOMElement from XMLParserExtractor

### DIFF
--- a/src/adapter/etl-adapter-xml/src/Flow/ETL/Adapter/XML/XMLParserExtractor.php
+++ b/src/adapter/etl-adapter-xml/src/Flow/ETL/Adapter/XML/XMLParserExtractor.php
@@ -98,11 +98,11 @@ final class XMLParserExtractor implements Extractor, FileExtractor, LimitableExt
                     foreach ($this->elements as $element) {
                         if ($shouldPutInputIntoRows) {
                             $rowData = [
-                                'node' => $this->createDOMElement($element),
+                                'node' => $this->createDOMNode($element),
                                 '_input_file_uri' => $stream->path()->uri(),
                             ];
                         } else {
-                            $rowData = ['node' => $this->createDOMElement($element)];
+                            $rowData = ['node' => $this->createDOMNode($element)];
                         }
 
                         $signal = yield array_to_rows($rowData, $context->entryFactory(), $stream->path()->partitions());
@@ -126,11 +126,11 @@ final class XMLParserExtractor implements Extractor, FileExtractor, LimitableExt
                 foreach ($this->elements as $element) {
                     if ($shouldPutInputIntoRows) {
                         $rowData = [
-                            'node' => $this->createDOMElement($element),
+                            'node' => $this->createDOMNode($element),
                             '_input_file_uri' => $stream->path()->uri(),
                         ];
                     } else {
-                        $rowData = ['node' => $this->createDOMElement($element)];
+                        $rowData = ['node' => $this->createDOMNode($element)];
                     }
 
                     $signal = yield array_to_rows([$rowData], $context->entryFactory(), $stream->path()->partitions());
@@ -194,18 +194,12 @@ final class XMLParserExtractor implements Extractor, FileExtractor, LimitableExt
         return $this;
     }
 
-    private function createDOMElement(string $xmlString) : \DOMElement
+    private function createDOMNode(string $xmlString) : \DOMNode
     {
         $doc = new \DOMDocument();
         $doc->loadXML($xmlString);
 
-        $element = $doc->documentElement;
-
-        if ($element === null) {
-            throw new RuntimeException('Cannot create DOMElement from XML string: ' . $xmlString);
-        }
-
-        return $element;
+        return $doc;
     }
 
     private function freeParser() : void


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Return DOMDocument instead of DOMElement from XMLParserExtractor</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

The reason behind this change is strictly related to performance. When extractors returns DOMElemenet, the most commonly used XPath scalar function (that is usually used at node entry of a row) needs to convert it back to DOMDocument which affects performance since it adds few more steps to the process. 
So in general returning DOMDocument as a `node` might not be the most logical approach (it feels more natural to return DOMElement) but it will hurt the performance and it's not worth it. 
