### PR TITLE
Improved performance of Scalar Function Parameter

### DIFF
--- a/src/core/etl/src/Flow/ETL/Function/DOMElementAttributeValue.php
+++ b/src/core/etl/src/Flow/ETL/Function/DOMElementAttributeValue.php
@@ -4,43 +4,40 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Function;
 
+use function Flow\ETL\DSL\{type_list, type_object};
 use Flow\ETL\Row;
 
 final class DOMElementAttributeValue extends ScalarFunctionChain
 {
     public function __construct(
-        private readonly ScalarFunction|\DOMElement $domElement,
+        private readonly ScalarFunction|\DOMNode $domElement,
         private readonly ScalarFunction|string $attribute,
     ) {
     }
 
     public function eval(Row $row) : ?string
     {
-        $domElement = Parameter::oneOf(
-            (new Parameter($this->domElement))->asInstanceOf($row, \DOMElement::class),
-            (new Parameter($this->domElement))->asInstanceOf($row, \DOMDocument::class),
-            (new Parameter($this->domElement))->asListOfObjects($row, \DOMElement::class),
-        );
+        $node = (new Parameter($this->domElement))->as($row, type_object(\DOMNode::class), type_list(type_object(\DOMNode::class)));
 
-        if ($domElement instanceof \DOMDocument) {
-            $domElement = $domElement->documentElement;
+        if ($node instanceof \DOMDocument) {
+            $node = $node->documentElement;
         }
 
-        if (\is_array($domElement) && \count($domElement)) {
-            $domElement = \reset($domElement);
+        if (\is_array($node) && \count($node)) {
+            $node = \reset($node);
         }
 
         $attributeName = (new Parameter($this->attribute))->asString($row);
 
-        if ($domElement === null || $attributeName === null) {
+        if ($node === null || $attributeName === null) {
             return null;
         }
 
-        if (!$domElement->hasAttributes()) {
+        if (!$node->hasAttributes()) {
             return null;
         }
 
-        $attributes = $domElement->attributes;
+        $attributes = $node->attributes;
 
         if (!$namedItem = $attributes->getNamedItem($attributeName)) {
             return null;

--- a/src/core/etl/src/Flow/ETL/Function/DOMElementAttributesCount.php
+++ b/src/core/etl/src/Flow/ETL/Function/DOMElementAttributesCount.php
@@ -8,7 +8,7 @@ use Flow\ETL\Row;
 
 final class DOMElementAttributesCount extends ScalarFunctionChain
 {
-    public function __construct(private readonly ScalarFunction|\DOMElement $domElement)
+    public function __construct(private readonly ScalarFunction|\DOMNode $domElement)
     {
     }
 

--- a/src/core/etl/src/Flow/ETL/Function/DOMElementValue.php
+++ b/src/core/etl/src/Flow/ETL/Function/DOMElementValue.php
@@ -4,34 +4,31 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Function;
 
+use function Flow\ETL\DSL\{type_list, type_object};
 use Flow\ETL\Row;
 
 final class DOMElementValue extends ScalarFunctionChain
 {
-    public function __construct(private readonly ScalarFunction|\DOMElement $domElement)
+    public function __construct(private readonly ScalarFunction|\DOMNode $node)
     {
     }
 
     public function eval(Row $row) : mixed
     {
-        $domElement = Parameter::oneOf(
-            (new Parameter($this->domElement))->asInstanceOf($row, \DOMElement::class),
-            (new Parameter($this->domElement))->asInstanceOf($row, \DOMDocument::class),
-            (new Parameter($this->domElement))->asListOfObjects($row, \DOMElement::class),
-        );
+        $node = (new Parameter($this->node))->as($row, type_object(\DOMNode::class), type_list(type_object(\DOMNode::class)));
 
-        if (\is_array($domElement) && \count($domElement)) {
-            $domElement = \reset($domElement);
+        if (\is_array($node) && \count($node)) {
+            $node = \reset($node);
         }
 
-        if ($domElement instanceof \DOMDocument) {
-            $domElement = $domElement->documentElement;
+        if ($node instanceof \DOMDocument) {
+            $node = $node->documentElement;
         }
 
-        if (!$domElement instanceof \DOMElement) {
+        if (!$node instanceof \DOMElement) {
             return null;
         }
 
-        return $domElement->nodeValue;
+        return $node->nodeValue;
     }
 }

--- a/src/core/etl/src/Flow/ETL/Function/Parameter.php
+++ b/src/core/etl/src/Flow/ETL/Function/Parameter.php
@@ -5,22 +5,24 @@ declare(strict_types=1);
 namespace Flow\ETL\Function;
 
 use function Flow\ETL\DSL\lit;
+use Flow\ETL\PHP\Type\Type;
 use Flow\ETL\Row;
 
 final class Parameter
 {
     private ScalarFunction $function;
 
-    public function __construct(
-        mixed $function,
-    ) {
+    public function __construct(mixed $function)
+    {
         $this->function = $function instanceof ScalarFunction ? $function : lit($function);
     }
 
-    public static function oneOf(mixed ...$values) : mixed
+    public function as(Row $row, Type $type, Type ...$types) : mixed
     {
-        foreach ($values as $value) {
-            if ($value !== null) {
+        $value = $this->function->eval($row);
+
+        foreach (\array_merge([$type], $types) as $nextType) {
+            if ($nextType->isValid($value)) {
                 return $value;
             }
         }
@@ -38,13 +40,6 @@ final class Parameter
     public function asBoolean(Row $row) : bool
     {
         return (bool) $this->function->eval($row);
-    }
-
-    public function asDateTime(Row $row) : ?\DateTimeInterface
-    {
-        $result = $this->function->eval($row);
-
-        return $result instanceof \DateTimeInterface ? $result : null;
     }
 
     /**

--- a/src/core/etl/src/Flow/ETL/Function/StrReplace.php
+++ b/src/core/etl/src/Flow/ETL/Function/StrReplace.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Function;
 
+use function Flow\ETL\DSL\{type_list, type_string};
 use Flow\ETL\Row;
 
 final class StrReplace extends ScalarFunctionChain
@@ -18,8 +19,8 @@ final class StrReplace extends ScalarFunctionChain
     public function eval(Row $row) : ?string
     {
         $value = (new Parameter($this->value))->asString($row);
-        $search = Parameter::oneOf((new Parameter($this->search))->asString($row), (new Parameter($this->search))->asArray($row));
-        $replace = Parameter::oneOf((new Parameter($this->replace))->asString($row), (new Parameter($this->replace))->asArray($row));
+        $search = (new Parameter($this->search))->as($row, type_string(), type_list(type_string()));
+        $replace = (new Parameter($this->replace))->as($row, type_string(), type_list(type_string()));
 
         if ($value === null || $search === null || $replace === null) {
             return null;

--- a/src/core/etl/src/Flow/ETL/Function/ToTimeZone.php
+++ b/src/core/etl/src/Flow/ETL/Function/ToTimeZone.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Function;
 
+use function Flow\ETL\DSL\{type_object, type_string};
 use Flow\ETL\Row;
 
 final class ToTimeZone extends ScalarFunctionChain
@@ -17,10 +18,7 @@ final class ToTimeZone extends ScalarFunctionChain
     public function eval(Row $row) : mixed
     {
         $dateTime = (new Parameter($this->value))->asInstanceOf($row, \DateTimeInterface::class);
-        $tz = Parameter::oneOf(
-            (new Parameter($this->timezone))->asString($row),
-            (new Parameter($this->timezone))->asInstanceOf($row, \DateTimeZone::class)
-        );
+        $tz = (new Parameter($this->timezone))->as($row, type_string(), type_object(\DateTimeZone::class));
 
         if ($dateTime === null || $tz === null) {
             return null;

--- a/src/core/etl/src/Flow/ETL/Function/Uuid.php
+++ b/src/core/etl/src/Flow/ETL/Function/Uuid.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Function;
 
+use function Flow\ETL\DSL\{type_object, type_string};
 use Flow\ETL\Exception\RuntimeException;
 use Flow\ETL\Row;
 
@@ -31,10 +32,7 @@ final class Uuid extends ScalarFunctionChain
 
     public function eval(Row $row) : mixed
     {
-        $param = Parameter::oneOf(
-            (new Parameter($this->value))->asString($row),
-            (new Parameter($this->value))->asInstanceOf($row, \DateTimeInterface::class)
-        );
+        $param = (new Parameter($this->value))->as($row, type_string(), type_object(\DateTimeInterface::class));
 
         $uuidVersion = (new Parameter($this->uuidVersion))->asString($row);
 

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Function/ParameterTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Function/ParameterTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Tests\Unit\Function;
+
+use function Flow\ETL\DSL\{object_entry, ref, row, str_entry, type_boolean, type_int, type_object, type_string};
+use Flow\ETL\Function\Parameter;
+use PHPUnit\Framework\TestCase;
+
+final class ParameterTest extends TestCase
+{
+    public function test_as_object() : void
+    {
+        $parameter = new Parameter(ref('value'));
+
+        $value = new \DateTimeImmutable();
+
+        self::assertNull($parameter->as(row(object_entry('value', $value)), type_int()));
+        self::assertSame($value, $parameter->as(row(object_entry('value', $value)), type_object(\DateTimeInterface::class)));
+        self::assertSame($value, $parameter->as(row(object_entry('value', $value)), type_object(\DateTimeImmutable::class)));
+        self::assertNull($parameter->as(row(object_entry('value', $value)), type_object(\DateTime::class)));
+    }
+
+    public function test_as_one_of() : void
+    {
+        $parameter = new Parameter(ref('value'));
+
+        self::assertNull($parameter->as(row(str_entry('value', '42')), type_int(), type_boolean()));
+        self::assertSame('42', $parameter->as(row(str_entry('value', '42')), type_string(), type_int()));
+    }
+
+    public function test_as_scalar() : void
+    {
+        $parameter = new Parameter(ref('value'));
+
+        self::assertNull($parameter->as(row(str_entry('value', '42')), type_int()));
+        self::assertSame('42', $parameter->as(row(str_entry('value', '42')), type_string()));
+    }
+}


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Improved performance of Scalar Function Parameter</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

That is another round of improving the performance of processing XML files. Parameter::asAnyOf was replaced with a more generic Parameter::as that is using Flow Type. The main difference is in how those two functions are executed, Paraeter::as evaluates scalar function only once, which in processing big datasets might reduce the execution of the same scalar function by a million times. 
