### PR TITLE
Fixed loading empty rows through dbal loader

### DIFF
--- a/src/adapter/etl-adapter-doctrine/src/Flow/ETL/Adapter/Doctrine/DbalLoader.php
+++ b/src/adapter/etl-adapter-doctrine/src/Flow/ETL/Adapter/Doctrine/DbalLoader.php
@@ -64,10 +64,6 @@ final class DbalLoader implements Loader
 
     public function load(Rows $rows, FlowContext $context) : void
     {
-        if (!$rows->count()) {
-            return;
-        }
-
         Bulk::create()->{$this->operation}(
             $this->connection(),
             $this->tableName,

--- a/src/adapter/etl-adapter-doctrine/src/Flow/ETL/Adapter/Doctrine/DbalLoader.php
+++ b/src/adapter/etl-adapter-doctrine/src/Flow/ETL/Adapter/Doctrine/DbalLoader.php
@@ -64,6 +64,10 @@ final class DbalLoader implements Loader
 
     public function load(Rows $rows, FlowContext $context) : void
     {
+        if (!$rows->count()) {
+            return;
+        }
+
         Bulk::create()->{$this->operation}(
             $this->connection(),
             $this->tableName,

--- a/src/core/etl/src/Flow/ETL/Pipeline/SynchronousPipeline.php
+++ b/src/core/etl/src/Flow/ETL/Pipeline/SynchronousPipeline.php
@@ -57,7 +57,13 @@ final class SynchronousPipeline implements Pipeline
                             $generator->send(Signal::STOP);
                         }
                     } elseif ($pipe instanceof Loader) {
-                        $pipe->load($rows, $context);
+                        if ($rows->count()) {
+                            /**
+                             * When there are no rows to load, we should not call the loader. This way we can avoid
+                             * checking rows count inside the loader implementation.
+                             */
+                            $pipe->load($rows, $context);
+                        }
                     }
                 } catch (\Throwable $exception) {
                     if ($context->errorHandler()->throw($exception, $rows)) {

--- a/src/core/etl/tests/Flow/ETL/Tests/Integration/Pipeline/SynchronousPipelineTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Integration/Pipeline/SynchronousPipelineTest.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Flow\ETL\Tests\Integration\Pipeline;
 
 use function Flow\ETL\Adapter\CSV\{from_csv, to_csv};
-use function Flow\ETL\DSL\from_array;
-use Flow\ETL\Flow;
+use function Flow\ETL\DSL\{df, from_array, lit};
+use Flow\ETL\Loader;
 use Flow\ETL\Tests\Integration\IntegrationTestCase;
 
 final class SynchronousPipelineTest extends IntegrationTestCase
@@ -26,7 +26,7 @@ final class SynchronousPipelineTest extends IntegrationTestCase
             \unlink($path);
         }
 
-        (new Flow())
+        df()
             ->read(from_array([
                 ['id' => 1],
                 ['id' => 2],
@@ -40,10 +40,29 @@ final class SynchronousPipelineTest extends IntegrationTestCase
 
         self::assertSame(
             3,
-            (new Flow())
+            df()
                 ->read(from_csv($path))
                 ->limit(3)
                 ->count()
         );
+    }
+
+    public function test_not_calling_loader_when_rows_are_empty() : void
+    {
+        $loader = $this->createMock(Loader::class);
+        $loader->expects(self::never())->method('load');
+
+        df()
+            ->read(from_array([
+                ['id' => 1],
+                ['id' => 2],
+                ['id' => 3],
+                ['id' => 4],
+                ['id' => 5],
+                ['id' => 6],
+            ]))
+            ->filter(lit(true)->equals(false))
+            ->write($loader)
+            ->run();
     }
 }


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>Don't call loaders when rows are empty</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

Resolves #1231

