### PR TITLE
Added more output styles for to_output() loader

### DIFF
--- a/src/core/etl/src/Flow/ETL/Loader/StreamLoader.php
+++ b/src/core/etl/src/Flow/ETL/Loader/StreamLoader.php
@@ -63,6 +63,9 @@ final class StreamLoader implements Closure, Loader
         \fwrite(
             $stream,
             match ($this->output) {
+                Output::rows_count => 'Rows: ' . $rows->count() . "\n",
+                Output::column_count => 'Columns: ' . $rows->schema()->count() . "\n",
+                Output::rows_and_column_count => 'Rows: ' . $rows->count() . ', Columns: ' . $rows->schema()->count() . "\n",
                 Output::rows => $this->formatter->format($rows, $this->truncate),
                 Output::schema => $this->schemaFormatter->format($rows->schema()),
                 Output::rows_and_schema => $this->formatter->format($rows, $this->truncate) . "\n" . $this->schemaFormatter->format($rows->schema()),

--- a/src/core/etl/src/Flow/ETL/Loader/StreamLoader/Output.php
+++ b/src/core/etl/src/Flow/ETL/Loader/StreamLoader/Output.php
@@ -6,7 +6,10 @@ namespace Flow\ETL\Loader\StreamLoader;
 
 enum Output
 {
+    case column_count;
     case rows;
+    case rows_and_column_count;
     case rows_and_schema;
+    case rows_count;
     case schema;
 }

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Loader/StreamLoaderTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Loader/StreamLoaderTest.php
@@ -13,6 +13,32 @@ use PHPUnit\Framework\TestCase;
 
 final class StreamLoaderTest extends TestCase
 {
+    public function test_columns_count_to_php_output_stream() : void
+    {
+        $loader = to_output(false, StreamLoader\Output::column_count);
+
+        \ob_start();
+
+        $loader->load(
+            rows(
+                row(int_entry('id', 1), str_entry('name', 'id_1')),
+                row(int_entry('id', 2), str_entry('name', 'id_2')),
+                row(int_entry('id', 3), str_entry('name', 'id_3'))
+            ),
+            new FlowContext(Config::default())
+        );
+        $output = \ob_get_contents();
+        \ob_end_clean();
+
+        self::assertSame(
+            <<<'ASCII'
+Columns: 2
+
+ASCII,
+            $output
+        );
+    }
+
     public function test_loading_data_into_invalid_stream() : void
     {
         $this->expectExceptionMessage("Can't open stream for url: php://qweqweqw in mode: w");
@@ -30,7 +56,7 @@ final class StreamLoaderTest extends TestCase
         );
     }
 
-    public function test_loading_partitioned_rows_into_php_memory_stream() : void
+    public function test_loading_partitioned_rows_into_php_output_stream() : void
     {
         $loader = new StreamLoader('php://output', Mode::WRITE, 0);
 
@@ -64,7 +90,7 @@ TABLE,
         );
     }
 
-    public function test_loading_rows_and_schema_into_php_memory_stream() : void
+    public function test_loading_rows_and_schema_into_output_stream() : void
     {
         $loader = to_output(false, StreamLoader\Output::rows_and_schema);
 
@@ -101,7 +127,7 @@ ASCII,
         );
     }
 
-    public function test_loading_rows_into_php_memory_stream() : void
+    public function test_loading_rows_into_php_output_stream() : void
     {
         $loader = new StreamLoader('php://output', Mode::WRITE, 0);
 
@@ -133,7 +159,7 @@ TABLE,
         );
     }
 
-    public function test_loading_schema_into_php_memory_stream() : void
+    public function test_loading_schema_into_php_output_stream() : void
     {
         $loader = new StreamLoader('php://output', Mode::WRITE, 0, StreamLoader\Output::schema);
 
@@ -155,6 +181,58 @@ TABLE,
 schema
 |-- id: integer
 |-- name: string
+
+ASCII,
+            $output
+        );
+    }
+
+    public function test_rows_and_columns_count_to_php_output_stream() : void
+    {
+        $loader = to_output(false, StreamLoader\Output::rows_and_column_count);
+
+        \ob_start();
+
+        $loader->load(
+            rows(
+                row(int_entry('id', 1), str_entry('name', 'id_1')),
+                row(int_entry('id', 2), str_entry('name', 'id_2')),
+                row(int_entry('id', 3), str_entry('name', 'id_3'))
+            ),
+            new FlowContext(Config::default())
+        );
+        $output = \ob_get_contents();
+        \ob_end_clean();
+
+        self::assertSame(
+            <<<'ASCII'
+Rows: 3, Columns: 2
+
+ASCII,
+            $output
+        );
+    }
+
+    public function test_rows_count_to_php_output_stream() : void
+    {
+        $loader = to_output(false, StreamLoader\Output::rows_count);
+
+        \ob_start();
+
+        $loader->load(
+            rows(
+                row(int_entry('id', 1), str_entry('name', 'id_1')),
+                row(int_entry('id', 2), str_entry('name', 'id_2')),
+                row(int_entry('id', 3), str_entry('name', 'id_3'))
+            ),
+            new FlowContext(Config::default())
+        );
+        $output = \ob_get_contents();
+        \ob_end_clean();
+
+        self::assertSame(
+            <<<'ASCII'
+Rows: 3
 
 ASCII,
             $output


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <li>Added more output styles for to_output() loader</li>
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

Example: 

```php
df()
    ->read(from_parquet(__DIR__ . '/orders_with_products.parquet'))
    ->batchSize(1000)
    ->write(to_output(output: Output::rows_and_column_count))
    ->run();
```

Output: 

```shell
php .scratchpad/flow/read.php
Rows: 1000, Columns: 9
Rows: 1000, Columns: 9
Rows: 1000, Columns: 9
Rows: 1000, Columns: 9
Rows: 1000, Columns: 9
Rows: 1000, Columns: 9
Rows: 1000, Columns: 9
Rows: 1000, Columns: 9
Rows: 1000, Columns: 9
Rows: 1000, Columns: 9
Rows: 1000, Columns: 9
```
