### PR TITLE
Simplified caching pipeline batch size configuration

### DIFF
--- a/src/core/etl/src/Flow/ETL/Config/Cache/CacheConfig.php
+++ b/src/core/etl/src/Flow/ETL/Config/Cache/CacheConfig.php
@@ -12,12 +12,10 @@ final class CacheConfig
     public const CACHE_DIR_ENV = 'FLOW_LOCAL_FILESYSTEM_CACHE_DIR';
 
     /**
-     * @param int<1, max> $cacheBatchSize
      * @param int<1, max> $externalSortBucketsCount
      */
     public function __construct(
         public readonly Cache $cache,
-        public readonly int $cacheBatchSize,
         public readonly Path $localFilesystemCacheDir,
         public readonly int $externalSortBucketsCount,
     ) {

--- a/src/core/etl/src/Flow/ETL/Config/Cache/CacheConfigBuilder.php
+++ b/src/core/etl/src/Flow/ETL/Config/Cache/CacheConfigBuilder.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Flow\ETL\Config\Cache;
 
 use function Flow\Filesystem\DSL\protocol;
+use Flow\ETL\Cache;
 use Flow\ETL\Cache\{Implementation\FilesystemCache};
 use Flow\ETL\Exception\{InvalidArgumentException, RuntimeException};
 use Flow\Filesystem\{FilesystemTable, Path};
@@ -12,12 +13,7 @@ use Flow\Serializer\Serializer;
 
 final class CacheConfigBuilder
 {
-    private ?\Flow\ETL\Cache $cache = null;
-
-    /**
-     * @var int<1, max>
-     */
-    private int $cacheBatchSize = 100;
+    private ?Cache $cache = null;
 
     /**
      * @var int<1, max>
@@ -46,29 +42,14 @@ final class CacheConfigBuilder
                 $serializer,
                 cacheDir: Path::realpath($cachePath)
             ),
-            cacheBatchSize: $this->cacheBatchSize,
             localFilesystemCacheDir: Path::realpath($cachePath),
             externalSortBucketsCount: $this->externalSortBucketsCount
         );
     }
 
-    public function cache(\Flow\ETL\Cache $cache) : self
+    public function cache(Cache $cache) : self
     {
         $this->cache = $cache;
-
-        return $this;
-    }
-
-    /**
-     * @param int<1, max> $cacheBatchSize
-     */
-    public function cacheBatchSize(int $cacheBatchSize) : self
-    {
-        if ($cacheBatchSize < 1) {
-            throw new InvalidArgumentException('Cache batch size must be greater than 0');
-        }
-
-        $this->cacheBatchSize = $cacheBatchSize;
 
         return $this;
     }

--- a/src/core/etl/src/Flow/ETL/Config/ConfigBuilder.php
+++ b/src/core/etl/src/Flow/ETL/Config/ConfigBuilder.php
@@ -7,7 +7,6 @@ namespace Flow\ETL\Config;
 use function Flow\Filesystem\DSL\fstab;
 use Flow\ETL\Config\Cache\CacheConfigBuilder;
 use Flow\ETL\Config\Sort\SortConfigBuilder;
-use Flow\ETL\Exception\InvalidArgumentException;
 use Flow\ETL\Filesystem\FilesystemStreams;
 use Flow\ETL\Monitoring\Memory\Unit;
 use Flow\ETL\PHP\Type\Caster;
@@ -80,18 +79,6 @@ final class ConfigBuilder
     public function cache(Cache $cache) : self
     {
         $this->cache->cache($cache);
-
-        return $this;
-    }
-
-    /**
-     * @param int<1, max> $cacheBatchSize
-     *
-     * @throws InvalidArgumentException
-     */
-    public function cacheBatchSize(int $cacheBatchSize) : self
-    {
-        $this->cache->cacheBatchSize($cacheBatchSize);
 
         return $this;
     }

--- a/src/core/etl/src/Flow/ETL/Pipeline/PipelineMessage.php
+++ b/src/core/etl/src/Flow/ETL/Pipeline/PipelineMessage.php
@@ -1,9 +1,0 @@
-<?php
-
-declare(strict_types=1);
-
-namespace Flow\ETL\Pipeline;
-
-interface PipelineMessage
-{
-}

--- a/src/core/etl/tests/Flow/ETL/Tests/Integration/DataFrame/CacheTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Integration/DataFrame/CacheTest.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Tests\Integration\DataFrame;
 
-use function Flow\ETL\DSL\{config_builder, df, from_cache};
+use function Flow\ETL\DSL\{config_builder, df, from_array, from_cache};
 use Flow\ETL\Cache\CacheIndex;
 use Flow\ETL\Cache\Implementation\InMemoryCache;
 use Flow\ETL\Tests\Double\FakeExtractor;
 use Flow\ETL\Tests\Integration\IntegrationTestCase;
-use Flow\ETL\{Extractor, FlowContext};
+use Flow\ETL\{Extractor, FlowContext, Rows};
 
 final class CacheTest extends IntegrationTestCase
 {
@@ -56,5 +56,58 @@ final class CacheTest extends IntegrationTestCase
 
         self::assertEquals(1, $spyExtractor->extractions);
         self::assertFalse($cache->has('test_etl_cache'));
+    }
+
+    public function test_cache_with_previously_set_batch_size() : void
+    {
+        $cache = new InMemoryCache();
+
+        df(config_builder()->cache($cache))
+            ->read(
+                from_array(\array_map(
+                    fn (int $i) => ['id' => $i],
+                    \range(1, 100)
+                ))
+            )
+            ->batchSize(20)
+            ->cache('test')
+            ->run();
+
+        /** @var CacheIndex $cacheIndex */
+        $cacheIndex = $cache->get('test');
+
+        self::assertCount(5, $cacheIndex->values());
+
+        foreach ($cacheIndex->values() as $index => $cacheRowsKey) {
+            $rows = $cache->get($cacheRowsKey);
+            self::assertInstanceOf(Rows::class, $rows);
+            self::assertCount(20, $rows);
+        }
+    }
+
+    public function test_cache_without_previously_set_batch_size() : void
+    {
+        $cache = new InMemoryCache();
+
+        df(config_builder()->cache($cache))
+            ->read(
+                from_array(\array_map(
+                    fn (int $i) => ['id' => $i],
+                    \range(1, 100)
+                ))
+            )
+            ->cache('test')
+            ->run();
+
+        /** @var CacheIndex $cacheIndex */
+        $cacheIndex = $cache->get('test');
+
+        self::assertCount(100, $cacheIndex->values());
+
+        foreach ($cacheIndex->values() as $index => $cacheRowsKey) {
+            $rows = $cache->get($cacheRowsKey);
+            self::assertInstanceOf(Rows::class, $rows);
+            self::assertCount(1, $rows);
+        }
     }
 }


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>CachingPipeline will relay only on previously set batch size without modifying it</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <li>Default global CachingPipeline batch size</li>
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

Previously using cache was changing the batch size which for long and complicated pipelines could end up in significant performance drop. 

Before
```php
df()
  ->read(...)
  ->batchSize(10_000)
  ->withEntry(...) // batch size here is 10k
  ->cache("test") // cache batch size is not provided so default batch size is used and changed to 100
  ->withEntry(...) // batch size here is 100 
  ->run()

df()
  ->read(...)
  ->batchSize(10_000)
  ->withEntry(...) // batch size here is 10k
  ->cache("test", cacheBatchSize: 10) // cache batch size is set to 10
  ->withEntry(...) // batch size here is 10
  ->run()
```

After
```php
df()
  ->read(...)
  ->batchSize(10_000)
  ->withEntry(...) // batch size here is 10k
  ->cache("test") // batch size here is still 10k 
  ->withEntry(...) // batch size here is still 10k
  ->run()

df()
  ->read(...)
  ->batchSize(10_000)
  ->withEntry(...) // batch size here is 10k
  ->cache("test", cacheBatchSize: 5000) // batch size here is still 5k
  ->withEntry(...) // batch size here is now 5k
  ->run()
```