### PR TITLE
Fixed writing column statistics when there is only one row that is null

### DIFF
--- a/src/lib/parquet/src/Flow/Parquet/ParquetFile/RowGroupBuilder/StatisticsBuilder.php
+++ b/src/lib/parquet/src/Flow/Parquet/ParquetFile/RowGroupBuilder/StatisticsBuilder.php
@@ -26,12 +26,12 @@ final class StatisticsBuilder
         (new PlainValuesPacker(new BinaryBufferWriter($maxBuffer), $this->dataConverter))->packValues($column, [$chunkStatistics->max()]);
 
         return new Statistics(
-            max: $maxBuffer,
-            min: $minBuffer,
+            max: $maxBuffer !== '' ? $maxBuffer : null,
+            min: $minBuffer !== '' ? $minBuffer : null,
             nullCount: $chunkStatistics->nullCount(),
             distinctCount: $chunkStatistics->distinctCount(),
-            maxValue: $maxBuffer,
-            minValue: $minBuffer,
+            maxValue: $maxBuffer !== '' ? $maxBuffer : null,
+            minValue: $minBuffer !== '' ? $minBuffer : null,
         );
     }
 }

--- a/src/lib/parquet/tests/Flow/Parquet/Tests/Integration/IO/WriterTest.php
+++ b/src/lib/parquet/tests/Flow/Parquet/Tests/Integration/IO/WriterTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Flow\Parquet\Tests\Integration\IO;
 
-use function Flow\ETL\DSL\generate_random_int;
+use function Flow\ETL\DSL\{generate_random_int, generate_random_string};
 use Composer\InstalledVersions;
 use Faker\Factory;
 use Flow\Filesystem\Stream\NativeLocalDestinationStream;
@@ -37,7 +37,7 @@ final class WriterTest extends TestCase
     {
         $writer = new Writer();
 
-        $path = __DIR__ . '/var/test-writer-parquet-test-' . \Flow\ETL\DSL\generate_random_string() . '.parquet';
+        $path = __DIR__ . '/var/test-writer-parquet-test-' . generate_random_string() . '.parquet';
 
         $schema = $this->createSchema();
         $writer->open($path, $schema);
@@ -52,7 +52,7 @@ final class WriterTest extends TestCase
     {
         $writer = new Writer();
 
-        $path = __DIR__ . '/var/test-writer-parquet-test-' . \Flow\ETL\DSL\generate_random_string() . '.parquet';
+        $path = __DIR__ . '/var/test-writer-parquet-test-' . generate_random_string() . '.parquet';
 
         $schema = $this->createSchema();
 
@@ -81,7 +81,7 @@ final class WriterTest extends TestCase
                 ->set(Option::WRITER_VERSION, 1)
         );
 
-        $path = __DIR__ . '/var/test-writer-parquet-test-v2-' . \Flow\ETL\DSL\generate_random_string() . '.parquet';
+        $path = __DIR__ . '/var/test-writer-parquet-test-v2-' . generate_random_string() . '.parquet';
 
         $schema = Schema::with($column = FlatColumn::int32('int32'));
 
@@ -110,7 +110,7 @@ final class WriterTest extends TestCase
                 ->set(Option::WRITER_VERSION, 2)
         );
 
-        $path = __DIR__ . '/var/test-writer-parquet-test-v2-' . \Flow\ETL\DSL\generate_random_string() . '.parquet';
+        $path = __DIR__ . '/var/test-writer-parquet-test-v2-' . generate_random_string() . '.parquet';
 
         $schema = Schema::with($column = FlatColumn::int32('int32'));
 
@@ -137,7 +137,7 @@ final class WriterTest extends TestCase
     {
         $writer = new Writer();
 
-        $path = __DIR__ . '/var/test-writer-parquet-test-' . \Flow\ETL\DSL\generate_random_string() . '.parquet';
+        $path = __DIR__ . '/var/test-writer-parquet-test-' . generate_random_string() . '.parquet';
 
         $schema = $this->createSchema();
 
@@ -164,7 +164,7 @@ final class WriterTest extends TestCase
     {
         $writer = new Writer();
 
-        $path = __DIR__ . '/var/test-writer-parquet-test-' . \Flow\ETL\DSL\generate_random_string() . '.parquet';
+        $path = __DIR__ . '/var/test-writer-parquet-test-' . generate_random_string() . '.parquet';
 
         $schema = $this->createSchema();
 
@@ -190,7 +190,7 @@ final class WriterTest extends TestCase
     {
         $writer = new Writer();
 
-        $path = __DIR__ . '/var/test-writer-parquet-test-' . \Flow\ETL\DSL\generate_random_string() . '.parquet';
+        $path = __DIR__ . '/var/test-writer-parquet-test-' . generate_random_string() . '.parquet';
 
         $schema = $this->createSchema();
 
@@ -214,6 +214,40 @@ final class WriterTest extends TestCase
         \unlink($path);
     }
 
+    public function test_writing_one_row_that_is_nullable() : void
+    {
+        $writer = new Writer();
+
+        $schema = Schema::with(
+            $column = FlatColumn::int32('id'),
+        );
+
+        $path = __DIR__ . '/var/test-writer-parquet-test-' . generate_random_string() . '.parquet';
+
+        $writer->write(
+            $path,
+            $schema,
+            [
+                [
+                    'id' => null,
+                ],
+            ]
+        );
+
+        $max = (new Reader())->read($path)->metadata()->columnChunks()[0]->statistics()->max($column);
+        $min = (new Reader())->read($path)->metadata()->columnChunks()[0]->statistics()->min($column);
+        $maxValue = (new Reader())->read($path)->metadata()->columnChunks()[0]->statistics()->max($column);
+        $minValue = (new Reader())->read($path)->metadata()->columnChunks()[0]->statistics()->min($column);
+
+        self::assertNull($max);
+        self::assertNull($min);
+        self::assertNull($maxValue);
+        self::assertNull($minValue);
+
+        self::assertFileExists($path);
+        \unlink($path);
+    }
+
     public function test_writing_row_to_not_open_stream() : void
     {
         $writer = new Writer();
@@ -228,7 +262,7 @@ final class WriterTest extends TestCase
     {
         $writer = new Writer();
 
-        $path = __DIR__ . '/var/test-writer-parquet-test-' . \Flow\ETL\DSL\generate_random_string() . '.parquet';
+        $path = __DIR__ . '/var/test-writer-parquet-test-' . generate_random_string() . '.parquet';
 
         $schema = $this->createSchema();
         $row = $this->createRow();
@@ -250,7 +284,7 @@ final class WriterTest extends TestCase
                 ->set(Option::WRITER_VERSION, 2)
         );
 
-        $path = __DIR__ . '/var/test-writer-parquet-test-v2-' . \Flow\ETL\DSL\generate_random_string() . '.parquet';
+        $path = __DIR__ . '/var/test-writer-parquet-test-v2-' . generate_random_string() . '.parquet';
 
         $schema = $this->createSchema();
         $row = $this->createRow();
@@ -270,7 +304,7 @@ final class WriterTest extends TestCase
     {
         $writer = new Writer();
 
-        $path = __DIR__ . '/var/test-writer-parquet-test-' . \Flow\ETL\DSL\generate_random_string() . '.parquet';
+        $path = __DIR__ . '/var/test-writer-parquet-test-' . generate_random_string() . '.parquet';
 
         $schema = $this->createSchema();
         $row = $this->createRow();


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>Fixed writing column statistics when there is only one row that is null</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

This issue was reported on our Discord channel by user `guiguiolol`. 
Code to reproduce this issue: 

```php
<?php

use Flow\Parquet\ParquetFile\Schema;
use Flow\Parquet\ParquetFile\Schema\FlatColumn;
use Flow\Parquet\Writer;

require_once __DIR__ . '/../../../vendor/autoload.php';

$writer = new Writer();

$schema = Schema::with(
    FlatColumn::int32('id'),
);

if (file_exists(__DIR__ . '/test.parquet')) {
    unlink(__DIR__ . '/test.parquet');
}

$writer->write(
    __DIR__ . '/test.parquet',
    $schema,
    [
        [
            'id' => null,
        ]
    ]
);
```

Parquet files created like this can't be read by other software (confirmed through duckdb). 

When min/max buffers are empty we can safely make them null (that's what pyarrow is doing). 
Below python code to reproduce the same scenario: 

```python
import pyarrow as pa
import pyarrow.parquet as pq
import os

# Define the directory and file path
dir_path = os.path.dirname(os.path.realpath(__file__))
file_path = os.path.join(dir_path, 'test.parquet')

# Define the schema with an int32 'id' column that is nullable
schema = pa.schema([
    pa.field('id', pa.int32(), nullable=True)
])

# Prepare the data with 'id' set to None (null)
data = {
    'id': [None]
}

# Create a PyArrow Table with the data and schema
table = pa.Table.from_pydict(data, schema=schema)

# Remove the Parquet file if it already exists
if os.path.exists(file_path):
    os.remove(file_path)

# Write the table to a Parquet file
pq.write_table(table, file_path)

```