### PR TITLE
Removed .md suffix from documentation urls

### DIFF
--- a/web/landing/src/Flow/Website/Service/Documentation/Pages.php
+++ b/web/landing/src/Flow/Website/Service/Documentation/Pages.php
@@ -34,6 +34,8 @@ final class Pages
                 continue;
             }
 
+            $relativePath = str_replace('.md', '', $relativePath);
+
             $pages[] = new Page($relativePath, \file_get_contents($file->path->path()));
         }
 

--- a/web/landing/src/Flow/Website/Service/Markdown/FlowLinkRenderer.php
+++ b/web/landing/src/Flow/Website/Service/Markdown/FlowLinkRenderer.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\Website\Service\Markdown;
+
+use League\CommonMark\Extension\CommonMark\Node\Inline\Link;
+use League\CommonMark\Node\Node;
+use League\CommonMark\Renderer\{ChildNodeRendererInterface, NodeRendererInterface};
+use League\CommonMark\Util\HtmlElement;
+
+class FlowLinkRenderer implements NodeRendererInterface
+{
+    public function render(Node $node, ChildNodeRendererInterface $childRenderer)
+    {
+        if (!$node instanceof Link) {
+            throw new \InvalidArgumentException('Incompatible node type: ' . $node::class);
+        }
+
+        $attrs = $node->data->get('attributes');
+
+        $urlParts = parse_url($node->getUrl());
+
+        if (!isset($urlParts['scheme']) && !isset($urlParts['host'])) {
+            $node->setUrl(str_replace('.md', '', $node->getUrl()));
+        }
+
+        $attrs['href'] = $node->getUrl();
+
+        if ($node->getTitle()) {
+            $attrs['title'] = $node->getTitle();
+        }
+
+        return new HtmlElement('a', $attrs, $childRenderer->renderNodes($node->children()));
+    }
+}

--- a/web/landing/src/Flow/Website/Service/Markdown/LeagueCommonMarkConverterFactory.php
+++ b/web/landing/src/Flow/Website/Service/Markdown/LeagueCommonMarkConverterFactory.php
@@ -7,6 +7,7 @@ namespace Flow\Website\Service\Markdown;
 use League\CommonMark\CommonMarkConverter;
 use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
 use League\CommonMark\Extension\CommonMark\Node\Block\FencedCode;
+use League\CommonMark\Extension\CommonMark\Node\Inline\Link;
 use League\CommonMark\Extension\ExternalLink\ExternalLinkExtension;
 
 final class LeagueCommonMarkConverterFactory
@@ -24,7 +25,8 @@ final class LeagueCommonMarkConverterFactory
 
         $converter->getEnvironment()
             ->addExtension(new ExternalLinkExtension())
-            ->addRenderer(FencedCode::class, new FlowCodeRenderer(), 0);
+            ->addRenderer(FencedCode::class, new FlowCodeRenderer(), 0)
+            ->addRenderer(Link::class, new FlowLinkRenderer(), 0);
         //        $converter->getEnvironment()->addExtension(new CommonMarkCoreExtension());
         //        foreach ($this->extensions as $extension) {
         //            $converter->getEnvironment()->addRenderer(new FlowCodeRenderer());


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>Removed .md suffix from documentation URLs</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

<!-- Please provide a short description of changes in this section, feel free to use markdown syntax -->
