### PR TITLE
Updated infection configuration to focus it at core only

### DIFF
--- a/infection.json
+++ b/infection.json
@@ -2,15 +2,16 @@
   "source": {
     "directories": [
       "src/core/etl/src",
-      "src/adapter/*/src",
-      "src/bridge/filesystem/*/src",
-      "src/bridge/monolog/*/src",
-      "src/bridge/symfony/*/src",
-      "src/lib/*/src"
+      "src/lib/array-dot/src",
+      "src/lib/doctrine-dbal-bulk/src",
+      "src/lib/filesystem/src",
+      "src/lib/parquet/src",
+      "src/lib/rdsl/src"
     ]
   },
   "logs": {
     "text": "./var/infection/infection.log",
+    "html": "./var/infection/infection.html",
     "summary": "./var/infection/infection_summary.log",
     "debug": "./var/infection/infection_summary.log",
     "stryker": {
@@ -48,11 +49,6 @@
         "Flow\\Doctrine\\Bulk\\BulkData::toSqlParameters"
       ]
     },
-    "MethodCallRemoval": {
-      "ignore": [
-        "Flow\\ETL\\Adapter\\Logger\\Logger\\DumpLogger::log"
-      ]
-    },
     "Identical": {
       "ignore": [
         "Flow\\Doctrine\\Bulk\\DbalPlatform"
@@ -69,7 +65,7 @@
     "customPath": "tools/phpunit/vendor/bin/phpunit"
   },
   "tmpDir": "var/infection/cache",
-  "testFrameworkOptions": "--testsuite=unit",
+  "testFrameworkOptions": "--testsuite=infection",
   "minMsi": 29,
   "minCoveredMsi": 75
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -164,12 +164,14 @@
     <testsuite name="adapter-xml-integration">
       <directory>src/adapter/etl-adapter-xml/tests/Flow/ETL/Adapter/XML/Tests/Integration</directory>
     </testsuite>
-    <testsuite name="unit">
-      <directory>src/adapter/**/**/**/**/**/**/Tests/Unit</directory>
-      <directory>src/bridge/**/**/**/**/**/**/**/Tests/Unit</directory>
+    <testsuite name="infection">
       <directory>src/core/etl/tests/Flow/ETL/Tests/Unit</directory>
-      <directory>src/lib/**/**/**/**/Tests/Unit</directory>
+      <directory>src/lib/array-dot/tests/Flow/ArrayDot/Tests/Unit</directory>
       <directory>src/lib/doctrine-dbal-bulk/tests/Flow/Doctrine/Bulk/Tests/Unit</directory>
+      <directory>src/lib/doctrine-dbal-bulk/tests/Flow/Doctrine/Bulk/Tests/Unit</directory>
+      <directory>src/lib/filesystem/tests/Flow/Filesystem/Tests/Unit</directory>
+      <directory>src/lib/parquet/tests/Flow/Parquet/Tests/Unit</directory>
+      <directory>src/lib/rdsl/tests/Flow/RDSL/Tests/Unit</directory>
     </testsuite>
   </testsuites>
   <source>

--- a/src/adapter/etl-adapter-elasticsearch/tests/Flow/ETL/Adapter/Elasticsearch/Tests/Unit/HashIdFactoryTest.php
+++ b/src/adapter/etl-adapter-elasticsearch/tests/Flow/ETL/Adapter/Elasticsearch/Tests/Unit/HashIdFactoryTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Flow\ETL\Adapter\Elasticsearch\Tests\Unit\EntryIdFactory;
+namespace Flow\ETL\Adapter\Elasticsearch\Tests\Unit;
 
 use function Flow\ETL\DSL\{str_entry, string_entry};
 use Flow\ETL\Adapter\Elasticsearch\EntryIdFactory\HashIdFactory;


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Updated infection configuration to focus it at core only</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

Since Adapters/Bridges in most cases are tested with integration tests anyway I removed them from infection testsuite in order to focus it only at Unit Tests of core building blocks.

There is still some space for improvement, especially around excluding Parquet Binary reading/writing/thrift files from it.

I also added HTML report to simplify debugging what's still missing. 