### PR TITLE
Use the FlowTestCase in all the Adapters tests

### DIFF
--- a/src/adapter/etl-adapter-chartjs/tests/Flow/ETL/Adapter/ChartJS/Tests/Integration/ChartJSLoaderTest.php
+++ b/src/adapter/etl-adapter-chartjs/tests/Flow/ETL/Adapter/ChartJS/Tests/Integration/ChartJSLoaderTest.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Adapter\ChartJS\Tests\Integration;
 
-use Flow\ETL\Tests\FlowTestCase;
 use function Flow\ETL\Adapter\ChartJS\{bar_chart, line_chart, pie_chart, to_chartjs, to_chartjs_file, to_chartjs_var};
 use function Flow\ETL\DSL\{df, first, from_array, lit, ref, refs, sum};
 use function Flow\Filesystem\DSL\path;
+use Flow\ETL\Tests\FlowTestCase;
 
 final class ChartJSLoaderTest extends FlowTestCase
 {

--- a/src/adapter/etl-adapter-chartjs/tests/Flow/ETL/Adapter/ChartJS/Tests/Integration/ChartJSLoaderTest.php
+++ b/src/adapter/etl-adapter-chartjs/tests/Flow/ETL/Adapter/ChartJS/Tests/Integration/ChartJSLoaderTest.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Adapter\ChartJS\Tests\Integration;
 
+use Flow\ETL\Tests\FlowTestCase;
 use function Flow\ETL\Adapter\ChartJS\{bar_chart, line_chart, pie_chart, to_chartjs, to_chartjs_file, to_chartjs_var};
 use function Flow\ETL\DSL\{df, first, from_array, lit, ref, refs, sum};
 use function Flow\Filesystem\DSL\path;
-use PHPUnit\Framework\TestCase;
 
-final class ChartJSLoaderTest extends TestCase
+final class ChartJSLoaderTest extends FlowTestCase
 {
     public function test_loading_data_to_bar_chart() : void
     {

--- a/src/adapter/etl-adapter-chartjs/tests/Flow/ETL/Adapter/ChartJS/Tests/Unit/Chart/BarChartTest.php
+++ b/src/adapter/etl-adapter-chartjs/tests/Flow/ETL/Adapter/ChartJS/Tests/Unit/Chart/BarChartTest.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Adapter\ChartJS\Tests\Unit\Chart;
 
+use Flow\ETL\Tests\FlowTestCase;
 use function Flow\ETL\DSL\{df, from_memory, ref, refs};
 use Flow\ETL\Adapter\ChartJS\Chart\BarChart;
 use Flow\ETL\Memory\ArrayMemory;
-use PHPUnit\Framework\TestCase;
 
-final class BarChartTest extends TestCase
+final class BarChartTest extends FlowTestCase
 {
     public function test_collecting_data_from_rows() : void
     {

--- a/src/adapter/etl-adapter-chartjs/tests/Flow/ETL/Adapter/ChartJS/Tests/Unit/Chart/BarChartTest.php
+++ b/src/adapter/etl-adapter-chartjs/tests/Flow/ETL/Adapter/ChartJS/Tests/Unit/Chart/BarChartTest.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Adapter\ChartJS\Tests\Unit\Chart;
 
-use Flow\ETL\Tests\FlowTestCase;
 use function Flow\ETL\DSL\{df, from_memory, ref, refs};
 use Flow\ETL\Adapter\ChartJS\Chart\BarChart;
 use Flow\ETL\Memory\ArrayMemory;
+use Flow\ETL\Tests\FlowTestCase;
 
 final class BarChartTest extends FlowTestCase
 {

--- a/src/adapter/etl-adapter-csv/tests/Flow/ETL/Adapter/CSV/Tests/Integration/CSVTest.php
+++ b/src/adapter/etl-adapter-csv/tests/Flow/ETL/Adapter/CSV/Tests/Integration/CSVTest.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Adapter\CSV\Tests\Integration;
 
+use Flow\ETL\Tests\FlowTestCase;
 use function Flow\ETL\Adapter\CSV\{from_csv, to_csv};
 use function Flow\ETL\DSL\{df, overwrite, ref};
 use Flow\ETL\Tests\Double\FakeExtractor;
-use PHPUnit\Framework\TestCase;
 
-final class CSVTest extends TestCase
+final class CSVTest extends FlowTestCase
 {
     protected function setUp() : void
     {

--- a/src/adapter/etl-adapter-csv/tests/Flow/ETL/Adapter/CSV/Tests/Integration/CSVTest.php
+++ b/src/adapter/etl-adapter-csv/tests/Flow/ETL/Adapter/CSV/Tests/Integration/CSVTest.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Adapter\CSV\Tests\Integration;
 
-use Flow\ETL\Tests\FlowTestCase;
 use function Flow\ETL\Adapter\CSV\{from_csv, to_csv};
 use function Flow\ETL\DSL\{df, overwrite, ref};
 use Flow\ETL\Tests\Double\FakeExtractor;
+use Flow\ETL\Tests\FlowTestCase;
 
 final class CSVTest extends FlowTestCase
 {

--- a/src/adapter/etl-adapter-csv/tests/Flow/ETL/Adapter/CSV/Tests/Unit/Detector/OptionTest.php
+++ b/src/adapter/etl-adapter-csv/tests/Flow/ETL/Adapter/CSV/Tests/Unit/Detector/OptionTest.php
@@ -6,9 +6,9 @@ namespace Flow\ETL\Adapter\CSV\Tests\Unit\Detector;
 
 use Flow\ETL\Adapter\CSV\Detector\Option;
 use Flow\ETL\Exception\InvalidArgumentException;
-use PHPUnit\Framework\TestCase;
+use Flow\ETL\Tests\FlowTestCase;
 
-final class OptionTest extends TestCase
+final class OptionTest extends FlowTestCase
 {
     public function test_empty_enclosure() : void
     {

--- a/src/adapter/etl-adapter-doctrine/tests/Flow/ETL/Adapter/Doctrine/Tests/IntegrationTestCase.php
+++ b/src/adapter/etl-adapter-doctrine/tests/Flow/ETL/Adapter/Doctrine/Tests/IntegrationTestCase.php
@@ -8,9 +8,9 @@ use Doctrine\DBAL\Logging\Middleware;
 use Doctrine\DBAL\Tools\DsnParser;
 use Doctrine\DBAL\{Configuration, DriverManager};
 use Flow\ETL\Adapter\Doctrine\Tests\Context\{DatabaseContext, InsertQueryCounter};
-use PHPUnit\Framework\TestCase;
+use Flow\ETL\Tests\FlowTestCase;
 
-abstract class IntegrationTestCase extends TestCase
+abstract class IntegrationTestCase extends FlowTestCase
 {
     protected DatabaseContext $pgsqlDatabaseContext;
 

--- a/src/adapter/etl-adapter-doctrine/tests/Flow/ETL/Adapter/Doctrine/Tests/Unit/PagesTest.php
+++ b/src/adapter/etl-adapter-doctrine/tests/Flow/ETL/Adapter/Doctrine/Tests/Unit/PagesTest.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Flow\ETL\Adapter\Doctrine\Tests\Unit;
 
 use Flow\ETL\Adapter\Doctrine\Pages;
-use PHPUnit\Framework\TestCase;
+use Flow\ETL\Tests\FlowTestCase;
 
-final class PagesTest extends TestCase
+final class PagesTest extends FlowTestCase
 {
     public function test_total_even_pages() : void
     {

--- a/src/adapter/etl-adapter-elasticsearch/tests/Flow/ETL/Adapter/Elasticsearch/Tests/Integration/ElasticsearchIntegrationTest.php
+++ b/src/adapter/etl-adapter-elasticsearch/tests/Flow/ETL/Adapter/Elasticsearch/Tests/Integration/ElasticsearchIntegrationTest.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Adapter\Elasticsearch\Tests\Integration;
 
-use Flow\ETL\{Flow, Row, Rows};
-use Flow\ETL\Adapter\Elasticsearch\EntryIdFactory\EntryIdFactory;
 use function Flow\ETL\Adapter\Elasticsearch\{es_hits_to_rows, from_es, to_es_bulk_index};
 use function Flow\ETL\DSL\{bool_entry, int_entry, string_entry};
+use Flow\ETL\Adapter\Elasticsearch\EntryIdFactory\EntryIdFactory;
+use Flow\ETL\{Flow, Row, Rows};
 
 final class ElasticsearchIntegrationTest extends ElasticsearchTestCase
 {

--- a/src/adapter/etl-adapter-elasticsearch/tests/Flow/ETL/Adapter/Elasticsearch/Tests/Integration/ElasticsearchIntegrationTest.php
+++ b/src/adapter/etl-adapter-elasticsearch/tests/Flow/ETL/Adapter/Elasticsearch/Tests/Integration/ElasticsearchIntegrationTest.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace Flow\ETL\Adapter\Elasticsearch\Tests\Integration\ElasticsearchPHP;
+namespace Flow\ETL\Adapter\Elasticsearch\Tests\Integration;
 
+use Flow\ETL\{Flow, Row, Rows};
+use Flow\ETL\Adapter\Elasticsearch\EntryIdFactory\EntryIdFactory;
 use function Flow\ETL\Adapter\Elasticsearch\{es_hits_to_rows, from_es, to_es_bulk_index};
 use function Flow\ETL\DSL\{bool_entry, int_entry, string_entry};
-use Flow\ETL\Adapter\Elasticsearch\EntryIdFactory\EntryIdFactory;
-use Flow\ETL\{Adapter\Elasticsearch\Tests\Integration\TestCase, Flow, Row, Rows};
 
-final class IntegrationTest extends TestCase
+final class ElasticsearchIntegrationTest extends ElasticsearchTestCase
 {
     public const DESTINATION_INDEX = 'etl-test-destination-index';
 

--- a/src/adapter/etl-adapter-elasticsearch/tests/Flow/ETL/Adapter/Elasticsearch/Tests/Integration/ElasticsearchPHP/ElasticsearchExtractorTest.php
+++ b/src/adapter/etl-adapter-elasticsearch/tests/Flow/ETL/Adapter/Elasticsearch/Tests/Integration/ElasticsearchPHP/ElasticsearchExtractorTest.php
@@ -8,9 +8,15 @@ use function Flow\ETL\Adapter\Elasticsearch\{es_hits_to_rows, from_es, to_es_bul
 use function Flow\ETL\DSL\{bool_entry, df, generate_random_int, int_entry, string_entry};
 use Flow\ETL\Adapter\Elasticsearch\ElasticsearchPHP\DocumentDataSource;
 use Flow\ETL\Adapter\Elasticsearch\EntryIdFactory\EntryIdFactory;
-use Flow\ETL\{Config, Flow, FlowContext, Row, Rows, Tests\FlowTestCase};
+use Flow\ETL\{Adapter\Elasticsearch\Tests\Integration\TestCase,
+    Config,
+    Flow,
+    FlowContext,
+    Row,
+    Rows
+    };
 
-final class ElasticsearchExtractorTest extends FlowTestCase
+final class ElasticsearchExtractorTest extends TestCase
 {
     public const INDEX_NAME = 'etl-test-index';
 

--- a/src/adapter/etl-adapter-elasticsearch/tests/Flow/ETL/Adapter/Elasticsearch/Tests/Integration/ElasticsearchPHP/ElasticsearchExtractorTest.php
+++ b/src/adapter/etl-adapter-elasticsearch/tests/Flow/ETL/Adapter/Elasticsearch/Tests/Integration/ElasticsearchPHP/ElasticsearchExtractorTest.php
@@ -8,7 +8,7 @@ use function Flow\ETL\Adapter\Elasticsearch\{es_hits_to_rows, from_es, to_es_bul
 use function Flow\ETL\DSL\{bool_entry, df, generate_random_int, int_entry, string_entry};
 use Flow\ETL\Adapter\Elasticsearch\ElasticsearchPHP\DocumentDataSource;
 use Flow\ETL\Adapter\Elasticsearch\EntryIdFactory\EntryIdFactory;
-use Flow\ETL\{Adapter\Elasticsearch\Tests\Integration\TestCase,
+use Flow\ETL\{Adapter\Elasticsearch\Tests\Integration\ElasticsearchTestCase,
     Config,
     Flow,
     FlowContext,
@@ -16,7 +16,7 @@ use Flow\ETL\{Adapter\Elasticsearch\Tests\Integration\TestCase,
     Rows
 };
 
-final class ElasticsearchExtractorTest extends TestCase
+final class ElasticsearchExtractorTest extends ElasticsearchTestCase
 {
     public const INDEX_NAME = 'etl-test-index';
 

--- a/src/adapter/etl-adapter-elasticsearch/tests/Flow/ETL/Adapter/Elasticsearch/Tests/Integration/ElasticsearchPHP/ElasticsearchExtractorTest.php
+++ b/src/adapter/etl-adapter-elasticsearch/tests/Flow/ETL/Adapter/Elasticsearch/Tests/Integration/ElasticsearchPHP/ElasticsearchExtractorTest.php
@@ -14,7 +14,7 @@ use Flow\ETL\{Adapter\Elasticsearch\Tests\Integration\TestCase,
     FlowContext,
     Row,
     Rows
-    };
+};
 
 final class ElasticsearchExtractorTest extends TestCase
 {

--- a/src/adapter/etl-adapter-elasticsearch/tests/Flow/ETL/Adapter/Elasticsearch/Tests/Integration/ElasticsearchPHP/ElasticsearchExtractorTest.php
+++ b/src/adapter/etl-adapter-elasticsearch/tests/Flow/ETL/Adapter/Elasticsearch/Tests/Integration/ElasticsearchPHP/ElasticsearchExtractorTest.php
@@ -8,10 +8,9 @@ use function Flow\ETL\Adapter\Elasticsearch\{es_hits_to_rows, from_es, to_es_bul
 use function Flow\ETL\DSL\{bool_entry, df, generate_random_int, int_entry, string_entry};
 use Flow\ETL\Adapter\Elasticsearch\ElasticsearchPHP\DocumentDataSource;
 use Flow\ETL\Adapter\Elasticsearch\EntryIdFactory\EntryIdFactory;
-use Flow\ETL\Adapter\Elasticsearch\Tests\Integration\TestCase;
-use Flow\ETL\{Config, Flow, FlowContext, Row, Rows};
+use Flow\ETL\{Config, Flow, FlowContext, Row, Rows, Tests\FlowTestCase};
 
-final class ElasticsearchExtractorTest extends TestCase
+final class ElasticsearchExtractorTest extends FlowTestCase
 {
     public const INDEX_NAME = 'etl-test-index';
 

--- a/src/adapter/etl-adapter-elasticsearch/tests/Flow/ETL/Adapter/Elasticsearch/Tests/Integration/ElasticsearchPHP/ElasticsearchLoaderTest.php
+++ b/src/adapter/etl-adapter-elasticsearch/tests/Flow/ETL/Adapter/Elasticsearch/Tests/Integration/ElasticsearchPHP/ElasticsearchLoaderTest.php
@@ -6,9 +6,9 @@ namespace Flow\ETL\Adapter\Elasticsearch\Tests\Integration\ElasticsearchPHP;
 
 use function Flow\ETL\Adapter\Elasticsearch\{entry_id_factory, hash_id_factory, to_es_bulk_index, to_es_bulk_update};
 use function Flow\ETL\DSL\{generate_random_string, string_entry};
-use Flow\ETL\{Adapter\Elasticsearch\Tests\Integration\TestCase, Config, FlowContext, Row, Rows};
+use Flow\ETL\{Adapter\Elasticsearch\Tests\Integration\ElasticsearchTestCase, Config, FlowContext, Row, Rows};
 
-final class ElasticsearchLoaderTest extends TestCase
+final class ElasticsearchLoaderTest extends ElasticsearchTestCase
 {
     public const INDEX_NAME = 'etl-test-index';
 

--- a/src/adapter/etl-adapter-elasticsearch/tests/Flow/ETL/Adapter/Elasticsearch/Tests/Integration/ElasticsearchPHP/ElasticsearchLoaderTest.php
+++ b/src/adapter/etl-adapter-elasticsearch/tests/Flow/ETL/Adapter/Elasticsearch/Tests/Integration/ElasticsearchPHP/ElasticsearchLoaderTest.php
@@ -6,10 +6,9 @@ namespace Flow\ETL\Adapter\Elasticsearch\Tests\Integration\ElasticsearchPHP;
 
 use function Flow\ETL\Adapter\Elasticsearch\{entry_id_factory, hash_id_factory, to_es_bulk_index, to_es_bulk_update};
 use function Flow\ETL\DSL\{generate_random_string, string_entry};
-use Flow\ETL\Adapter\Elasticsearch\Tests\Integration\TestCase;
-use Flow\ETL\{Config, FlowContext, Row, Rows};
+use Flow\ETL\{Config, FlowContext, Row, Rows, Tests\FlowTestCase};
 
-final class ElasticsearchLoaderTest extends TestCase
+final class ElasticsearchLoaderTest extends FlowTestCase
 {
     public const INDEX_NAME = 'etl-test-index';
 

--- a/src/adapter/etl-adapter-elasticsearch/tests/Flow/ETL/Adapter/Elasticsearch/Tests/Integration/ElasticsearchPHP/ElasticsearchLoaderTest.php
+++ b/src/adapter/etl-adapter-elasticsearch/tests/Flow/ETL/Adapter/Elasticsearch/Tests/Integration/ElasticsearchPHP/ElasticsearchLoaderTest.php
@@ -6,9 +6,9 @@ namespace Flow\ETL\Adapter\Elasticsearch\Tests\Integration\ElasticsearchPHP;
 
 use function Flow\ETL\Adapter\Elasticsearch\{entry_id_factory, hash_id_factory, to_es_bulk_index, to_es_bulk_update};
 use function Flow\ETL\DSL\{generate_random_string, string_entry};
-use Flow\ETL\{Config, FlowContext, Row, Rows, Tests\FlowTestCase};
+use Flow\ETL\{Adapter\Elasticsearch\Tests\Integration\TestCase, Config, FlowContext, Row, Rows};
 
-final class ElasticsearchLoaderTest extends FlowTestCase
+final class ElasticsearchLoaderTest extends TestCase
 {
     public const INDEX_NAME = 'etl-test-index';
 

--- a/src/adapter/etl-adapter-elasticsearch/tests/Flow/ETL/Adapter/Elasticsearch/Tests/Integration/ElasticsearchPHP/IntegrationTest.php
+++ b/src/adapter/etl-adapter-elasticsearch/tests/Flow/ETL/Adapter/Elasticsearch/Tests/Integration/ElasticsearchPHP/IntegrationTest.php
@@ -7,10 +7,9 @@ namespace Flow\ETL\Adapter\Elasticsearch\Tests\Integration\ElasticsearchPHP;
 use function Flow\ETL\Adapter\Elasticsearch\{es_hits_to_rows, from_es, to_es_bulk_index};
 use function Flow\ETL\DSL\{bool_entry, int_entry, string_entry};
 use Flow\ETL\Adapter\Elasticsearch\EntryIdFactory\EntryIdFactory;
-use Flow\ETL\Adapter\Elasticsearch\Tests\Integration\TestCase;
-use Flow\ETL\{Flow, Row, Rows};
+use Flow\ETL\{Flow, Row, Rows, Tests\FlowTestCase};
 
-final class IntegrationTest extends TestCase
+final class IntegrationTest extends FlowTestCase
 {
     public const DESTINATION_INDEX = 'etl-test-destination-index';
 

--- a/src/adapter/etl-adapter-elasticsearch/tests/Flow/ETL/Adapter/Elasticsearch/Tests/Integration/ElasticsearchPHP/IntegrationTest.php
+++ b/src/adapter/etl-adapter-elasticsearch/tests/Flow/ETL/Adapter/Elasticsearch/Tests/Integration/ElasticsearchPHP/IntegrationTest.php
@@ -7,9 +7,9 @@ namespace Flow\ETL\Adapter\Elasticsearch\Tests\Integration\ElasticsearchPHP;
 use function Flow\ETL\Adapter\Elasticsearch\{es_hits_to_rows, from_es, to_es_bulk_index};
 use function Flow\ETL\DSL\{bool_entry, int_entry, string_entry};
 use Flow\ETL\Adapter\Elasticsearch\EntryIdFactory\EntryIdFactory;
-use Flow\ETL\{Flow, Row, Rows, Tests\FlowTestCase};
+use Flow\ETL\{Adapter\Elasticsearch\Tests\Integration\TestCase, Flow, Row, Rows};
 
-final class IntegrationTest extends FlowTestCase
+final class IntegrationTest extends TestCase
 {
     public const DESTINATION_INDEX = 'etl-test-destination-index';
 

--- a/src/adapter/etl-adapter-elasticsearch/tests/Flow/ETL/Adapter/Elasticsearch/Tests/Integration/ElasticsearchTest.php
+++ b/src/adapter/etl-adapter-elasticsearch/tests/Flow/ETL/Adapter/Elasticsearch/Tests/Integration/ElasticsearchTest.php
@@ -10,7 +10,7 @@ use Flow\ETL\Adapter\Elasticsearch\EntryIdFactory\EntryIdFactory;
 use Flow\ETL\Adapter\Elasticsearch\Tests\Doubles\Spy\HttpClientSpy;
 use Flow\ETL\Flow;
 
-final class ElasticsearchTest extends TestCase
+final class ElasticsearchTest extends ElasticsearchTestCase
 {
     public function test_batch_size_when_its_not_explicitly_set() : void
     {

--- a/src/adapter/etl-adapter-elasticsearch/tests/Flow/ETL/Adapter/Elasticsearch/Tests/Integration/ElasticsearchTest.php
+++ b/src/adapter/etl-adapter-elasticsearch/tests/Flow/ETL/Adapter/Elasticsearch/Tests/Integration/ElasticsearchTest.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Adapter\Elasticsearch\Tests\Integration;
 
-use Flow\ETL\Tests\FlowTestCase;
 use function Flow\ETL\Adapter\Elasticsearch\to_es_bulk_index;
 use function Flow\ETL\DSL\from_array;
 use Flow\ETL\Adapter\Elasticsearch\EntryIdFactory\EntryIdFactory;
 use Flow\ETL\Adapter\Elasticsearch\Tests\Doubles\Spy\HttpClientSpy;
 use Flow\ETL\Flow;
+use Flow\ETL\Tests\FlowTestCase;
 
 final class ElasticsearchTest extends FlowTestCase
 {

--- a/src/adapter/etl-adapter-elasticsearch/tests/Flow/ETL/Adapter/Elasticsearch/Tests/Integration/ElasticsearchTest.php
+++ b/src/adapter/etl-adapter-elasticsearch/tests/Flow/ETL/Adapter/Elasticsearch/Tests/Integration/ElasticsearchTest.php
@@ -9,9 +9,8 @@ use function Flow\ETL\DSL\from_array;
 use Flow\ETL\Adapter\Elasticsearch\EntryIdFactory\EntryIdFactory;
 use Flow\ETL\Adapter\Elasticsearch\Tests\Doubles\Spy\HttpClientSpy;
 use Flow\ETL\Flow;
-use Flow\ETL\Tests\FlowTestCase;
 
-final class ElasticsearchTest extends FlowTestCase
+final class ElasticsearchTest extends TestCase
 {
     public function test_batch_size_when_its_not_explicitly_set() : void
     {

--- a/src/adapter/etl-adapter-elasticsearch/tests/Flow/ETL/Adapter/Elasticsearch/Tests/Integration/ElasticsearchTest.php
+++ b/src/adapter/etl-adapter-elasticsearch/tests/Flow/ETL/Adapter/Elasticsearch/Tests/Integration/ElasticsearchTest.php
@@ -4,13 +4,14 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Adapter\Elasticsearch\Tests\Integration;
 
+use Flow\ETL\Tests\FlowTestCase;
 use function Flow\ETL\Adapter\Elasticsearch\to_es_bulk_index;
 use function Flow\ETL\DSL\from_array;
 use Flow\ETL\Adapter\Elasticsearch\EntryIdFactory\EntryIdFactory;
 use Flow\ETL\Adapter\Elasticsearch\Tests\Doubles\Spy\HttpClientSpy;
 use Flow\ETL\Flow;
 
-final class ElasticsearchTest extends TestCase
+final class ElasticsearchTest extends FlowTestCase
 {
     public function test_batch_size_when_its_not_explicitly_set() : void
     {

--- a/src/adapter/etl-adapter-elasticsearch/tests/Flow/ETL/Adapter/Elasticsearch/Tests/Integration/ElasticsearchTestCase.php
+++ b/src/adapter/etl-adapter-elasticsearch/tests/Flow/ETL/Adapter/Elasticsearch/Tests/Integration/ElasticsearchTestCase.php
@@ -7,7 +7,7 @@ namespace Flow\ETL\Adapter\Elasticsearch\Tests\Integration;
 use Flow\ETL\Adapter\Elasticsearch\Tests\Context\{Elasticsearch7Context, Elasticsearch8Context, ElasticsearchContext};
 use Flow\ETL\Tests\FlowTestCase;
 
-abstract class TestCase extends FlowTestCase
+abstract class ElasticsearchTestCase extends FlowTestCase
 {
     protected ElasticsearchContext $elasticsearchContext;
 

--- a/src/adapter/etl-adapter-elasticsearch/tests/Flow/ETL/Adapter/Elasticsearch/Tests/Integration/TestCase.php
+++ b/src/adapter/etl-adapter-elasticsearch/tests/Flow/ETL/Adapter/Elasticsearch/Tests/Integration/TestCase.php
@@ -5,8 +5,9 @@ declare(strict_types=1);
 namespace Flow\ETL\Adapter\Elasticsearch\Tests\Integration;
 
 use Flow\ETL\Adapter\Elasticsearch\Tests\Context\{Elasticsearch7Context, Elasticsearch8Context, ElasticsearchContext};
+use Flow\ETL\Tests\FlowTestCase;
 
-abstract class TestCase extends \PHPUnit\Framework\TestCase
+abstract class TestCase extends FlowTestCase
 {
     protected ElasticsearchContext $elasticsearchContext;
 

--- a/src/adapter/etl-adapter-elasticsearch/tests/Flow/ETL/Adapter/Elasticsearch/Tests/Unit/HashIdFactoryTest.php
+++ b/src/adapter/etl-adapter-elasticsearch/tests/Flow/ETL/Adapter/Elasticsearch/Tests/Unit/HashIdFactoryTest.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Adapter\Elasticsearch\Tests\Unit;
 
-use Flow\ETL\Tests\FlowTestCase;
 use function Flow\ETL\DSL\{str_entry, string_entry};
 use Flow\ETL\Adapter\Elasticsearch\EntryIdFactory\HashIdFactory;
 use Flow\ETL\Hash\NativePHPHash;
 use Flow\ETL\Row;
+use Flow\ETL\Tests\FlowTestCase;
 
 final class HashIdFactoryTest extends FlowTestCase
 {

--- a/src/adapter/etl-adapter-elasticsearch/tests/Flow/ETL/Adapter/Elasticsearch/Tests/Unit/HashIdFactoryTest.php
+++ b/src/adapter/etl-adapter-elasticsearch/tests/Flow/ETL/Adapter/Elasticsearch/Tests/Unit/HashIdFactoryTest.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Adapter\Elasticsearch\Tests\Unit;
 
+use Flow\ETL\Tests\FlowTestCase;
 use function Flow\ETL\DSL\{str_entry, string_entry};
 use Flow\ETL\Adapter\Elasticsearch\EntryIdFactory\HashIdFactory;
 use Flow\ETL\Hash\NativePHPHash;
 use Flow\ETL\Row;
-use PHPUnit\Framework\TestCase;
 
-final class HashIdFactoryTest extends TestCase
+final class HashIdFactoryTest extends FlowTestCase
 {
     public function test_create_row() : void
     {

--- a/src/adapter/etl-adapter-google-sheet/tests/Flow/ETL/Adapter/GoogleSheet/Tests/Unit/ColumnsTest.php
+++ b/src/adapter/etl-adapter-google-sheet/tests/Flow/ETL/Adapter/GoogleSheet/Tests/Unit/ColumnsTest.php
@@ -6,10 +6,10 @@ namespace Flow\ETL\Adapter\GoogleSheet\Tests\Unit;
 
 use Flow\ETL\Adapter\GoogleSheet\Columns;
 use Flow\ETL\Exception\InvalidArgumentException;
+use Flow\ETL\Tests\FlowTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\TestCase;
 
-final class ColumnsTest extends TestCase
+final class ColumnsTest extends FlowTestCase
 {
     public static function invalid_cases() : \Generator
     {

--- a/src/adapter/etl-adapter-google-sheet/tests/Flow/ETL/Adapter/GoogleSheet/Tests/Unit/GoogleSheetExtractorTest.php
+++ b/src/adapter/etl-adapter-google-sheet/tests/Flow/ETL/Adapter/GoogleSheet/Tests/Unit/GoogleSheetExtractorTest.php
@@ -7,12 +7,11 @@ namespace Flow\ETL\Adapter\GoogleSheet\Tests\Unit;
 use function Flow\ETL\Adapter\GoogleSheet\from_google_sheet_columns;
 use function Flow\ETL\DSL\{str_entry, string_entry};
 use Flow\ETL\Exception\InvalidArgumentException;
-use Flow\ETL\{Config\ConfigBuilder, FlowContext, Row, Rows};
+use Flow\ETL\{Config\ConfigBuilder, FlowContext, Row, Rows, Tests\FlowTestCase};
 use Google\Service\Sheets;
 use Google\Service\Sheets\Resource\SpreadsheetsValues;
-use PHPUnit\Framework\TestCase;
 
-final class GoogleSheetExtractorTest extends TestCase
+final class GoogleSheetExtractorTest extends FlowTestCase
 {
     public function test_its_stop_fetching_data_if_processed_row_count_is_less_then_last_range_end_row() : void
     {

--- a/src/adapter/etl-adapter-google-sheet/tests/Flow/ETL/Adapter/GoogleSheet/Tests/Unit/SheetRangeTest.php
+++ b/src/adapter/etl-adapter-google-sheet/tests/Flow/ETL/Adapter/GoogleSheet/Tests/Unit/SheetRangeTest.php
@@ -6,10 +6,10 @@ namespace Flow\ETL\Adapter\GoogleSheet\Tests\Unit;
 
 use Flow\ETL\Adapter\GoogleSheet\{Columns, SheetRange};
 use Flow\ETL\Exception\InvalidArgumentException;
+use Flow\ETL\Tests\FlowTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\TestCase;
 
-final class SheetRangeTest extends TestCase
+final class SheetRangeTest extends FlowTestCase
 {
     public static function example_string_ranges() : \Generator
     {

--- a/src/adapter/etl-adapter-http/tests/Flow/ETL/Adapter/HTTP/Tests/Integration/PsrHttpClientDynamicExtractorTest.php
+++ b/src/adapter/etl-adapter-http/tests/Flow/ETL/Adapter/HTTP/Tests/Integration/PsrHttpClientDynamicExtractorTest.php
@@ -6,14 +6,13 @@ namespace Flow\ETL\Adapter\HTTP\Tests\Integration;
 
 use Flow\ETL\Adapter\Http\DynamicExtractor\NextRequestFactory;
 use Flow\ETL\Adapter\Http\PsrHttpClientDynamicExtractor;
-use Flow\ETL\{Config, FlowContext};
+use Flow\ETL\{Config, FlowContext, Tests\FlowTestCase};
 use Http\Mock\Client;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use Nyholm\Psr7\Response;
-use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\{RequestInterface, ResponseInterface};
 
-final class PsrHttpClientDynamicExtractorTest extends TestCase
+final class PsrHttpClientDynamicExtractorTest extends FlowTestCase
 {
     public function test_http_extractor() : void
     {

--- a/src/adapter/etl-adapter-http/tests/Flow/ETL/Adapter/HTTP/Tests/Integration/PsrHttpClientStaticExtractorTest.php
+++ b/src/adapter/etl-adapter-http/tests/Flow/ETL/Adapter/HTTP/Tests/Integration/PsrHttpClientStaticExtractorTest.php
@@ -5,13 +5,12 @@ declare(strict_types=1);
 namespace Flow\ETL\Adapter\HTTP\Tests\Integration;
 
 use Flow\ETL\Adapter\Http\PsrHttpClientStaticExtractor;
-use Flow\ETL\{Config, FlowContext, Rows};
+use Flow\ETL\{Config, FlowContext, Rows, Tests\FlowTestCase};
 use Http\Mock\Client;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use Nyholm\Psr7\Response;
-use PHPUnit\Framework\TestCase;
 
-final class PsrHttpClientStaticExtractorTest extends TestCase
+final class PsrHttpClientStaticExtractorTest extends FlowTestCase
 {
     public function test_http_extractor() : void
     {

--- a/src/adapter/etl-adapter-http/tests/Flow/ETL/Adapter/HTTP/Tests/Unit/RequestEntriesFactoryTest.php
+++ b/src/adapter/etl-adapter-http/tests/Flow/ETL/Adapter/HTTP/Tests/Unit/RequestEntriesFactoryTest.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Flow\ETL\Adapter\HTTP\Tests\Unit;
 
 use Flow\ETL\Adapter\Http\RequestEntriesFactory;
-use Flow\ETL\Tests\FlowTestCase;
 use Flow\ETL\Row\Entry\{JsonEntry, StringEntry};
+use Flow\ETL\Tests\FlowTestCase;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Psr\Http\Message\RequestInterface;

--- a/src/adapter/etl-adapter-http/tests/Flow/ETL/Adapter/HTTP/Tests/Unit/RequestEntriesFactoryTest.php
+++ b/src/adapter/etl-adapter-http/tests/Flow/ETL/Adapter/HTTP/Tests/Unit/RequestEntriesFactoryTest.php
@@ -5,13 +5,13 @@ declare(strict_types=1);
 namespace Flow\ETL\Adapter\HTTP\Tests\Unit;
 
 use Flow\ETL\Adapter\Http\RequestEntriesFactory;
+use Flow\ETL\Tests\FlowTestCase;
 use Flow\ETL\Row\Entry\{JsonEntry, StringEntry};
 use Nyholm\Psr7\Factory\Psr17Factory;
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
 
-final class RequestEntriesFactoryTest extends TestCase
+final class RequestEntriesFactoryTest extends FlowTestCase
 {
     public static function requests() : \Generator
     {

--- a/src/adapter/etl-adapter-json/tests/Flow/ETL/Adapter/JSON/Tests/Integration/JSONMachine/JsonExtractorTest.php
+++ b/src/adapter/etl-adapter-json/tests/Flow/ETL/Adapter/JSON/Tests/Integration/JSONMachine/JsonExtractorTest.php
@@ -8,11 +8,10 @@ use function Flow\ETL\Adapter\JSON\{from_json};
 use function Flow\ETL\DSL\{df, print_schema};
 use Flow\ETL\Adapter\JSON\JSONMachine\JsonExtractor;
 use Flow\ETL\Extractor\Signal;
-use Flow\ETL\{Config, Flow, FlowContext, Row, Rows};
+use Flow\ETL\{Config, Flow, FlowContext, Row, Rows, Tests\FlowTestCase};
 use Flow\Filesystem\Path;
-use PHPUnit\Framework\TestCase;
 
-final class JsonExtractorTest extends TestCase
+final class JsonExtractorTest extends FlowTestCase
 {
     public function test_extracting_json_from_local_file_stream() : void
     {

--- a/src/adapter/etl-adapter-json/tests/Flow/ETL/Adapter/JSON/Tests/Integration/JsonTest.php
+++ b/src/adapter/etl-adapter-json/tests/Flow/ETL/Adapter/JSON/Tests/Integration/JsonTest.php
@@ -10,10 +10,9 @@ use function Flow\ETL\DSL\{average, df, from_array, overwrite, ref};
 use function Flow\Filesystem\DSL\path;
 use Flow\ETL\Adapter\JSON\JsonLoader;
 use Flow\ETL\Tests\Double\FakeExtractor;
-use Flow\ETL\{Config, FlowContext, Rows};
-use PHPUnit\Framework\TestCase;
+use Flow\ETL\{Config, FlowContext, Rows, Tests\FlowTestCase};
 
-final class JsonTest extends TestCase
+final class JsonTest extends FlowTestCase
 {
     public function test_json_loader() : void
     {

--- a/src/adapter/etl-adapter-logger/tests/Flow/ETL/Adapter/Logger/Tests/Unit/Logger/DumpLoggerTest.php
+++ b/src/adapter/etl-adapter-logger/tests/Flow/ETL/Adapter/Logger/Tests/Unit/Logger/DumpLoggerTest.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Flow\ETL\Adapter\Logger\Tests\Unit\Logger;
 
 use Flow\ETL\Adapter\Logger\Logger\DumpLogger;
-use PHPUnit\Framework\TestCase;
+use Flow\ETL\Tests\FlowTestCase;
 
-final class DumpLoggerTest extends TestCase
+final class DumpLoggerTest extends FlowTestCase
 {
     public function test_logger() : void
     {

--- a/src/adapter/etl-adapter-logger/tests/Flow/ETL/Adapter/Logger/Tests/Unit/PsrLoggerLoaderTest.php
+++ b/src/adapter/etl-adapter-logger/tests/Flow/ETL/Adapter/Logger/Tests/Unit/PsrLoggerLoaderTest.php
@@ -6,12 +6,11 @@ namespace Flow\ETL\Adapter\Logger\Tests\Unit;
 
 use function Flow\ETL\DSL\{int_entry, string_entry};
 use Flow\ETL\Adapter\Logger\PsrLoggerLoader;
-use Flow\ETL\{Config, FlowContext, Row, Rows};
-use PHPUnit\Framework\TestCase;
+use Flow\ETL\{Config, FlowContext, Row, Rows, Tests\FlowTestCase};
 use Psr\Log\LogLevel;
 use Psr\Log\Test\TestLogger;
 
-final class PsrLoggerLoaderTest extends TestCase
+final class PsrLoggerLoaderTest extends FlowTestCase
 {
     public function test_psr_logger_loader() : void
     {

--- a/src/adapter/etl-adapter-meilisearch/tests/Flow/ETL/Adapter/Meilisearch/Tests/Integration/MeilisearchPHP/MailiSearchTest.php
+++ b/src/adapter/etl-adapter-meilisearch/tests/Flow/ETL/Adapter/Meilisearch/Tests/Integration/MeilisearchPHP/MailiSearchTest.php
@@ -8,10 +8,9 @@ use function Flow\ETL\Adapter\Meilisearch\{from_meilisearch, meilisearch_hits_to
 use function Flow\ETL\DSL\{from_array, string_entry};
 use Flow\ETL\Adapter\Meilisearch\Tests\Context\MeilisearchContext;
 use Flow\ETL\Adapter\Meilisearch\Tests\Double\Spy\HttpClientSpy;
-use Flow\ETL\{Flow, Row, Rows};
-use PHPUnit\Framework\TestCase;
+use Flow\ETL\{Flow, Row, Rows, Tests\FlowTestCase};
 
-final class MailiSearchTest extends TestCase
+final class MailiSearchTest extends FlowTestCase
 {
     private const DESTINATION_INDEX = 'etl-test-destination-index';
 

--- a/src/adapter/etl-adapter-meilisearch/tests/Flow/ETL/Adapter/Meilisearch/Tests/Integration/MeilisearchPHP/MeilisearchExtractorTest.php
+++ b/src/adapter/etl-adapter-meilisearch/tests/Flow/ETL/Adapter/Meilisearch/Tests/Integration/MeilisearchPHP/MeilisearchExtractorTest.php
@@ -7,10 +7,9 @@ namespace Flow\ETL\Adapter\Meilisearch\Tests\Integration\MeilisearchPHP;
 use function Flow\ETL\Adapter\Meilisearch\{from_meilisearch, meilisearch_hits_to_rows, to_meilisearch_bulk_index};
 use function Flow\ETL\DSL\{generate_random_int, string_entry};
 use Flow\ETL\Adapter\Meilisearch\Tests\Context\MeilisearchContext;
-use Flow\ETL\{Config, Flow, FlowContext, Row, Rows};
-use PHPUnit\Framework\TestCase;
+use Flow\ETL\{Config, Flow, FlowContext, Row, Rows, Tests\FlowTestCase};
 
-final class MeilisearchExtractorTest extends TestCase
+final class MeilisearchExtractorTest extends FlowTestCase
 {
     public const INDEX_NAME = 'etl-test-index';
 

--- a/src/adapter/etl-adapter-meilisearch/tests/Flow/ETL/Adapter/Meilisearch/Tests/Integration/MeilisearchPHP/MeilisearchLoaderTest.php
+++ b/src/adapter/etl-adapter-meilisearch/tests/Flow/ETL/Adapter/Meilisearch/Tests/Integration/MeilisearchPHP/MeilisearchLoaderTest.php
@@ -7,10 +7,9 @@ namespace Flow\ETL\Adapter\Meilisearch\Tests\Integration\MeilisearchPHP;
 use function Flow\ETL\Adapter\Meilisearch\{to_meilisearch_bulk_index, to_meilisearch_bulk_update};
 use function Flow\ETL\DSL\string_entry;
 use Flow\ETL\Adapter\Meilisearch\Tests\Context\MeilisearchContext;
-use Flow\ETL\{Config, FlowContext, Row, Rows};
-use PHPUnit\Framework\TestCase;
+use Flow\ETL\{Config, FlowContext, Row, Rows, Tests\FlowTestCase};
 
-final class MeilisearchLoaderTest extends TestCase
+final class MeilisearchLoaderTest extends FlowTestCase
 {
     private const INDEX_NAME = 'etl-test-index';
 

--- a/src/adapter/etl-adapter-parquet/tests/Flow/ETL/Adapter/Parquet/Tests/Integration/PaginationTest.php
+++ b/src/adapter/etl-adapter-parquet/tests/Flow/ETL/Adapter/Parquet/Tests/Integration/PaginationTest.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Adapter\Parquet\Tests\Integration;
 
-use Flow\ETL\Tests\FlowTestCase;
 use function Flow\ETL\DSL\{config, flow_context};
 use Flow\ETL\Adapter\Parquet\ParquetExtractor;
+use Flow\ETL\Tests\FlowTestCase;
 use Flow\Filesystem\Path;
 use Flow\Parquet\{Reader};
 

--- a/src/adapter/etl-adapter-parquet/tests/Flow/ETL/Adapter/Parquet/Tests/Integration/PaginationTest.php
+++ b/src/adapter/etl-adapter-parquet/tests/Flow/ETL/Adapter/Parquet/Tests/Integration/PaginationTest.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Adapter\Parquet\Tests\Integration;
 
+use Flow\ETL\Tests\FlowTestCase;
 use function Flow\ETL\DSL\{config, flow_context};
 use Flow\ETL\Adapter\Parquet\ParquetExtractor;
 use Flow\Filesystem\Path;
 use Flow\Parquet\{Reader};
-use PHPUnit\Framework\TestCase;
 
-final class PaginationTest extends TestCase
+final class PaginationTest extends FlowTestCase
 {
     public function test_multifile_pagination_from_beginning() : void
     {

--- a/src/adapter/etl-adapter-parquet/tests/Flow/ETL/Adapter/Parquet/Tests/Integration/ParquetExtractorTest.php
+++ b/src/adapter/etl-adapter-parquet/tests/Flow/ETL/Adapter/Parquet/Tests/Integration/ParquetExtractorTest.php
@@ -6,12 +6,11 @@ namespace Flow\ETL\Adapter\Parquet\Tests\Integration;
 
 use Flow\ETL\Adapter\Parquet\ParquetExtractor;
 use Flow\ETL\Extractor\Signal;
-use Flow\ETL\{Config, FlowContext};
+use Flow\ETL\{Config, FlowContext, Tests\FlowTestCase};
 use Flow\Filesystem\Path;
 use Flow\Parquet\{Options, Reader};
-use PHPUnit\Framework\TestCase;
 
-final class ParquetExtractorTest extends TestCase
+final class ParquetExtractorTest extends FlowTestCase
 {
     public function test_limit() : void
     {

--- a/src/adapter/etl-adapter-parquet/tests/Flow/ETL/Adapter/Parquet/Tests/Integration/ParquetTest.php
+++ b/src/adapter/etl-adapter-parquet/tests/Flow/ETL/Adapter/Parquet/Tests/Integration/ParquetTest.php
@@ -7,13 +7,12 @@ namespace Flow\ETL\Adapter\Parquet\Tests\Integration;
 use function Flow\ETL\Adapter\Parquet\{from_parquet, to_parquet};
 use function Flow\ETL\DSL\{df, from_array, json_schema, schema, str_schema};
 use Flow\ETL\Tests\Double\FakeExtractor;
-use Flow\ETL\{Flow};
+use Flow\ETL\{Flow, Tests\FlowTestCase};
 use Flow\Parquet\ParquetFile\Compressions;
 use Flow\Parquet\Reader;
-use PHPUnit\Framework\TestCase;
 use Ramsey\Uuid\Uuid;
 
-final class ParquetTest extends TestCase
+final class ParquetTest extends FlowTestCase
 {
     public function test_writing_to_file() : void
     {

--- a/src/adapter/etl-adapter-parquet/tests/Flow/ETL/Adapter/Parquet/Tests/Unit/FlowToParquetSchemaTest.php
+++ b/src/adapter/etl-adapter-parquet/tests/Flow/ETL/Adapter/Parquet/Tests/Unit/FlowToParquetSchemaTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Adapter\Parquet\Tests\Unit;
 
-use Flow\ETL\Tests\FlowTestCase;
 use function Flow\ETL\DSL\{type_boolean, type_int, type_string};
 use Flow\ETL\Adapter\Parquet\SchemaConverter;
 use Flow\ETL\PHP\Type\Logical\List\ListElement;
@@ -12,6 +11,7 @@ use Flow\ETL\PHP\Type\Logical\Map\{MapKey, MapValue};
 use Flow\ETL\PHP\Type\Logical\Structure\StructureElement;
 use Flow\ETL\PHP\Type\Logical\{ListType, MapType, StructureType};
 use Flow\ETL\Row\Schema;
+use Flow\ETL\Tests\FlowTestCase;
 use Flow\Parquet\ParquetFile\Schema as ParquetSchema;
 use Flow\Parquet\ParquetFile\Schema\{FlatColumn, NestedColumn};
 

--- a/src/adapter/etl-adapter-parquet/tests/Flow/ETL/Adapter/Parquet/Tests/Unit/FlowToParquetSchemaTest.php
+++ b/src/adapter/etl-adapter-parquet/tests/Flow/ETL/Adapter/Parquet/Tests/Unit/FlowToParquetSchemaTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Adapter\Parquet\Tests\Unit;
 
+use Flow\ETL\Tests\FlowTestCase;
 use function Flow\ETL\DSL\{type_boolean, type_int, type_string};
 use Flow\ETL\Adapter\Parquet\SchemaConverter;
 use Flow\ETL\PHP\Type\Logical\List\ListElement;
@@ -13,9 +14,8 @@ use Flow\ETL\PHP\Type\Logical\{ListType, MapType, StructureType};
 use Flow\ETL\Row\Schema;
 use Flow\Parquet\ParquetFile\Schema as ParquetSchema;
 use Flow\Parquet\ParquetFile\Schema\{FlatColumn, NestedColumn};
-use PHPUnit\Framework\TestCase;
 
-final class FlowToParquetSchemaTest extends TestCase
+final class FlowToParquetSchemaTest extends FlowTestCase
 {
     public function test_convert_etl_entries_to_parquet_fields() : void
     {

--- a/src/adapter/etl-adapter-parquet/tests/Flow/ETL/Adapter/Parquet/Tests/Unit/ParquetToFlowSchemaTest.php
+++ b/src/adapter/etl-adapter-parquet/tests/Flow/ETL/Adapter/Parquet/Tests/Unit/ParquetToFlowSchemaTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Adapter\Parquet\Tests\Unit;
 
-use Flow\ETL\Tests\FlowTestCase;
 use function Flow\ETL\DSL\{bool_schema,
     date_schema,
     datetime_schema,
@@ -26,6 +25,7 @@ use function Flow\ETL\DSL\{bool_schema,
     type_uuid,
     uuid_schema};
 use Flow\ETL\Adapter\Parquet\SchemaConverter;
+use Flow\ETL\Tests\FlowTestCase;
 use Flow\Parquet\ParquetFile\Schema;
 use Flow\Parquet\ParquetFile\Schema\{MapKey, MapValue};
 

--- a/src/adapter/etl-adapter-parquet/tests/Flow/ETL/Adapter/Parquet/Tests/Unit/ParquetToFlowSchemaTest.php
+++ b/src/adapter/etl-adapter-parquet/tests/Flow/ETL/Adapter/Parquet/Tests/Unit/ParquetToFlowSchemaTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Adapter\Parquet\Tests\Unit;
 
+use Flow\ETL\Tests\FlowTestCase;
 use function Flow\ETL\DSL\{bool_schema,
     date_schema,
     datetime_schema,
@@ -27,9 +28,8 @@ use function Flow\ETL\DSL\{bool_schema,
 use Flow\ETL\Adapter\Parquet\SchemaConverter;
 use Flow\Parquet\ParquetFile\Schema;
 use Flow\Parquet\ParquetFile\Schema\{MapKey, MapValue};
-use PHPUnit\Framework\TestCase;
 
-final class ParquetToFlowSchemaTest extends TestCase
+final class ParquetToFlowSchemaTest extends FlowTestCase
 {
     public function test_converting_flat_fields_to_flow_schema() : void
     {

--- a/src/adapter/etl-adapter-parquet/tests/Flow/ETL/Adapter/Parquet/Tests/Unit/RowsNormalizerTest.php
+++ b/src/adapter/etl-adapter-parquet/tests/Flow/ETL/Adapter/Parquet/Tests/Unit/RowsNormalizerTest.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Adapter\Parquet\Tests\Unit;
 
-use Flow\ETL\Tests\FlowTestCase;
 use function Flow\ETL\DSL\{row, rows, schema, str_entry, str_schema};
 use Flow\ETL\Adapter\Parquet\RowsNormalizer;
 use Flow\ETL\Exception\CastingException;
 use Flow\ETL\PHP\Type\Caster;
+use Flow\ETL\Tests\FlowTestCase;
 
 final class RowsNormalizerTest extends FlowTestCase
 {

--- a/src/adapter/etl-adapter-parquet/tests/Flow/ETL/Adapter/Parquet/Tests/Unit/RowsNormalizerTest.php
+++ b/src/adapter/etl-adapter-parquet/tests/Flow/ETL/Adapter/Parquet/Tests/Unit/RowsNormalizerTest.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Adapter\Parquet\Tests\Unit;
 
+use Flow\ETL\Tests\FlowTestCase;
 use function Flow\ETL\DSL\{row, rows, schema, str_entry, str_schema};
 use Flow\ETL\Adapter\Parquet\RowsNormalizer;
 use Flow\ETL\Exception\CastingException;
 use Flow\ETL\PHP\Type\Caster;
-use PHPUnit\Framework\TestCase;
 
-final class RowsNormalizerTest extends TestCase
+final class RowsNormalizerTest extends FlowTestCase
 {
     public function test_casting_error() : void
     {

--- a/src/adapter/etl-adapter-text/tests/Flow/ETL/Adapter/Text/Tests/Integration/TextExtractorTest.php
+++ b/src/adapter/etl-adapter-text/tests/Flow/ETL/Adapter/Text/Tests/Integration/TextExtractorTest.php
@@ -7,11 +7,10 @@ namespace Flow\ETL\Adapter\Text\Tests\Integration;
 use function Flow\ETL\Adapter\Text\{from_text};
 use Flow\ETL\Adapter\Text\TextExtractor;
 use Flow\ETL\Extractor\Signal;
-use Flow\ETL\{Config, Flow, FlowContext, Row};
+use Flow\ETL\{Config, Flow, FlowContext, Row, Tests\FlowTestCase};
 use Flow\Filesystem\Path;
-use PHPUnit\Framework\TestCase;
 
-final class TextExtractorTest extends TestCase
+final class TextExtractorTest extends FlowTestCase
 {
     public function test_extracting_text_file() : void
     {

--- a/src/adapter/etl-adapter-text/tests/Flow/ETL/Adapter/Text/Tests/Integration/TextTest.php
+++ b/src/adapter/etl-adapter-text/tests/Flow/ETL/Adapter/Text/Tests/Integration/TextTest.php
@@ -6,10 +6,9 @@ namespace Flow\ETL\Adapter\Text\Tests\Integration;
 
 use function Flow\ETL\Adapter\Text\to_text;
 use function Flow\ETL\DSL\string_entry;
-use Flow\ETL\{Flow, Row, Rows};
-use PHPUnit\Framework\TestCase;
+use Flow\ETL\{Flow, Row, Rows, Tests\FlowTestCase};
 
-final class TextTest extends TestCase
+final class TextTest extends FlowTestCase
 {
     public function test_loading_text_files() : void
     {

--- a/src/adapter/etl-adapter-xml/tests/Flow/ETL/Adapter/XML/Tests/Unit/RowsNormalizer/EntryNormalizer/PHPValueNormalizer/ListNormalizationTest.php
+++ b/src/adapter/etl-adapter-xml/tests/Flow/ETL/Adapter/XML/Tests/Unit/RowsNormalizer/EntryNormalizer/PHPValueNormalizer/ListNormalizationTest.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Adapter\XML\Tests\Unit\RowsNormalizer\EntryNormalizer\PHPValueNormalizer;
 
-use Flow\ETL\Tests\FlowTestCase;
 use function Flow\ETL\DSL\{structure_element, type_int, type_integer, type_list, type_map, type_string, type_structure};
 use Flow\ETL\Adapter\XML\Abstraction\XMLNode;
 use Flow\ETL\Adapter\XML\RowsNormalizer\EntryNormalizer\PHPValueNormalizer;
 use Flow\ETL\PHP\Type\Caster;
+use Flow\ETL\Tests\FlowTestCase;
 
 final class ListNormalizationTest extends FlowTestCase
 {

--- a/src/adapter/etl-adapter-xml/tests/Flow/ETL/Adapter/XML/Tests/Unit/RowsNormalizer/EntryNormalizer/PHPValueNormalizer/ListNormalizationTest.php
+++ b/src/adapter/etl-adapter-xml/tests/Flow/ETL/Adapter/XML/Tests/Unit/RowsNormalizer/EntryNormalizer/PHPValueNormalizer/ListNormalizationTest.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Adapter\XML\Tests\Unit\RowsNormalizer\EntryNormalizer\PHPValueNormalizer;
 
+use Flow\ETL\Tests\FlowTestCase;
 use function Flow\ETL\DSL\{structure_element, type_int, type_integer, type_list, type_map, type_string, type_structure};
 use Flow\ETL\Adapter\XML\Abstraction\XMLNode;
 use Flow\ETL\Adapter\XML\RowsNormalizer\EntryNormalizer\PHPValueNormalizer;
 use Flow\ETL\PHP\Type\Caster;
-use PHPUnit\Framework\TestCase;
 
-final class ListNormalizationTest extends TestCase
+final class ListNormalizationTest extends FlowTestCase
 {
     public function test_normalization_of_list_of_flat_structures() : void
     {

--- a/src/adapter/etl-adapter-xml/tests/Flow/ETL/Adapter/XML/Tests/Unit/RowsNormalizer/EntryNormalizer/PHPValueNormalizer/MapNormalizationTest.php
+++ b/src/adapter/etl-adapter-xml/tests/Flow/ETL/Adapter/XML/Tests/Unit/RowsNormalizer/EntryNormalizer/PHPValueNormalizer/MapNormalizationTest.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Adapter\XML\Tests\Unit\RowsNormalizer\EntryNormalizer\PHPValueNormalizer;
 
+use Flow\ETL\Tests\FlowTestCase;
 use function Flow\ETL\DSL\{type_integer, type_list, type_map, type_string};
-use Flow\ETL\Adapter\Elasticsearch\Tests\Integration\TestCase;
 use Flow\ETL\Adapter\XML\Abstraction\XMLNode;
 use Flow\ETL\Adapter\XML\RowsNormalizer\EntryNormalizer\PHPValueNormalizer;
 use Flow\ETL\PHP\Type\Caster;
 
-final class MapNormalizationTest extends TestCase
+final class MapNormalizationTest extends FlowTestCase
 {
     public function test_normalizing_empty_map_of_int_to_str() : void
     {

--- a/src/adapter/etl-adapter-xml/tests/Flow/ETL/Adapter/XML/Tests/Unit/RowsNormalizer/EntryNormalizer/PHPValueNormalizer/MapNormalizationTest.php
+++ b/src/adapter/etl-adapter-xml/tests/Flow/ETL/Adapter/XML/Tests/Unit/RowsNormalizer/EntryNormalizer/PHPValueNormalizer/MapNormalizationTest.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Adapter\XML\Tests\Unit\RowsNormalizer\EntryNormalizer\PHPValueNormalizer;
 
-use Flow\ETL\Tests\FlowTestCase;
 use function Flow\ETL\DSL\{type_integer, type_list, type_map, type_string};
 use Flow\ETL\Adapter\XML\Abstraction\XMLNode;
 use Flow\ETL\Adapter\XML\RowsNormalizer\EntryNormalizer\PHPValueNormalizer;
 use Flow\ETL\PHP\Type\Caster;
+use Flow\ETL\Tests\FlowTestCase;
 
 final class MapNormalizationTest extends FlowTestCase
 {

--- a/src/adapter/etl-adapter-xml/tests/Flow/ETL/Adapter/XML/Tests/Unit/RowsNormalizer/EntryNormalizer/PHPValueNormalizer/StructureNormalizationTest.php
+++ b/src/adapter/etl-adapter-xml/tests/Flow/ETL/Adapter/XML/Tests/Unit/RowsNormalizer/EntryNormalizer/PHPValueNormalizer/StructureNormalizationTest.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Adapter\XML\Tests\Unit\RowsNormalizer\EntryNormalizer\PHPValueNormalizer;
 
+use Flow\ETL\Tests\FlowTestCase;
 use function Flow\ETL\DSL\{structure_element, type_datetime, type_integer, type_list, type_string, type_structure};
 use Flow\ETL\Adapter\XML\Abstraction\{XMLAttribute, XMLNode};
 use Flow\ETL\Adapter\XML\RowsNormalizer\EntryNormalizer\PHPValueNormalizer;
 use Flow\ETL\PHP\Type\Caster;
-use PHPUnit\Framework\TestCase;
 
-final class StructureNormalizationTest extends TestCase
+final class StructureNormalizationTest extends FlowTestCase
 {
     public function test_normalization_of_flat_structure() : void
     {

--- a/src/adapter/etl-adapter-xml/tests/Flow/ETL/Adapter/XML/Tests/Unit/RowsNormalizer/EntryNormalizer/PHPValueNormalizer/StructureNormalizationTest.php
+++ b/src/adapter/etl-adapter-xml/tests/Flow/ETL/Adapter/XML/Tests/Unit/RowsNormalizer/EntryNormalizer/PHPValueNormalizer/StructureNormalizationTest.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Adapter\XML\Tests\Unit\RowsNormalizer\EntryNormalizer\PHPValueNormalizer;
 
-use Flow\ETL\Tests\FlowTestCase;
 use function Flow\ETL\DSL\{structure_element, type_datetime, type_integer, type_list, type_string, type_structure};
 use Flow\ETL\Adapter\XML\Abstraction\{XMLAttribute, XMLNode};
 use Flow\ETL\Adapter\XML\RowsNormalizer\EntryNormalizer\PHPValueNormalizer;
 use Flow\ETL\PHP\Type\Caster;
+use Flow\ETL\Tests\FlowTestCase;
 
 final class StructureNormalizationTest extends FlowTestCase
 {

--- a/src/adapter/etl-adapter-xml/tests/Flow/ETL/Adapter/XML/Tests/Unit/RowsNormalizer/EntryNormalizer/PHPValueNormalizerTest.php
+++ b/src/adapter/etl-adapter-xml/tests/Flow/ETL/Adapter/XML/Tests/Unit/RowsNormalizer/EntryNormalizer/PHPValueNormalizerTest.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Adapter\XML\Tests\Unit\RowsNormalizer\EntryNormalizer;
 
+use Flow\ETL\Tests\FlowTestCase;
 use function Flow\ETL\DSL\{type_array, type_boolean, type_datetime, type_float, type_integer, type_json, type_object, type_string};
 use Flow\ETL\Adapter\XML\Abstraction\{XMLAttribute, XMLNode};
 use Flow\ETL\Adapter\XML\RowsNormalizer\EntryNormalizer\PHPValueNormalizer;
 use Flow\ETL\PHP\Type\Caster;
-use PHPUnit\Framework\TestCase;
 
-final class PHPValueNormalizerTest extends TestCase
+final class PHPValueNormalizerTest extends FlowTestCase
 {
     public function test_normalizing_array_type() : void
     {

--- a/src/adapter/etl-adapter-xml/tests/Flow/ETL/Adapter/XML/Tests/Unit/RowsNormalizer/EntryNormalizer/PHPValueNormalizerTest.php
+++ b/src/adapter/etl-adapter-xml/tests/Flow/ETL/Adapter/XML/Tests/Unit/RowsNormalizer/EntryNormalizer/PHPValueNormalizerTest.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Adapter\XML\Tests\Unit\RowsNormalizer\EntryNormalizer;
 
-use Flow\ETL\Tests\FlowTestCase;
 use function Flow\ETL\DSL\{type_array, type_boolean, type_datetime, type_float, type_integer, type_json, type_object, type_string};
 use Flow\ETL\Adapter\XML\Abstraction\{XMLAttribute, XMLNode};
 use Flow\ETL\Adapter\XML\RowsNormalizer\EntryNormalizer\PHPValueNormalizer;
 use Flow\ETL\PHP\Type\Caster;
+use Flow\ETL\Tests\FlowTestCase;
 
 final class PHPValueNormalizerTest extends FlowTestCase
 {

--- a/src/adapter/etl-adapter-xml/tests/Flow/ETL/Adapter/XML/Tests/Unit/RowsNormalizer/EntryNormalizerTest.php
+++ b/src/adapter/etl-adapter-xml/tests/Flow/ETL/Adapter/XML/Tests/Unit/RowsNormalizer/EntryNormalizerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Adapter\XML\Tests\Unit\RowsNormalizer;
 
+use Flow\ETL\Tests\FlowTestCase;
 use function Flow\ETL\DSL\{str_entry,
     structure_element,
     structure_entry,
@@ -18,9 +19,8 @@ use Flow\ETL\Adapter\XML\Abstraction\{XMLAttribute, XMLNode};
 use Flow\ETL\Adapter\XML\RowsNormalizer\EntryNormalizer;
 use Flow\ETL\Adapter\XML\RowsNormalizer\EntryNormalizer\PHPValueNormalizer;
 use Flow\ETL\PHP\Type\Caster;
-use PHPUnit\Framework\TestCase;
 
-final class EntryNormalizerTest extends TestCase
+final class EntryNormalizerTest extends FlowTestCase
 {
     public function test_normalization_entries_into_attributes() : void
     {

--- a/src/adapter/etl-adapter-xml/tests/Flow/ETL/Adapter/XML/Tests/Unit/RowsNormalizer/EntryNormalizerTest.php
+++ b/src/adapter/etl-adapter-xml/tests/Flow/ETL/Adapter/XML/Tests/Unit/RowsNormalizer/EntryNormalizerTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Adapter\XML\Tests\Unit\RowsNormalizer;
 
-use Flow\ETL\Tests\FlowTestCase;
 use function Flow\ETL\DSL\{str_entry,
     structure_element,
     structure_entry,
@@ -19,6 +18,7 @@ use Flow\ETL\Adapter\XML\Abstraction\{XMLAttribute, XMLNode};
 use Flow\ETL\Adapter\XML\RowsNormalizer\EntryNormalizer;
 use Flow\ETL\Adapter\XML\RowsNormalizer\EntryNormalizer\PHPValueNormalizer;
 use Flow\ETL\PHP\Type\Caster;
+use Flow\ETL\Tests\FlowTestCase;
 
 final class EntryNormalizerTest extends FlowTestCase
 {

--- a/src/adapter/etl-adapter-xml/tests/Flow/ETL/Adapter/XML/Tests/Unit/RowsNormalizerTest.php
+++ b/src/adapter/etl-adapter-xml/tests/Flow/ETL/Adapter/XML/Tests/Unit/RowsNormalizerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Adapter\XML\Tests\Unit;
 
+use Flow\ETL\Tests\FlowTestCase;
 use function Flow\ETL\DSL\{row,
     rows,
     str_entry,
@@ -21,9 +22,8 @@ use Flow\ETL\Adapter\XML\RowsNormalizer;
 use Flow\ETL\Adapter\XML\RowsNormalizer\EntryNormalizer;
 use Flow\ETL\Adapter\XML\RowsNormalizer\EntryNormalizer\PHPValueNormalizer;
 use Flow\ETL\PHP\Type\Caster;
-use PHPUnit\Framework\TestCase;
 
-final class RowsNormalizerTest extends TestCase
+final class RowsNormalizerTest extends FlowTestCase
 {
     public function test_normalization_of_rows() : void
     {

--- a/src/adapter/etl-adapter-xml/tests/Flow/ETL/Adapter/XML/Tests/Unit/RowsNormalizerTest.php
+++ b/src/adapter/etl-adapter-xml/tests/Flow/ETL/Adapter/XML/Tests/Unit/RowsNormalizerTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Adapter\XML\Tests\Unit;
 
-use Flow\ETL\Tests\FlowTestCase;
 use function Flow\ETL\DSL\{row,
     rows,
     str_entry,
@@ -22,6 +21,7 @@ use Flow\ETL\Adapter\XML\RowsNormalizer;
 use Flow\ETL\Adapter\XML\RowsNormalizer\EntryNormalizer;
 use Flow\ETL\Adapter\XML\RowsNormalizer\EntryNormalizer\PHPValueNormalizer;
 use Flow\ETL\PHP\Type\Caster;
+use Flow\ETL\Tests\FlowTestCase;
 
 final class RowsNormalizerTest extends FlowTestCase
 {

--- a/src/adapter/etl-adapter-xml/tests/Flow/ETL/Adapter/XML/Tests/Unit/XMLWriter/DOMDocumentWriterTest.php
+++ b/src/adapter/etl-adapter-xml/tests/Flow/ETL/Adapter/XML/Tests/Unit/XMLWriter/DOMDocumentWriterTest.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Adapter\XML\Tests\Unit\XMLWriter;
 
-use Flow\ETL\Tests\FlowTestCase;
 use Flow\ETL\Adapter\XML\Abstraction\{XMLAttribute, XMLNode};
 use Flow\ETL\Adapter\XML\XMLWriter\DOMDocumentWriter;
+use Flow\ETL\Tests\FlowTestCase;
 
 final class DOMDocumentWriterTest extends FlowTestCase
 {

--- a/src/adapter/etl-adapter-xml/tests/Flow/ETL/Adapter/XML/Tests/Unit/XMLWriter/DOMDocumentWriterTest.php
+++ b/src/adapter/etl-adapter-xml/tests/Flow/ETL/Adapter/XML/Tests/Unit/XMLWriter/DOMDocumentWriterTest.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Adapter\XML\Tests\Unit\XMLWriter;
 
+use Flow\ETL\Tests\FlowTestCase;
 use Flow\ETL\Adapter\XML\Abstraction\{XMLAttribute, XMLNode};
 use Flow\ETL\Adapter\XML\XMLWriter\DOMDocumentWriter;
-use PHPUnit\Framework\TestCase;
 
-final class DOMDocumentWriterTest extends TestCase
+final class DOMDocumentWriterTest extends FlowTestCase
 {
     public function test_writing_empty_child_node() : void
     {

--- a/src/cli/tests/Flow/CLI/Tests/Integration/Options/ConfigOptionTest.php
+++ b/src/cli/tests/Flow/CLI/Tests/Integration/Options/ConfigOptionTest.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Flow\CLI\Tests\Integration\Options;
 
 use Flow\CLI\Options\ConfigOption;
-use Flow\ETL\Adapter\Elasticsearch\Tests\Integration\TestCase;
 use Flow\ETL\Config;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Exception\InvalidArgumentException;
 use Symfony\Component\Console\Input\{ArrayInput, InputDefinition, InputOption};
 

--- a/src/cli/tests/Flow/CLI/Tests/Unit/Options/FileFormatOptionTest.php
+++ b/src/cli/tests/Flow/CLI/Tests/Unit/Options/FileFormatOptionTest.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Flow\CLI\Tests\Unit\Options;
 
-use PHPUnit\Framework\TestCase;
 use function Flow\Filesystem\DSL\path;
 use Flow\CLI\Options\{FileFormat, FileFormatOption};
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\{ArrayInput, InputDefinition, InputOption};
 
 final class FileFormatOptionTest extends TestCase

--- a/src/cli/tests/Flow/CLI/Tests/Unit/Options/FileFormatOptionTest.php
+++ b/src/cli/tests/Flow/CLI/Tests/Unit/Options/FileFormatOptionTest.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Flow\CLI\Tests\Unit\Options;
 
+use PHPUnit\Framework\TestCase;
 use function Flow\Filesystem\DSL\path;
 use Flow\CLI\Options\{FileFormat, FileFormatOption};
-use Flow\ETL\Adapter\Elasticsearch\Tests\Integration\TestCase;
 use Symfony\Component\Console\Input\{ArrayInput, InputDefinition, InputOption};
 
 final class FileFormatOptionTest extends TestCase

--- a/src/lib/parquet/tests/Flow/Parquet/Tests/Unit/Data/Converter/TimeConverterTest.php
+++ b/src/lib/parquet/tests/Flow/Parquet/Tests/Unit/Data/Converter/TimeConverterTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Flow\Parquet\Tests\Unit\Data\Converter;
 
-use Flow\ETL\Adapter\Elasticsearch\Tests\Integration\TestCase;
 use Flow\Parquet\Data\Converter\TimeConverter;
+use PHPUnit\Framework\TestCase;
 
 final class TimeConverterTest extends TestCase
 {

--- a/src/lib/parquet/tests/Flow/Parquet/Tests/Unit/ParquetFile/SchemaTest.php
+++ b/src/lib/parquet/tests/Flow/Parquet/Tests/Unit/ParquetFile/SchemaTest.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Flow\Parquet\Tests\Unit\ParquetFile;
 
-use Flow\ETL\Adapter\Elasticsearch\Tests\Integration\TestCase;
 use Flow\Parquet\ParquetFile\Schema;
 use Flow\Parquet\ParquetFile\Schema\{FlatColumn, ListElement, NestedColumn, Repetition};
 use Flow\Parquet\Thrift\SchemaElement;
+use PHPUnit\Framework\TestCase;
 
 final class SchemaTest extends TestCase
 {


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Used the new `FlowTestCase` in all the ETL tests</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

Partially addresses https://github.com/flow-php/flow/issues/745.

Following the work of https://github.com/flow-php/flow/pull/1291 we will use the new `FlowTestCase` in all the Adapter tests.