### PR TITLE
Use the new FlowTestCase in all Bridges tests

### DIFF
--- a/src/bridge/filesystem/azure/tests/Flow/Filesystem/Bridge/Azure/Tests/Integration/AzureBlobServiceTestCase.php
+++ b/src/bridge/filesystem/azure/tests/Flow/Filesystem/Bridge/Azure/Tests/Integration/AzureBlobServiceTestCase.php
@@ -6,10 +6,10 @@ namespace Flow\Filesystem\Bridge\Azure\Tests\Integration;
 
 use function Flow\Azure\SDK\DSL\{azure_blob_service, azure_blob_service_config, azure_http_factory, azure_shared_key_authorization_factory, azurite_url_factory};
 use Flow\Azure\SDK\{BlobService, Exception\AzureException};
+use Flow\ETL\Tests\FlowTestCase;
 use Http\Discovery\{Psr17FactoryDiscovery, Psr18ClientDiscovery};
-use PHPUnit\Framework\TestCase;
 
-abstract class AzureBlobServiceTestCase extends TestCase
+abstract class AzureBlobServiceTestCase extends FlowTestCase
 {
     /**
      * @var array<string>

--- a/src/bridge/filesystem/azure/tests/Flow/Filesystem/Bridge/Azure/Tests/Unit/AzureBlobDestinationStreamTest.php
+++ b/src/bridge/filesystem/azure/tests/Flow/Filesystem/Bridge/Azure/Tests/Unit/AzureBlobDestinationStreamTest.php
@@ -9,12 +9,12 @@ use Flow\Azure\SDK\BlobService\PutBlockBlob\PutBlockBlobOptions;
 use Flow\Azure\SDK\BlobService\PutBlockBlobBlock\PutBlockBlobBlockOptions;
 use Flow\Azure\SDK\BlobService\PutBlockBlobBlockList\PutBlockBlobBlockListOptions;
 use Flow\Azure\SDK\BlobServiceInterface;
+use Flow\ETL\Tests\FlowTestCase;
 use Flow\Filesystem\Bridge\Azure\AzureBlobDestinationStream;
 use Flow\Filesystem\Path;
 use Flow\Filesystem\Stream\{Block, BlockFactory};
-use PHPUnit\Framework\TestCase;
 
-final class AzureBlobDestinationStreamTest extends TestCase
+final class AzureBlobDestinationStreamTest extends FlowTestCase
 {
     public function test_using_put_blob_with_content_when_data_is_larger_than_block_size() : void
     {

--- a/src/bridge/monolog/http/tests/Flow/Bridge/Monolog/Http/Tests/Unit/PSR7ProcessorTest.php
+++ b/src/bridge/monolog/http/tests/Flow/Bridge/Monolog/Http/Tests/Unit/PSR7ProcessorTest.php
@@ -6,10 +6,10 @@ namespace Flow\Bridge\Monolog\Http\Tests\Unit;
 
 use Flow\Bridge\Monolog\Http\Config\ResponseConfig;
 use Flow\Bridge\Monolog\Http\{Config, PSR7Processor};
+use Flow\ETL\Tests\FlowTestCase;
 use Nyholm\Psr7\Factory\Psr17Factory;
-use PHPUnit\Framework\TestCase;
 
-final class PSR7ProcessorTest extends TestCase
+final class PSR7ProcessorTest extends FlowTestCase
 {
     public function test_normalizing_http_request() : void
     {

--- a/src/bridge/symfony/http-foundation/tests/Flow/Bridge/Symfony/HttpFoundation/Tests/Integration/FlowStreamedResponseTest.php
+++ b/src/bridge/symfony/http-foundation/tests/Flow/Bridge/Symfony/HttpFoundation/Tests/Integration/FlowStreamedResponseTest.php
@@ -10,9 +10,9 @@ use Flow\Bridge\Symfony\HttpFoundation\{FlowStreamedResponse,
     Output\CSVOutput,
     Output\JsonOutput,
     Output\XMLOutput};
-use PHPUnit\Framework\TestCase;
+use Flow\ETL\Tests\FlowTestCase;
 
-final class FlowStreamedResponseTest extends TestCase
+final class FlowStreamedResponseTest extends FlowTestCase
 {
     public function test_streaming_array_response_to_csv() : void
     {

--- a/src/bridge/symfony/http-foundation/tests/Flow/Bridge/Symfony/HttpFoundation/Tests/Unit/Transformation/MaskColumnTransformationTest.php
+++ b/src/bridge/symfony/http-foundation/tests/Flow/Bridge/Symfony/HttpFoundation/Tests/Unit/Transformation/MaskColumnTransformationTest.php
@@ -6,9 +6,9 @@ namespace Flow\Bridge\Symfony\HttpFoundation\Tests\Unit\Transformation;
 
 use function Flow\ETL\DSL\{df, from_array};
 use Flow\Bridge\Symfony\HttpFoundation\Transformation\MaskColumns;
-use PHPUnit\Framework\TestCase;
+use Flow\ETL\Tests\FlowTestCase;
 
-final class MaskColumnTransformationTest extends TestCase
+final class MaskColumnTransformationTest extends FlowTestCase
 {
     public function test_masking_columns_transformation() : void
     {


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Used the new `FlowTestCase` in all the ETL tests</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

Partially addresses https://github.com/flow-php/flow/issues/745.

Following the work of https://github.com/flow-php/flow/pull/1291 we will use the new `FlowTestCase` in all the Bridges tests.