### PR TITLE
Added execution time to pipeline report

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
         "monolog/monolog": "^2.0||^3.0",
         "packaged/thrift": "^0.15.0",
         "php-http/discovery": "^1.0",
+        "psr/clock": "^1.0",
         "psr/http-client": "^1.0",
         "psr/http-message": "^1.0 || ^2.0",
         "psr/log": "^2.0 || ^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f116e7d09bc3a52f8d3288b08b9a263e",
+    "content-hash": "8400ea2b77c9a64e8896d8bf98426259",
     "packages": [
         {
             "name": "aeon-php/calendar",
@@ -1936,6 +1936,54 @@
                 "source": "https://github.com/php-fig/cache/tree/3.0.0"
             },
             "time": "2021-02-03T23:26:27+00:00"
+        },
+        {
+            "name": "psr/clock",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/clock.git",
+                "reference": "e41a24703d4560fd0acb709162f73b8adfc3aa0d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/clock/zipball/e41a24703d4560fd0acb709162f73b8adfc3aa0d",
+                "reference": "e41a24703d4560fd0acb709162f73b8adfc3aa0d",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Clock\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for reading the clock.",
+            "homepage": "https://github.com/php-fig/clock",
+            "keywords": [
+                "clock",
+                "now",
+                "psr",
+                "psr-20",
+                "time"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/clock/issues",
+                "source": "https://github.com/php-fig/clock/tree/1.0.0"
+            },
+            "time": "2022-11-25T14:36:26+00:00"
         },
         {
             "name": "psr/container",
@@ -5224,7 +5272,7 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": {},
+    "stability-flags": [],
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
@@ -5240,6 +5288,6 @@
         "ext-zlib": "*",
         "composer-runtime-api": "^2.1"
     },
-    "platform-dev": {},
+    "platform-dev": [],
     "plugin-api-version": "2.6.0"
 }

--- a/src/core/etl/composer.json
+++ b/src/core/etl/composer.json
@@ -12,6 +12,7 @@
         "php": "~8.2.0 || ~8.3.0 || ~8.4.0",
         "ext-json": "*",
         "ext-mbstring": "*",
+        "psr/clock": "^1.0",
         "flow-php/array-dot": "^0.10.0 || 1.x-dev",
         "flow-php/rdsl": "^0.10.0 || 1.x-dev",
         "flow-php/filesystem": "^0.10.0 || 1.x-dev",

--- a/src/core/etl/src/Flow/Clock/FakeClock.php
+++ b/src/core/etl/src/Flow/Clock/FakeClock.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\Clock;
+
+use Psr\Clock\ClockInterface;
+
+final class FakeClock implements ClockInterface
+{
+    public function __construct(private \DateTimeImmutable $dateTime = new \DateTimeImmutable('now'))
+    {
+    }
+
+    public function modify(string $modify) : void
+    {
+        $this->dateTime = $this->dateTime->modify($modify);
+    }
+
+    public function now() : \DateTimeImmutable
+    {
+        return $this->dateTime;
+    }
+
+    public function set(\DateTimeImmutable $dateTime) : void
+    {
+        $this->dateTime = $dateTime;
+    }
+}

--- a/src/core/etl/src/Flow/Clock/SystemClock.php
+++ b/src/core/etl/src/Flow/Clock/SystemClock.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\Clock;
+
+use Psr\Clock\ClockInterface;
+
+final readonly class SystemClock implements ClockInterface
+{
+    public function __construct(private \DateTimeZone $timezone)
+    {
+    }
+
+    public static function system() : self
+    {
+        return new self(new \DateTimeZone(date_default_timezone_get()));
+    }
+
+    public static function utc() : self
+    {
+        return new self(new \DateTimeZone('UTC'));
+    }
+
+    public function now() : \DateTimeImmutable
+    {
+        return new \DateTimeImmutable('now', $this->timezone);
+    }
+}

--- a/src/core/etl/src/Flow/ETL/Config.php
+++ b/src/core/etl/src/Flow/ETL/Config.php
@@ -13,6 +13,7 @@ use Flow\ETL\Pipeline\Optimizer;
 use Flow\ETL\Row\EntryFactory;
 use Flow\Filesystem\{FilesystemTable};
 use Flow\Serializer\Serializer;
+use Psr\Clock\ClockInterface;
 
 /**
  * Immutable configuration that can be used to initialize many contexts.
@@ -33,6 +34,7 @@ final readonly class Config
     public function __construct(
         private string $id,
         private Serializer $serializer,
+        private ClockInterface $clock,
         private FilesystemTable $filesystemTable,
         private FilesystemStreams $filesystemStreams,
         private Optimizer $optimizer,
@@ -57,6 +59,11 @@ final readonly class Config
     public function caster() : Caster
     {
         return $this->caster;
+    }
+
+    public function clock() : ClockInterface
+    {
+        return $this->clock;
     }
 
     public function entryFactory() : EntryFactory

--- a/src/core/etl/src/Flow/ETL/Dataset/Statistics.php
+++ b/src/core/etl/src/Flow/ETL/Dataset/Statistics.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Dataset;
 
+use Flow\ETL\Dataset\Statistics\ExecutionTime;
+
 final readonly class Statistics
 {
     public function __construct(
         private int $totalRows,
+        public readonly ExecutionTime $executionTime,
     ) {
     }
 

--- a/src/core/etl/src/Flow/ETL/Dataset/Statistics/ExecutionTime.php
+++ b/src/core/etl/src/Flow/ETL/Dataset/Statistics/ExecutionTime.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Dataset\Statistics;
+
+use Flow\ETL\Exception\InvalidArgumentException;
+
+final readonly class ExecutionTime
+{
+    public function __construct(public \DateTimeImmutable $startedAt, public \DateTimeImmutable $finishedAt)
+    {
+        if ($startedAt > $finishedAt) {
+            throw new InvalidArgumentException('Execution start date must be before finish date');
+        }
+    }
+
+    public function duration() : \DateInterval
+    {
+        return $this->startedAt->diff($this->finishedAt);
+    }
+
+    public function inSeconds() : int
+    {
+        return $this->finishedAt->getTimestamp() - $this->startedAt->getTimestamp();
+    }
+}

--- a/src/core/etl/tests/Flow/Clock/SystemClockTest.php
+++ b/src/core/etl/tests/Flow/Clock/SystemClockTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\Clock;
+
+use PHPUnit\Framework\TestCase;
+
+final class SystemClockTest extends TestCase
+{
+    public function test_now() : void
+    {
+        $clock = SystemClock::system();
+
+        self::assertInstanceOf(\DateTimeImmutable::class, $clock->now());
+    }
+
+    public function test_system_clock() : void
+    {
+        $clock = SystemClock::system();
+
+        self::assertInstanceOf(SystemClock::class, $clock);
+    }
+
+    public function test_utc_clock() : void
+    {
+        $clock = SystemClock::utc();
+
+        self::assertInstanceOf(SystemClock::class, $clock);
+    }
+}

--- a/src/core/etl/tests/Flow/ETL/Tests/Integration/DataFrame/AnalyzeTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Integration/DataFrame/AnalyzeTest.php
@@ -5,14 +5,27 @@ declare(strict_types=1);
 namespace Flow\ETL\Tests\Integration\DataFrame;
 
 use function Flow\ETL\Adapter\Text\from_text;
-use function Flow\ETL\DSL\{datetime_schema, df, float_schema, from_array, int_schema, schema, str_schema};
+use function Flow\ETL\DSL\{
+    config_builder,
+    datetime_schema,
+    df,
+    float_schema,
+    from_array,
+    int_schema,
+    schema,
+    str_schema};
+use Flow\Clock\FakeClock;
 use Flow\ETL\Tests\FlowIntegrationTestCase;
+use Flow\ETL\{FlowContext, Rows};
 
 final class AnalyzeTest extends FlowIntegrationTestCase
 {
     public function test_analyzing_csv_file_with_auto_cast() : void
     {
-        $report = df()
+        $config = config_builder()->clock($clock = new FakeClock())->build();
+
+        $clock->set(new \DateTimeImmutable('2025-01-01 00:00:00 UTC'));
+        $report = df($config)
             ->read(from_array([
                 ['Index' => 1, 'Date' => '2024-01-19', 'Close' => '2029.3', 'Volume' => '166078.0', 'Open' => '2027.4', 'High' => '2041.9', 'Low' => '2022.2'],
                 ['Index' => 2, 'Date' => '2024-01-20', 'Close' => '2029.3', 'Volume' => '166078.0', 'Open' => '2027.4', 'High' => '2041.9', 'Low' => '2022.2'],
@@ -21,7 +34,15 @@ final class AnalyzeTest extends FlowIntegrationTestCase
                 ['Index' => 5, 'Date' => '2024-01-23', 'Close' => '2029.3', 'Volume' => '166078.0', 'Open' => '2027.4', 'High' => '2041.9', 'Low' => '2022.2'],
             ]))
             ->autoCast()
-            ->run(analyze: true);
+            ->collect()
+            ->run(function (Rows $rows, FlowContext $context) : void {
+                $clock = $context->config->clock();
+
+                if ($clock instanceof FakeClock) {
+                    $clock->modify('+5 minutes');
+                }
+
+            }, analyze: true);
 
         self::assertNotNull($report);
         self::assertSame(5, $report->statistics()->totalRows());
@@ -38,6 +59,10 @@ final class AnalyzeTest extends FlowIntegrationTestCase
             $report->schema()
         );
         self::assertSame(7, $report->schema()->count());
+        self::assertInstanceOf(\DateTimeImmutable::class, $report->statistics()->executionTime->startedAt);
+        self::assertInstanceOf(\DateTimeImmutable::class, $report->statistics()->executionTime->finishedAt);
+        self::assertGreaterThanOrEqual($report->statistics()->executionTime->startedAt, $report->statistics()->executionTime->finishedAt);
+        self::assertEquals(5 * 60, $report->statistics()->executionTime->inSeconds());
     }
 
     public function test_analyzing_csv_file_with_limit() : void

--- a/tools/blackfire/composer.lock
+++ b/tools/blackfire/composer.lock
@@ -162,10 +162,10 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
-    "platform-dev": [],
+    "platform": {},
+    "platform-dev": {},
     "plugin-api-version": "2.6.0"
 }

--- a/tools/box/composer.lock
+++ b/tools/box/composer.lock
@@ -1395,16 +1395,16 @@
         },
         {
             "name": "humbug/php-scoper",
-            "version": "0.18.15",
+            "version": "0.18.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/humbug/php-scoper.git",
-                "reference": "79b2b4e0fbc1d1ef6ae99c4e078137b42bd43d19"
+                "reference": "aff0ef968d8a07ea5be8a2fe797dbf4927e750af"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/humbug/php-scoper/zipball/79b2b4e0fbc1d1ef6ae99c4e078137b42bd43d19",
-                "reference": "79b2b4e0fbc1d1ef6ae99c4e078137b42bd43d19",
+                "url": "https://api.github.com/repos/humbug/php-scoper/zipball/aff0ef968d8a07ea5be8a2fe797dbf4927e750af",
+                "reference": "aff0ef968d8a07ea5be8a2fe797dbf4927e750af",
                 "shasum": ""
             },
             "require": {
@@ -1425,7 +1425,7 @@
                 "fidry/makefile": "^1.0",
                 "humbug/box": "^4.6.2",
                 "phpspec/prophecy-phpunit": "^2.0",
-                "phpunit/phpunit": "^10.0",
+                "phpunit/phpunit": "^10.0 || ^11.0",
                 "symfony/yaml": "^6.4 || ^7.0"
             },
             "bin": [
@@ -1473,9 +1473,9 @@
             "description": "Prefixes all PHP namespaces in a file or directory.",
             "support": {
                 "issues": "https://github.com/humbug/php-scoper/issues",
-                "source": "https://github.com/humbug/php-scoper/tree/0.18.15"
+                "source": "https://github.com/humbug/php-scoper/tree/0.18.16"
             },
-            "time": "2024-09-02T13:35:10+00:00"
+            "time": "2025-01-12T15:48:25+00:00"
         },
         {
             "name": "jetbrains/phpstorm-stubs",

--- a/tools/cs-fixer/composer.lock
+++ b/tools/cs-fixer/composer.lock
@@ -2537,10 +2537,10 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
-    "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "platform": {},
+    "platform-dev": {},
+    "plugin-api-version": "2.6.0"
 }

--- a/tools/phpunit/composer.lock
+++ b/tools/phpunit/composer.lock
@@ -566,16 +566,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "10.5.40",
+            "version": "10.5.41",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "e6ddda95af52f69c1e0c7b4f977cccb58048798c"
+                "reference": "e76586fa3d49714f230221734b44892e384109d7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/e6ddda95af52f69c1e0c7b4f977cccb58048798c",
-                "reference": "e6ddda95af52f69c1e0c7b4f977cccb58048798c",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/e76586fa3d49714f230221734b44892e384109d7",
+                "reference": "e76586fa3d49714f230221734b44892e384109d7",
                 "shasum": ""
             },
             "require": {
@@ -647,7 +647,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.40"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.41"
             },
             "funding": [
                 {
@@ -663,7 +663,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-12-21T05:49:06+00:00"
+            "time": "2025-01-13T09:33:05+00:00"
         },
         {
             "name": "sebastian/cli-parser",


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <li>execution time to pipeline report</li>
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

```php
$report = df()
    ->read(from_csv(...))
    ->run(analyze: true);

// $report->statistics()->executionTime->startedAt;
// $report->statistics()->executionTime->finishedAt;
// $report->statistics()->executionTime->inSeconds();
```

When the argument `analyze` in the `DataFrame::run()` method is set to `true` the return of that method is `Report`. 

Now this report also provides total pipeline execution time (or just to be more precise, stared and finished at timestamps). 

<!-- Please provide a short description of changes in this section, feel free to use markdown syntax -->

Resolves: #1379 