### PR TITLE
Unified joins behavior

### DIFF
--- a/examples/topics/schema/apply/output.txt
+++ b/examples/topics/schema/apply/output.txt
@@ -1,4 +1,4 @@
 schema
 |-- id: integer
-|-- name: string
+|-- name: ?string
 |-- active: boolean

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -6,6 +6,7 @@
         colors="true"
         displayDetailsOnTestsThatTriggerWarnings="true"
         displayDetailsOnTestsThatTriggerErrors="true"
+        cacheDirectory="var/phpunit/cache"
 >
   <php>
     <env name="AZURITE_HOST" value="localhost"/>

--- a/src/core/etl/src/Flow/ETL/Rows.php
+++ b/src/core/etl/src/Flow/ETL/Rows.php
@@ -328,7 +328,7 @@ final class Rows implements \ArrayAccess, \Countable, \IteratorAggregate
             foreach ($right as $rightRow) {
                 if ($expression->meet($leftRow, $rightRow)) {
                     try {
-                        $joinedRow = $leftRow->merge($rightRow, $expression->prefix());
+                        $joinedRow = $leftRow->merge($expression->dropDuplicateRightEntries($rightRow), $expression->prefix());
                     } catch (DuplicatedEntriesException $e) {
                         throw new DuplicatedEntriesException($e->getMessage() . ' try to use a different join prefix than: "' . $expression->prefix() . '"');
                     }
@@ -364,7 +364,7 @@ final class Rows implements \ArrayAccess, \Countable, \IteratorAggregate
             foreach ($right as $rightRow) {
                 if ($expression->meet($leftRow, $rightRow)) {
                     try {
-                        $joinedRow = $leftRow->merge($rightRow, $expression->prefix());
+                        $joinedRow = $leftRow->merge($expression->dropDuplicateRightEntries($rightRow), $expression->prefix());
                     } catch (DuplicatedEntriesException $e) {
                         throw new DuplicatedEntriesException($e->getMessage() . ' try to use a different join prefix than: "' . $expression->prefix() . '"');
                     }
@@ -382,7 +382,7 @@ final class Rows implements \ArrayAccess, \Countable, \IteratorAggregate
                     $entries[] = $entryFactory->create($definition->entry()->name(), null, $definition->makeNullable());
                 }
 
-                $joinedRow = $leftRow->merge(row(...$entries), $expression->prefix());
+                $joinedRow = $leftRow->merge($expression->dropDuplicateRightEntries(row(...$entries)), $expression->prefix());
             }
 
             $joined[] = $joinedRow;
@@ -438,7 +438,7 @@ final class Rows implements \ArrayAccess, \Countable, \IteratorAggregate
             foreach ($this->rows as $leftRow) {
                 if ($expression->meet($leftRow, $rightRow)) {
                     try {
-                        $joinedRow = $leftRow->merge($rightRow, $expression->prefix());
+                        $joinedRow = $expression->dropDuplicateLeftEntries($leftRow)->merge($rightRow, $expression->prefix());
                     } catch (DuplicatedEntriesException $e) {
                         throw new DuplicatedEntriesException($e->getMessage() . ' try to use a different join prefix than: "' . $expression->prefix() . '"');
                     }
@@ -456,7 +456,7 @@ final class Rows implements \ArrayAccess, \Countable, \IteratorAggregate
                     $entries[] = $entryFactory->create($definition->entry()->name(), null, $definition->makeNullable());
                 }
 
-                $joined[] = row(...$entries)->merge($rightRow, $expression->prefix());
+                $joined[] = $expression->dropDuplicateLeftEntries(row(...$entries))->merge($rightRow, $expression->prefix());
             }
         }
 

--- a/src/core/etl/src/Flow/ETL/Transformer/JoinEachRowsTransformer.php
+++ b/src/core/etl/src/Flow/ETL/Transformer/JoinEachRowsTransformer.php
@@ -11,7 +11,7 @@ final readonly class JoinEachRowsTransformer implements Transformer
 {
     private function __construct(
         private DataFrameFactory $factory,
-        private Expression $condition,
+        private Expression $expression,
         private Join $type,
     ) {
     }
@@ -43,11 +43,13 @@ final readonly class JoinEachRowsTransformer implements Transformer
      */
     public function transform(Rows $rows, FlowContext $context) : Rows
     {
+        $rightRows = $this->factory->from($rows)->fetch();
+
         return match ($this->type) {
-            Join::left => $rows->joinLeft($this->factory->from($rows)->fetch(), $this->condition),
-            Join::left_anti => $rows->joinLeftAnti($this->factory->from($rows)->fetch(), $this->condition),
-            Join::right => $rows->joinRight($this->factory->from($rows)->fetch(), $this->condition),
-            default => $rows->joinInner($this->factory->from($rows)->fetch(), $this->condition),
+            Join::left => $rows->joinLeft($rightRows, $this->expression),
+            Join::left_anti => $rows->joinLeftAnti($rightRows, $this->expression),
+            Join::right => $rows->joinRight($rightRows, $this->expression),
+            default => $rows->joinInner($rightRows, $this->expression),
         };
     }
 }

--- a/src/core/etl/tests/Flow/ETL/Tests/Integration/DataFrame/JoinEachTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Integration/DataFrame/JoinEachTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Flow\ETL\Tests\Integration\DataFrame;
 
 use function Flow\ETL\DSL\data_frame;
-use function Flow\ETL\DSL\{df, from_rows, int_entry, row, rows, str_entry};
+use function Flow\ETL\DSL\{df, from_rows, int_entry, join_on, row, rows, str_entry};
 use Flow\ETL\Join\Expression;
 use Flow\ETL\{DataFrame, DataFrameFactory, Loader, Rows, Tests\FlowTestCase};
 
@@ -43,7 +43,7 @@ final class JoinEachTest extends FlowTestCase
                         );
                     }
                 },
-                Expression::on(['country' => 'code']),
+                Expression::on(['country' => 'code'], 'joined_'),
             )
             ->write($loader)
             ->fetch();
@@ -58,6 +58,58 @@ final class JoinEachTest extends FlowTestCase
                 ['id' => 6, 'country' => 'US', 'joined_code' => 'US', 'joined_name' => 'United States'],
                 ['id' => 7, 'country' => 'US', 'joined_code' => 'US', 'joined_name' => 'United States'],
                 ['id' => 9, 'country' => 'US', 'joined_code' => 'US', 'joined_name' => 'United States'],
+            ],
+            $rows->toArray()
+        );
+    }
+
+    public function test_join_each_without_prefix() : void
+    {
+        $loader = $this->createMock(Loader::class);
+        $loader->expects(self::exactly(2))
+            ->method('load');
+
+        $rows = df()
+            ->read(from_rows(
+                rows(
+                    row(int_entry('id', 1), str_entry('country_code', 'PL')),
+                    row(int_entry('id', 2), str_entry('country_code', 'PL')),
+                    row(int_entry('id', 3), str_entry('country_code', 'PL')),
+                    row(int_entry('id', 4), str_entry('country_code', 'PL')),
+                    row(int_entry('id', 5), str_entry('country_code', 'US')),
+                    row(int_entry('id', 6), str_entry('country_code', 'US')),
+                    row(int_entry('id', 7), str_entry('country_code', 'US')),
+                    row(int_entry('id', 9), str_entry('country_code', 'US')),
+                )
+            ))
+            ->batchSize(4)
+            ->joinEach(
+                new class implements DataFrameFactory {
+                    public function from(Rows $rows) : DataFrame
+                    {
+                        return data_frame()->process(
+                            rows(
+                                row(str_entry('country_code', 'PL'), str_entry('name', 'Poland')),
+                                row(str_entry('country_code', 'US'), str_entry('name', 'United States')),
+                            )
+                        );
+                    }
+                },
+                join_on(['country_code' => 'country_code']),
+            )
+            ->write($loader)
+            ->fetch();
+
+        self::assertEquals(
+            [
+                ['id' => 1, 'country_code' => 'PL', 'name' => 'Poland'],
+                ['id' => 2, 'country_code' => 'PL', 'name' => 'Poland'],
+                ['id' => 3, 'country_code' => 'PL', 'name' => 'Poland'],
+                ['id' => 4, 'country_code' => 'PL', 'name' => 'Poland'],
+                ['id' => 5, 'country_code' => 'US', 'name' => 'United States'],
+                ['id' => 6, 'country_code' => 'US', 'name' => 'United States'],
+                ['id' => 7, 'country_code' => 'US', 'name' => 'United States'],
+                ['id' => 9, 'country_code' => 'US', 'name' => 'United States'],
             ],
             $rows->toArray()
         );

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Transformer/JoinEachRowsTransformerTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Transformer/JoinEachRowsTransformerTest.php
@@ -34,7 +34,7 @@ final class JoinEachRowsTransformerTest extends FlowTestCase
             }
         };
 
-        $transformer = JoinEachRowsTransformer::inner($right, Expression::on(['country' => 'code']));
+        $transformer = JoinEachRowsTransformer::inner($right, Expression::on(['country' => 'code'], 'joined_'));
 
         self::assertEquals(
             [
@@ -65,7 +65,7 @@ final class JoinEachRowsTransformerTest extends FlowTestCase
             }
         };
 
-        $transformer = JoinEachRowsTransformer::left($right, Expression::on(['country' => 'code']));
+        $transformer = JoinEachRowsTransformer::left($right, Expression::on(['country' => 'code'], 'joined_'));
 
         self::assertEquals(
             [
@@ -97,7 +97,7 @@ final class JoinEachRowsTransformerTest extends FlowTestCase
             }
         };
 
-        $transformer = JoinEachRowsTransformer::right($right, Expression::on(['country' => 'code']));
+        $transformer = JoinEachRowsTransformer::right($right, Expression::on(['country' => 'code'], 'joined_'));
 
         self::assertEquals(
             [


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Join columns from a join expression won't trigger the join duplicated columns exception anymore.</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

Resolves: #1212 

<!-- Please provide a short description of changes in this section, feel free to use markdown syntax -->
