### PR TITLE
Improve `Expression::dropDuplicate*Entries` methods

### DIFF
--- a/src/core/etl/src/Flow/ETL/Join/Expression.php
+++ b/src/core/etl/src/Flow/ETL/Join/Expression.php
@@ -52,58 +52,44 @@ final readonly class Expression
 
     public function dropDuplicateLeftEntries(Row $left) : Row
     {
-        if ($this->joinPrefix === '') {
-            $leftEntries = [];
-            $rightEntries = [];
-
-            foreach ($this->left() as $leftReference) {
-                $leftEntries[] = $leftReference->name();
-            }
-
-            foreach ($this->right() as $rightReference) {
-                $rightEntries[] = $rightReference->name();
-            }
-
-            $dropLeft = [];
-
-            foreach ($leftEntries as $leftEntry) {
-                if (\in_array($leftEntry, $rightEntries, true)) {
-                    $dropLeft[] = $leftEntry;
-                }
-            }
-
-            return $left->remove(...$dropLeft);
+        if ($this->joinPrefix !== '') {
+            return $left;
         }
 
-        return $left;
+        $dropLeft = [];
+
+        foreach ($this->left() as $leftReference) {
+            foreach ($this->right() as $rightReference) {
+                if ($leftReference->name() === $rightReference->name()) {
+                    $dropLeft[] = $leftReference->name();
+
+                    continue 2;
+                }
+            }
+        }
+
+        return $left->remove(...$dropLeft);
     }
 
     public function dropDuplicateRightEntries(Row $right) : Row
     {
-        if ($this->joinPrefix === '') {
-            $leftEntries = [];
-            $rightEntries = [];
-
-            foreach ($this->left() as $leftReference) {
-                $leftEntries[] = $leftReference->name();
-            }
-
-            foreach ($this->right() as $rightReference) {
-                $rightEntries[] = $rightReference->name();
-            }
-
-            $dropRight = [];
-
-            foreach ($rightEntries as $rightEntry) {
-                if (\in_array($rightEntry, $leftEntries, true)) {
-                    $dropRight[] = $rightEntry;
-                }
-            }
-
-            return $right->remove(...$dropRight);
+        if ($this->joinPrefix !== '') {
+            return $right;
         }
 
-        return $right;
+        $dropRight = [];
+
+        foreach ($this->right() as $rightReference) {
+            foreach ($this->left() as $leftReference) {
+                if ($rightReference->name() === $leftReference->name()) {
+                    $dropRight[] = $rightReference->name();
+
+                    continue 2;
+                }
+            }
+        }
+
+        return $right->remove(...$dropRight);
     }
 
     /**


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Improve `Expression::dropDuplicate*Entries` methods</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

Cleaner to review without whitespace changes: https://github.com/flow-php/flow/pull/1406/files?w=1
