### PR TITLE
Remove usage of `References::init` in `Row` class

### DIFF
--- a/src/core/etl/src/Flow/ETL/Row.php
+++ b/src/core/etl/src/Flow/ETL/Row.php
@@ -6,7 +6,7 @@ namespace Flow\ETL;
 
 use Flow\ETL\Exception\InvalidArgumentException;
 use Flow\ETL\Hash\{Algorithm, NativePHPHash};
-use Flow\ETL\Row\{Entries, Entry, Reference, References, Schema};
+use Flow\ETL\Row\{Entries, Entry, Reference, Schema};
 
 final readonly class Row
 {
@@ -82,8 +82,8 @@ final readonly class Row
     {
         $entries = [];
 
-        foreach (References::init(...$names) as $ref) {
-            $entries[] = $this->entries->get($ref);
+        foreach ($names as $name) {
+            $entries[] = $this->entries->get($name);
         }
 
         return new self(new Entries(...$entries));
@@ -113,9 +113,9 @@ final readonly class Row
     {
         $namesToRemove = [];
 
-        foreach (References::init(...$names) as $ref) {
-            if ($this->entries->has($ref)) {
-                $namesToRemove[] = $ref;
+        foreach ($names as $name) {
+            if ($this->entries->has($name)) {
+                $namesToRemove[] = $name;
             }
         }
 


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Remove usage of `References::init` in `Row` class</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

Lower code works with both string & `Reference` so there is no point to enforce `Reference` class from string values.
