### PR TITLE
[Bug] Make ParquetOutput implement missing Output interface (#1446)

### DIFF
--- a/src/bridge/symfony/http-foundation/src/Flow/Bridge/Symfony/HttpFoundation/Output/ParquetOutput.php
+++ b/src/bridge/symfony/http-foundation/src/Flow/Bridge/Symfony/HttpFoundation/Output/ParquetOutput.php
@@ -6,6 +6,7 @@ namespace Flow\Bridge\Symfony\HttpFoundation\Output;
 
 use function Flow\ETL\Adapter\Parquet\to_parquet;
 use function Flow\Filesystem\DSL\path_stdout;
+use Flow\Bridge\Symfony\HttpFoundation\Output;
 use Flow\ETL\Loader;
 use Flow\ETL\Row\Schema;
 use Flow\Parquet\Options;
@@ -15,7 +16,7 @@ if (!function_exists('Flow\ETL\Adapter\Parquet\to_parquet')) {
     throw new \RuntimeException('Flow\ETL\Adapter\Parquet\to_parquet function is not available. Make sure that composer require flow-php/etl-adapter-json dependency is present in your composer.json.');
 }
 
-final readonly class ParquetOutput
+final readonly class ParquetOutput implements Output
 {
     public function __construct(
         private ?Options $options = null,


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>ParquetOutput didn't implement Output interface</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

<!-- Please provide a short description of changes in this section, feel free to use markdown syntax -->

Resolces: #1446 
