### PR TITLE
Allow to use different than mapped type to allow for usage of bigint on int entries

### DIFF
--- a/src/adapter/etl-adapter-doctrine/src/Flow/ETL/Adapter/Doctrine/DbalMetadata.php
+++ b/src/adapter/etl-adapter-doctrine/src/Flow/ETL/Adapter/Doctrine/DbalMetadata.php
@@ -20,6 +20,7 @@ enum DbalMetadata : string
     case PRECISION = 'precision';
     case PRIMARY_KEY = 'primary';
     case SCALE = 'scale';
+    case TYPE = 'type';
     case UNSIGNED = 'unsigned';
 
     public static function columnDefinition(string $definition) : Metadata
@@ -75,6 +76,11 @@ enum DbalMetadata : string
     public static function scale(int $scale) : Metadata
     {
         return Metadata::with(self::SCALE->value, $scale);
+    }
+
+    public static function type(string $type) : Metadata
+    {
+        return Metadata::with(self::TYPE->value, $type);
     }
 
     public static function unsigned(bool $unsigned = true) : Metadata

--- a/src/adapter/etl-adapter-doctrine/src/Flow/ETL/Adapter/Doctrine/SchemaConverter.php
+++ b/src/adapter/etl-adapter-doctrine/src/Flow/ETL/Adapter/Doctrine/SchemaConverter.php
@@ -90,7 +90,7 @@ final class SchemaConverter
         }
 
         if ($metadata?->has(DbalMetadata::TYPE->value)) {
-            $dbalType = DbalType::getType($metadata->getAs(DbalMetadata::TYPE->value, type_string()));
+            $dbalType = DbalType::getType((string) $metadata->getAs(DbalMetadata::TYPE->value, type_string()));
         } else {
 
             $dbalType = null;

--- a/src/adapter/etl-adapter-doctrine/src/Flow/ETL/Adapter/Doctrine/SchemaConverter.php
+++ b/src/adapter/etl-adapter-doctrine/src/Flow/ETL/Adapter/Doctrine/SchemaConverter.php
@@ -89,18 +89,23 @@ final class SchemaConverter
             throw new InvalidArgumentException(\sprintf('"%s" is not a valid Doctrine DBAL type.', $type::class));
         }
 
-        $dbalType = null;
+        if ($metadata?->has(DbalMetadata::TYPE->value)) {
+            $dbalType = DbalType::getType($metadata->getAs(DbalMetadata::TYPE->value, type_string()));
+        } else {
 
-        foreach (DbalType::getTypesMap() as $typeName => $class) {
-            if ($class === $dbalTypeClass) {
-                $dbalType = DbalType::getType($typeName);
+            $dbalType = null;
 
-                break;
+            foreach (DbalType::getTypesMap() as $typeName => $class) {
+                if ($class === $dbalTypeClass) {
+                    $dbalType = DbalType::getType($typeName);
+
+                    break;
+                }
             }
         }
 
         if ($dbalType === null) {
-            throw new InvalidArgumentException(\sprintf('"%s" is not a valid Doctrine DBAL type.', $type::class));
+            throw new InvalidArgumentException(\sprintf('"%s" is not a valid Doctrine DBAL type.', $dbalType));
         }
 
         $options = [

--- a/src/adapter/etl-adapter-doctrine/tests/Flow/ETL/Adapter/Doctrine/Tests/Unit/SchemaConverterTest.php
+++ b/src/adapter/etl-adapter-doctrine/tests/Flow/ETL/Adapter/Doctrine/Tests/Unit/SchemaConverterTest.php
@@ -18,6 +18,7 @@ final class SchemaConverterTest extends FlowTestCase
         $flowSchema = schema(
             int_schema('int', nullable: false, metadata: DbalMetadata::primaryKey('pk_test')),
             str_schema('str', nullable: true, metadata: DbalMetadata::primaryKey('pk_test')),
+            int_schema('bigint', nullable: false, metadata: DbalMetadata::type('bigint')),
             str_schema('str_with_length', true, DbalMetadata::length(255)),
             str_schema('str_unique', true, DbalMetadata::indexUnique('idx_str_unique')),
             date_schema('date', nullable: true, metadata: DbalMetadata::index('idx_date')),
@@ -35,6 +36,7 @@ final class SchemaConverterTest extends FlowTestCase
                 [
                     new Column('int', Type::getType('integer'), ['notnull' => true]),
                     new Column('str', Type::getType('string'), ['notnull' => true]), // pk changes nullable true into false
+                    new Column('bigint', Type::getType('bigint'), ['notnull' => true]),
                     new Column('str_with_length', Type::getType('string'), ['notnull' => false, 'length' => 255]),
                     new Column('str_unique', Type::getType('string'), ['notnull' => false]),
                     new Column('float', Type::getType('float'), ['notnull' => false, 'precision' => 10, 'scale' => 2]),


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <li>DbalMetadata::type - allowing to change the type mapping on a specific column level</li>
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

<!-- Please provide a short description of changes in this section, feel free to use markdown syntax -->
