### PR TITLE
Added missing types to JSON/CSV entry normalizers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -318,6 +318,7 @@
             "tools/phpunit/vendor/bin/phpunit --testsuite=adapter-http-integration --log-junit ./var/phpunit/coverage/clover/adapter-http-integration.junit.xml --coverage-clover=./var/phpunit/coverage/clover/adapter-http-integration.coverage.xml --coverage-html=./var/phpunit/coverage/html/adapter-http-integration"
         ],
         "test:adapter:json": [
+            "tools/phpunit/vendor/bin/phpunit --testsuite=adapter-json-unit --log-junit ./var/phpunit/logs/adapter-json-unit.junit.xml --coverage-clover=./var/phpunit/coverage/clover/adapter-json-unit.coverage.xml --coverage-html=./var/phpunit/coverage/html/adapter-json-unit",
             "tools/phpunit/vendor/bin/phpunit --testsuite=adapter-json-integration --log-junit ./var/phpunit/logs/adapter-json-integration.junit.xml --coverage-clover=./var/phpunit/coverage/clover/adapter-json-integration.coverage.xml --coverage-html=./var/phpunit/coverage/html/adapter-json-integration"
         ],
         "test:adapter:logger": [

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -131,6 +131,9 @@
     <testsuite name="adapter-http-integration">
       <directory>src/adapter/etl-adapter-http/tests/Flow/ETL/Adapter/HTTP/Tests/Integration</directory>
     </testsuite>
+    <testsuite name="adapter-json-unit">
+      <directory>src/adapter/etl-adapter-json/tests/Flow/ETL/Adapter/JSON/Tests/Unit</directory>
+    </testsuite>
     <testsuite name="adapter-json-integration">
       <directory>src/adapter/etl-adapter-json/tests/Flow/ETL/Adapter/JSON/Tests/Integration</directory>
     </testsuite>

--- a/src/adapter/etl-adapter-csv/src/Flow/ETL/Adapter/CSV/RowsNormalizer/EntryNormalizer.php
+++ b/src/adapter/etl-adapter-csv/src/Flow/ETL/Adapter/CSV/RowsNormalizer/EntryNormalizer.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Adapter\CSV\RowsNormalizer;
 
-use function Flow\ETL\DSL\type_json;
+use function Flow\ETL\DSL\{date_interval_to_microseconds, type_json};
 use Flow\ETL\PHP\Type\Caster;
 use Flow\ETL\Row\Entry;
 
@@ -13,6 +13,7 @@ final readonly class EntryNormalizer
     public function __construct(
         private Caster $caster,
         private string $dateTimeFormat = \DateTimeInterface::ATOM,
+        private string $dateFormat = 'Y-m-d',
     ) {
     }
 
@@ -26,6 +27,8 @@ final readonly class EntryNormalizer
             Entry\XMLElementEntry::class,
             Entry\XMLEntry::class => $entry->toString(),
             Entry\DateTimeEntry::class => $entry->value()?->format($this->dateTimeFormat),
+            Entry\DateEntry::class => $entry->value()?->format($this->dateFormat),
+            Entry\TimeEntry::class => $entry->value() ? date_interval_to_microseconds($entry->value()) : null,
             Entry\EnumEntry::class => $entry->value()?->name,
             Entry\ListEntry::class,
             Entry\MapEntry::class,

--- a/src/adapter/etl-adapter-csv/tests/Flow/ETL/Adapter/CSV/Tests/Unit/EntryNormalizerTest.php
+++ b/src/adapter/etl-adapter-csv/tests/Flow/ETL/Adapter/CSV/Tests/Unit/EntryNormalizerTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Adapter\CSV\Tests\Unit;
+
+use function Flow\ETL\DSL\{bool_entry, date_entry, datetime_entry, float_entry, int_entry, null_entry, str_entry, time_entry, uuid_entry};
+use Flow\ETL\Adapter\CSV\RowsNormalizer\EntryNormalizer;
+use Flow\ETL\PHP\Type\Caster;
+use Flow\ETL\Row\Entry;
+use Flow\ETL\Tests\FlowTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+final class EntryNormalizerTest extends FlowTestCase
+{
+    public static function entries_provider() : \Generator
+    {
+        yield 'string' => [str_entry('string', 'value'), 'value'];
+        yield 'int' => [int_entry('integer', 1), 1];
+        yield 'float' => [float_entry('float', 1.1), 1.1];
+        yield 'bool' => [bool_entry('bool', true), 'true'];
+        yield 'null' => [null_entry('null'), null];
+        yield 'date' => [date_entry('date', new \DateTimeImmutable('2023-10-01 12:02:01')), '2023-10-01'];
+        yield 'datetime' => [datetime_entry('datetime', new \DateTimeImmutable('2023-10-01 12:02:01')), '2023-10-01T12:02:01+00:00'];
+        yield 'time' => [time_entry('time', new \DateInterval('PT1H')), 3600000000];
+        yield 'uuid' => [uuid_entry('uuid', 'f47ac10b-58cc-4372-a567-0e02b2c3d479'), 'f47ac10b-58cc-4372-a567-0e02b2c3d479'];
+    }
+
+    /**
+     * @param Entry<mixed, mixed> $entry
+     */
+    #[DataProvider('entries_provider')]
+    public function test_normalizing_entries(Entry $entry, mixed $expected) : void
+    {
+        self::assertEquals($expected, (new EntryNormalizer(Caster::default()))->normalize($entry));
+    }
+}

--- a/src/adapter/etl-adapter-json/src/Flow/ETL/Adapter/JSON/RowsNormalizer/EntryNormalizer.php
+++ b/src/adapter/etl-adapter-json/src/Flow/ETL/Adapter/JSON/RowsNormalizer/EntryNormalizer.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Adapter\JSON\RowsNormalizer;
 
+use function Flow\ETL\DSL\date_interval_to_microseconds;
 use Flow\ETL\Row\Entry;
 
 final readonly class EntryNormalizer
 {
     public function __construct(
         private string $dateTimeFormat = \DateTimeInterface::ATOM,
+        private string $dateFormat = 'Y-m-d',
     ) {
     }
 
@@ -21,6 +23,8 @@ final readonly class EntryNormalizer
         return match ($entry::class) {
             Entry\UuidEntry::class => $entry->toString(),
             Entry\DateTimeEntry::class => $entry->value()?->format($this->dateTimeFormat),
+            Entry\DateEntry::class => $entry->value()?->format($this->dateFormat),
+            Entry\TimeEntry::class => $entry->value() ? date_interval_to_microseconds($entry->value()) : null,
             Entry\EnumEntry::class => $entry->value()?->name,
             Entry\ListEntry::class,
             Entry\MapEntry::class,

--- a/src/adapter/etl-adapter-json/tests/Flow/ETL/Adapter/JSON/Tests/Unit/EntryNormalizerTest.php
+++ b/src/adapter/etl-adapter-json/tests/Flow/ETL/Adapter/JSON/Tests/Unit/EntryNormalizerTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Adapter\JSON\Tests\Unit;
+
+use function Flow\ETL\DSL\{bool_entry, date_entry, datetime_entry, float_entry, int_entry, null_entry, str_entry, time_entry, uuid_entry};
+use Flow\ETL\Adapter\JSON\RowsNormalizer\EntryNormalizer;
+use Flow\ETL\Row\Entry;
+use Flow\ETL\Tests\FlowTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+final class EntryNormalizerTest extends FlowTestCase
+{
+    public static function entries_provider() : \Generator
+    {
+        yield 'string' => [str_entry('string', 'value'), 'value'];
+        yield 'int' => [int_entry('integer', 1), 1];
+        yield 'float' => [float_entry('float', 1.1), 1.1];
+        yield 'bool' => [bool_entry('bool', true), 'true'];
+        yield 'null' => [null_entry('null'), null];
+        yield 'date' => [date_entry('date', new \DateTimeImmutable('2023-10-01 12:02:01')), '2023-10-01'];
+        yield 'datetime' => [datetime_entry('datetime', new \DateTimeImmutable('2023-10-01 12:02:01')), '2023-10-01T12:02:01+00:00'];
+        yield 'time' => [time_entry('time', new \DateInterval('PT1H')), 3600000000];
+        yield 'uuid' => [uuid_entry('uuid', 'f47ac10b-58cc-4372-a567-0e02b2c3d479'), 'f47ac10b-58cc-4372-a567-0e02b2c3d479'];
+    }
+
+    /**
+     * @param Entry<mixed, mixed> $entry
+     */
+    #[DataProvider('entries_provider')]
+    public function test_normalizing_entries(Entry $entry, mixed $expected) : void
+    {
+        self::assertEquals($expected, (new EntryNormalizer())->normalize($entry));
+    }
+}

--- a/src/core/etl/tests/Flow/ETL/Tests/Integration/Function/CountTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Integration/Function/CountTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Tests\Integration\Function;
+
+use function Flow\ETL\DSL\{count, df, from_array};
+use Flow\ETL\Tests\FlowTestCase;
+
+final class CountTest extends FlowTestCase
+{
+    public function test_count_aggregation() : void
+    {
+        self::assertEquals(
+            [
+                ['_count' => 3],
+            ],
+            df()
+                ->read(from_array([
+                    ['a' => 1],
+                    ['a' => 2],
+                    ['a' => 3],
+                ]))
+                ->aggregate(count())
+                ->fetch()
+                ->toArray()
+        );
+    }
+
+    public function test_count_with_group_by() : void
+    {
+        self::assertEquals(
+            [
+                ['group' => 'a', '_count' => 3],
+                ['group' => 'b', '_count' => 2],
+            ],
+            df()
+                ->read(from_array([
+                    ['id' => 1, 'group' => 'a'],
+                    ['id' => 2, 'group' => 'a'],
+                    ['id' => 3, 'group' => 'a'],
+                    ['id' => 4, 'group' => 'b'],
+                    ['id' => 5, 'group' => 'b'],
+                ]))
+                ->groupBy('group')
+                ->aggregate(count())
+                ->fetch()
+                ->toArray()
+        );
+    }
+
+    public function test_count_with_group_by_on_multiple_columns() : void
+    {
+        self::assertEquals(
+            [
+                ['group' => 'a', '_count' => 2, 'subgroup' => 'x'],
+                ['group' => 'a', '_count' => 1, 'subgroup' => 'y'],
+                ['group' => 'b', '_count' => 1, 'subgroup' => 'x'],
+                ['group' => 'b', '_count' => 1, 'subgroup' => 'y'],
+            ],
+            df()
+                ->read(from_array([
+                    ['id' => 1, 'group' => 'a', 'subgroup' => 'x'],
+                    ['id' => 2, 'group' => 'a', 'subgroup' => 'y'],
+                    ['id' => 3, 'group' => 'a', 'subgroup' => 'x'],
+                    ['id' => 4, 'group' => 'b', 'subgroup' => 'x'],
+                    ['id' => 5, 'group' => 'b', 'subgroup' => 'y'],
+                ]))
+                ->groupBy('group', 'subgroup')
+                ->aggregate(count())
+                ->fetch()
+                ->toArray()
+        );
+    }
+}


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>missing entry types to JSON/CSV entry normalizers</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

<!-- Please provide a short description of changes in this section, feel free to use markdown syntax -->
