### PR TITLE
Improve error message when schema definition is duplicated

### DIFF
--- a/src/core/etl/src/Flow/ETL/Row/Schema.php
+++ b/src/core/etl/src/Flow/ETL/Row/Schema.php
@@ -338,13 +338,22 @@ final class Schema implements \Countable
     private function setDefinitions(Definition ...$definitions) : void
     {
         $uniqueDefinitions = [];
+        $duplicatedDefinitions = [];
 
         foreach ($definitions as $definition) {
+            if (\array_key_exists($definition->entry()->name(), $uniqueDefinitions)) {
+                $duplicatedDefinitions[] = $definition->entry()->name();
+            }
             $uniqueDefinitions[$definition->entry()->name()] = $definition;
         }
 
         if (\count($uniqueDefinitions) !== \count($definitions)) {
-            throw new SchemaDefinitionNotUniqueException(\sprintf('Entry definitions must be unique, given: [%s]', \implode(', ', \array_map(fn (Definition $d) => $d->entry()->name(), $definitions))));
+
+            throw new SchemaDefinitionNotUniqueException(\sprintf(
+                'Entry definitions must be unique, duplicated entries: [%s], all: [%s]',
+                \implode(', ', $duplicatedDefinitions),
+                \implode(', ', \array_map(fn (Definition $d) => $d->entry()->name(), $definitions)),
+            ));
         }
 
         $this->definitions = $uniqueDefinitions;

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/SchemaTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/SchemaTest.php
@@ -33,6 +33,7 @@ final class SchemaTest extends FlowTestCase
     public function test_adding_duplicated_definitions() : void
     {
         $this->expectException(SchemaDefinitionNotUniqueException::class);
+        $this->expectExceptionMessage('Entry definitions must be unique, duplicated entries: [str], all: [id, str, str]');
         schema(
             int_schema('id'),
             str_schema('str', true),


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Improve error message when schema definition is duplicated</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

<!-- Please provide a short description of changes in this section, feel free to use markdown syntax -->
