### PR TITLE
Don't track write count in the JSONLinesLoader

### DIFF
--- a/src/adapter/etl-adapter-json/src/Flow/ETL/Adapter/JSON/JsonLinesLoader.php
+++ b/src/adapter/etl-adapter-json/src/Flow/ETL/Adapter/JSON/JsonLinesLoader.php
@@ -15,11 +15,6 @@ final class JsonLinesLoader implements Closure, Loader, Loader\FileLoader
 
     private int $flags = JSON_THROW_ON_ERROR;
 
-    /**
-     * @var array<string, int>
-     */
-    private array $writes = [];
-
     public function __construct(private readonly Path $path)
     {
     }
@@ -65,16 +60,7 @@ final class JsonLinesLoader implements Closure, Loader, Loader\FileLoader
         $streams = $context->streams();
         $normalizer = new RowsNormalizer(new EntryNormalizer($this->dateTimeFormat));
 
-        if (!$streams->isOpen($this->path, $partitions)) {
-            $stream = $streams->writeTo($this->path, $partitions);
-
-            if (!\array_key_exists($stream->path()->path(), $this->writes)) {
-                $this->writes[$stream->path()->path()] = 0;
-            }
-
-        } else {
-            $stream = $streams->writeTo($this->path, $partitions);
-        }
+        $stream = $streams->writeTo($this->path, $partitions);
 
         $this->writeJSON($nextRows, $stream, $normalizer);
     }
@@ -103,11 +89,7 @@ final class JsonLinesLoader implements Closure, Loader, Loader\FileLoader
                 throw new RuntimeException('Failed to encode JSON: ' . $e->getMessage(), 0, $e);
             }
 
-            $json = ($this->writes[$stream->path()->path()] > 0) ? ("\n" . $json) : $json;
-
-            $stream->append($json);
-
-            $this->writes[$stream->path()->path()]++;
+            $stream->append($json . "\n");
         }
     }
 }


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>JSONLines Loader would occasionally write a newline to the start of the file.</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

<!-- Please provide a short description of changes in this section, feel free to use markdown syntax -->

In my local usage of this I would occasionally get a newline at the start of the file which causes upstream systems to reject the file, now I could not reproduce this in the test case and during my investigation of this I found I can simplify the writing  by not tracking the write count, which solves the newline at start of file issue and simplifies the code.

In JSONL specification
```
The last character in a file following the last JSON value may be a line separator. In this case the line separator does not indicate the start of another JSON value. 
```
This means we can happily writeln without worry that the last line is just \n



