### PR TITLE
Casting XML to string

### DIFF
--- a/src/adapter/etl-adapter-doctrine/tests/Flow/ETL/Adapter/Doctrine/Tests/Integration/DbalLoaderTest.php
+++ b/src/adapter/etl-adapter-doctrine/tests/Flow/ETL/Adapter/Doctrine/Tests/Integration/DbalLoaderTest.php
@@ -6,7 +6,7 @@ namespace Flow\ETL\Adapter\Doctrine\Tests\Integration;
 
 use function Flow\ETL\Adapter\Doctrine\{to_dbal_table_insert, to_dbal_table_update};
 use function Flow\ETL\DSL\data_frame;
-use function Flow\ETL\DSL\{from_array, ref};
+use function Flow\ETL\DSL\{from_array, int_schema, ref, str_schema, schema, xml_schema};
 use Doctrine\DBAL\Schema\{Column, Table};
 use Doctrine\DBAL\Types\{Type, Types};
 use Flow\ETL\Adapter\Doctrine\DbalLoader;
@@ -82,6 +82,48 @@ final class DbalLoaderTest extends IntegrationTestCase
             ->run();
 
         self::assertEquals(0, $this->pgsqlDatabaseContext->tableCount($table));
+    }
+
+    public function test_inserts_xml_entry() : void
+    {
+        $this->pgsqlDatabaseContext->createTable((new Table(
+            $table = 'flow_doctrine_bulk_test',
+            [
+                new Column('id', Type::getType(Types::INTEGER), ['notnull' => true]),
+                new Column('name', Type::getType(Types::STRING), ['notnull' => true, 'length' => 255]),
+                new Column('description', Type::getType(Types::STRING), ['notnull' => true, 'length' => 255]),
+            ],
+        ))
+            ->setPrimaryKey(['id']));
+
+        $loader = to_dbal_table_insert($this->connectionParams(), $table);
+
+        (data_frame())
+            ->read(
+                from_array([
+                    ['id' => 1, 'name' => 'Name One', 'description' => 'Description One'],
+                    ['id' => 2, 'name' => 'Name Two', 'description' => 'Description Two'],
+                    ['id' => 3, 'name' => 'Name Three', 'description' => '<b>Description Three</b>'],
+                ])->withSchema(
+                    schema(
+                        int_schema('id'),
+                        str_schema('name'),
+                        xml_schema('description')
+                    ),
+                )
+            )
+            ->load($loader)
+            ->run();
+
+        self::assertEquals(3, $this->pgsqlDatabaseContext->tableCount($table));
+        self::assertEquals(
+            [
+                ['id' => 1, 'name' => 'Name One', 'description' => 'Description One'],
+                ['id' => 2, 'name' => 'Name Two', 'description' => 'Description Two'],
+                ['id' => 3, 'name' => 'Name Three', 'description' => '<b>Description Three</b>'],
+            ],
+            $this->pgsqlDatabaseContext->selectAll($table)
+        );
     }
 
     public function test_inserts_multiple_rows_at_once() : void

--- a/src/adapter/etl-adapter-doctrine/tests/Flow/ETL/Adapter/Doctrine/Tests/Integration/DbalLoaderTest.php
+++ b/src/adapter/etl-adapter-doctrine/tests/Flow/ETL/Adapter/Doctrine/Tests/Integration/DbalLoaderTest.php
@@ -276,13 +276,13 @@ final class DbalLoaderTest extends IntegrationTestCase
         $loader = to_dbal_table_insert($this->connectionParams(), $table);
 
         $documentA = new \DOMDocument();
-        $documentA->loadHTML('Description One');
+        $documentA->loadXml('Description One');
 
         $documentB = new \DOMDocument();
-        $documentB->loadHTML('Description Two');
+        $documentB->loadXml('Description Two');
 
         $documentC = new \DOMDocument();
-        $documentC->loadHTML('<b>Description Three</b>');
+        $documentC->loadXml('<b>Description Three</b>');
 
         (data_frame())
             ->read(

--- a/src/adapter/etl-adapter-doctrine/tests/Flow/ETL/Adapter/Doctrine/Tests/Integration/DbalLoaderTest.php
+++ b/src/adapter/etl-adapter-doctrine/tests/Flow/ETL/Adapter/Doctrine/Tests/Integration/DbalLoaderTest.php
@@ -276,10 +276,10 @@ final class DbalLoaderTest extends IntegrationTestCase
         $loader = to_dbal_table_insert($this->connectionParams(), $table);
 
         $documentA = new \DOMDocument();
-        $documentA->loadXml('Description One');
+        $documentA->loadXml('<xml>Description One</xml>');
 
         $documentB = new \DOMDocument();
-        $documentB->loadXml('Description Two');
+        $documentB->loadXml('<xml>Description Two</xml>');
 
         $documentC = new \DOMDocument();
         $documentC->loadXml('<b>Description Three</b>');
@@ -298,8 +298,8 @@ final class DbalLoaderTest extends IntegrationTestCase
         self::assertEquals(3, $this->pgsqlDatabaseContext->tableCount($table));
         self::assertEquals(
             [
-                ['id' => 1, 'name' => 'Name One', 'description' => 'Description One'],
-                ['id' => 2, 'name' => 'Name Two', 'description' => 'Description Two'],
+                ['id' => 1, 'name' => 'Name One', 'description' => '<xml>Description One</xml>'],
+                ['id' => 2, 'name' => 'Name Two', 'description' => '<xml>Description Two</xml>'],
                 ['id' => 3, 'name' => 'Name Three', 'description' => '<b>Description Three</b>'],
             ],
             $this->pgsqlDatabaseContext->selectAll($table)

--- a/src/adapter/etl-adapter-doctrine/tests/Flow/ETL/Adapter/Doctrine/Tests/Integration/DbalLoaderTest.php
+++ b/src/adapter/etl-adapter-doctrine/tests/Flow/ETL/Adapter/Doctrine/Tests/Integration/DbalLoaderTest.php
@@ -4,13 +4,11 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Adapter\Doctrine\Tests\Integration;
 
-use function Amp\Socket\SocketAddress\fromString;
 use function Flow\ETL\Adapter\Doctrine\{to_dbal_table_insert, to_dbal_table_update};
 use function Flow\ETL\DSL\data_frame;
-use function Flow\ETL\DSL\{from_array, int_schema, ref, str_schema, schema, xml_schema};
+use function Flow\ETL\DSL\{from_array, ref};
 use Doctrine\DBAL\Schema\{Column, Table};
 use Doctrine\DBAL\Types\{Type, Types};
-use DOMDocument;
 use Flow\ETL\Adapter\Doctrine\DbalLoader;
 use Flow\ETL\Adapter\Doctrine\Tests\IntegrationTestCase;
 use Flow\ETL\Exception\InvalidArgumentException;
@@ -84,51 +82,6 @@ final class DbalLoaderTest extends IntegrationTestCase
             ->run();
 
         self::assertEquals(0, $this->pgsqlDatabaseContext->tableCount($table));
-    }
-
-    public function test_inserts_xml_entry() : void
-    {
-        $this->pgsqlDatabaseContext->createTable((new Table(
-            $table = 'flow_doctrine_bulk_test',
-            [
-                new Column('id', Type::getType(Types::INTEGER), ['notnull' => true]),
-                new Column('name', Type::getType(Types::STRING), ['notnull' => true, 'length' => 255]),
-                new Column('description', Type::getType(Types::STRING), ['notnull' => true, 'length' => 255]),
-            ],
-        ))
-            ->setPrimaryKey(['id']));
-
-        $loader = to_dbal_table_insert($this->connectionParams(), $table);
-
-        $documentA = new DOMDocument();
-        $documentA->loadHTML('Description One');
-
-        $documentB = new DOMDocument();
-        $documentB->loadHTML('Description Two');
-
-        $documentC = new DOMDocument();
-        $documentC->loadHTML('<b>Description Three</b>');
-
-        (data_frame())
-            ->read(
-                from_array([
-                    ['id' => 1, 'name' => 'Name One', 'description' => $documentA],
-                    ['id' => 2, 'name' => 'Name Two', 'description' => $documentB],
-                    ['id' => 3, 'name' => 'Name Three', 'description' => $documentC],
-                ]),
-            )
-            ->load($loader)
-            ->run();
-
-        self::assertEquals(3, $this->pgsqlDatabaseContext->tableCount($table));
-        self::assertEquals(
-            [
-                ['id' => 1, 'name' => 'Name One', 'description' => 'Description One'],
-                ['id' => 2, 'name' => 'Name Two', 'description' => 'Description Two'],
-                ['id' => 3, 'name' => 'Name Three', 'description' => '<b>Description Three</b>'],
-            ],
-            $this->pgsqlDatabaseContext->selectAll($table)
-        );
     }
 
     public function test_inserts_multiple_rows_at_once() : void
@@ -303,6 +256,51 @@ final class DbalLoaderTest extends IntegrationTestCase
                 ['id' => 2, 'name' => 'New Name Two', 'description' => 'New Description Two'],
                 ['id' => 3, 'name' => 'New Name Three', 'description' => 'New Description Three'],
                 ['id' => 4, 'name' => 'New Name Four', 'description' => 'New Description Three'],
+            ],
+            $this->pgsqlDatabaseContext->selectAll($table)
+        );
+    }
+
+    public function test_inserts_xml_entry() : void
+    {
+        $this->pgsqlDatabaseContext->createTable((new Table(
+            $table = 'flow_doctrine_bulk_test',
+            [
+                new Column('id', Type::getType(Types::INTEGER), ['notnull' => true]),
+                new Column('name', Type::getType(Types::STRING), ['notnull' => true, 'length' => 255]),
+                new Column('description', Type::getType(Types::STRING), ['notnull' => true, 'length' => 255]),
+            ],
+        ))
+            ->setPrimaryKey(['id']));
+
+        $loader = to_dbal_table_insert($this->connectionParams(), $table);
+
+        $documentA = new \DOMDocument();
+        $documentA->loadHTML('Description One');
+
+        $documentB = new \DOMDocument();
+        $documentB->loadHTML('Description Two');
+
+        $documentC = new \DOMDocument();
+        $documentC->loadHTML('<b>Description Three</b>');
+
+        (data_frame())
+            ->read(
+                from_array([
+                    ['id' => 1, 'name' => 'Name One', 'description' => $documentA],
+                    ['id' => 2, 'name' => 'Name Two', 'description' => $documentB],
+                    ['id' => 3, 'name' => 'Name Three', 'description' => $documentC],
+                ]),
+            )
+            ->load($loader)
+            ->run();
+
+        self::assertEquals(3, $this->pgsqlDatabaseContext->tableCount($table));
+        self::assertEquals(
+            [
+                ['id' => 1, 'name' => 'Name One', 'description' => 'Description One'],
+                ['id' => 2, 'name' => 'Name Two', 'description' => 'Description Two'],
+                ['id' => 3, 'name' => 'Name Three', 'description' => '<b>Description Three</b>'],
             ],
             $this->pgsqlDatabaseContext->selectAll($table)
         );

--- a/src/adapter/etl-adapter-doctrine/tests/Flow/ETL/Adapter/Doctrine/Tests/Integration/DbalLoaderTest.php
+++ b/src/adapter/etl-adapter-doctrine/tests/Flow/ETL/Adapter/Doctrine/Tests/Integration/DbalLoaderTest.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Adapter\Doctrine\Tests\Integration;
 
+use function Amp\Socket\SocketAddress\fromString;
 use function Flow\ETL\Adapter\Doctrine\{to_dbal_table_insert, to_dbal_table_update};
 use function Flow\ETL\DSL\data_frame;
 use function Flow\ETL\DSL\{from_array, int_schema, ref, str_schema, schema, xml_schema};
 use Doctrine\DBAL\Schema\{Column, Table};
 use Doctrine\DBAL\Types\{Type, Types};
+use DOMDocument;
 use Flow\ETL\Adapter\Doctrine\DbalLoader;
 use Flow\ETL\Adapter\Doctrine\Tests\IntegrationTestCase;
 use Flow\ETL\Exception\InvalidArgumentException;
@@ -98,19 +100,22 @@ final class DbalLoaderTest extends IntegrationTestCase
 
         $loader = to_dbal_table_insert($this->connectionParams(), $table);
 
+        $documentA = new DOMDocument();
+        $documentA->loadHTML('Description One');
+
+        $documentB = new DOMDocument();
+        $documentB->loadHTML('Description Two');
+
+        $documentC = new DOMDocument();
+        $documentC->loadHTML('<b>Description Three</b>');
+
         (data_frame())
             ->read(
                 from_array([
-                    ['id' => 1, 'name' => 'Name One', 'description' => 'Description One'],
-                    ['id' => 2, 'name' => 'Name Two', 'description' => 'Description Two'],
-                    ['id' => 3, 'name' => 'Name Three', 'description' => '<b>Description Three</b>'],
-                ])->withSchema(
-                    schema(
-                        int_schema('id'),
-                        str_schema('name'),
-                        xml_schema('description')
-                    ),
-                )
+                    ['id' => 1, 'name' => 'Name One', 'description' => $documentA],
+                    ['id' => 2, 'name' => 'Name Two', 'description' => $documentB],
+                    ['id' => 3, 'name' => 'Name Three', 'description' => $documentC],
+                ]),
             )
             ->load($loader)
             ->run();

--- a/src/adapter/etl-adapter-doctrine/tests/Flow/ETL/Adapter/Doctrine/Tests/Integration/DbalLoaderTest.php
+++ b/src/adapter/etl-adapter-doctrine/tests/Flow/ETL/Adapter/Doctrine/Tests/Integration/DbalLoaderTest.php
@@ -261,6 +261,51 @@ final class DbalLoaderTest extends IntegrationTestCase
         );
     }
 
+    public function test_inserts_xml_element_entry() : void
+    {
+        $this->pgsqlDatabaseContext->createTable((new Table(
+            $table = 'flow_doctrine_bulk_test',
+            [
+                new Column('id', Type::getType(Types::INTEGER), ['notnull' => true]),
+                new Column('name', Type::getType(Types::STRING), ['notnull' => true, 'length' => 255]),
+                new Column('description', Type::getType(Types::STRING), ['notnull' => true, 'length' => 255]),
+            ],
+        ))
+            ->setPrimaryKey(['id']));
+
+        $loader = to_dbal_table_insert($this->connectionParams(), $table);
+
+        $documentA = new \DOMDocument();
+        $documentA->loadXml('<xml>Description One</xml>');
+
+        $documentB = new \DOMDocument();
+        $documentB->loadXml('<xml>Description Two</xml>');
+
+        $documentC = new \DOMDocument();
+        $documentC->loadXml('<xml>Description Three</xml>');
+
+        (data_frame())
+            ->read(
+                from_array([
+                    ['id' => 1, 'name' => 'Name One', 'description' => $documentA->getElementsByTagName('xml')[0]],
+                    ['id' => 2, 'name' => 'Name Two', 'description' => $documentB->getElementsByTagName('xml')[0]],
+                    ['id' => 3, 'name' => 'Name Three', 'description' => $documentC->getElementsByTagName('xml')[0]],
+                ]),
+            )
+            ->load($loader)
+            ->run();
+
+        self::assertEquals(3, $this->pgsqlDatabaseContext->tableCount($table));
+        self::assertEquals(
+            [
+                ['id' => 1, 'name' => 'Name One', 'description' => '<xml>Description One</xml>'],
+                ['id' => 2, 'name' => 'Name Two', 'description' => '<xml>Description Two</xml>'],
+                ['id' => 3, 'name' => 'Name Three', 'description' => '<xml>Description Three</xml>'],
+            ],
+            $this->pgsqlDatabaseContext->selectAll($table)
+        );
+    }
+
     public function test_inserts_xml_entry() : void
     {
         $this->pgsqlDatabaseContext->createTable((new Table(

--- a/src/adapter/etl-adapter-json/tests/Flow/ETL/Adapter/JSON/Tests/Integration/JsonTest.php
+++ b/src/adapter/etl-adapter-json/tests/Flow/ETL/Adapter/JSON/Tests/Integration/JsonTest.php
@@ -9,12 +9,36 @@ use function Flow\ETL\Adapter\Json\to_json;
 use function Flow\ETL\DSL\{average, df, from_array, overwrite, ref};
 use function Flow\ETL\DSL\{config, flow_context, rows};
 use function Flow\Filesystem\DSL\path;
+
 use Flow\ETL\Adapter\JSON\JsonLoader;
 use Flow\ETL\Tests\Double\FakeExtractor;
 use Flow\ETL\{Tests\FlowTestCase};
 
 final class JsonTest extends FlowTestCase
 {
+    public function test_domdocument_json_file() : void
+    {
+        $domDocument = new \DOMDocument();
+        $domDocument->loadHtml('<b>red</b>');
+
+        df()
+            ->read(from_array([
+                ['id' => 1, 'descriptionHtml' => $domDocument, 'size' => 'small'],
+            ]))
+            ->saveMode(overwrite())
+            ->write(to_json($path = __DIR__ . '/var/test_domdocument.json'))
+            ->run();
+
+        self::assertStringContainsString(
+            <<<'JSON'
+[
+    [{"id":1,"descriptionHtml":"<b>red<\/b>","size":"small"}]
+]
+JSON,
+            \file_get_contents($path)
+        );
+    }
+
     public function test_json_loader() : void
     {
         $path = __DIR__ . '/var/test_json_loader.json';

--- a/src/adapter/etl-adapter-json/tests/Flow/ETL/Adapter/JSON/Tests/Integration/JsonTest.php
+++ b/src/adapter/etl-adapter-json/tests/Flow/ETL/Adapter/JSON/Tests/Integration/JsonTest.php
@@ -19,7 +19,7 @@ final class JsonTest extends FlowTestCase
     public function test_domdocument_json_file() : void
     {
         $domDocument = new \DOMDocument();
-        $domDocument->loadHtml('<b>red</b>');
+        $domDocument->loadXml('<b>red</b>');
 
         df()
             ->read(from_array([
@@ -31,9 +31,7 @@ final class JsonTest extends FlowTestCase
 
         self::assertStringContainsString(
             <<<'JSON'
-[
-    [{"id":1,"descriptionHtml":"<b>red<\/b>","size":"small"}]
-]
+[{"id":1,"descriptionHtml":"<b>red<\/b>","size":"small"}]
 JSON,
             \file_get_contents($path)
         );

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Caster/StringCastingHandler.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Caster/StringCastingHandler.php
@@ -41,7 +41,7 @@ final class StringCastingHandler implements CastingHandler
         }
 
         if ($value instanceof \DOMDocument) {
-            return $value->saveXML() ?: '';
+            return $value->saveXML($value->documentElement) ?: '';
         }
 
         if ($value instanceof \DOMElement) {

--- a/src/core/etl/tests/Flow/ETL/Tests/Integration/Function/DOMElementValueTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Integration/Function/DOMElementValueTest.php
@@ -98,7 +98,7 @@ final class DOMElementValueTest extends FlowTestCase
 
         self::assertSame(
             [
-                ['html' => '<b>User Name 01</b>'],
+                ['html' => 'User Name 01'],
             ],
             $rows->toArray()
         );

--- a/src/core/etl/tests/Flow/ETL/Tests/Integration/Function/DOMElementValueTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Integration/Function/DOMElementValueTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Tests\Integration\Function;
 
-use function Flow\ETL\DSL\{df, from_rows, ref, row, rows, xml_element_entry, xml_entry};
+use function Flow\ETL\DSL\{df, from_rows, ref, row, rows, xml_element_entry, xml_entry, type_string};
 
 use DOMDocument;
 use Flow\ETL\Tests\FlowTestCase;
@@ -69,6 +69,31 @@ final class DOMElementValueTest extends FlowTestCase
                 )
             ))
             ->withEntry('html', ref('html_raw')->domElementValue())
+            ->drop('html_raw')
+            ->fetch();
+
+        self::assertSame(
+            [
+                ['html' => '<b>User Name 01</b>'],
+            ],
+            $rows->toArray()
+        );
+    }
+
+    public function test_dom_element_cast_as_string() : void
+    {
+        $document = new DOMDocument();
+        $document->loadHTML('<b>User Name 01</b>');
+
+        $rows = df()
+            ->read(from_rows(
+                rows(
+                    row(
+                        xml_entry('html_raw', $document)
+                    )
+                )
+            ))
+            ->withEntry('html', ref('html_raw')->cast(type_string()))
             ->drop('html_raw')
             ->fetch();
 

--- a/src/core/etl/tests/Flow/ETL/Tests/Integration/Function/DOMElementValueTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Integration/Function/DOMElementValueTest.php
@@ -13,7 +13,7 @@ final class DOMElementValueTest extends FlowTestCase
     public function test_dom_element_cast_as_string() : void
     {
         $document = new \DOMDocument();
-        $document->loadHTML('<b>User Name 01</b>');
+        $document->loadXml('<b>User Name 01</b>');
 
         $rows = df()
             ->read(from_rows(
@@ -82,7 +82,7 @@ final class DOMElementValueTest extends FlowTestCase
     public function test_dom_element_value_on_dom_document() : void
     {
         $document = new \DOMDocument();
-        $document->loadHTML('<b>User Name 01</b>');
+        $document->loadXml('<b>User Name 01</b>');
 
         $rows = df()
             ->read(from_rows(

--- a/src/core/etl/tests/Flow/ETL/Tests/Integration/Function/DOMElementValueTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Integration/Function/DOMElementValueTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Flow\ETL\Tests\Integration\Function;
 
 use function Flow\ETL\DSL\{df, from_rows, ref, row, rows, xml_element_entry, xml_entry};
+
+use DOMDocument;
 use Flow\ETL\Tests\FlowTestCase;
 
 final class DOMElementValueTest extends FlowTestCase
@@ -48,6 +50,31 @@ final class DOMElementValueTest extends FlowTestCase
         self::assertSame(
             [
                 ['user_name' => 'User Name 01'],
+            ],
+            $rows->toArray()
+        );
+    }
+
+    public function test_dom_element_value_on_dom_document() : void
+    {
+        $document = new DOMDocument();
+        $document->loadHTML('<b>User Name 01</b>');
+
+        $rows = df()
+            ->read(from_rows(
+                rows(
+                    row(
+                        xml_entry('html_raw', $document)
+                    )
+                )
+            ))
+            ->withEntry('html', ref('html_raw')->domElementValue())
+            ->drop('html_raw')
+            ->fetch();
+
+        self::assertSame(
+            [
+                ['html' => '<b>User Name 01</b>'],
             ],
             $rows->toArray()
         );

--- a/src/core/etl/tests/Flow/ETL/Tests/Integration/Function/DOMElementValueTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Integration/Function/DOMElementValueTest.php
@@ -4,13 +4,37 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Tests\Integration\Function;
 
-use function Flow\ETL\DSL\{df, from_rows, ref, row, rows, xml_element_entry, xml_entry, type_string};
+use function Flow\ETL\DSL\{df, from_rows, ref, row, rows, type_string, xml_element_entry, xml_entry};
 
-use DOMDocument;
 use Flow\ETL\Tests\FlowTestCase;
 
 final class DOMElementValueTest extends FlowTestCase
 {
+    public function test_dom_element_cast_as_string() : void
+    {
+        $document = new \DOMDocument();
+        $document->loadHTML('<b>User Name 01</b>');
+
+        $rows = df()
+            ->read(from_rows(
+                rows(
+                    row(
+                        xml_entry('html_raw', $document)
+                    )
+                )
+            ))
+            ->withEntry('html', ref('html_raw')->cast(type_string()))
+            ->drop('html_raw')
+            ->fetch();
+
+        self::assertSame(
+            [
+                ['html' => '<b>User Name 01</b>'],
+            ],
+            $rows->toArray()
+        );
+    }
+
     public function test_dom_element_value() : void
     {
         $rows = df()
@@ -57,7 +81,7 @@ final class DOMElementValueTest extends FlowTestCase
 
     public function test_dom_element_value_on_dom_document() : void
     {
-        $document = new DOMDocument();
+        $document = new \DOMDocument();
         $document->loadHTML('<b>User Name 01</b>');
 
         $rows = df()
@@ -69,31 +93,6 @@ final class DOMElementValueTest extends FlowTestCase
                 )
             ))
             ->withEntry('html', ref('html_raw')->domElementValue())
-            ->drop('html_raw')
-            ->fetch();
-
-        self::assertSame(
-            [
-                ['html' => '<b>User Name 01</b>'],
-            ],
-            $rows->toArray()
-        );
-    }
-
-    public function test_dom_element_cast_as_string() : void
-    {
-        $document = new DOMDocument();
-        $document->loadHTML('<b>User Name 01</b>');
-
-        $rows = df()
-            ->read(from_rows(
-                rows(
-                    row(
-                        xml_entry('html_raw', $document)
-                    )
-                )
-            ))
-            ->withEntry('html', ref('html_raw')->cast(type_string()))
             ->drop('html_raw')
             ->fetch();
 

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Function/CastTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Function/CastTest.php
@@ -41,7 +41,7 @@ XML;
             'json_pretty' => [[1], 'json_pretty', "[\n    1\n]"],
             'xml_to_array' => [$xml, 'array', ['root' => ['foo' => ['@attributes' => ['baz' => 'buz'], '@value' => 'bar']]]],
             'string_to_xml' => [$xmlString, 'xml', $xml],
-            'xml_to_string' => [$xml, 'string', $fullXMLString],
+            'xml_to_string' => [$xml, 'string', '<root><foo baz="buz">bar</foo></root>'],
             'datetime' => [new \DateTimeImmutable('2023-01-01 00:00:00 UTC'), 'string', '2023-01-01T00:00:00+00:00'],
             'datetime_to_date' => [new \DateTimeImmutable('2023-01-01 00:01:00 UTC'), 'date', new \DateTimeImmutable('2023-01-01T00:00:00+00:00')],
             'uuid' => [Uuid::fromString('a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11'), 'string', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11'],

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/PHP/Type/Caster/StringCastingHandlerTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/PHP/Type/Caster/StringCastingHandlerTest.php
@@ -27,6 +27,11 @@ final class StringCastingHandlerTest extends FlowTestCase
             }
         }, 'stringable'];
         yield 'DOMDocument' => [new \DOMDocument(), '<?xml version="1.0"?>'];
+
+        $xml = (new \DOMDocument());
+        $xml->loadXML('<xml>Some Happy XML</xml>');
+
+        yield 'Not Empty DOMDocument' => [$xml, '<xml>Some Happy XML</xml>'];
         yield 'DOMElement' => [new \DOMElement('element'), '<element/>'];
     }
 

--- a/src/lib/doctrine-dbal-bulk/src/Flow/Doctrine/Bulk/BulkData.php
+++ b/src/lib/doctrine-dbal-bulk/src/Flow/Doctrine/Bulk/BulkData.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Flow\Doctrine\Bulk;
 
+use function Flow\ETL\DSL\dom_element_to_string;
 use Doctrine\DBAL\Types\{Type, Types};
 use Flow\Doctrine\Bulk\Exception\RuntimeException;
 
@@ -146,6 +147,11 @@ final readonly class BulkData
                         \DOMDocument::class => match (Type::getTypeRegistry()->lookupName($table->dbalColumn($column)->getType())) {
                             Types::TEXT,
                             Types::STRING => $entry->saveXML($entry->documentElement),
+                            default => $entry,
+                        },
+                        \DOMElement::class => match (Type::getTypeRegistry()->lookupName($table->dbalColumn($column)->getType())) {
+                            Types::TEXT,
+                            Types::STRING => (string) dom_element_to_string($entry),
                             default => $entry,
                         },
                         default => $entry,

--- a/src/lib/doctrine-dbal-bulk/src/Flow/Doctrine/Bulk/BulkData.php
+++ b/src/lib/doctrine-dbal-bulk/src/Flow/Doctrine/Bulk/BulkData.php
@@ -131,7 +131,7 @@ final readonly class BulkData
                         default => $entry,
                     },
                     'array' => match (Type::getTypeRegistry()->lookupName($table->dbalColumn($column)->getType())) {
-                        Types::TEXT => \json_encode($entry, JSON_THROW_ON_ERROR),
+                        Types::TEXT, Types::STRING => \json_encode($entry, JSON_THROW_ON_ERROR),
                         default => $entry,
                     },
                     'object' => match ($entry::class) {
@@ -141,6 +141,11 @@ final readonly class BulkData
                         },
                         \DateTime::class => match (Type::getTypeRegistry()->lookupName($table->dbalColumn($column)->getType())) {
                             Types::DATETIME_IMMUTABLE => \DateTimeImmutable::createFromMutable($entry),
+                            default => $entry,
+                        },
+                        \DOMDocument::class => match (Type::getTypeRegistry()->lookupName($table->dbalColumn($column)->getType())) {
+                            Types::TEXT,
+                            Types::STRING => $entry->saveXML($entry->documentElement),
                             default => $entry,
                         },
                         default => $entry,


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <li>Early detection of XML type in dbal bulk</li>
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>Incosistency between XMLEntry::toString and Casting XML's to strings</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

<!-- Please provide a short description of changes in this section, feel free to use markdown syntax -->

Resolves: #1472 
