### PR TITLE
Add localTitle function with Test for 'en' and 'nl'

### DIFF
--- a/src/core/etl/src/Flow/ETL/Function/ScalarFunctionChain.php
+++ b/src/core/etl/src/Flow/ETL/Function/ScalarFunctionChain.php
@@ -487,6 +487,11 @@ abstract class ScalarFunctionChain implements ScalarFunction
         return new StringFold($this);
     }
 
+    public function stringLocaleTitle(ScalarFunction|string $locale) : self
+    {
+        return new StringLocaleTitle($this, $locale);
+    }
+
     public function stringStyle(ScalarFunction|string|StringStyles $style) : self
     {
         return new StringStyle($this, $style);

--- a/src/core/etl/src/Flow/ETL/Function/StringLocaleTitle.php
+++ b/src/core/etl/src/Flow/ETL/Function/StringLocaleTitle.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Function;
+
+use function Flow\ETL\DSL\type_string;
+use function Symfony\Component\String\u;
+use Flow\ETL\Function\ScalarFunction\TypedScalarFunction;
+use Flow\ETL\PHP\Type\Type;
+use Flow\ETL\Row;
+
+final class StringLocaleTitle extends ScalarFunctionChain implements TypedScalarFunction
+{
+    public function __construct(
+        private readonly ScalarFunction|string $string,
+        private readonly ScalarFunction|string $locale,
+    ) {
+    }
+
+    public function eval(Row $row) : mixed
+    {
+        $string = (new Parameter($this->string))->asString($row);
+        $locale = (new Parameter($this->locale))->asString($row);
+
+        if ($string === null || $locale === null) {
+            return null;
+        }
+
+        return u($string)->localeTitle($locale)->toString();
+    }
+
+    public function returns() : Type
+    {
+        return type_string();
+    }
+}

--- a/src/core/etl/src/Flow/ETL/Function/StringLocaleTitle.php
+++ b/src/core/etl/src/Flow/ETL/Function/StringLocaleTitle.php
@@ -9,6 +9,7 @@ use function Symfony\Component\String\u;
 use Flow\ETL\Function\ScalarFunction\TypedScalarFunction;
 use Flow\ETL\PHP\Type\Type;
 use Flow\ETL\Row;
+use Symfony\Component\String\AbstractUnicodeString;
 
 final class StringLocaleTitle extends ScalarFunctionChain implements TypedScalarFunction
 {
@@ -25,6 +26,11 @@ final class StringLocaleTitle extends ScalarFunctionChain implements TypedScalar
 
         if ($string === null || $locale === null) {
             return null;
+        }
+
+        /** @phpstan-ignore-next-line */
+        if (!method_exists(AbstractUnicodeString::class, 'localeTitle')) {
+            return u($string)->title()->toString();
         }
 
         return u($string)->localeTitle($locale)->toString();

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Function/StringLocaleTitleTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Function/StringLocaleTitleTest.php
@@ -26,7 +26,7 @@ final class StringLocaleTitleTest extends FlowTestCase
     public function test_string_locale_title_en() : void
     {
         /** @phpstan-ignore-next-line */
-        if (!method_exists(AbstractUnicodeString::class, 'localeTitle')) {
+        if (method_exists(AbstractUnicodeString::class, 'localeTitle')) {
             self::assertSame(
                 'Foo ijssel',
                 ref('str')->stringLocaleTitle('en')->eval(
@@ -46,7 +46,7 @@ final class StringLocaleTitleTest extends FlowTestCase
     public function test_string_locale_title_nl() : void
     {
         /** @phpstan-ignore-next-line */
-        if (!method_exists(AbstractUnicodeString::class, 'localeTitle')) {
+        if (method_exists(AbstractUnicodeString::class, 'localeTitle')) {
             self::assertSame(
                 'Foo IJssel',
                 ref('str')->stringLocaleTitle('nl')->eval(

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Function/StringLocaleTitleTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Function/StringLocaleTitleTest.php
@@ -9,6 +9,7 @@ use function Flow\ETL\DSL\{ref, str_entry, type_string};
 use Flow\ETL\Function\StringLocaleTitle;
 use Flow\ETL\PHP\Type\Type;
 use Flow\ETL\Tests\FlowTestCase;
+use Symfony\Component\String\AbstractUnicodeString;
 
 final class StringLocaleTitleTest extends FlowTestCase
 {
@@ -24,21 +25,42 @@ final class StringLocaleTitleTest extends FlowTestCase
 
     public function test_string_locale_title_en() : void
     {
-        self::assertSame(
-            'Foo ijssel',
-            ref('str')->stringLocaleTitle('en')->eval(
-                row(str_entry('str', 'foo ijssel'))
-            )
-        );
+        /** @phpstan-ignore-next-line */
+        if (!method_exists(AbstractUnicodeString::class, 'localeTitle')) {
+            self::assertSame(
+                'Foo ijssel',
+                ref('str')->stringLocaleTitle('en')->eval(
+                    row(str_entry('str', 'foo ijssel'))
+                )
+            );
+        } else {
+            self::assertSame(
+                'Foo ijssel',
+                ref('str')->stringTitle()->eval(
+                    row(str_entry('str', 'foo ijssel'))
+                )
+            );
+        }
     }
 
     public function test_string_locale_title_nl() : void
     {
-        self::assertSame(
-            'Foo IJssel',
-            ref('str')->stringLocaleTitle('nl')->eval(
-                row(str_entry('str', 'foo ijssel'))
-            )
-        );
+        /** @phpstan-ignore-next-line */
+        if (!method_exists(AbstractUnicodeString::class, 'localeTitle')) {
+            self::assertSame(
+                'Foo IJssel',
+                ref('str')->stringLocaleTitle('nl')->eval(
+                    row(str_entry('str', 'foo ijssel'))
+                )
+            );
+        } else {
+            self::assertNotSame(
+                'Foo IJssel',
+                ref('str')->stringTitle()->eval(
+                    row(str_entry('str', 'foo ijssel'))
+                )
+            );
+        }
+
     }
 }

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Function/StringLocaleTitleTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Function/StringLocaleTitleTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Tests\Unit\Function;
+
+use function Flow\ETL\DSL\row;
+use function Flow\ETL\DSL\{ref, str_entry, type_string};
+use Flow\ETL\Function\StringLocaleTitle;
+use Flow\ETL\PHP\Type\Type;
+use Flow\ETL\Tests\FlowTestCase;
+
+final class StringLocaleTitleTest extends FlowTestCase
+{
+    public function test_returns_method_returns_string_type() : void
+    {
+        $stringTitleFunction = new StringLocaleTitle('str', 'en');
+        $returnType = $stringTitleFunction->returns();
+
+        self::assertInstanceOf(Type::class, $returnType);
+
+        self::assertTrue($returnType->isEqual(type_string()));
+    }
+
+    public function test_string_locale_title_en() : void
+    {
+        self::assertSame(
+            'Foo ijssel',
+            ref('str')->stringLocaleTitle('en')->eval(
+                row(str_entry('str', 'foo ijssel'))
+            )
+        );
+    }
+
+    public function test_string_locale_title_nl() : void
+    {
+        self::assertSame(
+            'Foo IJssel',
+            ref('str')->stringLocaleTitle('nl')->eval(
+                row(str_entry('str', 'foo ijssel'))
+            )
+        );
+    }
+}


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
<li>localeTitle function added with test coverage of 'en' and 'nl' examples and return type
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

<!-- Please provide a short description of changes in this section, feel free to use markdown syntax -->
<p>Added function localeTitle() changes all graphemes/code points to "title case" according to locale-specific case mappings.

For example:
<li>- localeTitle('en')</li>
</p>