### PR TITLE
Add StringAfter function with test

### DIFF
--- a/src/core/etl/src/Flow/ETL/Function/ScalarFunctionChain.php
+++ b/src/core/etl/src/Flow/ETL/Function/ScalarFunctionChain.php
@@ -482,6 +482,11 @@ abstract class ScalarFunctionChain implements ScalarFunction
         return new StartsWith($this, $needle);
     }
 
+    public function stringAfter(ScalarFunction|string $needle, ScalarFunction|bool $includeNeedle = false) : self
+    {
+        return new StringAfter($this, $needle, $includeNeedle);
+    }
+
     public function stringFold() : self
     {
         return new StringFold($this);

--- a/src/core/etl/src/Flow/ETL/Function/StringAfter.php
+++ b/src/core/etl/src/Flow/ETL/Function/StringAfter.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Function;
+
+use function Flow\ETL\DSL\{type_list, type_string};
+use function Symfony\Component\String\u;
+use Flow\ETL\Function\ScalarFunction\TypedScalarFunction;
+use Flow\ETL\PHP\Type\Type;
+use Flow\ETL\Row;
+
+final class StringAfter extends ScalarFunctionChain implements TypedScalarFunction
+{
+    public function __construct(
+        private readonly ScalarFunction|string $string,
+        private readonly ScalarFunction|string $needle,
+        private readonly ScalarFunction|bool $includeNeedle = false,
+    ) {
+    }
+
+    public function eval(Row $row) : mixed
+    {
+        $string = (new Parameter($this->string))->asString($row);
+
+        if ($string === null) {
+            return null;
+        }
+
+        $needle = (new Parameter($this->needle))->as($row, type_string(), type_list(type_string()));
+        $includeNeedle = (new Parameter($this->includeNeedle))->asBoolean($row);
+
+        return u($string)->after($needle, $includeNeedle)->toString();
+    }
+
+    public function returns() : Type
+    {
+        return type_string();
+    }
+}

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Function/StringAfterTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Function/StringAfterTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Tests\Unit\Function;
+
+use function Flow\ETL\DSL\row;
+use function Flow\ETL\DSL\{ref, str_entry, type_string};
+use Flow\ETL\Function\StringTitle;
+use Flow\ETL\PHP\Type\Type;
+use Flow\ETL\Tests\FlowTestCase;
+
+final class StringAfterTest extends FlowTestCase
+{
+    public function test_returns_method_returns_string_type() : void
+    {
+        $stringTitleFunction = new StringTitle('str');
+        $returnType = $stringTitleFunction->returns();
+
+        self::assertInstanceOf(Type::class, $returnType);
+
+        self::assertTrue($returnType->isEqual(type_string()));
+    }
+
+    public function test_string_after() : void
+    {
+        self::assertSame(
+            ' world',
+            ref('str')->stringAfter(ref('needle'))->eval(
+                row(
+                    str_entry('str', 'hello world'),
+                    str_entry('needle', 'hello')
+                )
+            )
+        );
+
+        self::assertSame(
+            ' world',
+            ref('str')->stringAfter(ref('needle'))->eval(
+                row(
+                    str_entry('str', 'hello world'),
+                    str_entry('needle', 'o')
+                )
+            )
+        );
+    }
+
+    public function test_string_after_including_needle() : void
+    {
+        self::assertSame(
+            'o world',
+            ref('str')->stringAfter(ref('needle'), includeNeedle: true)->eval(
+                row(
+                    str_entry('str', 'hello world'),
+                    str_entry('needle', 'o')
+                )
+            )
+        );
+    }
+}


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
<li>Added function StringBefore and Tests stringAfter($needle, $includingNeedle including needle is set false by default</li>
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

Ref: #1316

<h2>Description</h2>
<p>This function extracts the substring after a given delimiter, ensuring proper UTF-8</p>
<!-- Please provide a short description of changes in this section, feel free to use markdown syntax -->
