### PR TITLE
Allow to pass limit as null to not break the pipeline

### DIFF
--- a/src/core/etl/src/Flow/ETL/DataFrame.php
+++ b/src/core/etl/src/Flow/ETL/DataFrame.php
@@ -540,8 +540,12 @@ final class DataFrame
      *
      * @throws InvalidArgumentException
      */
-    public function limit(int $limit) : self
+    public function limit(?int $limit) : self
     {
+        if ($limit === null) {
+            return $this;
+        }
+
         $this->pipeline = $this->context->config->optimizer()->optimize(new LimitTransformer($limit), $this->pipeline);
 
         return $this;

--- a/src/core/etl/src/Flow/ETL/Transformation/Limit.php
+++ b/src/core/etl/src/Flow/ETL/Transformation/Limit.php
@@ -8,7 +8,7 @@ use Flow\ETL\{DataFrame, Transformation};
 
 final readonly class Limit implements Transformation
 {
-    public function __construct(private int $limit)
+    public function __construct(private ?int $limit)
     {
     }
 

--- a/src/core/etl/tests/Flow/ETL/Tests/Integration/DataFrame/LimitTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Integration/DataFrame/LimitTest.php
@@ -36,6 +36,21 @@ final class LimitTest extends FlowIntegrationTestCase
         self::assertCount(9, $rows);
     }
 
+    public function test_limit_null() : void
+    {
+        $rows = df()
+            ->read(from_array(
+                \array_map(
+                    fn (int $id) : array => ['id' => $id],
+                    \range(1, 10)
+                )
+            ))
+            ->limit(null)
+            ->fetch();
+
+        self::assertCount(10, $rows);
+    }
+
     public function test_fetch_with_limit() : void
     {
         $rows = df()

--- a/src/core/etl/tests/Flow/ETL/Tests/Integration/DataFrame/LimitTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Integration/DataFrame/LimitTest.php
@@ -36,21 +36,6 @@ final class LimitTest extends FlowIntegrationTestCase
         self::assertCount(9, $rows);
     }
 
-    public function test_limit_null() : void
-    {
-        $rows = df()
-            ->read(from_array(
-                \array_map(
-                    fn (int $id) : array => ['id' => $id],
-                    \range(1, 10)
-                )
-            ))
-            ->limit(null)
-            ->fetch();
-
-        self::assertCount(10, $rows);
-    }
-
     public function test_fetch_with_limit() : void
     {
         $rows = df()
@@ -128,6 +113,21 @@ final class LimitTest extends FlowIntegrationTestCase
         $this->expectExceptionMessage("Limit can't be lower or equal zero, given: -1");
 
         df()->read(from_rows(\Flow\ETL\DSL\rows()))->limit(-1);
+    }
+
+    public function test_limit_null() : void
+    {
+        $rows = df()
+            ->read(from_array(
+                \array_map(
+                    fn (int $id) : array => ['id' => $id],
+                    \range(1, 10)
+                )
+            ))
+            ->limit(null)
+            ->fetch();
+
+        self::assertCount(10, $rows);
     }
 
     public function test_limit_when_transformation_is_expanding_rows_extracted_from_extractor() : void


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Allow to pass limit as null to avoid breaking a pipeline</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

<!-- Please provide a short description of changes in this section, feel free to use markdown syntax -->

Now when limit needs to come from a user input, we need to split the pipeline in order to check if limit is not null. 


```php

$df = df()
  ->read(from_());

if ($limit !== null) { 
  $df->limit($limit);
}

$df->run()
```

After we merge this PR it wont be necessary anymore:

```php

if ($limit < 0) {
   $limit = null;
}

$df = df()
  ->read(from_())
  ->limit($limit)
  ->run();
```