### PR TITLE
Prevent double etl evaluation in buffered response

### DIFF
--- a/src/bridge/symfony/http-foundation/src/Flow/Bridge/Symfony/HttpFoundation/Response/FlowBufferedResponse.php
+++ b/src/bridge/symfony/http-foundation/src/Flow/Bridge/Symfony/HttpFoundation/Response/FlowBufferedResponse.php
@@ -60,6 +60,17 @@ final class FlowBufferedResponse extends Response
             ->write($this->output->memoryLoader($id = \bin2hex(\random_bytes(16)) . '.memory'))
             ->run();
 
-        $this->content = $config->fstab()->for(protocol('memory'))->readFrom(path_memory($id))->content();
+        $fs = $config->fstab()->for(protocol('memory'));
+
+        if ($fs->status(path_memory($id)) === null) {
+            $this->buffered = true;
+            $this->content = '';
+            $this->statusCode = self::HTTP_NO_CONTENT;
+
+            return;
+        }
+
+        $this->content = $fs->readFrom(path_memory($id))->content();
+        $this->buffered = true;
     }
 }

--- a/src/bridge/symfony/http-foundation/tests/Flow/Bridge/Symfony/HttpFoundation/Tests/Unit/Response/FlowBufferedResponseTest.php
+++ b/src/bridge/symfony/http-foundation/tests/Flow/Bridge/Symfony/HttpFoundation/Tests/Unit/Response/FlowBufferedResponseTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\Bridge\Symfony\HttpFoundation\Tests\Unit\Response;
+
+use function Flow\Bridge\Symfony\HttpFoundation\{http_json_output, http_stream_open};
+use function Flow\ETL\DSL\{from_array, int_entry, row, rows};
+use Flow\ETL\Extractor;
+use Flow\ETL\Tests\FlowTestCase;
+
+final class FlowBufferedResponseTest extends FlowTestCase
+{
+    public function test_response_from_empty_dataset() : void
+    {
+        $response = http_stream_open(from_array([]))->response(http_json_output());
+
+        self::assertEquals('', $response->getContent());
+        self::assertEquals(204, $response->getStatusCode());
+    }
+
+    public function test_response_is_buffered_only_once() : void
+    {
+        $extractor = $this->createMock(Extractor::class);
+
+        $extractor->expects(self::once())->method('extract')->willReturn((function () : \Generator {
+            yield rows(row(int_entry('id', 1)));
+        })());
+
+        $response = http_stream_open($extractor)->response(http_json_output());
+
+        $response->getContent();
+        $response->getContent();
+
+        self::assertEquals('[{"id":1}]', $response->getContent());
+        self::assertEquals(200, $response->getStatusCode());
+    }
+}

--- a/src/bridge/symfony/http-foundation/tests/Flow/Bridge/Symfony/HttpFoundation/Tests/Unit/Response/FlowStreamedResponseTest.php
+++ b/src/bridge/symfony/http-foundation/tests/Flow/Bridge/Symfony/HttpFoundation/Tests/Unit/Response/FlowStreamedResponseTest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\Bridge\Symfony\HttpFoundation\Tests\Unit\Response;
+
+use function Flow\Bridge\Symfony\HttpFoundation\{http_json_output, http_stream_open};
+use function Flow\ETL\DSL\from_array;
+use PHPUnit\Framework\TestCase;
+
+final class FlowStreamedResponseTest extends TestCase
+{
+    public function test_response_from_empty_dataset() : void
+    {
+        $response = http_stream_open(from_array([]))->streamedResponse(http_json_output());
+
+        self::assertEquals('', $response->getContent());
+        self::assertEquals(200, $response->getStatusCode());
+    }
+}


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>Prevent double ETL evaluation in buffered response</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Return 204 for buffered response when dataset is empty</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

<!-- Please provide a short description of changes in this section, feel free to use markdown syntax -->
