### PR TITLE
Add StringBeforeLast function

### DIFF
--- a/src/core/etl/src/Flow/ETL/Function/ScalarFunctionChain.php
+++ b/src/core/etl/src/Flow/ETL/Function/ScalarFunctionChain.php
@@ -513,6 +513,14 @@ abstract class ScalarFunctionChain implements ScalarFunction
     }
 
     /**
+     * Returns the contents found before the last occurrence of the given string.
+     */
+    public function stringBeforeLast(ScalarFunction|string $needle, ScalarFunction|bool $includeNeedle = false) : self
+    {
+        return new StringBeforeLast($this, $needle, $includeNeedle);
+    }
+
+    /**
      * Returns a string that you can use in case-insensitive comparisons.
      */
     public function stringFold() : self

--- a/src/core/etl/src/Flow/ETL/Function/StringBeforeLast.php
+++ b/src/core/etl/src/Flow/ETL/Function/StringBeforeLast.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Function;
+
+use function Flow\ETL\DSL\{type_list, type_string};
+use function Symfony\Component\String\u;
+use Flow\ETL\Function\ScalarFunction\TypedScalarFunction;
+use Flow\ETL\PHP\Type\Type;
+use Flow\ETL\Row;
+
+final class StringBeforeLast extends ScalarFunctionChain implements TypedScalarFunction
+{
+    public function __construct(
+        private readonly ScalarFunction|string $string,
+        private readonly ScalarFunction|string $needle,
+        private readonly ScalarFunction|bool $includeNeedle = false,
+    ) {
+    }
+
+    public function eval(Row $row) : ?string
+    {
+        $string = (new Parameter($this->string))->asString($row);
+
+        if ($string === null) {
+            return null;
+        }
+
+        $needle = (new Parameter($this->needle))->as($row, type_string(), type_list(type_string()));
+        $includeNeedle = (new Parameter($this->includeNeedle))->asBoolean($row);
+
+        return u($string)->beforeLast($needle, $includeNeedle)->toString();
+    }
+
+    public function returns() : Type
+    {
+        return type_string();
+    }
+}

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Function/StringAfterLastTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Function/StringAfterLastTest.php
@@ -14,8 +14,8 @@ final class StringAfterLastTest extends FlowTestCase
 {
     public function test_returns_method_returns_string_type() : void
     {
-        $stringAfterFunction = new StringAfterLast('test', 'e');
-        $returnType = $stringAfterFunction->returns();
+        $stringAfterLastFunction = new StringAfterLast('test', 'e');
+        $returnType = $stringAfterLastFunction->returns();
 
         self::assertInstanceOf(Type::class, $returnType);
 

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Function/StringBeforeLastTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Function/StringBeforeLastTest.php
@@ -6,37 +6,27 @@ namespace Flow\ETL\Tests\Unit\Function;
 
 use function Flow\ETL\DSL\row;
 use function Flow\ETL\DSL\{ref, str_entry, type_string};
-use Flow\ETL\Function\StringBefore;
+use Flow\ETL\Function\StringBeforeLast;
 use Flow\ETL\PHP\Type\Type;
 use Flow\ETL\Tests\FlowTestCase;
 
-final class StringBeforeTest extends FlowTestCase
+final class StringBeforeLastTest extends FlowTestCase
 {
     public function test_returns_method_returns_string_type() : void
     {
-        $stringBeforeFunction = new StringBefore('str', 't', false);
-        $returnType = $stringBeforeFunction->returns();
+        $stringBeforeLastFunction = new StringBeforeLast('str', 't', false);
+        $returnType = $stringBeforeLastFunction->returns();
 
         self::assertInstanceOf(Type::class, $returnType);
 
         self::assertTrue($returnType->isEqual(type_string()));
     }
 
-    public function test_string_before() : void
+    public function test_string_before_last() : void
     {
         self::assertSame(
-            'hello ',
-            ref('str')->stringBefore(ref('needle'))->eval(
-                row(
-                    str_entry('str', 'hello world'),
-                    str_entry('needle', 'world')
-                )
-            )
-        );
-
-        self::assertSame(
-            'hell',
-            ref('str')->stringBefore(ref('needle'))->eval(
+            'hello w',
+            ref('str')->stringBeforeLast(ref('needle'))->eval(
                 row(
                     str_entry('str', 'hello world'),
                     str_entry('needle', 'o')
@@ -45,11 +35,11 @@ final class StringBeforeTest extends FlowTestCase
         );
     }
 
-    public function test_string_before_including_needle() : void
+    public function test_string_before_last_including_needle() : void
     {
         self::assertSame(
-            'hello',
-            ref('str')->stringBefore(ref('needle'), includeNeedle: true)->eval(
+            'hello wo',
+            ref('str')->stringBeforeLast(ref('needle'), includeNeedle: true)->eval(
                 row(
                     str_entry('str', 'hello world'),
                     str_entry('needle', 'o')
@@ -58,11 +48,11 @@ final class StringBeforeTest extends FlowTestCase
         );
     }
 
-    public function test_string_before_returns_empty_string() : void
+    public function test_string_before_last_returns_empty_string() : void
     {
         self::assertSame(
             '',
-            ref('str')->stringBefore(ref('needle'))->eval(
+            ref('str')->stringBeforeLast(ref('needle'))->eval(
                 row(
                     str_entry('str', ''),
                     str_entry('needle', 'o')
@@ -71,10 +61,10 @@ final class StringBeforeTest extends FlowTestCase
         );
     }
 
-    public function test_string_before_returns_null() : void
+    public function test_string_before_last_returns_null() : void
     {
         self::assertNull(
-            ref('str')->stringBefore(ref('needle'))->eval(
+            ref('str')->stringBeforeLast(ref('needle'))->eval(
                 row(
                     str_entry('str', null),
                     str_entry('needle', 'o')


### PR DESCRIPTION
Fix variable name in two tests

<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
<li>Add string function BeforeLast with Tests</li>
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
<li>Fix some variable names in previous functions tests</li> 
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

Ref: #1316

<!-- Please provide a short description of changes in this section, feel free to use markdown syntax -->
<p>Returns the contents found before/after the last occurrence of the given string.</p>
