### PR TITLE
Improve readability of schema validation exception

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -33,7 +33,8 @@ $finder = Finder::create()
     ])
     ->exclude([
         'Flow/Parquet/Thrift',
-        'Flow/CLI/Tests/Integration'
+        'Flow/CLI/Tests/Integration',
+        'Flow/ETL/Tests/Unit/Loader'
     ]);
 
 return (new Config())

--- a/src/core/etl/src/Flow/ETL/Exception/SchemaValidationException.php
+++ b/src/core/etl/src/Flow/ETL/Exception/SchemaValidationException.php
@@ -5,33 +5,83 @@ declare(strict_types=1);
 namespace Flow\ETL\Exception;
 
 use Flow\ETL\Row\Schema;
-use Flow\ETL\Row\Schema\Formatter\ASCIISchemaFormatter;
-use Flow\ETL\Rows;
 
 final class SchemaValidationException extends RuntimeException
 {
-    public function __construct(private readonly Schema $schema, private readonly Rows $rows)
+    public function __construct(private readonly Schema $expected, private readonly Schema $given)
     {
-        $schema = (new ASCIISchemaFormatter())->format($this->schema);
-        $rowsSchema = (new ASCIISchemaFormatter())->format($rows->schema());
+        /**
+         * @var array<string> $missingDefinitions
+         */
+        $missingDefinitions = [];
 
-        parent::__construct(
-            <<<SCHEMA
-Given schema:
-{$schema}
-Does not match rows:
-{$rowsSchema}
-SCHEMA
-        );
+        /**
+         * @var array<string> $mismatchedDefinitions
+         */
+        $mismatchedDefinitions = [];
+
+        /**
+         * @var array<string> $unexpectedDefinitions
+         */
+        $unexpectedDefinitions = [];
+
+        foreach ($this->expected->definitions() as $expectedDefinition) {
+            $givenDefinition = $this->given->findDefinition($expectedDefinition->entry());
+
+            if ($givenDefinition === null) {
+                $missingDefinitions[] = $expectedDefinition->entry() . '<' . $expectedDefinition->type()->toString() . '>';
+
+                continue;
+            }
+
+            if (!$expectedDefinition->isEqual($givenDefinition)) {
+                $mismatchedDefinitions[] = 'expected: ' . $expectedDefinition->entry()->name() . '<' . $expectedDefinition->type()->toString() . '>, ' .
+                    'given: ' . $givenDefinition->entry()->name() . '<' . $givenDefinition->type()->toString() . '>';
+            }
+        }
+
+        foreach ($this->given->definitions() as $givenDefinition) {
+            if ($this->expected->findDefinition($givenDefinition->entry()) === null) {
+                $unexpectedDefinitions[] = $givenDefinition->entry() . '<' . $givenDefinition->type()->toString() . '>';
+            }
+        }
+
+        $message = '';
+
+        if (\count($missingDefinitions)) {
+            $message .= "  Missing Definitions: \n";
+
+            foreach ($missingDefinitions as $missingDefinition) {
+                $message .= '    |-- ' . $missingDefinition . "\n";
+            }
+        }
+
+        if (\count($mismatchedDefinitions)) {
+            $message .= "  Mismatched Definitions: \n";
+
+            foreach ($mismatchedDefinitions as $mismatchedDefinition) {
+                $message .= '    |-- ' . $mismatchedDefinition . "\n";
+            }
+        }
+
+        if (\count($unexpectedDefinitions)) {
+            $message .= "  Unexpected Definitions: \n";
+
+            foreach ($unexpectedDefinitions as $unexpectedDefinition) {
+                $message .= '    |-- ' . $unexpectedDefinition . "\n";
+            }
+        }
+
+        parent::__construct("Schema validation failed: \n" . $message);
     }
 
-    public function rows() : Rows
+    public function given() : Schema
     {
-        return $this->rows;
+        return $this->given;
     }
 
     public function schema() : Schema
     {
-        return $this->schema;
+        return $this->expected;
     }
 }

--- a/src/core/etl/src/Flow/ETL/Loader/SchemaValidationLoader.php
+++ b/src/core/etl/src/Flow/ETL/Loader/SchemaValidationLoader.php
@@ -11,15 +11,17 @@ use Flow\ETL\{FlowContext, Loader, Rows, SchemaValidator};
 final readonly class SchemaValidationLoader implements Loader
 {
     public function __construct(
-        private Schema $schema,
+        private Schema $expected,
         private SchemaValidator $validator,
     ) {
     }
 
     public function load(Rows $rows, FlowContext $context) : void
     {
-        if (!$this->validator->isValid($rows, $this->schema)) {
-            throw new SchemaValidationException($this->schema, $rows);
+        $given = $rows->schema();
+
+        if (!$this->validator->isValid($given, $this->expected)) {
+            throw new SchemaValidationException($this->expected, $given);
         }
     }
 }

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Logical/DateTimeType.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Logical/DateTimeType.php
@@ -35,6 +35,15 @@ final readonly class DateTimeType implements Type
         return false;
     }
 
+    public function isCompatibleWith(Type $type) : bool
+    {
+        if (!$this->nullable && $type->nullable()) {
+            return false;
+        }
+
+        return $this->isEqual($type);
+    }
+
     public function isEqual(Type $type) : bool
     {
         return $type instanceof self;

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Logical/DateType.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Logical/DateType.php
@@ -35,6 +35,15 @@ final readonly class DateType implements Type
         return false;
     }
 
+    public function isCompatibleWith(Type $type) : bool
+    {
+        if (!$this->nullable && $type->nullable()) {
+            return false;
+        }
+
+        return $this->isEqual($type);
+    }
+
     public function isEqual(Type $type) : bool
     {
         return $type instanceof self;

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Logical/JsonType.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Logical/JsonType.php
@@ -36,6 +36,15 @@ final readonly class JsonType implements Type
         return false;
     }
 
+    public function isCompatibleWith(Type $type) : bool
+    {
+        if (!$this->nullable && $type->nullable()) {
+            return false;
+        }
+
+        return $this->isEqual($type);
+    }
+
     public function isEqual(Type $type) : bool
     {
         return $type instanceof self;

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Logical/ListType.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Logical/ListType.php
@@ -47,6 +47,20 @@ final readonly class ListType implements Type
         return false;
     }
 
+    public function isCompatibleWith(Type $type) : bool
+    {
+        if (!$this->isEqual($type)) {
+            return false;
+        }
+
+        /** @var self $type */
+        if (!$this->nullable && $type->nullable()) {
+            return false;
+        }
+
+        return $this->element->isCompatibleWith($type->element());
+    }
+
     public function isEqual(Type $type) : bool
     {
         if (!$type instanceof self) {

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Logical/MapType.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Logical/MapType.php
@@ -47,6 +47,24 @@ final readonly class MapType implements Type
         return false;
     }
 
+    public function isCompatibleWith(Type $type) : bool
+    {
+        if (!$this->isEqual($type)) {
+            return false;
+        }
+
+        /** @var self $type */
+        if (!$this->nullable && $type->nullable()) {
+            return false;
+        }
+
+        if (!$this->key->isCompatibleWith($type->key())) {
+            return false;
+        }
+
+        return $this->value->isCompatibleWith($type->value());
+    }
+
     public function isEqual(Type $type) : bool
     {
         if (!$type instanceof self) {

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Logical/StructureType.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Logical/StructureType.php
@@ -79,6 +79,28 @@ final readonly class StructureType implements Type
         return false;
     }
 
+    public function isCompatibleWith(Type $type) : bool
+    {
+        if (!$this->isEqual($type)) {
+            return false;
+        }
+
+        /** @var self $type */
+        if (!$this->nullable && $type->nullable()) {
+            return false;
+        }
+
+        foreach ($this->elements as $internalElementName => $internalElement) {
+            foreach ($type->elements as $elementName => $element) {
+                if ($elementName === $internalElementName && !$element->isCompatibleWith($internalElement)) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
     public function isEqual(Type $type) : bool
     {
         if (!$type instanceof self) {

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Logical/TimeType.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Logical/TimeType.php
@@ -35,6 +35,15 @@ final readonly class TimeType implements Type
         return false;
     }
 
+    public function isCompatibleWith(Type $type) : bool
+    {
+        if (!$this->nullable && $type->nullable()) {
+            return false;
+        }
+
+        return $this->isEqual($type);
+    }
+
     public function isEqual(Type $type) : bool
     {
         return $type instanceof self;

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Logical/UuidType.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Logical/UuidType.php
@@ -36,6 +36,15 @@ final readonly class UuidType implements Type
         return false;
     }
 
+    public function isCompatibleWith(Type $type) : bool
+    {
+        if (!$this->nullable && $type->nullable()) {
+            return false;
+        }
+
+        return $this->isEqual($type);
+    }
+
     public function isEqual(Type $type) : bool
     {
         return $type instanceof self;

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Logical/XMLElementType.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Logical/XMLElementType.php
@@ -31,6 +31,15 @@ final readonly class XMLElementType implements Type
         return false;
     }
 
+    public function isCompatibleWith(Type $type) : bool
+    {
+        if (!$this->nullable && $type->nullable()) {
+            return false;
+        }
+
+        return $this->isEqual($type);
+    }
+
     public function isEqual(Type $type) : bool
     {
         return $type instanceof self;

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Logical/XMLType.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Logical/XMLType.php
@@ -31,6 +31,15 @@ final readonly class XMLType implements Type
         return false;
     }
 
+    public function isCompatibleWith(Type $type) : bool
+    {
+        if (!$this->nullable && $type->nullable()) {
+            return false;
+        }
+
+        return $this->isEqual($type);
+    }
+
     public function isEqual(Type $type) : bool
     {
         return $type instanceof self;

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Native/ArrayType.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Native/ArrayType.php
@@ -39,6 +39,15 @@ final readonly class ArrayType implements Type
         return false;
     }
 
+    public function isCompatibleWith(Type $type) : bool
+    {
+        if (!$this->nullable && $type->nullable()) {
+            return false;
+        }
+
+        return $this->isEqual($type);
+    }
+
     /**
      * @psalm
      */

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Native/BooleanType.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Native/BooleanType.php
@@ -36,6 +36,15 @@ final readonly class BooleanType implements Type
         return false;
     }
 
+    public function isCompatibleWith(Type $type) : bool
+    {
+        if (!$this->nullable && $type->nullable()) {
+            return false;
+        }
+
+        return $this->isEqual($type);
+    }
+
     public function isEqual(Type $type) : bool
     {
         return $type instanceof self;

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Native/CallableType.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Native/CallableType.php
@@ -31,6 +31,15 @@ final readonly class CallableType implements Type
         return false;
     }
 
+    public function isCompatibleWith(Type $type) : bool
+    {
+        if (!$this->nullable && $type->nullable()) {
+            return false;
+        }
+
+        return $this->isEqual($type);
+    }
+
     public function isEqual(Type $type) : bool
     {
         return $type instanceof self;

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Native/EnumType.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Native/EnumType.php
@@ -58,6 +58,15 @@ final readonly class EnumType implements Type
         return false;
     }
 
+    public function isCompatibleWith(Type $type) : bool
+    {
+        if (!$this->nullable && $type->nullable()) {
+            return false;
+        }
+
+        return $this->isEqual($type);
+    }
+
     public function isEqual(Type $type) : bool
     {
         return $type instanceof self && $this->class === $type->class;

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Native/FloatType.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Native/FloatType.php
@@ -41,6 +41,15 @@ final readonly class FloatType implements Type
         return false;
     }
 
+    public function isCompatibleWith(Type $type) : bool
+    {
+        if (!$this->nullable && $type->nullable()) {
+            return false;
+        }
+
+        return $this->isEqual($type);
+    }
+
     public function isEqual(Type $type) : bool
     {
         return $type instanceof self && $this->precision === $type->precision;

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Native/IntegerType.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Native/IntegerType.php
@@ -41,6 +41,15 @@ final readonly class IntegerType implements Type
         return false;
     }
 
+    public function isCompatibleWith(Type $type) : bool
+    {
+        if (!$this->nullable && $type->nullable()) {
+            return false;
+        }
+
+        return $this->isEqual($type);
+    }
+
     public function isEqual(Type $type) : bool
     {
         return $type instanceof self;

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Native/NullType.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Native/NullType.php
@@ -21,6 +21,11 @@ final class NullType implements Type
         return true;
     }
 
+    public function isCompatibleWith(Type $type) : bool
+    {
+        return $this->isEqual($type);
+    }
+
     public function isEqual(Type $type) : bool
     {
         return $type instanceof self;

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Native/ObjectType.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Native/ObjectType.php
@@ -42,6 +42,15 @@ final readonly class ObjectType implements Type
         return false;
     }
 
+    public function isCompatibleWith(Type $type) : bool
+    {
+        if (!$this->nullable && $type->nullable()) {
+            return false;
+        }
+
+        return $this->isEqual($type);
+    }
+
     public function isEqual(Type $type) : bool
     {
         return $type instanceof self && $this->class === $type->class;

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Native/ResourceType.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Native/ResourceType.php
@@ -31,6 +31,15 @@ final readonly class ResourceType implements Type
         return false;
     }
 
+    public function isCompatibleWith(Type $type) : bool
+    {
+        if (!$this->nullable && $type->nullable()) {
+            return false;
+        }
+
+        return $this->isEqual($type);
+    }
+
     public function isEqual(Type $type) : bool
     {
         return $type instanceof self;

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Native/StringType.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Native/StringType.php
@@ -36,6 +36,15 @@ final readonly class StringType implements Type
         return false;
     }
 
+    public function isCompatibleWith(Type $type) : bool
+    {
+        if (!$this->nullable && $type->nullable()) {
+            return false;
+        }
+
+        return $this->isEqual($type);
+    }
+
     public function isEqual(Type $type) : bool
     {
         return $type instanceof self;

--- a/src/core/etl/src/Flow/ETL/PHP/Type/Type.php
+++ b/src/core/etl/src/Flow/ETL/PHP/Type/Type.php
@@ -20,8 +20,16 @@ interface Type
     public function isComparableWith(self $type) : bool;
 
     /**
-     * Checks if another type is equal to this type.
-     * Nullability is not considered in this comparison.
+     * Checks if another type is compatible with this type. Nullability is validated from a schema evolution perspective.
+     * This means that when current type is nullable and ther other type is not nullable, it is still compatible.
+     * When given type is not nullable and current type is nullable, it is not compatible.
+     *
+     * @param Type<mixed> $type
+     */
+    public function isCompatibleWith(self $type) : bool;
+
+    /**
+     * Checks if another type is equal to this type. Nullability is not considered in this comparison.
      *
      * @param Type<mixed> $type
      */

--- a/src/core/etl/src/Flow/ETL/Row/Schema/Definition.php
+++ b/src/core/etl/src/Flow/ETL/Row/Schema/Definition.php
@@ -174,7 +174,7 @@ final class Definition
 
     public function isEqual(self $definition) : bool
     {
-        if ($this->type->isSame($definition->type) === false) {
+        if ($this->type->isCompatibleWith($definition->type) === false) {
             return false;
         }
 

--- a/src/core/etl/src/Flow/ETL/Row/Schema/SelectiveValidator.php
+++ b/src/core/etl/src/Flow/ETL/Row/Schema/SelectiveValidator.php
@@ -4,30 +4,25 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Row\Schema;
 
-use Flow\ETL\Exception\InvalidArgumentException;
 use Flow\ETL\Row\Schema;
-use Flow\ETL\{Rows, SchemaValidator};
+use Flow\ETL\{SchemaValidator};
 
 /**
- * Matches only entries defined in the schema, ignoring every other entries in the row.
+ * Matches only entries defined in the expected schema allowing for extra entries in given schema.
  */
 final class SelectiveValidator implements SchemaValidator
 {
-    public function isValid(Rows $rows, Schema $schema) : bool
+    public function isValid(Schema $given, Schema $expected) : bool
     {
-        foreach ($schema->references() as $ref) {
-            $definition = $schema->get($ref);
+        foreach ($expected->definitions() as $expectedDefinition) {
+            $givenDefinition = $given->findDefinition($expectedDefinition->entry());
 
-            foreach ($rows as $row) {
-                try {
-                    $entry = $row->entries()->get($ref);
+            if (!$givenDefinition) {
+                return false;
+            }
 
-                    if (!$definition->matches($entry)) {
-                        return false;
-                    }
-                } catch (InvalidArgumentException) {
-                    return false;
-                }
+            if (!$givenDefinition->isEqual($expectedDefinition)) {
+                return false;
             }
         }
 

--- a/src/core/etl/src/Flow/ETL/Row/Schema/StrictValidator.php
+++ b/src/core/etl/src/Flow/ETL/Row/Schema/StrictValidator.php
@@ -5,30 +5,28 @@ declare(strict_types=1);
 namespace Flow\ETL\Row\Schema;
 
 use Flow\ETL\Row\Schema;
-use Flow\ETL\{Rows, SchemaValidator};
+use Flow\ETL\{SchemaValidator};
 
 /**
  * Matches all entries in the schema, if row comes with any extra entry it will fail validation.
  */
 final class StrictValidator implements SchemaValidator
 {
-    public function isValid(Rows $rows, Schema $schema) : bool
+    public function isValid(Schema $given, Schema $expected) : bool
     {
-        foreach ($rows as $row) {
-            if ($schema->count() !== $row->entries()->count()) {
+        if ($expected->count() !== $given->count()) {
+            return false;
+        }
+
+        foreach ($given->definitions() as $definition) {
+            $expectedDefinition = $expected->findDefinition($definition->entry());
+
+            if ($expectedDefinition === null) {
                 return false;
             }
 
-            foreach ($row->entries()->all() as $entry) {
-                $definition = $schema->findDefinition($entry->name());
-
-                if ($definition === null) {
-                    return false;
-                }
-
-                if (!$definition->matches($entry)) {
-                    return false;
-                }
+            if (!$expectedDefinition->isEqual($definition)) {
+                return false;
             }
         }
 

--- a/src/core/etl/src/Flow/ETL/SchemaValidator.php
+++ b/src/core/etl/src/Flow/ETL/SchemaValidator.php
@@ -8,5 +8,5 @@ use Flow\ETL\Row\Schema;
 
 interface SchemaValidator
 {
-    public function isValid(Rows $rows, Schema $schema) : bool;
+    public function isValid(Schema $given, Schema $expected) : bool;
 }

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Loader/SchemaValidationLoaderTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Loader/SchemaValidationLoaderTest.php
@@ -14,19 +14,14 @@ use Flow\ETL\{Tests\FlowTestCase};
 
 final class SchemaValidationLoaderTest extends FlowTestCase
 {
-    public function test_schema_validation_failed() : void
+    public function test_schema_validation_failed_by_mismatching() : void
     {
         $this->expectException(SchemaValidationException::class);
         $this->expectExceptionMessage(
             <<<'EXCEPTION'
-Given schema:
-schema
-|-- id: integer
-
-Does not match rows:
-schema
-|-- id: string
-
+Schema validation failed:
+  Mismatched Definitions:
+    |-- expected: id<integer>, given: id<string>
 EXCEPTION
         );
 
@@ -36,6 +31,27 @@ EXCEPTION
         );
 
         $loader->load(rows(row(str_entry('id', '1'))), flow_context(config()));
+    }
+
+    public function test_schema_validation_failed_by_unexpected() : void
+    {
+        $this->expectException(SchemaValidationException::class);
+        $this->expectExceptionMessage(
+            <<<'EXCEPTION'
+Schema validation failed:
+  Missing Definitions:
+    |-- id<integer>
+  Unexpected Definitions:
+    |-- name<string>
+EXCEPTION
+        );
+
+        $loader = new SchemaValidationLoader(
+            schema(integer_schema('id')),
+            new StrictValidator()
+        );
+
+        $loader->load(rows(row(str_entry('name', '1'))), flow_context(config()));
     }
 
     public function test_schema_validation_succeed() : void

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Loader/SchemaValidationLoaderTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Loader/SchemaValidationLoaderTest.php
@@ -19,8 +19,8 @@ final class SchemaValidationLoaderTest extends FlowTestCase
         $this->expectException(SchemaValidationException::class);
         $this->expectExceptionMessage(
             <<<'EXCEPTION'
-Schema validation failed:
-  Mismatched Definitions:
+Schema validation failed: 
+  Mismatched Definitions: 
     |-- expected: id<integer>, given: id<string>
 EXCEPTION
         );
@@ -38,10 +38,10 @@ EXCEPTION
         $this->expectException(SchemaValidationException::class);
         $this->expectExceptionMessage(
             <<<'EXCEPTION'
-Schema validation failed:
-  Missing Definitions:
+Schema validation failed: 
+  Missing Definitions: 
     |-- id<integer>
-  Unexpected Definitions:
+  Unexpected Definitions: 
     |-- name<string>
 EXCEPTION
         );

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/PHP/Type/TypesCompatibilityTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/PHP/Type/TypesCompatibilityTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Tests\Unit\PHP\Type;
+
+use function Flow\ETL\DSL\{type_boolean, type_float, type_int, type_list, type_map, type_string};
+use Flow\ETL\PHP\Type\Type;
+use Flow\ETL\Tests\FlowTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+final class TypesCompatibilityTest extends FlowTestCase
+{
+    public static function list_compatibility_provider() : \Generator
+    {
+        yield [type_list(type_int()), type_list(type_int()), true];
+        yield [type_list(type_int()), type_list(type_int(), true), false];
+        yield [type_list(type_int(), true), type_list(type_int()), true];
+        yield [type_list(type_int(), true), type_list(type_int(), true), true];
+
+        yield [type_list(type_int()), type_list(type_string()), false];
+
+        yield [type_list(type_int()), type_list(type_int(true)), false];
+    }
+
+    public static function map_compatibility_provider() : \Generator
+    {
+        yield [type_map(type_string(), type_int()), type_map(type_string(), type_int()), true];
+        yield [type_map(type_string(), type_int()), type_map(type_string(), type_int(), true), false];
+        yield [type_map(type_string(), type_int(), true), type_map(type_string(), type_int()), true];
+
+        yield [type_map(type_string(), type_int(), true), type_map(type_string(), type_int(), true), true];
+        yield [type_map(type_string(), type_int()), type_map(type_string(), type_string()), false];
+        yield [type_map(type_string(), type_int()), type_map(type_string(), type_int(true)), false];
+        yield [type_map(type_string(), type_int(true)), type_map(type_string(), type_int()), true];
+    }
+
+    public static function scalar_types_compatibility_provider() : \Generator
+    {
+        yield [type_int(), type_int(), true];
+        yield [type_int(true), type_int(), true];
+        yield [type_int(), type_int(true), false];
+        yield [type_int(true), type_int(true), true];
+
+        yield [type_string(), type_string(), true];
+        yield [type_string(true), type_string(), true];
+        yield [type_string(), type_string(true), false];
+        yield [type_string(true), type_string(true), true];
+
+        yield [type_float(), type_float(), true];
+        yield [type_float(true), type_float(), true];
+        yield [type_float(), type_float(true), false];
+        yield [type_float(true), type_float(true), true];
+
+        yield [type_boolean(), type_boolean(), true];
+        yield [type_boolean(true), type_boolean(), true];
+        yield [type_boolean(), type_boolean(true), false];
+        yield [type_boolean(true), type_boolean(true), true];
+    }
+
+    /**
+     * @param Type<mixed> $given
+     * @param Type<mixed> $expected
+     */
+    #[DataProvider('list_compatibility_provider')]
+    public function test_list_type_compatibility(Type $given, Type $expected, bool $compatible) : void
+    {
+        self::assertSame($compatible, $given->isCompatibleWith($expected));
+    }
+
+    /**
+     * @param Type<mixed> $given
+     * @param Type<mixed> $expected
+     */
+    #[DataProvider('map_compatibility_provider')]
+    public function test_map_type_compatibility(Type $given, Type $expected, bool $compatible) : void
+    {
+        self::assertSame($compatible, $given->isCompatibleWith($expected));
+    }
+
+    /**
+     * @param Type<mixed> $given
+     * @param Type<mixed> $expected
+     */
+    #[DataProvider('scalar_types_compatibility_provider')]
+    public function test_scalar_type_compatibility(Type $given, Type $expected, bool $compatible) : void
+    {
+        self::assertSame($compatible, $given->isCompatibleWith($expected));
+    }
+}

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Schema/DefinitionTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Schema/DefinitionTest.php
@@ -26,7 +26,7 @@ final class DefinitionTest extends FlowTestCase
     {
         $def = integer_schema('id', nullable: true);
 
-        self::assertFalse(
+        self::assertTrue(
             $def->isEqual(
                 integer_schema('id', nullable: false)
             )

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Schema/Matcher/StrictSchemaMatcherTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Schema/Matcher/StrictSchemaMatcherTest.php
@@ -45,12 +45,12 @@ final class StrictSchemaMatcherTest extends FlowTestCase
     {
         $left = schema(
             str_schema('id'),
-            str_schema('name', nullable: true),
+            str_schema('name'),
         );
 
         $right = schema(
             str_schema('id'),
-            str_schema('name'),
+            str_schema('name', nullable: true),
         );
 
         self::assertFalse((new StrictSchemaMatcher())->match($left, $right));

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Schema/SelectiveValidatorTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Schema/SelectiveValidatorTest.php
@@ -18,7 +18,7 @@ final class SelectiveValidatorTest extends FlowTestCase
 
         self::assertFalse(
             (new SelectiveValidator())->isValid(
-                rows(row(int_entry('id', 1), bool_entry('active', true))),
+                rows(row(int_entry('id', 1), bool_entry('active', true)))->schema(),
                 $schema
             )
         );
@@ -30,7 +30,7 @@ final class SelectiveValidatorTest extends FlowTestCase
 
         self::assertTrue(
             (new SelectiveValidator())->isValid(
-                rows(row(int_entry('id', 1), str_entry('name', 'test'), bool_entry('active', true))),
+                rows(row(int_entry('id', 1), str_entry('name', 'test'), bool_entry('active', true)))->schema(),
                 $schema
             )
         );
@@ -42,7 +42,7 @@ final class SelectiveValidatorTest extends FlowTestCase
 
         self::assertFalse(
             (new SelectiveValidator())->isValid(
-                rows(row(int_entry('id', 1), str_entry('name', 'test'), bool_entry('active', true))),
+                rows(row(int_entry('id', 1), str_entry('name', 'test'), bool_entry('active', true)))->schema(),
                 $schema
             )
         );
@@ -52,9 +52,12 @@ final class SelectiveValidatorTest extends FlowTestCase
     {
         $schema = schema(string_schema('name'), bool_schema('active'));
 
-        self::assertFalse(
+        self::assertTrue(
             (new SelectiveValidator())->isValid(
-                rows(row(int_entry('id', 1), str_entry('name', 'test'), bool_entry('active', true)), row(int_entry('id', 1), bool_entry('active', true))),
+                rows(
+                    row(int_entry('id', 1), str_entry('name', 'test'), bool_entry('active', true)),
+                    row(int_entry('id', 1), bool_entry('active', true))
+                )->schema(),
                 $schema
             )
         );

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Schema/StrictValidatorTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Schema/StrictValidatorTest.php
@@ -18,7 +18,7 @@ final class StrictValidatorTest extends FlowTestCase
 
         self::assertFalse(
             (new StrictValidator())->isValid(
-                rows(row(int_entry('id', 1), str_entry('name', 'test'), bool_entry('active', true))),
+                rows(row(int_entry('id', 1), str_entry('name', 'test'), bool_entry('active', true)))->schema(),
                 $schema
             )
         );
@@ -30,7 +30,7 @@ final class StrictValidatorTest extends FlowTestCase
 
         self::assertTrue(
             (new StrictValidator())->isValid(
-                rows(row(int_entry('id', 1), str_entry('name', 'test'), bool_entry('active', true))),
+                rows(row(int_entry('id', 1), str_entry('name', 'test'), bool_entry('active', true)))->schema(),
                 $schema
             )
         );
@@ -42,7 +42,7 @@ final class StrictValidatorTest extends FlowTestCase
 
         self::assertFalse(
             (new StrictValidator())->isValid(
-                rows(row(int_entry('id', 1), str_entry('name', 'test'), bool_entry('active', true))),
+                rows(row(int_entry('id', 1), str_entry('name', 'test'), bool_entry('active', true)))->schema(),
                 $schema
             )
         );
@@ -54,7 +54,7 @@ final class StrictValidatorTest extends FlowTestCase
 
         self::assertFalse(
             (new StrictValidator())->isValid(
-                rows(row(int_entry('id', 1), str_entry('name', 'test'), bool_entry('active', true))),
+                rows(row(int_entry('id', 1), str_entry('name', 'test'), bool_entry('active', true)))->schema(),
                 $schema
             )
         );
@@ -66,7 +66,7 @@ final class StrictValidatorTest extends FlowTestCase
 
         self::assertFalse(
             (new StrictValidator())->isValid(
-                rows(row(int_entry('id', 1), str_entry('name', 'test'), bool_entry('active', true)), row(int_entry('id', 1), bool_entry('active', true))),
+                rows(row(int_entry('id', 1), str_entry('name', 'test'), bool_entry('active', true)), row(int_entry('id', 1), bool_entry('active', true)))->schema(),
                 $schema
             )
         );


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <li>Type::isCompatible(self $type): bool - method</li>
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Improve readability of schema validation exception</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

<!-- Please provide a short description of changes in this section, feel free to use markdown syntax -->

Resolves: #1528 

Before schema validation exception was only dumping both schema's as an ascii list. 
This PR improves the readability by explaining which columns are missing, which are extra and which are mismatched (different types, incompatible). 
