### PR TITLE
Fixed merging two definitions created from null

### DIFF
--- a/src/cli/tests/Flow/CLI/Tests/Integration/FileSchemaCommandTest.php
+++ b/src/cli/tests/Flow/CLI/Tests/Integration/FileSchemaCommandTest.php
@@ -244,19 +244,19 @@ OUTPUT,
 
         self::assertSame(
             <<<'OUTPUT'
-+--------------+-----------+----------+----------+
-|         name |      type | nullable | metadata |
-+--------------+-----------+----------+----------+
-|     order_id |      uuid |    false |       [] |
-|   created_at |  datetime |    false |       [] |
-|   updated_at |  datetime |    false |       [] |
-| cancelled_at |    string |     true |       [] |
-|  total_price |     float |    false |       [] |
-|     discount |     float |    false |       [] |
-|     customer | structure |    false |       [] |
-|      address | structure |    false |       [] |
-|        notes |      list |    false |       [] |
-+--------------+-----------+----------+----------+
++--------------+-----------+----------+--------------------+
+|         name |      type | nullable |           metadata |
++--------------+-----------+----------+--------------------+
+|     order_id |      uuid |    false |                 [] |
+|   created_at |  datetime |    false |                 [] |
+|   updated_at |  datetime |    false |                 [] |
+| cancelled_at |    string |     true | {"from_null":true} |
+|  total_price |     float |    false |                 [] |
+|     discount |     float |    false |                 [] |
+|     customer | structure |    false |                 [] |
+|      address | structure |    false |                 [] |
+|        notes |      list |    false |                 [] |
++--------------+-----------+----------+--------------------+
 9 rows
 
 OUTPUT,

--- a/src/core/etl/src/Flow/ETL/Row/Schema/Definition.php
+++ b/src/core/etl/src/Flow/ETL/Row/Schema/Definition.php
@@ -218,6 +218,14 @@ final class Definition
             throw new RuntimeException(\sprintf('Cannot merge different definitions, %s and %s', $this->ref->name(), $definition->ref->name()));
         }
 
+        if ($this->metadata->has(Metadata::FROM_NULL) && $definition->metadata()->has(Metadata::FROM_NULL)) {
+            return new self(
+                $this->ref,
+                $this->type()->makeNullable($this->isNullable() || $definition->isNullable()),
+                $this->metadata->merge($definition->metadata)
+            );
+        }
+
         if ($this->metadata->has(Metadata::FROM_NULL)) {
             return new self(
                 $this->ref,

--- a/src/core/etl/tests/Flow/ETL/Tests/Integration/DataFrame/SchemaTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Integration/DataFrame/SchemaTest.php
@@ -23,6 +23,7 @@ use function Flow\ETL\DSL\{array_to_rows,
     string_entry};
 use Flow\ETL\Pipeline\SynchronousPipeline;
 use Flow\ETL\Row\Schema;
+use Flow\ETL\Row\Schema\Metadata;
 use Flow\ETL\Tests\FlowIntegrationTestCase;
 
 final class SchemaTest extends FlowIntegrationTestCase
@@ -84,7 +85,7 @@ final class SchemaTest extends FlowIntegrationTestCase
             schema(
                 int_schema('id'),
                 str_schema('name'),
-                str_schema('active', nullable: true)
+                str_schema('active', nullable: true, metadata: Metadata::fromArray([Metadata::FROM_NULL => true]))
             ),
             $rows->schema()
         );

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Schema/DefinitionTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Schema/DefinitionTest.php
@@ -191,6 +191,15 @@ final class DefinitionTest extends FlowTestCase
         );
     }
 
+    public function test_merging_two_definitions_created_from_null() : void
+    {
+        self::assertTrue(
+            string_schema('id', true, Metadata::fromArray([Metadata::FROM_NULL => true]))
+                ->merge(string_schema('id', true, Metadata::fromArray([Metadata::FROM_NULL => true])))
+                ->metadata()->has(Metadata::FROM_NULL)
+        );
+    }
+
     public function test_merging_two_different_lists() : void
     {
         self::assertEquals(


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>Merging two definitions created from null does not remove FROM_NULL metadata</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

<!-- Please provide a short description of changes in this section, feel free to use markdown syntax -->
