### PR TITLE
Remove entry object from column statistics

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @norberttech

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,5 @@
 <!-- 
-    Bellow section will be used to automatically generate changelog, please do not modify HTML code structure 
-
+    Below section will be used to automatically generate changelog, please do not modify HTML code structure
     DO NOT REMOVE that HTML STRUCTURE, INSTEAD ADD YOUR CHANGES INSIDE THE LISTS 
     PULL REQUESTS WITHOUT CHANGELOG CAN'T BE MERGED 
 -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,9 @@
-<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
+<!-- 
+    Bellow section will be used to automatically generate changelog, please do not modify HTML code structure 
+
+    DO NOT REMOVE that HTML STRUCTURE, INSTEAD ADD YOUR CHANGES INSIDE THE LISTS 
+    PULL REQUESTS WITHOUT CHANGELOG CAN'T BE MERGED 
+-->
 <h2>Change Log</h2>
 <div id="change-log">
   <h4>Added</h4>

--- a/src/cli/src/Flow/CLI/Formatter/PipelineReportFormatter.php
+++ b/src/cli/src/Flow/CLI/Formatter/PipelineReportFormatter.php
@@ -53,7 +53,7 @@ final readonly class PipelineReportFormatter
             foreach ($columnsStatistics->all() as $columnStatistics) {
                 $normalizedColumnStatistics[] = [
                     'name' => $columnStatistics->name(),
-                    'type' => $columnStatistics->type()->toString(),
+                    'type' => $schema ? $schema->get($columnStatistics->reference())->type()->toString() : 'N/A',
                     'nulls_count' => $valueFormatter->format($columnStatistics->nullCount()),
                     'distinct_count' => $valueFormatter->format($columnStatistics->distinctCount()),
                     'min' => $valueFormatter->format($columnStatistics->min()),

--- a/src/cli/tests/Flow/CLI/Tests/Integration/FileAnalyzeCommandTest.php
+++ b/src/cli/tests/Flow/CLI/Tests/Integration/FileAnalyzeCommandTest.php
@@ -54,11 +54,56 @@ Columns
 │ order_id   │ uuid                                                          │ 0     │ 5               │ -                         │ -                         │ -          │ -          │ -                  │ -                  │
 │ created_at │ datetime                                                      │ 0     │ 5               │ 2024-02-23T19:18:53+00:00 │ 2024-06-17T19:24:49+00:00 │ -          │ -          │ -                  │ -                  │
 │ updated_at │ datetime                                                      │ 0     │ 5               │ 2024-02-23T19:18:53+00:00 │ 2024-06-17T19:24:49+00:00 │ -          │ -          │ -                  │ -                  │
-│ discount   │ float                                                         │ 2     │ 3               │ 12.45                     │ 47.10                     │ -          │ -          │ -                  │ -                  │
+│ discount   │ ?float                                                        │ 2     │ 3               │ 12.45                     │ 47.10                     │ -          │ -          │ -                  │ -                  │
 │ address    │ map<string, string>                                           │ 0     │ 5               │ -                         │ -                         │ -          │ -          │ 4                  │ 4                  │
 │ notes      │ list<string>                                                  │ 0     │ 5               │ -                         │ -                         │ -          │ -          │ 1                  │ 5                  │
 │ items      │ list<structure{sku: string, quantity: integer, price: float}> │ 0     │ 5               │ -                         │ -                         │ -          │ -          │ 2                  │ 4                  │
 └────────────┴───────────────────────────────────────────────────────────────┴───────┴─────────────────┴───────────────────────────┴───────────────────────────┴────────────┴────────────┴────────────────────┴────────────────────┘
+OUTPUT,
+            $tester->getDisplay()
+        );
+
+        self::assertStringContainsString("Analyzed Rows", $tester->getDisplay());
+
+        self::assertStringContainsString("Execution Time", $tester->getDisplay());
+    }
+
+    public function test_read_rows_csv_without_schema() : void
+    {
+        $application = new Application();
+        $application->add(new FileAnalyzeCommand());
+        $tester = new CommandTester($application->get('file:analyze'));
+
+        $tester->execute(['input-file' => __DIR__ . '/Fixtures/orders.csv', '--input-file-limit' => 5, '--stats-columns' => true]);
+
+        $tester->assertCommandIsSuccessful();
+
+        self::assertStringContainsString(
+            <<<'OUTPUT'
+Analyzing File
+==============
+
+ [INFO] File path: orders.csv
+OUTPUT,
+            $tester->getDisplay()
+        );
+
+        self::assertStringContainsString(
+            <<<'OUTPUT'
+Columns
+-------
+
+┌────────────┬──────┬───────┬─────────────────┬───────────────────────────┬───────────────────────────┬────────────┬────────────┬────────────────────┬────────────────────┐
+│ Name       │ Type │ Nulls │ Distinct Values │ Min                       │ Max                       │ Min Length │ Max Length │ Min Elements Count │ Max Elements Count │
+├────────────┼──────┼───────┼─────────────────┼───────────────────────────┼───────────────────────────┼────────────┼────────────┼────────────────────┼────────────────────┤
+│ order_id   │ N/A  │ 0     │ 5               │ -                         │ -                         │ -          │ -          │ -                  │ -                  │
+│ created_at │ N/A  │ 0     │ 5               │ 2024-02-23T19:18:53+00:00 │ 2024-06-17T19:24:49+00:00 │ -          │ -          │ -                  │ -                  │
+│ updated_at │ N/A  │ 0     │ 5               │ 2024-02-23T19:18:53+00:00 │ 2024-06-17T19:24:49+00:00 │ -          │ -          │ -                  │ -                  │
+│ discount   │ N/A  │ 2     │ 3               │ 12.45                     │ 47.10                     │ -          │ -          │ -                  │ -                  │
+│ address    │ N/A  │ 0     │ 5               │ -                         │ -                         │ -          │ -          │ 4                  │ 4                  │
+│ notes      │ N/A  │ 0     │ 5               │ -                         │ -                         │ -          │ -          │ 1                  │ 5                  │
+│ items      │ N/A  │ 0     │ 5               │ -                         │ -                         │ -          │ -          │ 2                  │ 4                  │
+└────────────┴──────┴───────┴─────────────────┴───────────────────────────┴───────────────────────────┴────────────┴────────────┴────────────────────┴────────────────────┘
 OUTPUT,
             $tester->getDisplay()
         );

--- a/src/core/etl/src/Flow/ETL/Dataset/Statistics/Column.php
+++ b/src/core/etl/src/Flow/ETL/Dataset/Statistics/Column.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Dataset\Statistics;
 
-use Flow\ETL\PHP\Type\Type;
-use Flow\ETL\Row\Entry;
+use Flow\ETL\Row\{Entry, Reference};
 
 final class Column
 {
@@ -25,15 +24,18 @@ final class Column
 
     private int $nullsCount = 0;
 
+    private readonly Reference $reference;
+
     /**
      * @param Entry<mixed, mixed> $entry
      *
      * @throws \JsonException
      */
-    public function __construct(public readonly Entry $entry)
+    public function __construct(Entry $entry)
     {
+        $this->reference = $entry->ref();
         $this->distinctCounter = new DistinctCounter();
-        $this->calculate($this->entry);
+        $this->calculate($entry);
     }
 
     /**
@@ -41,7 +43,7 @@ final class Column
      */
     public function calculate(Entry $entry) : void
     {
-        if (!$entry->is($this->entry->name())) {
+        if (!$this->reference->is($entry->ref())) {
             return;
         }
 
@@ -134,7 +136,7 @@ final class Column
 
     public function name() : string
     {
-        return $this->entry->name();
+        return $this->reference->name();
     }
 
     public function nullCount() : int
@@ -142,11 +144,8 @@ final class Column
         return $this->nullsCount;
     }
 
-    /**
-     * @return Type<mixed>
-     */
-    public function type() : Type
+    public function reference() : Reference
     {
-        return $this->entry->type();
+        return $this->reference;
     }
 }


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <li>codeowners definition</li>
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Analyze will only take column type from schema when available to display column statistics</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <li>Entry object from column statistics, use reference instead</li>
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

<!-- Please provide a short description of changes in this section, feel free to use markdown syntax -->
