### PR TITLE
Fixed schema comparison

### DIFF
--- a/src/core/etl/src/Flow/ETL/Exception/SchemaValidationException.php
+++ b/src/core/etl/src/Flow/ETL/Exception/SchemaValidationException.php
@@ -34,7 +34,7 @@ final class SchemaValidationException extends RuntimeException
                 continue;
             }
 
-            if (!$expectedDefinition->isEqual($givenDefinition)) {
+            if (!$expectedDefinition->isCompatible($givenDefinition)) {
                 $mismatchedDefinitions[] = 'expected: ' . $expectedDefinition->entry()->name() . '<' . $expectedDefinition->type()->toString() . '>, ' .
                     'given: ' . $givenDefinition->entry()->name() . '<' . $givenDefinition->type()->toString() . '>';
             }

--- a/src/core/etl/src/Flow/ETL/Exception/SchemaValidationException.php
+++ b/src/core/etl/src/Flow/ETL/Exception/SchemaValidationException.php
@@ -34,7 +34,7 @@ final class SchemaValidationException extends RuntimeException
                 continue;
             }
 
-            if (!$expectedDefinition->isCompatible($givenDefinition)) {
+            if (!$expectedDefinition->isEqual($givenDefinition)) {
                 $mismatchedDefinitions[] = 'expected: ' . $expectedDefinition->entry()->name() . '<' . $expectedDefinition->type()->toString() . '>, ' .
                     'given: ' . $givenDefinition->entry()->name() . '<' . $givenDefinition->type()->toString() . '>';
             }

--- a/src/core/etl/src/Flow/ETL/Row/Schema/Definition.php
+++ b/src/core/etl/src/Flow/ETL/Row/Schema/Definition.php
@@ -175,7 +175,12 @@ final class Definition
 
     public function isEqual(self $definition) : bool
     {
-        return $this->type->isSame($definition->type);
+        return $this->type->isCompatible($definition->type);
+    }
+
+    public function isNullable() : bool
+    {
+        return $this->type->nullable();
     }
 
     public function isSame(self $definition) : bool
@@ -185,11 +190,6 @@ final class Definition
         }
 
         return $this->metadata->isEqual($definition->metadata);
-    }
-
-    public function isNullable() : bool
-    {
-        return $this->type->nullable();
     }
 
     public function makeNullable(bool $nullable = true) : self

--- a/src/core/etl/src/Flow/ETL/Row/Schema/Definition.php
+++ b/src/core/etl/src/Flow/ETL/Row/Schema/Definition.php
@@ -173,7 +173,7 @@ final class Definition
         return $this->ref;
     }
 
-    public function isEqual(self $definition) : bool
+    public function isCompatible(self $definition) : bool
     {
         return $this->type->isCompatible($definition->type);
     }

--- a/src/core/etl/src/Flow/ETL/Row/Schema/Definition.php
+++ b/src/core/etl/src/Flow/ETL/Row/Schema/Definition.php
@@ -173,14 +173,14 @@ final class Definition
         return $this->ref;
     }
 
-    public function isCompatible(self $definition) : bool
-    {
-        return $this->type->isCompatible($definition->type);
-    }
-
     public function isEqual(self $definition) : bool
     {
-        if ($this->type->isEqual($definition->type) === false) {
+        return $this->type->isSame($definition->type);
+    }
+
+    public function isSame(self $definition) : bool
+    {
+        if ($this->type->isSame($definition->type) === false) {
             return false;
         }
 

--- a/src/core/etl/src/Flow/ETL/Row/Schema/Matcher/StrictSchemaMatcher.php
+++ b/src/core/etl/src/Flow/ETL/Row/Schema/Matcher/StrictSchemaMatcher.php
@@ -22,7 +22,7 @@ final class StrictSchemaMatcher implements SchemaMatcher
                 return false;
             }
 
-            if (!$leftDefinition->isEqual($rightDefinition)) {
+            if (!$leftDefinition->isSame($rightDefinition)) {
                 return false;
             }
         }

--- a/src/core/etl/src/Flow/ETL/Row/Schema/SelectiveValidator.php
+++ b/src/core/etl/src/Flow/ETL/Row/Schema/SelectiveValidator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Row\Schema;
 
+use function Flow\ETL\DSL\type_string;
 use Flow\ETL\Row\Schema;
 use Flow\ETL\{SchemaValidator};
 
@@ -21,7 +22,7 @@ final class SelectiveValidator implements SchemaValidator
                 return false;
             }
 
-            if ($expectedDefinition->isNullable() && $givenDefinition->metadata()->has(Metadata::FROM_NULL)) {
+            if ($expectedDefinition->isNullable() && $givenDefinition->metadata()->has(Metadata::FROM_NULL) && $givenDefinition->type()->isSame(type_string(true))) {
                 continue;
             }
 

--- a/src/core/etl/src/Flow/ETL/Row/Schema/SelectiveValidator.php
+++ b/src/core/etl/src/Flow/ETL/Row/Schema/SelectiveValidator.php
@@ -25,7 +25,7 @@ final class SelectiveValidator implements SchemaValidator
                 continue;
             }
 
-            if (!$expectedDefinition->isEqual($givenDefinition)) {
+            if (!$expectedDefinition->isCompatible($givenDefinition)) {
                 return false;
             }
         }

--- a/src/core/etl/src/Flow/ETL/Row/Schema/SelectiveValidator.php
+++ b/src/core/etl/src/Flow/ETL/Row/Schema/SelectiveValidator.php
@@ -22,10 +22,10 @@ final class SelectiveValidator implements SchemaValidator
             }
 
             if ($expectedDefinition->isNullable() && $givenDefinition->metadata()->has(Metadata::FROM_NULL)) {
-                return true;
+                continue;
             }
 
-            if (!$givenDefinition->isCompatible($expectedDefinition)) {
+            if (!$givenDefinition->isEqual($expectedDefinition)) {
                 return false;
             }
         }

--- a/src/core/etl/src/Flow/ETL/Row/Schema/SelectiveValidator.php
+++ b/src/core/etl/src/Flow/ETL/Row/Schema/SelectiveValidator.php
@@ -17,7 +17,7 @@ final class SelectiveValidator implements SchemaValidator
         foreach ($expected->definitions() as $expectedDefinition) {
             $givenDefinition = $given->findDefinition($expectedDefinition->entry());
 
-            if (!$givenDefinition) {
+            if ($givenDefinition === null) {
                 return false;
             }
 
@@ -25,7 +25,7 @@ final class SelectiveValidator implements SchemaValidator
                 continue;
             }
 
-            if (!$givenDefinition->isEqual($expectedDefinition)) {
+            if (!$expectedDefinition->isEqual($givenDefinition)) {
                 return false;
             }
         }

--- a/src/core/etl/src/Flow/ETL/Row/Schema/StrictValidator.php
+++ b/src/core/etl/src/Flow/ETL/Row/Schema/StrictValidator.php
@@ -19,17 +19,17 @@ final class StrictValidator implements SchemaValidator
         }
 
         foreach ($given->definitions() as $givenDefinition) {
-            $definition = $expected->findDefinition($givenDefinition->entry());
+            $expectedDefinition = $expected->findDefinition($givenDefinition->entry());
 
-            if ($definition === null) {
+            if ($expectedDefinition === null) {
                 return false;
             }
 
-            if ($definition->isNullable() && $givenDefinition->metadata()->has(Metadata::FROM_NULL)) {
+            if ($expectedDefinition->isNullable() && $givenDefinition->metadata()->has(Metadata::FROM_NULL)) {
                 continue;
             }
 
-            if (!$definition->isEqual($givenDefinition)) {
+            if (!$expectedDefinition->isEqual($givenDefinition)) {
                 return false;
             }
         }

--- a/src/core/etl/src/Flow/ETL/Row/Schema/StrictValidator.php
+++ b/src/core/etl/src/Flow/ETL/Row/Schema/StrictValidator.php
@@ -26,10 +26,10 @@ final class StrictValidator implements SchemaValidator
             }
 
             if ($definition->isNullable() && $givenDefinition->metadata()->has(Metadata::FROM_NULL)) {
-                return true;
+                continue;
             }
 
-            if (!$definition->isCompatible($givenDefinition)) {
+            if (!$definition->isEqual($givenDefinition)) {
                 return false;
             }
         }

--- a/src/core/etl/src/Flow/ETL/Row/Schema/StrictValidator.php
+++ b/src/core/etl/src/Flow/ETL/Row/Schema/StrictValidator.php
@@ -29,7 +29,7 @@ final class StrictValidator implements SchemaValidator
                 continue;
             }
 
-            if (!$expectedDefinition->isEqual($givenDefinition)) {
+            if (!$expectedDefinition->isCompatible($givenDefinition)) {
                 return false;
             }
         }

--- a/src/core/etl/src/Flow/ETL/Row/Schema/StrictValidator.php
+++ b/src/core/etl/src/Flow/ETL/Row/Schema/StrictValidator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Row\Schema;
 
+use function Flow\ETL\DSL\type_string;
 use Flow\ETL\Row\Schema;
 use Flow\ETL\{SchemaValidator};
 
@@ -25,7 +26,7 @@ final class StrictValidator implements SchemaValidator
                 return false;
             }
 
-            if ($expectedDefinition->isNullable() && $givenDefinition->metadata()->has(Metadata::FROM_NULL)) {
+            if ($expectedDefinition->isNullable() && $givenDefinition->metadata()->has(Metadata::FROM_NULL) && $givenDefinition->type()->isSame(type_string(true))) {
                 continue;
             }
 

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Schema/DefinitionTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Schema/DefinitionTest.php
@@ -28,7 +28,7 @@ final class DefinitionTest extends FlowTestCase
         $definition = integer_schema('id', metadata: Metadata::fromArray(['test' => 'test']));
 
         self::assertTrue(
-            $definition->isEqual(
+            $definition->isCompatible(
                 integer_schema('id', false, Metadata::fromArray(['description' => 'some_random_description']))
             )
         );
@@ -39,7 +39,7 @@ final class DefinitionTest extends FlowTestCase
         $definition = integer_schema('id', metadata: Metadata::fromArray(['test' => 'test']));
 
         self::assertFalse(
-            $definition->isEqual(
+            $definition->isCompatible(
                 integer_schema('id', true, Metadata::fromArray(['description' => 'some_random_description']))
             )
         );

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Schema/DefinitionTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Schema/DefinitionTest.php
@@ -28,7 +28,7 @@ final class DefinitionTest extends FlowTestCase
         $definition = integer_schema('id', metadata: Metadata::fromArray(['test' => 'test']));
 
         self::assertTrue(
-            $definition->isCompatible(
+            $definition->isEqual(
                 integer_schema('id', false, Metadata::fromArray(['description' => 'some_random_description']))
             )
         );
@@ -39,7 +39,7 @@ final class DefinitionTest extends FlowTestCase
         $definition = integer_schema('id', metadata: Metadata::fromArray(['test' => 'test']));
 
         self::assertFalse(
-            $definition->isCompatible(
+            $definition->isEqual(
                 integer_schema('id', true, Metadata::fromArray(['description' => 'some_random_description']))
             )
         );
@@ -49,13 +49,13 @@ final class DefinitionTest extends FlowTestCase
     {
         $def = integer_schema('id', nullable: true);
 
-        self::assertTrue(
-            $def->isEqual(
+        self::assertFalse(
+            $def->isSame(
                 integer_schema('id', nullable: false)
             )
         );
         self::assertTrue(
-            $def->isEqual(
+            $def->isSame(
                 integer_schema('id', nullable: true)
             )
         );
@@ -66,7 +66,7 @@ final class DefinitionTest extends FlowTestCase
         $def = list_schema('list', type_list(type_integer()));
 
         self::assertTrue(
-            $def->isEqual(
+            $def->isSame(
                 list_schema('list', type_list(type_integer()))
             )
         );

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Schema/Matcher/StrictSchemaMatcherTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Schema/Matcher/StrictSchemaMatcherTest.php
@@ -53,7 +53,7 @@ final class StrictSchemaMatcherTest extends FlowTestCase
             str_schema('name', nullable: true),
         );
 
-        self::assertTrue((new StrictSchemaMatcher())->match($left, $right));
+        self::assertFalse((new StrictSchemaMatcher())->match($left, $right));
     }
 
     public function test_matching_the_same_schema() : void

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Schema/SelectiveValidatorTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Schema/SelectiveValidatorTest.php
@@ -4,116 +4,117 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Tests\Unit\Row\Schema;
 
-use function Flow\ETL\DSL\{bool_entry, int_entry, str_entry};
 use function Flow\ETL\DSL\{bool_schema, integer_schema, schema, string_schema};
-use function Flow\ETL\DSL\{row, rows, string_entry};
 use Flow\ETL\{Row\Schema\Metadata, Tests\FlowTestCase};
 use Flow\ETL\Row\Schema\SelectiveValidator;
 
 final class SelectiveValidatorTest extends FlowTestCase
 {
-    public function test_rows_with_a_missing_entry() : void
+    public function test_given_schema_non_nullable_expected_nullable() : void
     {
-        $schema = schema(integer_schema('id'), string_schema('name'));
-
-        self::assertFalse(
-            (new SelectiveValidator())->isValid(
-                rows(row(int_entry('id', 1), bool_entry('active', true)))->schema(),
-                $schema
-            )
-        );
-    }
-
-    public function test_rows_with_an_extra_entry() : void
-    {
-        $schema = schema(integer_schema('id'), string_schema('name'));
-
         self::assertTrue(
             (new SelectiveValidator())->isValid(
-                rows(row(int_entry('id', 1), str_entry('name', 'test'), bool_entry('active', true)))->schema(),
-                $schema
+                given: schema(integer_schema('id'), string_schema('name'), bool_schema('active')),
+                expected: schema(integer_schema('id'), string_schema('name'), bool_schema('active', true))
             )
         );
     }
 
-    public function test_rows_with_from_null_metadata() : void
+    public function test_given_schema_nullable_expected_non_nullable() : void
     {
-        $schema = schema(integer_schema('id', nullable: true));
+        self::assertFalse(
+            (new SelectiveValidator())->isValid(
+                given: schema(integer_schema('id'), string_schema('name'), bool_schema('active', true)),
+                expected: schema(integer_schema('id'), string_schema('name'), bool_schema('active'))
+            )
+        );
+    }
 
+    public function test_schema_with_a_missing_entry() : void
+    {
+        self::assertFalse(
+            (new SelectiveValidator())->isValid(
+                schema(integer_schema('id'), bool_schema('active')),
+                schema(integer_schema('id'), string_schema('name'))
+            )
+        );
+    }
+
+    public function test_schema_with_an_extra_entry() : void
+    {
         self::assertTrue(
             (new SelectiveValidator())->isValid(
-                rows(
-                    row(string_entry('id', null, Metadata::with(Metadata::FROM_NULL, true))),
-                )->schema(),
-                $schema
-            )
-        );
-
-        self::assertFalse(
-            (new SelectiveValidator())->isValid(
-                rows(
-                    row(string_entry('id', null)),
-                )->schema(),
-                $schema
+                schema(integer_schema('id'), string_schema('name'), bool_schema('active', true)),
+                schema(integer_schema('id'), string_schema('name'))
             )
         );
     }
 
-    public function test_rows_with_multiple_columns_with_from_null_metadata() : void
+    public function test_schema_with_from_null_metadata() : void
     {
-        $schema = schema(
-            integer_schema('id', nullable: true),
-            string_schema('name')
-        );
-
-        self::assertFalse(
-            (new SelectiveValidator())->isValid(
-                rows(
-                    row(
-                        string_entry('id', null, Metadata::with(Metadata::FROM_NULL, true)),
-                        string_entry('name', null)
-                    ),
-                )->schema(),
-                $schema
-            )
-        );
-
         self::assertTrue(
             (new SelectiveValidator())->isValid(
-                rows(
-                    row(
-                        string_entry('id', null, Metadata::with(Metadata::FROM_NULL, true)),
-                        string_entry('name', 'Norbert')
-                    ),
-                )->schema(),
-                $schema
+                schema(string_schema('id', nullable: true, metadata: Metadata::with(Metadata::FROM_NULL, true))),
+                schema(integer_schema('id', nullable: true)),
+            )
+        );
+
+        self::assertFalse(
+            (new SelectiveValidator())->isValid(
+                schema(string_schema('id', nullable: true)),
+                schema(integer_schema('id', nullable: true)),
             )
         );
     }
 
-    public function test_rows_with_single_invalid_entry() : void
+    public function test_schema_with_multiple_columns_with_from_null_metadata() : void
     {
-        $schema = schema(integer_schema('id'), bool_schema('name'), bool_schema('active'));
+        self::assertTrue(
+            (new SelectiveValidator())->isValid(
+                given: schema(
+                    string_schema('id', nullable: true, metadata: Metadata::with(Metadata::FROM_NULL, true)),
+                    string_schema('name')
+                ),
+                expected: schema(
+                    integer_schema('id', nullable: true),
+                    string_schema('name')
+                )
+            )
+        );
 
         self::assertFalse(
             (new SelectiveValidator())->isValid(
-                rows(row(int_entry('id', 1), str_entry('name', 'test'), bool_entry('active', true)))->schema(),
-                $schema
+                given: schema(
+                    string_schema('id', nullable: true),
+                    string_schema('name')
+                ),
+                expected: schema(
+                    integer_schema('id', nullable: true),
+                    string_schema('name', nullable: true)
+                )
+            )
+        );
+
+        self::assertFalse(
+            (new SelectiveValidator())->isValid(
+                given: schema(
+                    string_schema('id', nullable: true),
+                    string_schema('name')
+                ),
+                expected: schema(
+                    integer_schema('id', nullable: true),
+                    string_schema('name')
+                )
             )
         );
     }
 
-    public function test_rows_with_single_invalid_row() : void
+    public function test_schema_with_single_invalid_column() : void
     {
-        $schema = schema(string_schema('name'), bool_schema('active', true));
-
         self::assertFalse(
             (new SelectiveValidator())->isValid(
-                rows(
-                    row(int_entry('id', 1), str_entry('name', 'test'), bool_entry('active', true)),
-                    row(bool_entry('active', true))
-                )->schema(),
-                $schema
+                schema(integer_schema('id'), string_schema('name'), bool_schema('active', true)),
+                schema(integer_schema('id'), bool_schema('name'), bool_schema('active'))
             )
         );
     }

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Schema/SelectiveValidatorTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Schema/SelectiveValidatorTest.php
@@ -118,4 +118,14 @@ final class SelectiveValidatorTest extends FlowTestCase
             )
         );
     }
+
+    public function test_with_from_null_metadata_but_non_string_type() : void
+    {
+        self::assertFalse(
+            (new SelectiveValidator())->isValid(
+                given: schema(bool_schema('id', nullable: true, metadata: Metadata::with(Metadata::FROM_NULL, true))),
+                expected: schema(integer_schema('id', nullable: true)),
+            )
+        );
+    }
 }

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Schema/SelectiveValidatorTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Schema/SelectiveValidatorTest.php
@@ -59,6 +59,38 @@ final class SelectiveValidatorTest extends FlowTestCase
         );
     }
 
+    public function test_rows_with_multiple_columns_with_from_null_metadata() : void
+    {
+        $schema = schema(
+            integer_schema('id', nullable: true),
+            string_schema('name')
+        );
+
+        self::assertFalse(
+            (new SelectiveValidator())->isValid(
+                rows(
+                    row(
+                        string_entry('id', null, Metadata::with(Metadata::FROM_NULL, true)),
+                        string_entry('name', null)
+                    ),
+                )->schema(),
+                $schema
+            )
+        );
+
+        self::assertTrue(
+            (new SelectiveValidator())->isValid(
+                rows(
+                    row(
+                        string_entry('id', null, Metadata::with(Metadata::FROM_NULL, true)),
+                        string_entry('name', 'Norbert')
+                    ),
+                )->schema(),
+                $schema
+            )
+        );
+    }
+
     public function test_rows_with_single_invalid_entry() : void
     {
         $schema = schema(integer_schema('id'), bool_schema('name'), bool_schema('active'));
@@ -73,13 +105,13 @@ final class SelectiveValidatorTest extends FlowTestCase
 
     public function test_rows_with_single_invalid_row() : void
     {
-        $schema = schema(string_schema('name'), bool_schema('active'));
+        $schema = schema(string_schema('name'), bool_schema('active', true));
 
-        self::assertTrue(
+        self::assertFalse(
             (new SelectiveValidator())->isValid(
                 rows(
                     row(int_entry('id', 1), str_entry('name', 'test'), bool_entry('active', true)),
-                    row(int_entry('id', 1), bool_entry('active', true))
+                    row(bool_entry('active', true))
                 )->schema(),
                 $schema
             )

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Schema/StrictValidatorTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Schema/StrictValidatorTest.php
@@ -71,6 +71,38 @@ final class StrictValidatorTest extends FlowTestCase
         );
     }
 
+    public function test_rows_with_multiple_columns_with_from_null_metadata() : void
+    {
+        $schema = schema(
+            integer_schema('id', nullable: true),
+            string_schema('name')
+        );
+
+        self::assertFalse(
+            (new StrictValidator())->isValid(
+                rows(
+                    row(
+                        string_entry('id', null, Metadata::with(Metadata::FROM_NULL, true)),
+                        string_entry('name', null)
+                    ),
+                )->schema(),
+                $schema
+            )
+        );
+
+        self::assertTrue(
+            (new StrictValidator())->isValid(
+                rows(
+                    row(
+                        string_entry('id', null, Metadata::with(Metadata::FROM_NULL, true)),
+                        string_entry('name', 'Norbert')
+                    ),
+                )->schema(),
+                $schema
+            )
+        );
+    }
+
     public function test_rows_with_single_invalid_entry() : void
     {
         $schema = schema(integer_schema('id'), bool_schema('name'), bool_schema('active'));

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Schema/StrictValidatorTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Schema/StrictValidatorTest.php
@@ -4,125 +4,84 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Tests\Unit\Row\Schema;
 
-use function Flow\ETL\DSL\{bool_entry, int_entry, str_entry, type_list, type_string};
 use function Flow\ETL\DSL\{bool_schema, integer_schema, list_schema, schema, string_schema};
-use function Flow\ETL\DSL\{row, rows, string_entry};
+use function Flow\ETL\DSL\{type_list, type_string};
 use Flow\ETL\{Row\Schema\Metadata, Tests\FlowTestCase};
 use Flow\ETL\Row\Schema\StrictValidator;
 
 final class StrictValidatorTest extends FlowTestCase
 {
-    public function test_rows_with_a_missing_entry() : void
+    public function test_given_schema_non_nullable_expected_nullable() : void
     {
-        $schema = schema(integer_schema('id'), string_schema('name'));
-
-        self::assertFalse(
+        self::assertTrue(
             (new StrictValidator())->isValid(
-                rows(row(int_entry('id', 1), str_entry('name', 'test'), bool_entry('active', true)))->schema(),
-                $schema
+                given: schema(integer_schema('id'), string_schema('name'), bool_schema('active')),
+                expected: schema(integer_schema('id'), string_schema('name'), bool_schema('active', true))
             )
         );
     }
 
-    public function test_rows_with_all_entries_valid() : void
+    public function test_given_schema_nullable_expected_non_nullable() : void
     {
-        $schema = schema(integer_schema('id'), string_schema('name'), bool_schema('active'));
-
-        self::assertTrue(
+        self::assertFalse(
             (new StrictValidator())->isValid(
-                rows(row(int_entry('id', 1), str_entry('name', 'test'), bool_entry('active', true)))->schema(),
-                $schema
+                given: schema(integer_schema('id'), string_schema('name'), bool_schema('active', true)),
+                expected: schema(integer_schema('id'), string_schema('name'), bool_schema('active'))
+            )
+        );
+    }
+
+    public function test_rows_with_a_missing_entry() : void
+    {
+        self::assertFalse(
+            (new StrictValidator())->isValid(
+                given: schema(integer_schema('id'), string_schema('name')),
+                expected: schema(integer_schema('id'), string_schema('name'), bool_schema('active', true))
             )
         );
     }
 
     public function test_rows_with_an_extra_entry() : void
     {
-        $schema = schema(integer_schema('id'), string_schema('name'), bool_schema('active'), list_schema('tags', type_list(type_string())));
-
         self::assertFalse(
             (new StrictValidator())->isValid(
-                rows(row(int_entry('id', 1), str_entry('name', 'test'), bool_entry('active', true)))->schema(),
-                $schema
+                given: schema(integer_schema('id'), string_schema('name'), bool_schema('active'), list_schema('tags', type_list(type_string()))),
+                expected: schema(integer_schema('id'), string_schema('name'), bool_schema('active')),
             )
         );
     }
 
     public function test_rows_with_from_null_metadata() : void
     {
-        $schema = schema(integer_schema('id', nullable: true));
-
         self::assertTrue(
             (new StrictValidator())->isValid(
-                rows(
-                    row(string_entry('id', null, Metadata::with(Metadata::FROM_NULL, true))),
-                )->schema(),
-                $schema
+                given: schema(string_schema('id', nullable: true, metadata: Metadata::with(Metadata::FROM_NULL, true))),
+                expected: schema(integer_schema('id', nullable: true)),
             )
         );
 
         self::assertFalse(
             (new StrictValidator())->isValid(
-                rows(
-                    row(string_entry('id', null)),
-                )->schema(),
-                $schema
+                given: schema(integer_schema('id', nullable: true)),
+                expected: schema(string_schema('id', nullable: true))
             )
         );
     }
 
     public function test_rows_with_multiple_columns_with_from_null_metadata() : void
     {
-        $schema = schema(
-            integer_schema('id', nullable: true),
-            string_schema('name')
-        );
 
         self::assertFalse(
             (new StrictValidator())->isValid(
-                rows(
-                    row(
-                        string_entry('id', null, Metadata::with(Metadata::FROM_NULL, true)),
-                        string_entry('name', null)
-                    ),
-                )->schema(),
-                $schema
+                given: schema(string_schema('id', nullable: true), string_schema('name')),
+                expected: schema(integer_schema('id', nullable: true), string_schema('name'))
             )
         );
 
         self::assertTrue(
             (new StrictValidator())->isValid(
-                rows(
-                    row(
-                        string_entry('id', null, Metadata::with(Metadata::FROM_NULL, true)),
-                        string_entry('name', 'Norbert')
-                    ),
-                )->schema(),
-                $schema
-            )
-        );
-    }
-
-    public function test_rows_with_single_invalid_entry() : void
-    {
-        $schema = schema(integer_schema('id'), bool_schema('name'), bool_schema('active'));
-
-        self::assertFalse(
-            (new StrictValidator())->isValid(
-                rows(row(int_entry('id', 1), str_entry('name', 'test'), bool_entry('active', true)))->schema(),
-                $schema
-            )
-        );
-    }
-
-    public function test_rows_with_single_invalid_row() : void
-    {
-        $schema = schema(integer_schema('id'), string_schema('name'), bool_schema('active'));
-
-        self::assertFalse(
-            (new StrictValidator())->isValid(
-                rows(row(int_entry('id', 1), str_entry('name', 'test'), bool_entry('active', true)), row(int_entry('id', 1), bool_entry('active', true)))->schema(),
-                $schema
+                given: schema(string_schema('id', nullable: true, metadata: Metadata::with(Metadata::FROM_NULL, true)), string_schema('name')),
+                expected: schema(integer_schema('id', nullable: true), string_schema('name'))
             )
         );
     }

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Schema/StrictValidatorTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Schema/StrictValidatorTest.php
@@ -85,4 +85,14 @@ final class StrictValidatorTest extends FlowTestCase
             )
         );
     }
+
+    public function test_with_from_null_metadata_but_non_string_type() : void
+    {
+        self::assertFalse(
+            (new StrictValidator())->isValid(
+                given: schema(bool_schema('id', nullable: true, metadata: Metadata::with(Metadata::FROM_NULL, true))),
+                expected: schema(integer_schema('id', nullable: true)),
+            )
+        );
+    }
 }


### PR DESCRIPTION
<!-- 
    Below section will be used to automatically generate changelog, please do not modify HTML code structure
    DO NOT REMOVE that HTML STRUCTURE, INSTEAD ADD YOUR CHANGES INSIDE THE LISTS 
    PULL REQUESTS WITHOUT CHANGELOG CAN'T BE MERGED 
-->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>schema comparison for nullability</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

Long story short, I accidentally introduced a regression #1587 by returning `true`. 

So what happened is that first entry that was a `string entry created from null` (with FROM_NULL) metadata was pausing the schema validation with a result `true`. 

This behavior was fixed, so whenever both schema validators will encounter a `string_schema` with `FROM_NULL` metadata and the expected definition is nullable, it will let it pass. 

This behavior is here to not fail schema validation when schema allows value to be null and there is only one row (or it's a first row) where entry is created from null.  

Entry Factory when creating entry from null without provided definition will create it as a `string_entry('name', null, Metadata::with(Metadata::FROM_NULL))`. 