### PR TITLE
Allow custom way of renaming values

### DIFF
--- a/src/core/etl/src/Flow/ETL/DataFrame.php
+++ b/src/core/etl/src/Flow/ETL/DataFrame.php
@@ -637,6 +637,16 @@ final class DataFrame
     /**
      * @lazy
      */
+    public function renameAllCallback(\Closure $callback) : self
+    {
+        $this->pipeline->add(new RenameAllCaseTransformer(callback: $callback));
+
+        return $this;
+    }
+
+    /**
+     * @lazy
+     */
     public function renameAllLowerCase() : self
     {
         $this->pipeline->add(new RenameAllCaseTransformer(lower: true));

--- a/src/core/etl/src/Flow/ETL/Transformer/RenameAllCaseTransformer.php
+++ b/src/core/etl/src/Flow/ETL/Transformer/RenameAllCaseTransformer.php
@@ -13,6 +13,7 @@ final readonly class RenameAllCaseTransformer implements Transformer
         private bool $lower = false,
         private bool $ucfirst = false,
         private bool $ucwords = false,
+        private ?\Closure $callback = null,
     ) {
     }
 
@@ -20,21 +21,14 @@ final readonly class RenameAllCaseTransformer implements Transformer
     {
         return $rows->map(function (Row $row) : Row {
             foreach ($row->entries()->all() as $entry) {
-                if ($this->upper) {
-                    $row = $row->rename($entry->name(), \mb_strtoupper($entry->name()));
-                }
-
-                if ($this->lower) {
-                    $row = $row->rename($entry->name(), \mb_strtolower($entry->name()));
-                }
-
-                if ($this->ucfirst) {
-                    $row = $row->rename($entry->name(), $this->ucFirst($entry->name()));
-                }
-
-                if ($this->ucwords) {
-                    $row = $row->rename($entry->name(), $this->ucWords($entry->name()));
-                }
+                $row = match (true) {
+                    $this->upper => $row->rename($entry->name(), \mb_strtoupper($entry->name())),
+                    $this->lower => $row->rename($entry->name(), \mb_strtolower($entry->name())),
+                    $this->ucfirst => $row->rename($entry->name(), $this->ucFirst($entry->name())),
+                    $this->ucwords => $row->rename($entry->name(), $this->ucWords($entry->name())),
+                    $this->callback !== null => $row->rename($entry->name(), ($this->callback)($entry->name())),
+                    default => $row,
+                };
             }
 
             return $row;

--- a/src/core/etl/tests/Flow/ETL/Tests/Integration/DataFrame/RenameTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Integration/DataFrame/RenameTest.php
@@ -52,7 +52,7 @@ final class RenameTest extends FlowIntegrationTestCase
             self::markTestSkipped('Transliterator is not installed');
         }
 
-        $rows = rows(row(int_entry('ósmy', 8)), row(int_entry('dziewiąty', 9)));
+        $rows = rows(row(int_entry('ÓSMY', 8)), row(int_entry('DZIEWIĄTY', 9)));
 
         $ds = df()
             ->read(from_rows($rows))

--- a/src/core/etl/tests/Flow/ETL/Tests/Integration/DataFrame/RenameTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Integration/DataFrame/RenameTest.php
@@ -46,6 +46,28 @@ final class RenameTest extends FlowIntegrationTestCase
         );
     }
 
+    public function test_rename_all_callback() : void
+    {
+        if (!\function_exists('transliterator_transliterate')) {
+            $this->markTestSkipped('Transliterator is not installed');
+        }
+
+        $rows = rows(row(int_entry('ósmy', 8)), row(int_entry('dziewiąty', 9)));
+
+        $ds = df()
+            ->read(from_rows($rows))
+            ->renameAllCallback(fn (string $value) : string => \transliterator_transliterate('Any-Latin; Latin-ASCII; Lower()', $value) ?: '')
+            ->getEachAsArray();
+
+        self::assertEquals(
+            [
+                ['osmy' => 8],
+                ['dziewiaty' => 9],
+            ],
+            \iterator_to_array($ds)
+        );
+    }
+
     public function test_rename_all_lower_case() : void
     {
         $rows = rows(row(int_entry('ID', 1), str_entry('NAME', 'name'), bool_entry('ACTIVE', true)), row(int_entry('ID', 2), str_entry('NAME', 'name'), bool_entry('ACTIVE', false)));

--- a/src/core/etl/tests/Flow/ETL/Tests/Integration/DataFrame/RenameTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Integration/DataFrame/RenameTest.php
@@ -49,7 +49,7 @@ final class RenameTest extends FlowIntegrationTestCase
     public function test_rename_all_callback() : void
     {
         if (!\function_exists('transliterator_transliterate')) {
-            $this->markTestSkipped('Transliterator is not installed');
+            self::markTestSkipped('Transliterator is not installed');
         }
 
         $rows = rows(row(int_entry('ósmy', 8)), row(int_entry('dziewiąty', 9)));


### PR DESCRIPTION
<!-- 
    Below section will be used to automatically generate changelog, please do not modify HTML code structure
    DO NOT REMOVE that HTML STRUCTURE, INSTEAD ADD YOUR CHANGES INSIDE THE LISTS 
    PULL REQUESTS WITHOUT CHANGELOG CAN'T BE MERGED 
-->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <li>Allow custom way of renaming values</li>
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

As provided in test examples, we can easily apply custom renaming, i.e., translitering non-Latin characters to Latin ones with a callback function.
