### PR TITLE
Fixed key set pagination when key column was ambiguous

### DIFF
--- a/src/adapter/etl-adapter-doctrine/src/Flow/ETL/Adapter/Doctrine/DbalKeySetExtractor.php
+++ b/src/adapter/etl-adapter-doctrine/src/Flow/ETL/Adapter/Doctrine/DbalKeySetExtractor.php
@@ -20,6 +20,8 @@ use Flow\ETL\Exception\{InvalidArgumentException, RuntimeException};
  */
 final class DbalKeySetExtractor implements Extractor
 {
+    private string $keyAliasSuffix = '_previous';
+
     private ?int $maximum = null;
 
     private int $pageSize = 1000;
@@ -56,6 +58,7 @@ final class DbalKeySetExtractor implements Extractor
 
             foreach ($this->keySet->keys as $key) {
                 $qb->addOrderBy($key->column, $key->order->value);
+                $qb->addSelect($key->column . ' AS ' . $this->keyAlias($key));
             }
 
             if ($lastRow !== null) {
@@ -64,28 +67,30 @@ final class DbalKeySetExtractor implements Extractor
                 $parameterTypes = [];
 
                 foreach ($this->keySet->keys as $index => $key) {
-                    if (!\array_key_exists($key->column, $lastRow)) {
+                    $keyAlias = $this->keyAlias($key);
+
+                    if (!\array_key_exists($keyAlias, $lastRow)) {
                         throw new RuntimeException(sprintf('Column "%s" not found in last row for keyset pagination', $key->column));
                     }
 
-                    $lastValue = $lastRow[$key->column];
+                    $lastValue = $lastRow[$keyAlias];
 
                     if ($lastValue === null) {
                         throw new RuntimeException(sprintf('NULL value found in column "%s" for keyset pagination; key columns must be non-null', $key->column));
                     }
 
-                    $paramName = $key->column . '_previous';
-                    $parameters[$paramName] = $lastValue;
-                    $parameterTypes[$paramName] = $key->type;
+                    $parameters[$keyAlias] = $lastValue;
+                    $parameterTypes[$keyAlias] = $key->type;
 
                     $subConditions = [];
 
                     for ($i = 0; $i < $index; $i++) {
                         $prevKey = $this->keySet->keys[$i];
-                        $subConditions[] = $qb->expr()->eq($prevKey->column, ':' . $prevKey->column . '_previous');
+                        $subConditions[] = $qb->expr()->eq($prevKey->column, ':' . $keyAlias);
                     }
+
                     $operator = $key->order->value === 'DESC' ? 'lt' : 'gt';
-                    $subConditions[] = $qb->expr()->{$operator}($key->column, ':' . $paramName);
+                    $subConditions[] = $qb->expr()->{$operator}($key->column, ':' . $keyAlias);
 
                     $conditions[] = $qb->expr()->and(...$subConditions);
                 }
@@ -112,6 +117,14 @@ final class DbalKeySetExtractor implements Extractor
                 $hasRows = true;
                 $lastRow = $row;
 
+                foreach ($this->keySet->keys as $key) {
+                    $keyAlias = $this->keyAlias($key);
+
+                    if (\array_key_exists($keyAlias, $row)) {
+                        unset($row[$keyAlias]);
+                    }
+                }
+
                 $signal = yield array_to_rows($row, $context->entryFactory(), [], $this->schema);
 
                 if ($signal === Extractor\Signal::STOP) {
@@ -129,6 +142,13 @@ final class DbalKeySetExtractor implements Extractor
                 break;
             }
         }
+    }
+
+    public function withKeyAliasSuffix(string $keyAliasSuffix) : self
+    {
+        $this->keyAliasSuffix = $keyAliasSuffix;
+
+        return $this;
     }
 
     /**
@@ -183,5 +203,10 @@ final class DbalKeySetExtractor implements Extractor
         $this->schema = $schema;
 
         return $this;
+    }
+
+    private function keyAlias(Pagination\Key $key) : string
+    {
+        return (string) preg_replace('/[^a-zA-Z0-9_]/', '_', str_replace('.', '_', $key->column . $this->keyAliasSuffix));
     }
 }

--- a/src/adapter/etl-adapter-doctrine/src/Flow/ETL/Adapter/Doctrine/DbalKeySetExtractor.php
+++ b/src/adapter/etl-adapter-doctrine/src/Flow/ETL/Adapter/Doctrine/DbalKeySetExtractor.php
@@ -86,7 +86,7 @@ final class DbalKeySetExtractor implements Extractor
 
                     for ($i = 0; $i < $index; $i++) {
                         $prevKey = $this->keySet->keys[$i];
-                        $subConditions[] = $qb->expr()->eq($prevKey->column, ':' . $keyAlias);
+                        $subConditions[] = $qb->expr()->eq($prevKey->column, ':' . $this->keyAlias($prevKey));
                     }
 
                     $operator = $key->order->value === 'DESC' ? 'lt' : 'gt';
@@ -100,7 +100,11 @@ final class DbalKeySetExtractor implements Extractor
 
                     foreach ($parameters as $param => $value) {
                         /** @phpstan-ignore-next-line */
-                        $qb->setParameter($param, $value, $parameterTypes[$param]);
+                        if ($parameterTypes[$param] !== null) {
+                            $qb->setParameter($param, $value, $parameterTypes[$param]);
+                        } else {
+                            $qb->setParameter($param, $value);
+                        }
                     }
                 }
             }

--- a/src/adapter/etl-adapter-doctrine/src/Flow/ETL/Adapter/Doctrine/DbalKeySetExtractor.php
+++ b/src/adapter/etl-adapter-doctrine/src/Flow/ETL/Adapter/Doctrine/DbalKeySetExtractor.php
@@ -100,11 +100,7 @@ final class DbalKeySetExtractor implements Extractor
 
                     foreach ($parameters as $param => $value) {
                         /** @phpstan-ignore-next-line */
-                        if ($parameterTypes[$param] !== null) {
-                            $qb->setParameter($param, $value, $parameterTypes[$param]);
-                        } else {
-                            $qb->setParameter($param, $value);
-                        }
+                        $qb->setParameter($param, $value, $parameterTypes[$param]);
                     }
                 }
             }

--- a/src/adapter/etl-adapter-doctrine/tests/Flow/ETL/Adapter/Doctrine/Tests/Integration/DbalKeySetExtractorTest.php
+++ b/src/adapter/etl-adapter-doctrine/tests/Flow/ETL/Adapter/Doctrine/Tests/Integration/DbalKeySetExtractorTest.php
@@ -266,6 +266,127 @@ final class DbalKeySetExtractorTest extends IntegrationTestCase
         );
     }
 
+    public function test_extraction_when_key_is_ambiguous_column() : void
+    {
+        $this->pgsqlDatabaseContext->createTable(
+            to_dbal_schema_table(
+                schema(
+                    int_schema('id', metadata: DbalMetadata::primaryKey()),
+                    str_schema('name', metadata: DbalMetadata::length(255)),
+                ),
+                $table = 'flow_key_set_extractor_test_01',
+            )
+        );
+
+        $this->pgsqlDatabaseContext->createTable(
+            to_dbal_schema_table(
+                schema(
+                    int_schema('id', metadata: DbalMetadata::primaryKey()),
+                    int_schema('id_01'),
+                    str_schema('name', metadata: DbalMetadata::length(255)),
+                ),
+                'flow_key_set_extractor_test_02',
+            )
+        );
+
+        for ($i = 1; $i <= 25; $i++) {
+            $this->pgsqlDatabaseContext->insert($table, ['id' => $i, 'name' => 'name_' . $i]);
+
+            $this->pgsqlDatabaseContext->insert('flow_key_set_extractor_test_02', ['id' => $i, 'id_01' => $i, 'name' => 'name_' . $i]);
+        }
+
+        $rows = data_frame()
+            ->extract(
+                from_dbal_key_set_qb(
+                    $this->pgsqlDatabaseContext->connection(),
+                    $this->pgsqlDatabaseContext->connection()->createQueryBuilder()
+                        ->from($table)
+                        ->select('flow_key_set_extractor_test_01.id as id')
+                        ->leftJoin(
+                            'flow_key_set_extractor_test_01',
+                            'flow_key_set_extractor_test_02',
+                            'flow_key_set_extractor_test_02',
+                            'flow_key_set_extractor_test_01.id = flow_key_set_extractor_test_02.id_01'
+                        ),
+                    pagination_key_set(pagination_key_desc('flow_key_set_extractor_test_01.id'))
+                )
+                ->withSchema(schema(int_schema('id')))
+                ->withPageSize(5)
+                ->withMaximum(5)
+            )
+            ->fetch()
+            ->toArray();
+
+        self::assertSame([
+            ['id' => 25],
+            ['id' => 24],
+            ['id' => 23],
+            ['id' => 22],
+            ['id' => 21],
+        ], $rows);
+    }
+
+    public function test_extraction_when_key_is_ambiguous_column_with_custom_key_column_alias_suffix() : void
+    {
+        $this->pgsqlDatabaseContext->createTable(
+            to_dbal_schema_table(
+                schema(
+                    int_schema('id', metadata: DbalMetadata::primaryKey()),
+                    str_schema('name', metadata: DbalMetadata::length(255)),
+                ),
+                $table = 'flow_key_set_extractor_test_01',
+            )
+        );
+
+        $this->pgsqlDatabaseContext->createTable(
+            to_dbal_schema_table(
+                schema(
+                    int_schema('id', metadata: DbalMetadata::primaryKey()),
+                    int_schema('id_01'),
+                    str_schema('name', metadata: DbalMetadata::length(255)),
+                ),
+                'flow_key_set_extractor_test_02',
+            )
+        );
+
+        for ($i = 1; $i <= 25; $i++) {
+            $this->pgsqlDatabaseContext->insert($table, ['id' => $i, 'name' => 'name_' . $i]);
+
+            $this->pgsqlDatabaseContext->insert('flow_key_set_extractor_test_02', ['id' => $i, 'id_01' => $i, 'name' => 'name_' . $i]);
+        }
+
+        $rows = data_frame()
+            ->extract(
+                from_dbal_key_set_qb(
+                    $this->pgsqlDatabaseContext->connection(),
+                    $this->pgsqlDatabaseContext->connection()->createQueryBuilder()
+                        ->from($table)
+                        ->select('flow_key_set_extractor_test_01.id as id')
+                        ->leftJoin(
+                            'flow_key_set_extractor_test_01',
+                            'flow_key_set_extractor_test_02',
+                            'flow_key_set_extractor_test_02',
+                            'flow_key_set_extractor_test_01.id = flow_key_set_extractor_test_02.id_01'
+                        ),
+                    pagination_key_set(pagination_key_desc('flow_key_set_extractor_test_01.id'))
+                )
+                    ->withKeyAliasSuffix('_something_custom')
+                    ->withSchema(schema(int_schema('id')))
+                    ->withPageSize(5)
+                    ->withMaximum(5)
+            )
+            ->fetch()
+            ->toArray();
+
+        self::assertSame([
+            ['id' => 25],
+            ['id' => 24],
+            ['id' => 23],
+            ['id' => 22],
+            ['id' => 21],
+        ], $rows);
+    }
+
     public function test_throws_exception_for_empty_key_set() : void
     {
         $this->pgsqlDatabaseContext->createTable(


### PR DESCRIPTION
<!-- 
    Below section will be used to automatically generate changelog, please do not modify HTML code structure
    DO NOT REMOVE that HTML STRUCTURE, INSTEAD ADD YOUR CHANGES INSIDE THE LISTS 
    PULL REQUESTS WITHOUT CHANGELOG CAN'T BE MERGED 
-->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>key set pagination query for ambiguous column names</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

<!-- Please provide a short description of changes in this section, feel free to use markdown syntax -->
