### PR TITLE
fix: error message when to_csv is not available

### DIFF
--- a/src/bridge/symfony/http-foundation/src/Flow/Bridge/Symfony/HttpFoundation/Output/CSVOutput.php
+++ b/src/bridge/symfony/http-foundation/src/Flow/Bridge/Symfony/HttpFoundation/Output/CSVOutput.php
@@ -10,7 +10,7 @@ use Flow\Bridge\Symfony\HttpFoundation\Output;
 use Flow\ETL\Loader;
 
 if (!function_exists('Flow\ETL\Adapter\CSV\to_csv')) {
-    throw new \RuntimeException('Flow\ETL\Adapter\CSV\to_csv function is not available. Make sure that composer require flow-php/etl-adapter-json dependency is present in your composer.json.');
+    throw new \RuntimeException('Flow\ETL\Adapter\CSV\to_csv function is not available. Make sure that composer require flow-php/etl-adapter-csv dependency is present in your composer.json.');
 }
 
 final readonly class CSVOutput implements Output


### PR DESCRIPTION
<!-- 
    Below section will be used to automatically generate changelog, please do not modify HTML code structure
    DO NOT REMOVE that HTML STRUCTURE, INSTEAD ADD YOUR CHANGES INSIDE THE LISTS 
    PULL REQUESTS WITHOUT CHANGELOG CAN'T BE MERGED 
-->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>fix: error message when to_csv is not available</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

fix: error message when to_csv is not available
