### PR TITLE
Add a new `RenameEachEntryTransformerBench` benchmark

### DIFF
--- a/src/core/etl/tests/Flow/ETL/Tests/Benchmark/Transformer/RenameEachEntryTransformerBench.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Benchmark/Transformer/RenameEachEntryTransformerBench.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Tests\Benchmark\Transformer;
+
+use function Flow\ETL\DSL\{config, flow_context, rename_style};
+use Flow\ETL\{FlowContext, Rows, String\StringStyles, Transformer\RenameEachEntryTransformer};
+use PhpBench\Attributes\{BeforeMethods, Groups};
+
+#[BeforeMethods('setUp')]
+#[Groups(['transformer'])]
+final class RenameEachEntryTransformerBench
+{
+    private FlowContext $context;
+
+    private Rows $rows;
+
+    public function setUp() : void
+    {
+        $this->rows = Rows::fromArray(
+            \array_merge(...\array_map(static fn () : array => [
+                ['id' => 1, 'random text' => null, 'from' => 666],
+                ['id' => 2, 'random text' => null, 'from' => 666],
+                ['id' => 3, 'random text' => null, 'from' => 666],
+                ['id' => 4, 'random text' => null, 'from' => 666],
+                ['id' => 5, 'random text' => null, 'from' => 666],
+            ], \range(0, 1_000)))
+        );
+        $this->context = flow_context(config());
+    }
+
+    public function bench_transform_10k_rows() : void
+    {
+        (new RenameEachEntryTransformer(rename_style(StringStyles::KEBAB)))->transform($this->rows, $this->context);
+    }
+}


### PR DESCRIPTION
<!-- 
    Below section will be used to automatically generate changelog, please do not modify HTML code structure
    DO NOT REMOVE that HTML STRUCTURE, INSTEAD ADD YOUR CHANGES INSIDE THE LISTS 
    PULL REQUESTS WITHOUT CHANGELOG CAN'T BE MERGED 
-->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <li>Add a new `RenameEachEntryTransformerBench` benchmark</li>
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

To optimise this transformer, I would like to cover it with a benchmark, as we have for a single rename one.
