### PR TITLE
Rework `RenameEachEntryTransformer` to a single instance on multiple strategies

### DIFF
--- a/src/core/etl/src/Flow/ETL/DataFrame.php
+++ b/src/core/etl/src/Flow/ETL/DataFrame.php
@@ -714,9 +714,7 @@ final class DataFrame
 
     public function renameEach(RenameEntryStrategy ...$strategies) : self
     {
-        foreach ($strategies as $strategy) {
-            $this->pipeline->add(new RenameEachEntryTransformer($strategy));
-        }
+        $this->pipeline->add(new RenameEachEntryTransformer(...$strategies));
 
         return $this;
     }

--- a/src/core/etl/src/Flow/ETL/Transformer/RenameEachEntryTransformer.php
+++ b/src/core/etl/src/Flow/ETL/Transformer/RenameEachEntryTransformer.php
@@ -4,20 +4,36 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Transformer;
 
-use Flow\ETL\{FlowContext, Row, Rows, Transformer, Transformer\Rename\RenameEntryStrategy};
+use Flow\ETL\{Exception\InvalidArgumentException,
+    FlowContext,
+    Row,
+    Rows,
+    Transformer,
+    Transformer\Rename\RenameEntryStrategy};
 
 final readonly class RenameEachEntryTransformer implements Transformer
 {
-    public function __construct(
-        private RenameEntryStrategy $strategy,
-    ) {
+    /**
+     * @var array<RenameEntryStrategy>
+     */
+    private array $strategies;
+
+    public function __construct(RenameEntryStrategy ...$strategies)
+    {
+        if ([] === $strategies) {
+            throw new InvalidArgumentException('At least one strategy must be provided.');
+        }
+
+        $this->strategies = $strategies;
     }
 
     public function transform(Rows $rows, FlowContext $context) : Rows
     {
         return $rows->map(function (Row $row) use ($context) : Row {
-            foreach ($row->entries()->all() as $entry) {
-                $row = $this->strategy->rename($row, $entry, $context);
+            foreach ($this->strategies as $strategy) {
+                foreach ($row->entries()->all() as $entry) {
+                    $row = $strategy->rename($row, $entry, $context);
+                }
             }
 
             return $row;

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Transformer/RenameEachEntryTransformerTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Transformer/RenameEachEntryTransformerTest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Tests\Unit\Transformer;
+
+use Flow\ETL\{Exception\InvalidArgumentException, Tests\FlowTestCase, Transformer\RenameEachEntryTransformer};
+
+final class RenameEachEntryTransformerTest extends FlowTestCase
+{
+    public function test_renaming_fails_without_any_strategy() : void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('At least one strategy must be provided.');
+
+        new RenameEachEntryTransformer();
+    }
+}


### PR DESCRIPTION
<!-- 
    Below section will be used to automatically generate changelog, please do not modify HTML code structure
    DO NOT REMOVE that HTML STRUCTURE, INSTEAD ADD YOUR CHANGES INSIDE THE LISTS 
    PULL REQUESTS WITHOUT CHANGELOG CAN'T BE MERGED 
-->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Rework `RenameEachEntryTransformer` to a single instance on multiple strategies</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

<!-- Please provide a short description of changes in this section, feel free to use markdown syntax -->
