### PR TITLE
Fixed auto generated aliases length in dbal key set extractor

### DIFF
--- a/src/adapter/etl-adapter-doctrine/src/Flow/ETL/Adapter/Doctrine/DbalKeySetExtractor.php
+++ b/src/adapter/etl-adapter-doctrine/src/Flow/ETL/Adapter/Doctrine/DbalKeySetExtractor.php
@@ -209,6 +209,6 @@ final class DbalKeySetExtractor implements Extractor
 
     private function keyAlias(Key $key) : string
     {
-        return (string) preg_replace('/[^a-zA-Z0-9_]/', '_', str_replace('.', '_', $key->column . $this->keyAliasSuffix));
+        return 'key_' . \sha1((string) preg_replace('/[^a-zA-Z0-9_]/', '_', str_replace('.', '_', $key->column . $this->keyAliasSuffix)));
     }
 }

--- a/src/adapter/etl-adapter-doctrine/tests/Flow/ETL/Adapter/Doctrine/Tests/Integration/Dialects/MySQLKeySetExtractorTest.php
+++ b/src/adapter/etl-adapter-doctrine/tests/Flow/ETL/Adapter/Doctrine/Tests/Integration/Dialects/MySQLKeySetExtractorTest.php
@@ -55,7 +55,7 @@ final class MySQLKeySetExtractorTest extends IntegrationTestCase
                     str_schema('name', metadata: DbalMetadata::length(255)),
                     str_schema('description', metadata: DbalMetadata::length(255)),
                 ),
-                $table = 'flow_key_set_extractor_test',
+                $table = 'flow_key_set_extractor_with_a_very_long_table_name_test',
             )
         );
 
@@ -69,7 +69,7 @@ final class MySQLKeySetExtractorTest extends IntegrationTestCase
                 $this->mysqlDatabaseContext->connection()->createQueryBuilder()
                     ->from($table)
                     ->select('*'),
-                pagination_key_set(pagination_key_asc('id')),
+                pagination_key_set(pagination_key_asc('flow_key_set_extractor_with_a_very_long_table_name_test.id')),
             ))
             ->fetch();
 

--- a/src/adapter/etl-adapter-doctrine/tests/Flow/ETL/Adapter/Doctrine/Tests/Integration/Dialects/PostgreSQLKeySetExtractorTest.php
+++ b/src/adapter/etl-adapter-doctrine/tests/Flow/ETL/Adapter/Doctrine/Tests/Integration/Dialects/PostgreSQLKeySetExtractorTest.php
@@ -55,7 +55,7 @@ final class PostgreSQLKeySetExtractorTest extends IntegrationTestCase
                     str_schema('name', metadata: DbalMetadata::length(255)),
                     str_schema('description', metadata: DbalMetadata::length(255)),
                 ),
-                $table = 'flow_key_set_extractor_test',
+                $table = 'flow_key_set_extractor_with_a_very_long_table_name_test',
             )
         );
 
@@ -69,7 +69,7 @@ final class PostgreSQLKeySetExtractorTest extends IntegrationTestCase
                 $this->pgsqlDatabaseContext->connection()->createQueryBuilder()
                     ->from($table)
                     ->select('*'),
-                pagination_key_set(pagination_key_asc('id')),
+                pagination_key_set(pagination_key_asc('flow_key_set_extractor_with_a_very_long_table_name_test.id')),
             ))
             ->fetch();
 

--- a/src/adapter/etl-adapter-doctrine/tests/Flow/ETL/Adapter/Doctrine/Tests/Integration/Dialects/SqliteKeySetExtractorTest.php
+++ b/src/adapter/etl-adapter-doctrine/tests/Flow/ETL/Adapter/Doctrine/Tests/Integration/Dialects/SqliteKeySetExtractorTest.php
@@ -55,7 +55,7 @@ final class SqliteKeySetExtractorTest extends IntegrationTestCase
                     str_schema('name', metadata: DbalMetadata::length(255)),
                     str_schema('description', metadata: DbalMetadata::length(255)),
                 ),
-                $table = 'flow_key_set_extractor_test',
+                $table = 'flow_key_set_extractor_with_a_very_long_table_name_test',
             )
         );
 
@@ -69,7 +69,7 @@ final class SqliteKeySetExtractorTest extends IntegrationTestCase
                 $this->sqliteDatabaseContext->connection()->createQueryBuilder()
                     ->from($table)
                     ->select('*'),
-                pagination_key_set(pagination_key_asc('id')),
+                pagination_key_set(pagination_key_asc('flow_key_set_extractor_with_a_very_long_table_name_test.id')),
             ))
             ->fetch();
 


### PR DESCRIPTION
<!-- 
    Please replace #xxx with a GitHub issue id from flow-php/flow repository. For example #1234 
    If there is no item in a roadmap related to this PR, please check our contributing guidelines first. 
-->
Resolves: #xxx

<!-- 
    Below section will be used to automatically generate changelog, please do not modify HTML code structure
    DO NOT REMOVE that HTML STRUCTURE, INSTEAD ADD YOUR CHANGES INSIDE THE LISTS 
    PULL REQUESTS WITHOUT CHANGELOG CAN'T BE MERGED 
-->
<h2>Change Log</h2>
<hr /> 
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>length of auto generate aliases in dbal key set extractor</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>