### PR TITLE
Skip double size counting on csv row normalizer

### DIFF
--- a/src/adapter/etl-adapter-csv/src/Flow/ETL/Adapter/CSV/CSVExtractor.php
+++ b/src/adapter/etl-adapter-csv/src/Flow/ETL/Adapter/CSV/CSVExtractor.php
@@ -75,7 +75,7 @@ final class CSVExtractor implements Extractor, FileExtractor, LimitableExtractor
                     $headersCount = $rowDataCount;
                 }
 
-                $rowData = $rowNormalizer->normalize($rowData, $headersCount);
+                $rowData = $rowNormalizer->normalize($rowData, $rowDataCount, $headersCount);
 
                 $row = \array_combine($headers, $rowData);
 

--- a/src/adapter/etl-adapter-csv/src/Flow/ETL/Adapter/CSV/CSVRowNormalizer.php
+++ b/src/adapter/etl-adapter-csv/src/Flow/ETL/Adapter/CSV/CSVRowNormalizer.php
@@ -17,14 +17,13 @@ final readonly class CSVRowNormalizer
      * - Converts empty strings to null if emptyToNull is enabled.
      *
      * @param array<int, null|string> $rowData
+     * @param int $rowDataCount
      * @param int $headersCount
      *
      * @return array<int, null|string>
      */
-    public function normalize(array $rowData, int $headersCount) : array
+    public function normalize(array $rowData, int $rowDataCount, int $headersCount) : array
     {
-        $rowDataCount = \count($rowData);
-
         if ($rowDataCount < $headersCount) {
             $fillValue = $this->emptyToNull ? null : '';
 

--- a/src/adapter/etl-adapter-csv/tests/Flow/ETL/Adapter/CSV/Tests/Unit/CSVRowNormalizerTest.php
+++ b/src/adapter/etl-adapter-csv/tests/Flow/ETL/Adapter/CSV/Tests/Unit/CSVRowNormalizerTest.php
@@ -13,21 +13,23 @@ final class CSVRowNormalizerTest extends TestCase
     {
         $normalizer = new CSVRowNormalizer(true);
         $rowData = ['value1', '', 'value3', '', 'extraValue'];
+        $rowCount = \count($rowData);
         $headersCount = 4;
 
-        $result = $normalizer->normalize($rowData, $headersCount);
+        $result = $normalizer->normalize($rowData, $rowCount, $headersCount);
 
         self::assertSame(['value1', null, 'value3', null], $result);
-        self::assertCount(4, $result);
+        self::assertCount($headersCount, $result);
     }
 
     public function test_normalize_converts_empty_strings_to_null_when_enabled() : void
     {
         $normalizer = new CSVRowNormalizer(true);
         $rowData = ['value1', '', 'value3', ''];
+        $rowCount = \count($rowData);
         $headersCount = 4;
 
-        $result = $normalizer->normalize($rowData, $headersCount);
+        $result = $normalizer->normalize($rowData, $rowCount, $headersCount);
 
         self::assertSame(['value1', null, 'value3', null], $result);
     }
@@ -36,9 +38,10 @@ final class CSVRowNormalizerTest extends TestCase
     {
         $normalizer = new CSVRowNormalizer(true);
         $rowData = ['value1', '   ', 'value3', "\t"];
+        $rowCount = \count($rowData);
         $headersCount = 4;
 
-        $result = $normalizer->normalize($rowData, $headersCount);
+        $result = $normalizer->normalize($rowData, $rowCount, $headersCount);
 
         self::assertSame(['value1', '   ', 'value3', "\t"], $result);
     }
@@ -47,9 +50,10 @@ final class CSVRowNormalizerTest extends TestCase
     {
         $normalizer = new CSVRowNormalizer(true);
         $rowData = ['string', '', null, '0', 'false'];
+        $rowCount = \count($rowData);
         $headersCount = 5;
 
-        $result = $normalizer->normalize($rowData, $headersCount);
+        $result = $normalizer->normalize($rowData, $rowCount, $headersCount);
 
         self::assertSame(['string', null, null, '0', 'false'], $result);
     }
@@ -58,9 +62,10 @@ final class CSVRowNormalizerTest extends TestCase
     {
         $normalizer = new CSVRowNormalizer(true);
         $rowData = [0 => 'value1', 1 => 'value2', 2 => 'value3', 3 => 'value4'];
+        $rowCount = \count($rowData);
         $headersCount = 2;
 
-        $result = $normalizer->normalize($rowData, $headersCount);
+        $result = $normalizer->normalize($rowData, $rowCount, $headersCount);
 
         self::assertSame([0 => 'value1', 1 => 'value2'], $result);
         self::assertArrayHasKey(0, $result);
@@ -72,9 +77,10 @@ final class CSVRowNormalizerTest extends TestCase
     {
         $normalizer = new CSVRowNormalizer(false);
         $rowData = ['value1', '', 'value3', ''];
+        $rowCount = \count($rowData);
         $headersCount = 4;
 
-        $result = $normalizer->normalize($rowData, $headersCount);
+        $result = $normalizer->normalize($rowData, $rowCount, $headersCount);
 
         self::assertSame(['value1', '', 'value3', ''], $result);
     }
@@ -83,9 +89,10 @@ final class CSVRowNormalizerTest extends TestCase
     {
         $normalizer = new CSVRowNormalizer(true);
         $rowData = ['value1', null, 'value3'];
+        $rowCount = \count($rowData);
         $headersCount = 3;
 
-        $result = $normalizer->normalize($rowData, $headersCount);
+        $result = $normalizer->normalize($rowData, $rowCount, $headersCount);
 
         self::assertSame(['value1', null, 'value3'], $result);
     }
@@ -94,9 +101,10 @@ final class CSVRowNormalizerTest extends TestCase
     {
         $normalizer = new CSVRowNormalizer(false);
         $rowData = ['value1', 'value2'];
+        $rowCount = \count($rowData);
         $headersCount = 4;
 
-        $result = $normalizer->normalize($rowData, $headersCount);
+        $result = $normalizer->normalize($rowData, $rowCount, $headersCount);
 
         self::assertSame(['value1', 'value2', '', ''], $result);
         self::assertCount(4, $result);
@@ -106,9 +114,10 @@ final class CSVRowNormalizerTest extends TestCase
     {
         $normalizer = new CSVRowNormalizer(true);
         $rowData = ['value1', 'value2'];
+        $rowCount = \count($rowData);
         $headersCount = 4;
 
-        $result = $normalizer->normalize($rowData, $headersCount);
+        $result = $normalizer->normalize($rowData, $rowCount, $headersCount);
 
         self::assertSame(['value1', 'value2', null, null], $result);
         self::assertCount(4, $result);
@@ -118,9 +127,10 @@ final class CSVRowNormalizerTest extends TestCase
     {
         $normalizer = new CSVRowNormalizer(true);
         $rowData = ['value1', 'value2', 'value3', 'value4', 'value5'];
+        $rowCount = \count($rowData);
         $headersCount = 3;
 
-        $result = $normalizer->normalize($rowData, $headersCount);
+        $result = $normalizer->normalize($rowData, $rowCount, $headersCount);
 
         self::assertSame(['value1', 'value2', 'value3'], $result);
         self::assertCount(3, $result);
@@ -130,9 +140,10 @@ final class CSVRowNormalizerTest extends TestCase
     {
         $normalizer = new CSVRowNormalizer(true);
         $rowData = ['value1', 'value2', 'value3'];
+        $rowCount = \count($rowData);
         $headersCount = 3;
 
-        $result = $normalizer->normalize($rowData, $headersCount);
+        $result = $normalizer->normalize($rowData, $rowCount, $headersCount);
 
         self::assertSame(['value1', 'value2', 'value3'], $result);
         self::assertCount(3, $result);
@@ -144,7 +155,7 @@ final class CSVRowNormalizerTest extends TestCase
         $rowData = [];
         $headersCount = 3;
 
-        $result = $normalizer->normalize($rowData, $headersCount);
+        $result = $normalizer->normalize($rowData, 0, $headersCount);
 
         self::assertSame([null, null, null], $result);
         self::assertCount(3, $result);
@@ -156,7 +167,7 @@ final class CSVRowNormalizerTest extends TestCase
         $rowData = [];
         $headersCount = 3;
 
-        $result = $normalizer->normalize($rowData, $headersCount);
+        $result = $normalizer->normalize($rowData, 0, $headersCount);
 
         self::assertSame(['', '', ''], $result);
         self::assertCount(3, $result);
@@ -166,9 +177,10 @@ final class CSVRowNormalizerTest extends TestCase
     {
         $normalizer = new CSVRowNormalizer(true);
         $rowData = ['value1', 'value2'];
+        $rowCount = \count($rowData);
         $headersCount = 0;
 
-        $result = $normalizer->normalize($rowData, $headersCount);
+        $result = $normalizer->normalize($rowData, $rowCount, $headersCount);
 
         self::assertSame([], $result);
         self::assertCount(0, $result);


### PR DESCRIPTION
Reason: there is already a count of the size for the row at the beginning of the loop, so there is no point in recalculating it, while it cannot be modified in the middle of the loop.

<!-- 
    Below section will be used to automatically generate changelog, please do not modify HTML code structure
    DO NOT REMOVE that HTML STRUCTURE, INSTEAD ADD YOUR CHANGES INSIDE THE LISTS 
    PULL REQUESTS WITHOUT CHANGELOG CAN'T BE MERGED 
-->
<h2>Change Log</h2>
<hr /> 
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Skip double size counting on csv row normalizer</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>