### PR TITLE
Partitioning should not overwrite schema

### DIFF
--- a/src/core/etl/src/Flow/ETL/Filesystem/FilesystemStreams.php
+++ b/src/core/etl/src/Flow/ETL/Filesystem/FilesystemStreams.php
@@ -16,17 +16,15 @@ final class FilesystemStreams implements \Countable, \IteratorAggregate
 {
     public const FLOW_TMP_FILE_PREFIX = '._flow_php_tmp.';
 
-    private SaveMode $saveMode;
+    private SaveMode $saveMode = SaveMode::ExceptionIfExists;
 
     /**
      * @var array<string, array<string, DestinationStream>>
      */
-    private array $writingStreams;
+    private array $writingStreams = [];
 
     public function __construct(private readonly FilesystemTable $fstab)
     {
-        $this->writingStreams = [];
-        $this->saveMode = SaveMode::ExceptionIfExists;
     }
 
     public function closeStreams(Path $path) : void
@@ -38,14 +36,13 @@ final class FilesystemStreams implements \Countable, \IteratorAggregate
         foreach ($this->writingStreams as $nextBasePath => $nextStreams) {
             if ($path->uri() === $nextBasePath) {
                 foreach ($nextStreams as $fileStream) {
-
                     if ($fileStream->isOpen()) {
                         $fileStream->close();
                     }
 
                     if ($this->saveMode === SaveMode::Overwrite) {
                         if ($fileStream->path()->partitions()->count()) {
-                            $partitionFilesPatter = new Path($fileStream->path()->parentDirectory()->path() . '/*', $fileStream->path()->options());
+                            $partitionFilesPatter = new Path($fileStream->path()->parentDirectory()->uri() . '/*', $fileStream->path()->options());
 
                             foreach ($fs->list($partitionFilesPatter) as $partitionFile) {
                                 if (\str_contains($partitionFile->path->path(), self::FLOW_TMP_FILE_PREFIX)) {

--- a/src/core/etl/tests/Flow/ETL/Tests/Double/FakeNativeLocalFilesystem.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Double/FakeNativeLocalFilesystem.php
@@ -1,0 +1,208 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Tests\Double;
+
+use Flow\Filesystem\{DestinationStream, FileStatus, Filesystem, Path, Protocol, SourceStream};
+use Flow\Filesystem\Exception\{InvalidArgumentException, RuntimeException};
+use Flow\Filesystem\Path\Filter;
+use Flow\Filesystem\Path\Filter\OnlyFiles;
+use Flow\Filesystem\Stream\{NativeLocalDestinationStream, NativeLocalSourceStream};
+use Webmozart\Glob\Glob;
+
+final class FakeNativeLocalFilesystem implements Filesystem
+{
+    public function appendTo(Path $path) : DestinationStream
+    {
+        if ($path->isEqual($this->getSystemTmpDir())) {
+            throw new RuntimeException('Cannot write to system tmp directory');
+        }
+
+        $this->protocol()->validateScheme($path);
+
+        if ($path->isPattern()) {
+            throw new InvalidArgumentException("Pattern paths can't be written: " . $path->uri());
+        }
+
+        if (!$this->status($path->parentDirectory())) {
+            if (!\mkdir($concurrentDirectory = $path->parentDirectory()->path(), recursive: true) && !\is_dir($concurrentDirectory)) {
+                throw new RuntimeException(\sprintf('Directory "%s" was not created', $concurrentDirectory));
+            }
+        }
+
+        return NativeLocalDestinationStream::openAppend($path);
+    }
+
+    public function getSystemTmpDir() : Path
+    {
+        return new Path(\sys_get_temp_dir());
+    }
+
+    public function list(Path $path, Filter $pathFilter = new OnlyFiles()) : \Generator
+    {
+        $this->protocol()->validateScheme($path);
+
+        if (!$path->isPattern()) {
+            if ($pathFilter->accept($status = new FileStatus($path, \is_file($path->path())))) {
+                yield $status;
+            }
+
+            return;
+
+        }
+
+        foreach (Glob::glob($path->path()) as $filePath) {
+            $status = new FileStatus(Path::realpath($filePath, $path->options()), \is_file($filePath));
+
+            if ($pathFilter->accept($status)) {
+                yield $status;
+            }
+        }
+    }
+
+    public function mv(Path $from, Path $to) : bool
+    {
+        $this->protocol()->validateScheme($from);
+        $this->protocol()->validateScheme($to);
+
+        if (\file_exists($to->path())) {
+            $this->rm($to);
+        }
+
+        if (!\rename($from->path(), $to->path())) {
+            return false;
+        }
+
+        return true;
+    }
+
+    public function protocol() : Protocol
+    {
+        return new Protocol('fake');
+    }
+
+    public function readFrom(Path $path) : SourceStream
+    {
+        $this->protocol()->validateScheme($path);
+
+        if ($path->isPattern()) {
+            throw new InvalidArgumentException("Pattern paths can't be open: " . $path->uri());
+        }
+
+        if (!$this->status($path->parentDirectory())) {
+            if (!\mkdir($concurrentDirectory = $path->parentDirectory()->path(), recursive: true) && !\is_dir($concurrentDirectory)) {
+                throw new RuntimeException(\sprintf('Directory "%s" was not created', $concurrentDirectory));
+            }
+        }
+
+        return NativeLocalSourceStream::open($path);
+    }
+
+    public function rm(Path $path) : bool
+    {
+        $this->protocol()->validateScheme($path);
+
+        if (!$path->isPattern()) {
+            if (!\file_exists($path->path())) {
+                return false;
+            }
+
+            if (\is_dir($path->path())) {
+                $this->rmdir($path->path());
+            } else {
+                \unlink($path->path());
+            }
+
+            return true;
+        }
+
+        $deletedCount = 0;
+
+        foreach (Glob::glob($path->path()) as $filePath) {
+            if (\is_dir($filePath)) {
+                $this->rmdir($filePath);
+            } else {
+                \unlink($filePath);
+            }
+
+            $deletedCount++;
+        }
+
+        return (bool) $deletedCount;
+    }
+
+    public function status(Path $path) : ?FileStatus
+    {
+        $this->protocol()->validateScheme($path);
+
+        if (!$path->isPattern() && \file_exists($path->path())) {
+            return new FileStatus(
+                $path,
+                \is_file($path->path())
+            );
+        }
+
+        foreach (Glob::glob($path->path()) as $filePath) {
+            if (\file_exists($filePath)) {
+                return new FileStatus(new Path($filePath, $path->options()), true);
+            }
+        }
+
+        return null;
+    }
+
+    public function writeTo(Path $path) : DestinationStream
+    {
+        if ($path->isEqual($this->getSystemTmpDir())) {
+            throw new RuntimeException('Cannot write to system tmp directory');
+        }
+
+        $this->protocol()->validateScheme($path);
+
+        if ($path->isPattern()) {
+            throw new InvalidArgumentException("Pattern paths can't be written: " . $path->uri());
+        }
+
+        if (!$this->status($path->parentDirectory())) {
+            if (!\mkdir($concurrentDirectory = $path->parentDirectory()->path(), recursive: true) && !\is_dir($concurrentDirectory)) {
+                throw new RuntimeException(\sprintf('Directory "%s" was not created', $concurrentDirectory));
+            }
+        }
+
+        return NativeLocalDestinationStream::openBlank($path);
+    }
+
+    private function rmdir(string $dirPath) : void
+    {
+        if (!\is_dir($dirPath)) {
+            throw new InvalidArgumentException("{$dirPath} must be a directory");
+        }
+
+        if (!\str_ends_with($dirPath, '/')) {
+            $dirPath .= '/';
+        }
+
+        $files = \scandir($dirPath);
+
+        if (!$files) {
+            throw new RuntimeException("Can't read directory: {$dirPath}");
+        }
+
+        foreach ($files as $file) {
+            if (\in_array($file, ['.', '..'], true)) {
+                continue;
+            }
+
+            $filePath = $dirPath . $file;
+
+            if (\is_dir($filePath)) {
+                $this->rmdir($filePath);
+            } else {
+                \unlink($filePath);
+            }
+        }
+
+        \rmdir($dirPath);
+    }
+}

--- a/src/core/etl/tests/Flow/ETL/Tests/Integration/Filesystem/FilesystemStreams/Partitioned/OverwriteModeTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Integration/Filesystem/FilesystemStreams/Partitioned/OverwriteModeTest.php
@@ -6,8 +6,9 @@ namespace Flow\ETL\Tests\Integration\Filesystem\FilesystemStreams\Partitioned;
 
 use function Flow\ETL\DSL\overwrite;
 use Flow\ETL\Filesystem\{FilesystemStreams};
+use Flow\ETL\Tests\Double\FakeNativeLocalFilesystem;
 use Flow\ETL\Tests\Integration\Filesystem\FilesystemStreams\FilesystemStreamsTestCase;
-use Flow\Filesystem\{Partition, Path};
+use Flow\Filesystem\{FilesystemTable, Partition, Path};
 
 final class OverwriteModeTest extends FilesystemStreamsTestCase
 {
@@ -76,6 +77,29 @@ final class OverwriteModeTest extends FilesystemStreamsTestCase
 
         $appendedFile = $streams->writeTo($file, partitions: [new Partition('partition', 'value')]);
         $appendedFile->append('new content');
+        $streams->closeStreams($file);
+        $files = \iterator_to_array($this->fs()->list(new Path($file->parentDirectory()->path() . '/partition=value/*')));
+
+        self::assertCount(1, $files);
+
+        self::assertSame('file.txt', $files[0]->path->basename());
+        self::assertSame('new content', \file_get_contents($files[0]->path->path()));
+    }
+
+    public function test_open_stream_for_non_existing_partition_with_custom_schema() : void
+    {
+        $this->setupFiles([__FUNCTION__ => []]);
+
+        $fs = new FakeNativeLocalFilesystem();
+
+        $file = new Path($fs->protocol()->scheme() . $this->filesDirectory() . DIRECTORY_SEPARATOR . __FUNCTION__ . '/file.txt');
+
+        $streams = new FilesystemStreams(new FilesystemTable($fs));
+        $streams->setSaveMode(overwrite());
+
+        $appendedFile = $streams->writeTo($file, partitions: [new Partition('partition', 'value')]);
+        $appendedFile->append('new content');
+
         $streams->closeStreams($file);
         $files = \iterator_to_array($this->fs()->list(new Path($file->parentDirectory()->path() . '/partition=value/*')));
 


### PR DESCRIPTION
<!-- 
    Please replace #xxx with a GitHub issue id from flow-php/flow repository. For example #1234 
    If there is no item in a roadmap related to this PR, please check our contributing guidelines first. 
-->
Resolves: #1750

Added new (in fact, it's a copy of the existing filesystem stream) filesystem with a custom scheme to confirm that the protocol is lost when partitioning is done.

<!-- 
    Below section will be used to automatically generate changelog, please do not modify HTML code structure
    DO NOT REMOVE that HTML STRUCTURE, INSTEAD ADD YOUR CHANGES INSIDE THE LISTS 
    PULL REQUESTS WITHOUT CHANGELOG CAN'T BE MERGED 
-->
<h2>Change Log</h2>
<hr /> 
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>Partitioning should not overwrite schema</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>