### PR TITLE
OpenAPI Specification Bridge

### DIFF
--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -55,6 +55,10 @@ component_management:
       name: bridge-monolog-http
       paths:
         - src/bridge/monolog/http/**
+    - component_id: bridge-openapi-specification
+      name: bridge-openapi-specification
+      paths:
+        - src/bridge/openapi/specification/**
     - component_id: symfony-http-foundation
       name: symfony-http-foundation
       paths:

--- a/.github/workflows/monorepo-split.yml
+++ b/.github/workflows/monorepo-split.yml
@@ -80,6 +80,8 @@ jobs:
             split_repository: 'filesystem-async-aws-bridge'
           - local_path: 'src/bridge/monolog/http'
             split_repository: 'monolog-http-bridge'
+          - local_path: 'src/bridge/openapi/specification'
+            split_repository: 'openapi-specification-bridge'
           - local_path: 'src/bridge/symfony/http-foundation'
             split_repository: 'symfony-http-foundation-bridge'
 

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -207,6 +207,9 @@ jobs:
       - name: "Test - Bridge - Monolog Http"
         run: "composer test:bridge:monolog-http"
 
+      - name: "Test - Bridge - OpenAPI Specification"
+        run: "composer test:bridge:openapi-specification"
+
       - name: "Test - Bridge - Symfony Http Foundation"
         run: "composer test:bridge:symfony-http-foundation"
 

--- a/composer.json
+++ b/composer.json
@@ -87,6 +87,7 @@
         "flow-php/filesytem-async-aws-bridge": "self.version",
         "flow-php/filesytem-azure-bridge": "self.version",
         "flow-php/monolog-http-bridge": "self.version",
+        "flow-php/openapi-specification-bridge": "self.version",
         "flow-php/parquet": "self.version",
         "flow-php/parquet-viewer": "self.version",
         "flow-php/snappy": "self.version",
@@ -115,6 +116,7 @@
                 "src/bridge/filesystem/async-aws/src/Flow",
                 "src/bridge/filesystem/azure/src/Flow",
                 "src/bridge/monolog/http/src/Flow",
+                "src/bridge/openapi/specification/src/Flow",
                 "src/bridge/symfony/http-foundation/src/Flow",
                 "src/cli/src/Flow",
                 "src/core/etl/src/Flow",
@@ -153,6 +155,11 @@
             "src/bridge/filesystem/azure/src/Flow/Filesystem/Bridge/Azure/DSL/functions.php",
             "src/bridge/monolog/http/src/Flow/Bridge/Monolog/Http/DSL/functions.php",
             "src/bridge/symfony/http-foundation/src/Flow/Bridge/Symfony/HttpFoundation/functions.php",
+            "src/bridge/monolog/http/src/Flow/Bridge/Monolog/Http/DSL/functions.php",
+            "src/bridge/openapi/specification/src/Flow/Bridge/OpenAPI/Specification/DSL/functions.php",
+            "src/bridge/symfony/http-foundation/src/Flow/Bridge/Symfony/HttpFoundation/functions.php",
+            "src/cli/src/Flow/CLI/DSL/functions.php",
+            "src/core/etl/src/Flow/ETL/DSL/functions.php",
             "src/cli/src/Flow/CLI/DSL/functions.php",
             "src/core/etl/src/Flow/ETL/DSL/functions.php",
             "src/functions.php",
@@ -185,6 +192,7 @@
                 "src/bridge/filesystem/async-aws/tests/Flow",
                 "src/bridge/filesystem/azure/tests/Flow",
                 "src/bridge/monolog/http/tests/Flow",
+                "src/bridge/openapi/specification/tests/Flow",
                 "src/bridge/symfony/http-foundation/tests/Flow",
                 "src/cli/tests/Flow",
                 "src/core/etl/tests/Flow",
@@ -241,6 +249,7 @@
             "@test:bridge:filesystem-azure",
             "@test:bridge:filesystem-async-aws",
             "@test:bridge:monolog-http",
+            "@test:bridge:openapi-specification",
             "@test:bridge:symfony-http-foundation",
             "@test:adapter:chartjs",
             "@test:adapter:csv",
@@ -300,6 +309,9 @@
         ],
         "test:bridge:monolog-http": [
             "tools/phpunit/vendor/bin/phpunit --testsuite=bridge-monolog-http-unit --log-junit ./var/phpunit/logs/bridge-monolog-http-unit.junit.xml --coverage-clover=./var/phpunit/coverage/clover/bridge-monolog-http-unit.coverage.xml --coverage-html=./var/phpunit/coverage/html/bridge-monolog-http-unit"
+        ],
+        "test:bridge:openapi-specification": [
+            "tools/phpunit/vendor/bin/phpunit --testsuite=bridge-openapi-specification-unit --log-junit ./var/phpunit/logs/bridge-openapi-specification-unit.junit.xml --coverage-clover=./var/phpunit/coverage/clover/bridge-openapi-specification-unit.coverage.xml --coverage-html=./var/phpunit/coverage/html/bridge-openapi-specification-unit"
         ],
         "test:bridge:symfony-http-foundation": [
             "tools/phpunit/vendor/bin/phpunit --testsuite=bridge-symfony-http-foundation-unit --log-junit ./var/phpunit/logs/bridge-symfony-http-foundation-unit.junit.xml --coverage-clover=./var/phpunit/coverage/clover/bridge-symfony-http-foundation-unit.coverage.xml --coverage-html=./var/phpunit/coverage/html/bridge-symfony-http-foundation-unit",

--- a/composer.json
+++ b/composer.json
@@ -454,8 +454,9 @@
             "./tools/phpdocumentor/vendor/bin/phpdoc --config=./phpdoc/adapter.xml.xml",
             "./tools/phpdocumentor/vendor/bin/phpdoc --config=./phpdoc/bridge.filesystem.async-aws.xml",
             "./tools/phpdocumentor/vendor/bin/phpdoc --config=./phpdoc/bridge.filesystem.azure.xml",
-            "./tools/phpdocumentor/vendor/bin/phpdoc --config=./phpdoc/bridge.symfony.http-foundation.xml",
-            "./tools/phpdocumentor/vendor/bin/phpdoc --config=./phpdoc/bridge.monolog.http.xml"
+            "./tools/phpdocumentor/vendor/bin/phpdoc --config=./phpdoc/bridge.monolog.http.xml",
+            "./tools/phpdocumentor/vendor/bin/phpdoc --config=./phpdoc/bridge.openapi.specification.xml",
+            "./tools/phpdocumentor/vendor/bin/phpdoc --config=./phpdoc/bridge.symfony.http-foundation.xml"
         ],
         "build:parquet:thrift": [
             "grep -q 'namespace php Flow.Parquet.Thrift' src/lib/parquet/src/Flow/Parquet/Resources/Thrift/parquet.thrift || { echo \"Flow php namespace not found in thrift definition!\"; exit 1; }\n",

--- a/documentation/components/bridges/openapi-specification-bridge.md
+++ b/documentation/components/bridges/openapi-specification-bridge.md
@@ -1,0 +1,172 @@
+# OpenAPI Specification Bridge
+
+- [⬅️️ Back](../../introduction.md)
+- [📚API Reference](/documentation/api/bridge/openapi/specification)
+- [📁Files](/documentation/api/bridge/openapi/specification/indices/files.html)
+
+This package provides bidirectional conversion between Flow PHP schemas and OpenAPI 3.0 specifications. 
+It enables you to generate OpenAPI documentation from Flow schemas and vice versa, facilitating API-first development and documentation workflows.
+
+## Installation
+
+```
+composer require flow-php/openapi-specification-bridge:~--FLOW_PHP_VERSION--
+```
+
+## Usage
+
+This bridge allows you to convert Flow PHP schemas to OpenAPI specification format and vice versa.
+
+### Converting Flow Schema to OpenAPI
+
+```php
+<?php
+
+use function Flow\ETL\DSL\{schema, int_schema, str_schema, bool_schema};
+use function Flow\Bridge\OpenAPI\Specification\DSL\to_openapi_spec;
+use Flow\ETL\Schema\Metadata;
+
+$userSchema = schema(
+    int_schema('id', false, Metadata::empty()
+        ->add('description', 'Unique user identifier')
+        ->add('example', 123)
+    ),
+    str_schema('name', true, Metadata::empty()
+        ->add('description', 'User full name')
+        ->add('example', 'John Doe')
+    ),
+    bool_schema('active', false, Metadata::empty()
+        ->add('description', 'Account status')
+    )
+);
+
+$openApiSpec = to_openapi_spec($userSchema);
+
+// Output:
+// [
+//     'type' => 'object',
+//     'properties' => [
+//         'id' => [
+//             'type' => 'integer', 
+//             'nullable' => false,
+//             'description' => 'Unique user identifier',
+//             'example' => 123
+//         ],
+//         'name' => [
+//             'type' => 'string', 
+//             'nullable' => true,
+//             'description' => 'User full name', 
+//             'example' => 'John Doe'
+//         ],
+//         'active' => [
+//             'type' => 'boolean', 
+//             'nullable' => false,
+//             'description' => 'Account status'
+//         ]
+//     ]
+// ]
+```
+
+### Converting OpenAPI to Flow Schema
+
+```php
+<?php
+
+use function Flow\Bridge\OpenAPI\Specification\DSL\from_openapi_spec;
+
+$openApiSpec = [
+    'type' => 'object',
+    'properties' => [
+        'id' => ['type' => 'integer', 'nullable' => false],
+        'email' => [
+            'type' => 'string', 
+            'format' => 'email', 
+            'nullable' => false,
+            'description' => 'User email address'
+        ],
+        'profile' => [
+            'type' => 'object',
+            'properties' => [
+                'name' => ['type' => 'string', 'nullable' => false],
+                'bio' => ['type' => 'string', 'nullable' => true]
+            ],
+            'nullable' => false
+        ],
+        'tags' => [
+            'type' => 'array',
+            'items' => ['type' => 'string'],
+            'nullable' => true
+        ]
+    ]
+];
+
+$flowSchema = from_openapi_spec($openApiSpec);
+
+// Now you can use $flowSchema in Flow ETL pipelines
+```
+
+
+### Usage Example
+
+```php
+<?php
+
+use function Flow\ETL\DSL\{schema, int_schema, str_schema, list_schema, structure_schema};
+use function Flow\Types\DSL\{type_list, type_string, type_structure};
+use function Flow\Bridge\OpenAPI\Specification\DSL\to_openapi_spec;
+
+// Define your data schema
+$productSchema = schema(
+    int_schema('id', false),
+    str_schema('name', false),
+    str_schema('description', true),
+    structure_schema('category', type_structure([
+        'id' => type_string(),
+        'name' => type_string()
+    ]), false),
+    list_schema('tags', type_list(type_string()), true)
+);
+
+// Generate OpenAPI specification
+$apiSpec = to_openapi_spec($productSchema);
+
+// Use in your API documentation
+$fullApiSpec = [
+    'openapi' => '3.0.0',
+    'info' => [
+        'title' => 'Product API',
+        'version' => '1.0.0'
+    ],
+    'paths' => [
+        '/products' => [
+            'get' => [
+                'summary' => 'List products',
+                'responses' => [
+                    '200' => [
+                        'description' => 'A list of products',
+                        'content' => [
+                            'application/json' => [
+                                'schema' => [
+                                    'type' => 'array',
+                                    'items' => $apiSpec
+                                ]
+                            ]
+                        ]
+                    ]
+                ]
+            ]
+        ]
+    ]
+];
+```
+
+## Supported OpenAPI Features
+
+### ✅ Supported
+- Basic types (boolean, integer, number, string)
+- String formats (date, date-time, time, uuid, json, xml)
+- Arrays with typed items
+- Objects with properties and additionalProperties
+- Nullable types
+- Descriptions and examples
+- Nested structures

--- a/documentation/components/bridges/openapi-specification-bridge.md
+++ b/documentation/components/bridges/openapi-specification-bridge.md
@@ -23,7 +23,7 @@ This bridge allows you to convert Flow PHP schemas to OpenAPI specification form
 <?php
 
 use function Flow\ETL\DSL\{schema, int_schema, str_schema, bool_schema};
-use function Flow\Bridge\OpenAPI\Specification\DSL\to_openapi_spec;
+use function Flow\Bridge\OpenAPI\Specification\DSL\schema_to_openapi_specification;
 use Flow\ETL\Schema\Metadata;
 
 $userSchema = schema(
@@ -40,7 +40,7 @@ $userSchema = schema(
     )
 );
 
-$openApiSpec = to_openapi_spec($userSchema);
+$openApiSpec = schema_to_openapi_specification($userSchema);
 
 // Output:
 // [
@@ -72,7 +72,7 @@ $openApiSpec = to_openapi_spec($userSchema);
 ```php
 <?php
 
-use function Flow\Bridge\OpenAPI\Specification\DSL\from_openapi_spec;
+use function Flow\Bridge\OpenAPI\Specification\DSL\schema_from_openapi_specification;
 
 $openApiSpec = [
     'type' => 'object',
@@ -100,7 +100,7 @@ $openApiSpec = [
     ]
 ];
 
-$flowSchema = from_openapi_spec($openApiSpec);
+$flowSchema = schema_from_openapi_specification($openApiSpec);
 
 // Now you can use $flowSchema in Flow ETL pipelines
 ```
@@ -113,7 +113,7 @@ $flowSchema = from_openapi_spec($openApiSpec);
 
 use function Flow\ETL\DSL\{schema, int_schema, str_schema, list_schema, structure_schema};
 use function Flow\Types\DSL\{type_list, type_string, type_structure};
-use function Flow\Bridge\OpenAPI\Specification\DSL\to_openapi_spec;
+use function Flow\Bridge\OpenAPI\Specification\DSL\schema_to_openapi_specification;
 
 // Define your data schema
 $productSchema = schema(
@@ -127,8 +127,7 @@ $productSchema = schema(
     list_schema('tags', type_list(type_string()), true)
 );
 
-// Generate OpenAPI specification
-$apiSpec = to_openapi_spec($productSchema);
+$apiSpec = schema_to_openapi_specification($productSchema);
 
 // Use in your API documentation
 $fullApiSpec = [

--- a/phpdoc/bridge.openapi.specification.xml
+++ b/phpdoc/bridge.openapi.specification.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<phpdocumentor
+        configVersion="3"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="https://www.phpdoc.org"
+>
+    <title>Flow PHP</title>
+    <paths>
+        <output>./../web/landing/build/documentation/api/bridge/openapi/specification</output>
+        <cache>./../var/phpdocumentor/cache/bridge/openapi/specification</cache>
+    </paths>
+    <version number="1.x">
+        <api format="php">
+            <source dsn="./../">
+                <path>src/bridge/openapi/specification/src</path>
+            </source>
+            <output>openapi-specification</output>
+            <default-package-name>OpenAPI Specification</default-package-name>
+            <visibility>public</visibility>
+            <include-source>false</include-source>
+        </api>
+    </version>
+    <setting name="template.color" value="orange"/>
+</phpdocumentor>

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -24,6 +24,7 @@ parameters:
         - src/bridge/filesystem/azure/src
         - src/bridge/filesystem/async-aws/src
         - src/bridge/monolog/http/src
+        - src/bridge/openapi/specification/src
         - src/bridge/symfony/http-foundation/src
         - src/lib/array-dot/src
         - src/lib/azure-sdk/src
@@ -53,6 +54,7 @@ parameters:
         - src/bridge/filesystem/async-aws/tests
         - src/bridge/filesystem/azure/tests
         - src/bridge/monolog/http/tests
+        - src/bridge/openapi/specification/tests
         - src/bridge/symfony/http-foundation/tests
 
     excludePaths:

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -90,6 +90,9 @@
     <testsuite name="bridge-monolog-http-unit">
       <directory>src/bridge/monolog/http/tests/Flow/Bridge/Monolog/Http/Tests/Unit</directory>
     </testsuite>
+    <testsuite name="bridge-openapi-specification-unit">
+      <directory>src/bridge/openapi/specification/tests/Flow/Bridge/OpenAPI/Specification/Tests/Unit</directory>
+    </testsuite>
     <testsuite name="bridge-symfony-http-foundation-unit">
       <directory>src/bridge/symfony/http-foundation/tests/Flow/Bridge/Symfony/HttpFoundation/Tests/Unit</directory>
     </testsuite>

--- a/src/bridge/openapi/specification/.github/workflows/readonly.yaml
+++ b/src/bridge/openapi/specification/.github/workflows/readonly.yaml
@@ -1,0 +1,17 @@
+name: Readonly
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: superbrothers/close-pull-request@v3
+        with:
+          comment: |
+            Hi, thank you for your contribution.
+            Unfortunately, this repository is read-only. It's a split from our main monorepo repository.
+            In order to proceed with this PR please open it against https://github.com/flow-php/flow repository.
+            Thank you.

--- a/src/bridge/openapi/specification/CONTRIBUTING.md
+++ b/src/bridge/openapi/specification/CONTRIBUTING.md
@@ -1,0 +1,6 @@
+## Contributing
+
+This repo is **READ ONLY**, in order to contribute to Flow PHP project, please
+open PR against [flow](https://github.com/flow-php/flow) monorepo.
+
+Changes merged to monorepo are automatically propagated into sub repositories.

--- a/src/bridge/openapi/specification/LICENSE
+++ b/src/bridge/openapi/specification/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2020-present Flow PHP
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/bridge/openapi/specification/README.md
+++ b/src/bridge/openapi/specification/README.md
@@ -1,0 +1,12 @@
+# OpenAPI Specification Bridge
+
+This package provides bidirectional conversion between Flow PHP schemas and OpenAPI 3.0 specifications. 
+It enables you to generate OpenAPI documentation from Flow schemas and vice versa, facilitating API-first development and documentation workflows.
+
+> [!IMPORTANT]  
+> This repository is a subtree split from our monorepo. If you'd like to contribute, please visit our main monorepo [flow-php/flow](https://github.com/flow-php/flow).
+
+- 📜 [Documentation](https://flow-php.com/documentation/components/bridges/openapi-specification-bridge/)
+- ➡️ [Installation](https://flow-php.com/documentation/installation/)
+- 🛠️ [Contributing](https://flow-php.com/documentation/contributing/)
+- 🚧 [Upgrading](https://flow-php.com/documentation/upgrading/)

--- a/src/bridge/openapi/specification/composer.json
+++ b/src/bridge/openapi/specification/composer.json
@@ -1,0 +1,37 @@
+{
+    "name": "flow-php/openapi-specification-bridge",
+    "type": "library",
+    "description": "Flow PHP - OpenAPI Specification bridge",
+    "keywords": [
+        "openapi",
+        "specification",
+        "bridge",
+        "api",
+        "schema"
+    ],
+    "require": {
+        "php": "~8.2.0 || ~8.3.0 || ~8.4.0"
+    },
+    "config": {
+        "optimize-autoloader": true,
+        "sort-packages": true
+    },
+    "license": "MIT",
+    "autoload": {
+        "psr-4": {
+            "Flow\\": [
+                "src/Flow"
+            ]
+        },
+        "files": [
+            "src/Flow/Bridge/OpenAPI/Specification/DSL/functions.php"
+        ]
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Flow\\": "tests/Flow"
+        }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
+}

--- a/src/bridge/openapi/specification/src/Flow/Bridge/OpenAPI/Specification/DSL/functions.php
+++ b/src/bridge/openapi/specification/src/Flow/Bridge/OpenAPI/Specification/DSL/functions.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\Bridge\OpenAPI\Specification\DSL;
+
+use Flow\Bridge\OpenAPI\Specification\OpenAPIConverter;
+use Flow\ETL\Schema;
+
+/**
+ * Convert Flow Schema to OpenAPI specification format.
+ *
+ * @return array<string, mixed>
+ */
+function to_openapi_spec(Schema $schema) : array
+{
+    return (new OpenAPIConverter())->toOpenAPI($schema);
+}
+
+/**
+ * Convert OpenAPI specification to Flow Schema.
+ *
+ * @param array<string, mixed> $openApiSpec
+ */
+function from_openapi_spec(array $openApiSpec) : Schema
+{
+    return (new OpenAPIConverter())->fromOpenAPI($openApiSpec);
+}

--- a/src/bridge/openapi/specification/src/Flow/Bridge/OpenAPI/Specification/DSL/functions.php
+++ b/src/bridge/openapi/specification/src/Flow/Bridge/OpenAPI/Specification/DSL/functions.php
@@ -12,7 +12,7 @@ use Flow\ETL\Schema;
  *
  * @return array<string, mixed>
  */
-function to_openapi_spec(Schema $schema) : array
+function schema_to_openapi_specification(Schema $schema) : array
 {
     return (new OpenAPIConverter())->toOpenAPI($schema);
 }
@@ -22,7 +22,7 @@ function to_openapi_spec(Schema $schema) : array
  *
  * @param array<string, mixed> $openApiSpec
  */
-function from_openapi_spec(array $openApiSpec) : Schema
+function schema_from_openapi_specification(array $openApiSpec) : Schema
 {
     return (new OpenAPIConverter())->fromOpenAPI($openApiSpec);
 }

--- a/src/bridge/openapi/specification/src/Flow/Bridge/OpenAPI/Specification/Exception/Exception.php
+++ b/src/bridge/openapi/specification/src/Flow/Bridge/OpenAPI/Specification/Exception/Exception.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\Bridge\OpenAPI\Specification\Exception;
+
+class Exception extends \Exception
+{
+}

--- a/src/bridge/openapi/specification/src/Flow/Bridge/OpenAPI/Specification/Exception/InvalidArgumentException.php
+++ b/src/bridge/openapi/specification/src/Flow/Bridge/OpenAPI/Specification/Exception/InvalidArgumentException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\Bridge\OpenAPI\Specification\Exception;
+
+class InvalidArgumentException extends Exception
+{
+}

--- a/src/bridge/openapi/specification/src/Flow/Bridge/OpenAPI/Specification/Exception/RuntimeException.php
+++ b/src/bridge/openapi/specification/src/Flow/Bridge/OpenAPI/Specification/Exception/RuntimeException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\Bridge\OpenAPI\Specification\Exception;
+
+class RuntimeException extends Exception
+{
+}

--- a/src/bridge/openapi/specification/src/Flow/Bridge/OpenAPI/Specification/OpenAPIConverter.php
+++ b/src/bridge/openapi/specification/src/Flow/Bridge/OpenAPI/Specification/OpenAPIConverter.php
@@ -1,0 +1,404 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\Bridge\OpenAPI\Specification;
+
+use function Flow\Types\DSL\{type_boolean, type_date, type_datetime, type_float, type_integer, type_json, type_list, type_map, type_string, type_structure, type_time, type_uuid, type_xml};
+use Flow\Bridge\OpenAPI\Specification\Exception\{InvalidArgumentException, RuntimeException};
+use Flow\ETL\Schema;
+use Flow\ETL\Schema\{Definition, Metadata};
+use Flow\Types\Type;
+use Flow\Types\Type\Logical\{DateTimeType, DateType, JsonType, ListType, MapType, StructureType, TimeType, UuidType, XMLElementType, XMLType};
+use Flow\Types\Type\Native\{ArrayType, BooleanType, EnumType, FloatType, IntegerType, StringType};
+
+/**
+ * Bidirectional converter between Flow PHP schemas and OpenAPI 3.0 specifications.
+ *
+ * This converter enables you to:
+ * - Generate OpenAPI documentation from Flow schemas
+ * - Parse OpenAPI specifications to create Flow schemas
+ * - Preserve metadata (descriptions, examples) during conversion
+ * - Support all common data types and structures
+ *
+ * @example Basic Flow to OpenAPI conversion
+ * ```php
+ * $schema = schema(
+ *     int_schema('id', false),
+ *     str_schema('name', true)
+ * );
+ * $openApi = $converter->toOpenAPI($schema);
+ * ```
+ * @example Basic OpenAPI to Flow conversion
+ * ```php
+ * $openApiSpec = [
+ *     'type' => 'object',
+ *     'properties' => [
+ *         'id' => ['type' => 'integer', 'nullable' => false],
+ *         'name' => ['type' => 'string', 'nullable' => true]
+ *     ]
+ * ];
+ * $schema = $converter->fromOpenAPI($openApiSpec);
+ * ```
+ */
+final class OpenAPIConverter
+{
+    /**
+     * @param array<string, mixed> $openApiSpec OpenAPI object specification with 'type' and 'properties'
+     *
+     * @throws InvalidArgumentException When the specification is invalid or unsupported
+     */
+    public function fromOpenAPI(array $openApiSpec) : Schema
+    {
+        if (!isset($openApiSpec['type']) || $openApiSpec['type'] !== 'object') {
+            throw new InvalidArgumentException('OpenAPI specification must have type "object"');
+        }
+
+        if (!isset($openApiSpec['properties']) || !\is_array($openApiSpec['properties'])) {
+            throw new InvalidArgumentException('OpenAPI specification must have properties array');
+        }
+
+        $definitions = [];
+
+        foreach ($openApiSpec['properties'] as $propertyName => $propertySpec) {
+            if (!\is_string($propertyName)) {
+                throw new InvalidArgumentException('Property name must be a string');
+            }
+
+            if (!\is_array($propertySpec)) {
+                throw new InvalidArgumentException("Property '{$propertyName}' specification must be an array");
+            }
+
+            /** @var array<string, mixed> $propertySpec */
+            $definitions[] = $this->convertOpenAPIPropertyToDefinition($propertyName, $propertySpec);
+        }
+
+        return new Schema(...$definitions);
+    }
+
+    /**
+     * @param Schema $schema Flow schema containing field definitions
+     *
+     * @return array<string, mixed> OpenAPI object specification with 'type' and 'properties'
+     */
+    public function toOpenAPI(Schema $schema) : array
+    {
+        $properties = [];
+
+        foreach ($schema->definitions() as $definition) {
+            $properties[$definition->entry()->name()] = $this->convertDefinitionToOpenAPI($definition);
+        }
+
+        return [
+            'type' => 'object',
+            'properties' => $properties,
+        ];
+    }
+
+    /**
+     * @param Type<mixed> $type
+     *
+     * @return array<string, mixed>
+     */
+    private function convertArrayToOpenAPI(Type $type) : array
+    {
+        return [
+            'type' => 'array',
+            'items' => ['type' => 'string'],
+        ];
+    }
+
+    /**
+     * Convert a single Flow Schema Definition to OpenAPI property format.
+     *
+     * @param Definition<mixed> $definition
+     *
+     * @return array<string, mixed>
+     */
+    private function convertDefinitionToOpenAPI(Definition $definition) : array
+    {
+        $property = $this->convertTypeToOpenAPI($definition->type());
+        $property['nullable'] = $definition->isNullable();
+
+        if ($definition->metadata()->has('description')) {
+            $property['description'] = $definition->metadata()->get('description');
+        }
+
+        if ($definition->metadata()->has('example')) {
+            $property['example'] = $definition->metadata()->get('example');
+        }
+
+        return $property;
+    }
+
+    /**
+     * @param Type<mixed> $type
+     *
+     * @return array<string, mixed>
+     */
+    private function convertEnumToOpenAPI(Type $type) : array
+    {
+        if (!$type instanceof EnumType) {
+            return ['type' => 'string'];
+        }
+
+        $enumClass = $type->class;
+        $values = [];
+
+        if (\enum_exists($enumClass)) {
+            $values = \array_map(
+                static fn (\UnitEnum $case) => $case instanceof \BackedEnum ? $case->value : $case->name,
+                $enumClass::cases()
+            );
+        }
+
+        return [
+            'type' => 'string',
+            'enum' => $values,
+        ];
+    }
+
+    /**
+     * @param Type<mixed> $type
+     *
+     * @return array<string, mixed>
+     */
+    private function convertListToOpenAPI(Type $type) : array
+    {
+        if (!$type instanceof ListType) {
+            return ['type' => 'array', 'items' => ['type' => 'string']];
+        }
+
+        return [
+            'type' => 'array',
+            'items' => $this->convertTypeToOpenAPI($type->element()),
+        ];
+    }
+
+    /**
+     * @param Type<mixed> $type
+     *
+     * @return array<string, mixed>
+     */
+    private function convertMapToOpenAPI(Type $type) : array
+    {
+        if (!$type instanceof MapType) {
+            return ['type' => 'object'];
+        }
+
+        return [
+            'type' => 'object',
+            'additionalProperties' => $this->convertTypeToOpenAPI($type->value()),
+        ];
+    }
+
+    /**
+     * Convert OpenAPI array type to Flow ListType.
+     *
+     * @param array<string, mixed> $typeSpec
+     *
+     * @return Type<mixed>
+     */
+    private function convertOpenAPIArrayToFlowType(array $typeSpec) : Type
+    {
+        if (!isset($typeSpec['items'])) {
+            return type_list(type_string());
+        }
+
+        if (!\is_array($typeSpec['items'])) {
+            throw new InvalidArgumentException('OpenAPI array items must be an array specification');
+        }
+
+        /** @var array<string, mixed> $items */
+        $items = $typeSpec['items'];
+        $itemType = $this->convertOpenAPITypeToFlowType($items);
+
+        return type_list($itemType);
+    }
+
+    /**
+     * Convert OpenAPI object type to Flow StructureType or MapType.
+     *
+     * @param array<string, mixed> $typeSpec
+     *
+     * @return Type<mixed>
+     */
+    private function convertOpenAPIObjectToFlowType(array $typeSpec) : Type
+    {
+        // If it has additionalProperties, it's a map
+        if (isset($typeSpec['additionalProperties'])) {
+            if (!\is_array($typeSpec['additionalProperties'])) {
+                throw new InvalidArgumentException('OpenAPI additionalProperties must be an array specification');
+            }
+
+            /** @var array<string, mixed> $additionalProperties */
+            $additionalProperties = $typeSpec['additionalProperties'];
+            $valueType = $this->convertOpenAPITypeToFlowType($additionalProperties);
+
+            return type_map(type_string(), $valueType);
+        }
+
+        // If it has properties, it's a structure
+        if (isset($typeSpec['properties']) && \is_array($typeSpec['properties'])) {
+            $elements = [];
+            $optionalElements = [];
+
+            foreach ($typeSpec['properties'] as $propName => $propSpec) {
+                if (!\is_array($propSpec)) {
+                    throw new InvalidArgumentException("Property '{$propName}' specification must be an array");
+                }
+
+                /** @var array<string, mixed> $propSpec */
+                $propType = $this->convertOpenAPITypeToFlowType($propSpec);
+                $isNullable = \is_bool($propSpec['nullable'] ?? false) ? $propSpec['nullable'] : false;
+
+                if ($isNullable) {
+                    $optionalElements[$propName] = $propType;
+                } else {
+                    $elements[$propName] = $propType;
+                }
+            }
+
+            return type_structure($elements, $optionalElements);
+        }
+
+        // Default to empty map
+        return type_map(type_string(), type_string());
+    }
+
+    /**
+     * Convert OpenAPI property specification to Flow Schema Definition.
+     *
+     * @param array<string, mixed> $propertySpec
+     *
+     * @return Definition<mixed>
+     */
+    private function convertOpenAPIPropertyToDefinition(string $propertyName, array $propertySpec) : Definition
+    {
+        if (!isset($propertySpec['type'])) {
+            throw new InvalidArgumentException("Property '{$propertyName}' must have a type");
+        }
+
+        $nullable = \is_bool($propertySpec['nullable'] ?? false) ? ($propertySpec['nullable'] ?? false) : false;
+        $metadata = Metadata::empty();
+
+        if (isset($propertySpec['description']) && \is_string($propertySpec['description'])) {
+            $metadata = $metadata->add('description', $propertySpec['description']);
+        }
+
+        if (isset($propertySpec['example']) && (\is_string($propertySpec['example']) || \is_int($propertySpec['example']) || \is_float($propertySpec['example']) || \is_bool($propertySpec['example']) || \is_array($propertySpec['example']))) {
+            $metadata = $metadata->add('example', $propertySpec['example']);
+        }
+
+        $type = $this->convertOpenAPITypeToFlowType($propertySpec);
+
+        return new Definition($propertyName, $type, $nullable, $metadata);
+    }
+
+    /**
+     * Convert OpenAPI string type to Flow Type based on format.
+     *
+     * @param array<string, mixed> $typeSpec
+     *
+     * @return Type<mixed>
+     */
+    private function convertOpenAPIStringToFlowType(array $typeSpec) : Type
+    {
+        $format = $typeSpec['format'] ?? null;
+
+        return match ($format) {
+            'date' => type_date(),
+            'date-time' => type_datetime(),
+            'time' => type_time(),
+            'uuid' => type_uuid(),
+            'json' => type_json(),
+            'xml' => type_xml(),
+            default => type_string(),
+        };
+    }
+
+    /**
+     * Convert OpenAPI type specification to Flow Type.
+     *
+     * @param array<string, mixed> $typeSpec
+     *
+     * @return Type<mixed>
+     */
+    private function convertOpenAPITypeToFlowType(array $typeSpec) : Type
+    {
+        if (!isset($typeSpec['type']) || !\is_string($typeSpec['type'])) {
+            throw new InvalidArgumentException('OpenAPI type specification must have a string type');
+        }
+
+        $openApiType = $typeSpec['type'];
+
+        return match ($openApiType) {
+            'boolean' => type_boolean(),
+            'integer' => type_integer(),
+            'number' => type_float(),
+            'string' => $this->convertOpenAPIStringToFlowType($typeSpec),
+            'array' => $this->convertOpenAPIArrayToFlowType($typeSpec),
+            'object' => $this->convertOpenAPIObjectToFlowType($typeSpec),
+            default => throw new InvalidArgumentException("Unsupported OpenAPI type: {$openApiType}"),
+        };
+    }
+
+    /**
+     * @param Type<mixed> $type
+     *
+     * @return array<string, mixed>
+     */
+    private function convertStructureToOpenAPI(Type $type) : array
+    {
+        if (!$type instanceof StructureType) {
+            return ['type' => 'object'];
+        }
+
+        $properties = [];
+
+        foreach ($type->elements() as $name => $elementType) {
+            $properties[$name] = $this->convertTypeToOpenAPI($elementType);
+            $properties[$name]['nullable'] = false;
+        }
+
+        foreach ($type->optionalElements() as $name => $elementType) {
+            $properties[$name] = $this->convertTypeToOpenAPI($elementType);
+            $properties[$name]['nullable'] = true;
+        }
+
+        return [
+            'type' => 'object',
+            'properties' => $properties,
+        ];
+    }
+
+    /**
+     * Convert Flow Type to OpenAPI type format.
+     *
+     * @param Type<mixed> $type
+     *
+     * @return array<string, mixed>
+     */
+    private function convertTypeToOpenAPI(Type $type) : array
+    {
+        return match ($type::class) {
+            BooleanType::class => ['type' => 'boolean'],
+            IntegerType::class => ['type' => 'integer'],
+            FloatType::class => ['type' => 'number'],
+            StringType::class => ['type' => 'string'],
+            DateType::class => ['type' => 'string', 'format' => 'date'],
+            DateTimeType::class => ['type' => 'string', 'format' => 'date-time'],
+            TimeType::class => ['type' => 'string', 'format' => 'time'],
+            UuidType::class => ['type' => 'string', 'format' => 'uuid'],
+            JsonType::class => ['type' => 'string', 'format' => 'json'],
+            XMLType::class => ['type' => 'string', 'format' => 'xml'],
+            XMLElementType::class => ['type' => 'string', 'format' => 'xml'],
+            EnumType::class => $this->convertEnumToOpenAPI($type),
+            ArrayType::class => $this->convertArrayToOpenAPI($type),
+            ListType::class => $this->convertListToOpenAPI($type),
+            MapType::class => $this->convertMapToOpenAPI($type),
+            StructureType::class => $this->convertStructureToOpenAPI($type),
+            default => throw new RuntimeException('Unsupported type: ' . $type::class),
+        };
+    }
+}

--- a/src/bridge/openapi/specification/tests/Flow/Bridge/OpenAPI/Specification/Tests/Unit/FlowToOpenAPIConverterTest.php
+++ b/src/bridge/openapi/specification/tests/Flow/Bridge/OpenAPI/Specification/Tests/Unit/FlowToOpenAPIConverterTest.php
@@ -1,0 +1,865 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\Bridge\OpenAPI\Specification\Tests\Unit;
+
+use function Flow\Bridge\OpenAPI\Specification\DSL\to_openapi_spec;
+use function Flow\ETL\DSL\{bool_schema, date_schema, datetime_schema, enum_schema, float_schema, int_schema, json_schema, list_schema, map_schema, schema, str_schema, structure_schema, time_schema, uuid_schema, xml_element_schema, xml_schema};
+use function Flow\Types\DSL\{type_array, type_callable, type_integer, type_list, type_map, type_string, type_structure};
+use Flow\Bridge\OpenAPI\Specification\OpenAPIConverter;
+use Flow\ETL\Schema\{Definition, Metadata};
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class FlowToOpenAPIConverterTest extends TestCase
+{
+    public static function basic_types_provider() : \Generator
+    {
+        yield 'boolean non-nullable' => [
+            bool_schema('active', false),
+            ['type' => 'boolean', 'nullable' => false],
+        ];
+
+        yield 'boolean nullable' => [
+            bool_schema('active', true),
+            ['type' => 'boolean', 'nullable' => true],
+        ];
+
+        yield 'integer non-nullable' => [
+            int_schema('id', false),
+            ['type' => 'integer', 'nullable' => false],
+        ];
+
+        yield 'integer nullable' => [
+            int_schema('id', true),
+            ['type' => 'integer', 'nullable' => true],
+        ];
+
+        yield 'float non-nullable' => [
+            float_schema('price', false),
+            ['type' => 'number', 'nullable' => false],
+        ];
+
+        yield 'float nullable' => [
+            float_schema('price', true),
+            ['type' => 'number', 'nullable' => true],
+        ];
+
+        yield 'string non-nullable' => [
+            str_schema('name', false),
+            ['type' => 'string', 'nullable' => false],
+        ];
+
+        yield 'string nullable' => [
+            str_schema('name', true),
+            ['type' => 'string', 'nullable' => true],
+        ];
+    }
+
+    public static function special_types_provider() : \Generator
+    {
+        yield 'date non-nullable' => [
+            date_schema('birth_date', false),
+            ['type' => 'string', 'format' => 'date', 'nullable' => false],
+        ];
+
+        yield 'date nullable' => [
+            date_schema('birth_date', true),
+            ['type' => 'string', 'format' => 'date', 'nullable' => true],
+        ];
+
+        yield 'datetime non-nullable' => [
+            datetime_schema('created_at', false),
+            ['type' => 'string', 'format' => 'date-time', 'nullable' => false],
+        ];
+
+        yield 'datetime nullable' => [
+            datetime_schema('created_at', true),
+            ['type' => 'string', 'format' => 'date-time', 'nullable' => true],
+        ];
+
+        yield 'time non-nullable' => [
+            time_schema('duration', false),
+            ['type' => 'string', 'format' => 'time', 'nullable' => false],
+        ];
+
+        yield 'time nullable' => [
+            time_schema('duration', true),
+            ['type' => 'string', 'format' => 'time', 'nullable' => true],
+        ];
+
+        yield 'uuid non-nullable' => [
+            uuid_schema('uuid', false),
+            ['type' => 'string', 'format' => 'uuid', 'nullable' => false],
+        ];
+
+        yield 'uuid nullable' => [
+            uuid_schema('uuid', true),
+            ['type' => 'string', 'format' => 'uuid', 'nullable' => true],
+        ];
+
+        yield 'json non-nullable' => [
+            json_schema('data', false),
+            ['type' => 'string', 'format' => 'json', 'nullable' => false],
+        ];
+
+        yield 'json nullable' => [
+            json_schema('data', true),
+            ['type' => 'string', 'format' => 'json', 'nullable' => true],
+        ];
+
+        yield 'xml non-nullable' => [
+            xml_schema('xml', false),
+            ['type' => 'string', 'format' => 'xml', 'nullable' => false],
+        ];
+
+        yield 'xml nullable' => [
+            xml_schema('xml', true),
+            ['type' => 'string', 'format' => 'xml', 'nullable' => true],
+        ];
+
+        yield 'xml_element non-nullable' => [
+            xml_element_schema('xml_element', false),
+            ['type' => 'string', 'format' => 'xml', 'nullable' => false],
+        ];
+
+        yield 'xml_element nullable' => [
+            xml_element_schema('xml_element', true),
+            ['type' => 'string', 'format' => 'xml', 'nullable' => true],
+        ];
+    }
+
+    public function test_to_open_api_enum_edge_cases() : void
+    {
+        $converter = new OpenAPIConverter();
+        $definition = enum_schema('single_enum', FlowTestSingleEnum::class, false);
+        $schema = schema($definition);
+
+        $result = $converter->toOpenAPI($schema);
+
+        self::assertSame([
+            'type' => 'object',
+            'properties' => [
+                'single_enum' => [
+                    'type' => 'string',
+                    'enum' => ['ONLY'],
+                    'nullable' => false,
+                ],
+            ],
+        ], $result);
+    }
+
+    public function test_to_open_api_preserves_definition_order() : void
+    {
+        $converter = new OpenAPIConverter();
+        $schema = schema(
+            str_schema('c'),
+            str_schema('a'),
+            str_schema('b')
+        );
+
+        $result = $converter->toOpenAPI($schema);
+
+        $properties = type_array()->assert($result['properties']);
+        self::assertSame(['c', 'a', 'b'], \array_keys($properties));
+    }
+
+    public function test_to_open_api_with_array_type() : void
+    {
+        $converter = new OpenAPIConverter();
+        $arrayType = type_array();
+        $definition = map_schema('items', $arrayType, false);
+        $schema = schema($definition);
+
+        $result = $converter->toOpenAPI($schema);
+
+        self::assertSame([
+            'type' => 'object',
+            'properties' => [
+                'items' => [
+                    'type' => 'array',
+                    'items' => ['type' => 'string'],
+                    'nullable' => false,
+                ],
+            ],
+        ], $result);
+    }
+
+    public function test_to_open_api_with_backed_enum() : void
+    {
+        $converter = new OpenAPIConverter();
+        $definition = enum_schema('priority', FlowTestBackedEnum::class, false);
+        $schema = schema($definition);
+
+        $result = $converter->toOpenAPI($schema);
+
+        self::assertSame([
+            'type' => 'object',
+            'properties' => [
+                'priority' => [
+                    'type' => 'string',
+                    'enum' => ['high', 'low', 'medium'],
+                    'nullable' => false,
+                ],
+            ],
+        ], $result);
+    }
+
+    public function test_to_open_api_with_backed_enum_different_types() : void
+    {
+        $converter = new OpenAPIConverter();
+        $definition = enum_schema('int_enum', FlowTestIntBackedEnum::class, false);
+        $schema = schema($definition);
+
+        $result = $converter->toOpenAPI($schema);
+
+        self::assertSame([
+            'type' => 'object',
+            'properties' => [
+                'int_enum' => [
+                    'type' => 'string',
+                    'enum' => [1, 2, 3],
+                    'nullable' => false,
+                ],
+            ],
+        ], $result);
+    }
+
+    /**
+     * @param Definition<mixed> $definition
+     * @param array<string, mixed> $expected
+     */
+    #[DataProvider('basic_types_provider')]
+    public function test_to_open_api_with_basic_types(Definition $definition, array $expected) : void
+    {
+        $converter = new OpenAPIConverter();
+        $schema = schema($definition);
+
+        $result = $converter->toOpenAPI($schema);
+
+        self::assertSame([
+            'type' => 'object',
+            'properties' => [
+                $definition->entry()->name() => $expected,
+            ],
+        ], $result);
+    }
+
+    public function test_to_open_api_with_complex_schema() : void
+    {
+        $converter = new OpenAPIConverter();
+        $schema = schema(
+            int_schema('id', false),
+            str_schema('name', true, Metadata::empty()->add('description', 'User name')),
+            bool_schema('active', false, Metadata::empty()->add('example', true)),
+            enum_schema('status', FlowTestUnitEnum::class, false),
+            list_schema('tags', type_list(type_string()), true),
+            structure_schema('address', type_structure([
+                'street' => type_string(),
+            ], [
+                'city' => type_string(),
+            ]), false)
+        );
+
+        $result = $converter->toOpenAPI($schema);
+
+        self::assertSame([
+            'type' => 'object',
+            'properties' => [
+                'id' => ['type' => 'integer', 'nullable' => false],
+                'name' => ['type' => 'string', 'nullable' => true, 'description' => 'User name'],
+                'active' => ['type' => 'boolean', 'nullable' => false, 'example' => true],
+                'status' => ['type' => 'string', 'enum' => ['ACTIVE', 'INACTIVE', 'PENDING'], 'nullable' => false],
+                'tags' => ['type' => 'array', 'items' => ['type' => 'string'], 'nullable' => true],
+                'address' => [
+                    'type' => 'object',
+                    'properties' => [
+                        'street' => ['type' => 'string', 'nullable' => false],
+                        'city' => ['type' => 'string', 'nullable' => true],
+                    ],
+                    'nullable' => false,
+                ],
+            ],
+        ], $result);
+    }
+
+    public function test_to_open_api_with_deeply_nested_structures() : void
+    {
+        $converter = new OpenAPIConverter();
+        $definition = structure_schema('nested', type_structure([
+            'level1' => type_structure([
+                'level2' => type_structure([
+                    'value' => type_integer(),
+                ]),
+            ]),
+        ]), false);
+        $schema = schema($definition);
+
+        $result = $converter->toOpenAPI($schema);
+
+        self::assertSame([
+            'type' => 'object',
+            'properties' => [
+                'nested' => [
+                    'type' => 'object',
+                    'properties' => [
+                        'level1' => [
+                            'type' => 'object',
+                            'properties' => [
+                                'level2' => [
+                                    'type' => 'object',
+                                    'properties' => [
+                                        'value' => ['type' => 'integer', 'nullable' => false],
+                                    ],
+                                    'nullable' => false,
+                                ],
+                            ],
+                            'nullable' => false,
+                        ],
+                    ],
+                    'nullable' => false,
+                ],
+            ],
+        ], $result);
+    }
+
+    public function test_to_open_api_with_empty_schema() : void
+    {
+        $converter = new OpenAPIConverter();
+        $schema = schema();
+
+        $result = $converter->toOpenAPI($schema);
+
+        self::assertSame([
+            'type' => 'object',
+            'properties' => [],
+        ], $result);
+    }
+
+    public function test_to_open_api_with_list_type() : void
+    {
+        $converter = new OpenAPIConverter();
+        $definition = list_schema('tags', type_list(type_string()), false);
+        $schema = schema($definition);
+
+        $result = $converter->toOpenAPI($schema);
+
+        self::assertSame([
+            'type' => 'object',
+            'properties' => [
+                'tags' => [
+                    'type' => 'array',
+                    'items' => ['type' => 'string'],
+                    'nullable' => false,
+                ],
+            ],
+        ], $result);
+    }
+
+    public function test_to_open_api_with_map_type() : void
+    {
+        $converter = new OpenAPIConverter();
+        $definition = map_schema('metadata', type_map(type_string(), type_integer()), false);
+        $schema = schema($definition);
+
+        $result = $converter->toOpenAPI($schema);
+
+        self::assertSame([
+            'type' => 'object',
+            'properties' => [
+                'metadata' => [
+                    'type' => 'object',
+                    'additionalProperties' => ['type' => 'integer'],
+                    'nullable' => false,
+                ],
+            ],
+        ], $result);
+    }
+
+    public function test_to_open_api_with_metadata() : void
+    {
+        $converter = new OpenAPIConverter();
+        $definition = str_schema(
+            'name',
+            false,
+            Metadata::empty()
+                ->add('description', 'User full name')
+                ->add('example', 'John Doe')
+        );
+        $schema = schema($definition);
+
+        $result = $converter->toOpenAPI($schema);
+
+        self::assertSame([
+            'type' => 'object',
+            'properties' => [
+                'name' => [
+                    'type' => 'string',
+                    'nullable' => false,
+                    'description' => 'User full name',
+                    'example' => 'John Doe',
+                ],
+            ],
+        ], $result);
+    }
+
+    public function test_to_open_api_with_metadata_description_only() : void
+    {
+        $converter = new OpenAPIConverter();
+        $definition = str_schema(
+            'name',
+            false,
+            Metadata::empty()->add('description', 'User name')
+        );
+        $schema = schema($definition);
+
+        $result = $converter->toOpenAPI($schema);
+
+        self::assertSame([
+            'type' => 'object',
+            'properties' => [
+                'name' => [
+                    'type' => 'string',
+                    'nullable' => false,
+                    'description' => 'User name',
+                ],
+            ],
+        ], $result);
+    }
+
+    public function test_to_open_api_with_metadata_example_only() : void
+    {
+        $converter = new OpenAPIConverter();
+        $definition = int_schema(
+            'age',
+            false,
+            Metadata::empty()->add('example', 25)
+        );
+        $schema = schema($definition);
+
+        $result = $converter->toOpenAPI($schema);
+
+        self::assertSame([
+            'type' => 'object',
+            'properties' => [
+                'age' => [
+                    'type' => 'integer',
+                    'nullable' => false,
+                    'example' => 25,
+                ],
+            ],
+        ], $result);
+    }
+
+    public function test_to_open_api_with_metadata_other_keys() : void
+    {
+        $converter = new OpenAPIConverter();
+        $definition = str_schema(
+            'name',
+            false,
+            Metadata::empty()->add('custom_key', 'custom_value')
+        );
+        $schema = schema($definition);
+
+        $result = $converter->toOpenAPI($schema);
+
+        self::assertSame([
+            'type' => 'object',
+            'properties' => [
+                'name' => [
+                    'type' => 'string',
+                    'nullable' => false,
+                ],
+            ],
+        ], $result);
+    }
+
+    public function test_to_open_api_with_mixed_metadata_values() : void
+    {
+        $converter = new OpenAPIConverter();
+        $definition = str_schema(
+            'mixed_meta',
+            false,
+            Metadata::empty()
+                ->add('description', 'A description')
+                ->add('example', 42) // Integer example for string field
+                ->add('other_prop', ['array', 'value'])
+                ->add('bool_prop', true)
+        );
+        $schema = schema($definition);
+
+        $result = $converter->toOpenAPI($schema);
+
+        self::assertSame([
+            'type' => 'object',
+            'properties' => [
+                'mixed_meta' => [
+                    'type' => 'string',
+                    'nullable' => false,
+                    'description' => 'A description',
+                    'example' => 42,
+                ],
+            ],
+        ], $result);
+    }
+
+    public function test_to_open_api_with_multiple_definitions() : void
+    {
+        $converter = new OpenAPIConverter();
+        $schema = schema(
+            int_schema('id', false),
+            str_schema('name', true),
+            bool_schema('active', false),
+            float_schema('price', true)
+        );
+
+        $result = $converter->toOpenAPI($schema);
+
+        self::assertSame([
+            'type' => 'object',
+            'properties' => [
+                'id' => ['type' => 'integer', 'nullable' => false],
+                'name' => ['type' => 'string', 'nullable' => true],
+                'active' => ['type' => 'boolean', 'nullable' => false],
+                'price' => ['type' => 'number', 'nullable' => true],
+            ],
+        ], $result);
+    }
+
+    public function test_to_open_api_with_nested_list_type() : void
+    {
+        $converter = new OpenAPIConverter();
+        $definition = list_schema('nested_tags', type_list(type_list(type_integer())), false);
+        $schema = schema($definition);
+
+        $result = $converter->toOpenAPI($schema);
+
+        self::assertSame([
+            'type' => 'object',
+            'properties' => [
+                'nested_tags' => [
+                    'type' => 'array',
+                    'items' => [
+                        'type' => 'array',
+                        'items' => ['type' => 'integer'],
+                    ],
+                    'nullable' => false,
+                ],
+            ],
+        ], $result);
+    }
+
+    public function test_to_open_api_with_special_field_names() : void
+    {
+        $converter = new OpenAPIConverter();
+        $schema = schema(
+            str_schema('field-with-dashes', false),
+            str_schema('field_with_underscores', false),
+            str_schema('fieldWithCamelCase', false),
+            str_schema('FIELD_WITH_CAPS', false),
+            str_schema('field123', false),
+            str_schema('123field', false), // Edge case: field starting with number
+        );
+
+        $result = $converter->toOpenAPI($schema);
+
+        $properties = type_array()->assert($result['properties']);
+        self::assertArrayHasKey('field-with-dashes', $properties);
+        self::assertArrayHasKey('field_with_underscores', $properties);
+        self::assertArrayHasKey('fieldWithCamelCase', $properties);
+        self::assertArrayHasKey('FIELD_WITH_CAPS', $properties);
+        self::assertArrayHasKey('field123', $properties);
+        self::assertArrayHasKey('123field', $properties);
+    }
+
+    /**
+     * @param Definition<mixed> $definition
+     * @param array<string, mixed> $expected
+     */
+    #[DataProvider('special_types_provider')]
+    public function test_to_open_api_with_special_types(Definition $definition, array $expected) : void
+    {
+        $converter = new OpenAPIConverter();
+        $schema = schema($definition);
+
+        $result = $converter->toOpenAPI($schema);
+
+        self::assertSame([
+            'type' => 'object',
+            'properties' => [
+                $definition->entry()->name() => $expected,
+            ],
+        ], $result);
+    }
+
+    public function test_to_open_api_with_structure_only_optional_elements() : void
+    {
+        $converter = new OpenAPIConverter();
+        $definition = structure_schema('optional_only', type_structure([], [
+            'optional_field' => type_string(),
+        ]), false);
+        $schema = schema($definition);
+
+        $result = $converter->toOpenAPI($schema);
+
+        self::assertSame([
+            'type' => 'object',
+            'properties' => [
+                'optional_only' => [
+                    'type' => 'object',
+                    'properties' => [
+                        'optional_field' => ['type' => 'string', 'nullable' => true],
+                    ],
+                    'nullable' => false,
+                ],
+            ],
+        ], $result);
+    }
+
+    public function test_to_open_api_with_structure_type() : void
+    {
+        $converter = new OpenAPIConverter();
+        $definition = structure_schema('address', type_structure([
+            'street' => type_string(),
+            'city' => type_string(),
+        ], [
+            'postal_code' => type_string(),
+        ]), false);
+        $schema = schema($definition);
+
+        $result = $converter->toOpenAPI($schema);
+
+        self::assertSame([
+            'type' => 'object',
+            'properties' => [
+                'address' => [
+                    'type' => 'object',
+                    'properties' => [
+                        'street' => ['type' => 'string', 'nullable' => false],
+                        'city' => ['type' => 'string', 'nullable' => false],
+                        'postal_code' => ['type' => 'string', 'nullable' => true],
+                    ],
+                    'nullable' => false,
+                ],
+            ],
+        ], $result);
+    }
+
+    public function test_to_open_api_with_task_example_schema() : void
+    {
+        $converter = new OpenAPIConverter();
+        $schema = schema(
+            int_schema('id', false),
+            str_schema('name', true),
+            bool_schema('active', false, Metadata::empty()->add('key', 'value'))
+        );
+
+        $result = $converter->toOpenAPI($schema);
+
+        self::assertSame([
+            'type' => 'object',
+            'properties' => [
+                'id' => ['type' => 'integer', 'nullable' => false],
+                'name' => ['type' => 'string', 'nullable' => true],
+                'active' => ['type' => 'boolean', 'nullable' => false],
+            ],
+        ], $result);
+    }
+
+    public function test_to_open_api_with_unit_enum() : void
+    {
+        $converter = new OpenAPIConverter();
+        $definition = enum_schema('status', FlowTestUnitEnum::class, false);
+        $schema = schema($definition);
+
+        $result = $converter->toOpenAPI($schema);
+
+        self::assertSame([
+            'type' => 'object',
+            'properties' => [
+                'status' => [
+                    'type' => 'string',
+                    'enum' => ['ACTIVE', 'INACTIVE', 'PENDING'],
+                    'nullable' => false,
+                ],
+            ],
+        ], $result);
+    }
+
+    public function test_to_open_api_with_unsupported_type() : void
+    {
+        $converter = new OpenAPIConverter();
+        $unsupportedType = type_callable();
+        $definition = map_schema('callback', type_map(type_string(), $unsupportedType), false);
+        $schema = schema($definition);
+
+        $this->expectExceptionMessage('Unsupported type: Flow\Types\Type\Native\CallableType');
+        $converter->toOpenAPI($schema);
+    }
+
+    public function test_to_openapi_spec_dsl_function() : void
+    {
+        $schema = schema(
+            int_schema('id', false),
+            str_schema('name', true)
+        );
+
+        $result = to_openapi_spec($schema);
+
+        self::assertSame([
+            'type' => 'object',
+            'properties' => [
+                'id' => ['type' => 'integer', 'nullable' => false],
+                'name' => ['type' => 'string', 'nullable' => true],
+            ],
+        ], $result);
+    }
+
+    public function test_to_openapi_spec_dsl_usage_example() : void
+    {
+        // This test demonstrates practical usage of the DSL function
+        // for creating API documentation from Flow schemas
+        $userSchema = schema(
+            int_schema(
+                'id',
+                false,
+                Metadata::empty()
+                ->add('description', 'Unique user identifier')
+                ->add('example', 123)
+            ),
+            str_schema(
+                'username',
+                false,
+                Metadata::empty()
+                ->add('description', 'Username for login')
+                ->add('example', 'johndoe')
+            ),
+            str_schema(
+                'email',
+                false,
+                Metadata::empty()
+                ->add('description', 'User email address')
+                ->add('example', 'john@example.com')
+            ),
+            bool_schema(
+                'is_active',
+                false,
+                Metadata::empty()
+                ->add('description', 'Whether the user account is active')
+                ->add('example', true)
+            ),
+            enum_schema(
+                'role',
+                FlowTestBackedEnum::class,
+                false,
+                Metadata::empty()
+                ->add('description', 'User role level')
+            ),
+            list_schema(
+                'permissions',
+                type_list(type_string()),
+                true,
+                Metadata::empty()
+                ->add('description', 'List of user permissions')
+                ->add('example', ['read', 'write'])
+            )
+        );
+
+        $openApiSpec = to_openapi_spec($userSchema);
+
+        self::assertSame('object', $openApiSpec['type']);
+        $properties = type_array()->assert($openApiSpec['properties']);
+        self::assertCount(6, $properties);
+
+        $id = type_array()->assert($properties['id']);
+        self::assertSame('integer', $id['type']);
+        self::assertSame('Unique user identifier', $id['description']);
+        self::assertSame(123, $id['example']);
+
+        $role = type_array()->assert($properties['role']);
+        self::assertSame('string', $role['type']);
+        self::assertSame(['high', 'low', 'medium'], $role['enum']);
+        self::assertSame('User role level', $role['description']);
+
+        $permissions = type_array()->assert($properties['permissions']);
+        self::assertSame('array', $permissions['type']);
+        self::assertTrue($permissions['nullable']);
+        self::assertSame('List of user permissions', $permissions['description']);
+    }
+
+    public function test_to_openapi_spec_dsl_with_complex_schema() : void
+    {
+        $schema = schema(
+            int_schema('id', false),
+            str_schema('name', true, Metadata::empty()->add('description', 'User name')),
+            enum_schema('status', FlowTestUnitEnum::class, false),
+            list_schema('tags', type_list(type_string()), true)
+        );
+
+        $result = to_openapi_spec($schema);
+
+        self::assertSame([
+            'type' => 'object',
+            'properties' => [
+                'id' => ['type' => 'integer', 'nullable' => false],
+                'name' => ['type' => 'string', 'nullable' => true, 'description' => 'User name'],
+                'status' => ['type' => 'string', 'enum' => ['ACTIVE', 'INACTIVE', 'PENDING'], 'nullable' => false],
+                'tags' => ['type' => 'array', 'items' => ['type' => 'string'], 'nullable' => true],
+            ],
+        ], $result);
+    }
+
+    public function test_to_openapi_spec_dsl_with_metadata() : void
+    {
+        $schema = schema(
+            str_schema(
+                'email',
+                false,
+                Metadata::empty()
+                ->add('description', 'User email address')
+                ->add('example', 'user@example.com')
+            )
+        );
+
+        $result = to_openapi_spec($schema);
+
+        self::assertSame([
+            'type' => 'object',
+            'properties' => [
+                'email' => [
+                    'type' => 'string',
+                    'nullable' => false,
+                    'description' => 'User email address',
+                    'example' => 'user@example.com',
+                ],
+            ],
+        ], $result);
+    }
+}
+
+enum FlowTestUnitEnum
+{
+    case ACTIVE;
+    case INACTIVE;
+    case PENDING;
+}
+
+enum FlowTestBackedEnum : string
+{
+    case HIGH = 'high';
+    case LOW = 'low';
+    case MEDIUM = 'medium';
+}
+
+enum FlowTestSingleEnum
+{
+    case ONLY;
+}
+
+enum FlowTestIntBackedEnum : int
+{
+    case FIRST = 1;
+    case SECOND = 2;
+    case THIRD = 3;
+}

--- a/src/bridge/openapi/specification/tests/Flow/Bridge/OpenAPI/Specification/Tests/Unit/FlowToOpenAPIConverterTest.php
+++ b/src/bridge/openapi/specification/tests/Flow/Bridge/OpenAPI/Specification/Tests/Unit/FlowToOpenAPIConverterTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Flow\Bridge\OpenAPI\Specification\Tests\Unit;
 
-use function Flow\Bridge\OpenAPI\Specification\DSL\to_openapi_spec;
+use function Flow\Bridge\OpenAPI\Specification\DSL\schema_to_openapi_specification;
 use function Flow\ETL\DSL\{bool_schema, date_schema, datetime_schema, enum_schema, float_schema, int_schema, json_schema, list_schema, map_schema, schema, str_schema, structure_schema, time_schema, uuid_schema, xml_element_schema, xml_schema};
 use function Flow\Types\DSL\{type_array, type_callable, type_integer, type_list, type_map, type_string, type_structure};
 use Flow\Bridge\OpenAPI\Specification\OpenAPIConverter;
@@ -705,7 +705,7 @@ final class FlowToOpenAPIConverterTest extends TestCase
             str_schema('name', true)
         );
 
-        $result = to_openapi_spec($schema);
+        $result = schema_to_openapi_specification($schema);
 
         self::assertSame([
             'type' => 'object',
@@ -766,7 +766,7 @@ final class FlowToOpenAPIConverterTest extends TestCase
             )
         );
 
-        $openApiSpec = to_openapi_spec($userSchema);
+        $openApiSpec = schema_to_openapi_specification($userSchema);
 
         self::assertSame('object', $openApiSpec['type']);
         $properties = type_array()->assert($openApiSpec['properties']);
@@ -797,7 +797,7 @@ final class FlowToOpenAPIConverterTest extends TestCase
             list_schema('tags', type_list(type_string()), true)
         );
 
-        $result = to_openapi_spec($schema);
+        $result = schema_to_openapi_specification($schema);
 
         self::assertSame([
             'type' => 'object',
@@ -822,7 +822,7 @@ final class FlowToOpenAPIConverterTest extends TestCase
             )
         );
 
-        $result = to_openapi_spec($schema);
+        $result = schema_to_openapi_specification($schema);
 
         self::assertSame([
             'type' => 'object',

--- a/src/bridge/openapi/specification/tests/Flow/Bridge/OpenAPI/Specification/Tests/Unit/OpenAPIConverterTest.php
+++ b/src/bridge/openapi/specification/tests/Flow/Bridge/OpenAPI/Specification/Tests/Unit/OpenAPIConverterTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Flow\Bridge\OpenAPI\Specification\Tests\Unit;
 
-use function Flow\Bridge\OpenAPI\Specification\DSL\{from_openapi_spec, to_openapi_spec};
+use function Flow\Bridge\OpenAPI\Specification\DSL\{schema_from_openapi_specification, schema_to_openapi_specification};
 use function Flow\ETL\DSL\{bool_schema, enum_schema, int_schema, list_schema, schema, str_schema, structure_schema};
 use function Flow\Types\DSL\{type_array, type_list, type_string, type_structure};
 use Flow\Bridge\OpenAPI\Specification\Exception\InvalidArgumentException;
@@ -82,7 +82,7 @@ final class OpenAPIConverterTest extends TestCase
             bool_schema('active', false)
         );
 
-        $openApiSpec = to_openapi_spec($schema);
+        $openApiSpec = schema_to_openapi_specification($schema);
 
         self::assertSame('object', $openApiSpec['type']);
         $properties = type_array()->assert($openApiSpec['properties']);
@@ -91,7 +91,7 @@ final class OpenAPIConverterTest extends TestCase
         self::assertArrayHasKey('name', $properties);
         self::assertArrayHasKey('active', $properties);
 
-        $convertedSchema = from_openapi_spec($openApiSpec);
+        $convertedSchema = schema_from_openapi_specification($openApiSpec);
 
         self::assertCount(3, $convertedSchema->definitions());
         $definitions = \array_values($convertedSchema->definitions());

--- a/src/bridge/openapi/specification/tests/Flow/Bridge/OpenAPI/Specification/Tests/Unit/OpenAPIConverterTest.php
+++ b/src/bridge/openapi/specification/tests/Flow/Bridge/OpenAPI/Specification/Tests/Unit/OpenAPIConverterTest.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\Bridge\OpenAPI\Specification\Tests\Unit;
+
+use function Flow\Bridge\OpenAPI\Specification\DSL\{from_openapi_spec, to_openapi_spec};
+use function Flow\ETL\DSL\{bool_schema, enum_schema, int_schema, list_schema, schema, str_schema, structure_schema};
+use function Flow\Types\DSL\{type_array, type_list, type_string, type_structure};
+use Flow\Bridge\OpenAPI\Specification\Exception\InvalidArgumentException;
+use Flow\Bridge\OpenAPI\Specification\OpenAPIConverter;
+use Flow\ETL\Schema\Metadata;
+use Flow\Types\Type\Logical\{ListType, StructureType};
+use Flow\Types\Type\Native\{BooleanType, IntegerType, StringType};
+use PHPUnit\Framework\TestCase;
+
+final class OpenAPIConverterTest extends TestCase
+{
+    public function test_bidirectional_conversion_with_complex_schema() : void
+    {
+        $converter = new OpenAPIConverter();
+
+        $originalSchema = schema(
+            int_schema('id', false, Metadata::empty()->add('description', 'User ID')->add('example', 123)),
+            str_schema('name', true, Metadata::empty()->add('description', 'User name')),
+            bool_schema('active', false),
+            enum_schema('status', IntegrationTestUnitEnum::class, false),
+            list_schema('tags', type_list(type_string()), true),
+            structure_schema('address', type_structure([
+                'street' => type_string(),
+            ], [
+                'city' => type_string(),
+            ]), false)
+        );
+
+        $openApiSpec = $converter->toOpenAPI($originalSchema);
+        $convertedSchema = $converter->fromOpenAPI($openApiSpec);
+
+        self::assertCount(6, $convertedSchema->definitions());
+
+        $definitions = \array_values($convertedSchema->definitions());
+
+        self::assertSame('id', $definitions[0]->entry()->name());
+        self::assertSame(IntegerType::class, $definitions[0]->type()::class);
+        self::assertFalse($definitions[0]->isNullable());
+        self::assertTrue($definitions[0]->metadata()->has('description'));
+        self::assertTrue($definitions[0]->metadata()->has('example'));
+
+        self::assertSame('name', $definitions[1]->entry()->name());
+        self::assertSame(StringType::class, $definitions[1]->type()::class);
+        self::assertTrue($definitions[1]->isNullable());
+        self::assertTrue($definitions[1]->metadata()->has('description'));
+
+        self::assertSame('active', $definitions[2]->entry()->name());
+        self::assertSame(BooleanType::class, $definitions[2]->type()::class);
+        self::assertFalse($definitions[2]->isNullable());
+
+        self::assertSame('tags', $definitions[4]->entry()->name());
+        self::assertSame(ListType::class, $definitions[4]->type()::class);
+        self::assertTrue($definitions[4]->isNullable());
+
+        self::assertSame('address', $definitions[5]->entry()->name());
+        self::assertSame(StructureType::class, $definitions[5]->type()::class);
+        self::assertFalse($definitions[5]->isNullable());
+    }
+
+    public function test_converter_error_handling() : void
+    {
+        $converter = new OpenAPIConverter();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('OpenAPI specification must have type "object"');
+
+        $converter->fromOpenAPI(['type' => 'array']);
+    }
+
+    public function test_dsl_functions_integration() : void
+    {
+        $schema = schema(
+            int_schema('id', false),
+            str_schema('name', true, Metadata::empty()->add('description', 'User name')),
+            bool_schema('active', false)
+        );
+
+        $openApiSpec = to_openapi_spec($schema);
+
+        self::assertSame('object', $openApiSpec['type']);
+        $properties = type_array()->assert($openApiSpec['properties']);
+        self::assertCount(3, $properties);
+        self::assertArrayHasKey('id', $properties);
+        self::assertArrayHasKey('name', $properties);
+        self::assertArrayHasKey('active', $properties);
+
+        $convertedSchema = from_openapi_spec($openApiSpec);
+
+        self::assertCount(3, $convertedSchema->definitions());
+        $definitions = \array_values($convertedSchema->definitions());
+        self::assertSame('id', $definitions[0]->entry()->name());
+        self::assertSame('name', $definitions[1]->entry()->name());
+        self::assertSame('active', $definitions[2]->entry()->name());
+
+        self::assertTrue($definitions[1]->metadata()->has('description'));
+        self::assertSame('User name', $definitions[1]->metadata()->get('description'));
+    }
+
+    public function test_task_requirement_example() : void
+    {
+        $converter = new OpenAPIConverter();
+
+        $schema = schema(
+            int_schema('id', false),
+            str_schema('name', true),
+            bool_schema('active', false, Metadata::empty()->add('key', 'value'))
+        );
+
+        $result = $converter->toOpenAPI($schema);
+
+        self::assertSame([
+            'type' => 'object',
+            'properties' => [
+                'id' => ['type' => 'integer', 'nullable' => false],
+                'name' => ['type' => 'string', 'nullable' => true],
+                'active' => ['type' => 'boolean', 'nullable' => false],
+            ],
+        ], $result);
+
+        $convertedSchema = $converter->fromOpenAPI($result);
+        self::assertCount(3, $convertedSchema->definitions());
+    }
+}
+
+enum IntegrationTestUnitEnum
+{
+    case ACTIVE;
+    case INACTIVE;
+    case PENDING;
+}

--- a/src/bridge/openapi/specification/tests/Flow/Bridge/OpenAPI/Specification/Tests/Unit/OpenAPIToFlowConverterTest.php
+++ b/src/bridge/openapi/specification/tests/Flow/Bridge/OpenAPI/Specification/Tests/Unit/OpenAPIToFlowConverterTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Flow\Bridge\OpenAPI\Specification\Tests\Unit;
 
-use function Flow\Bridge\OpenAPI\Specification\DSL\{from_openapi_spec, to_openapi_spec};
+use function Flow\Bridge\OpenAPI\Specification\DSL\{schema_from_openapi_specification, schema_to_openapi_specification};
 use function Flow\ETL\DSL\{bool_schema, int_schema, schema, str_schema};
 use Flow\Bridge\OpenAPI\Specification\Exception\InvalidArgumentException;
 use Flow\Bridge\OpenAPI\Specification\OpenAPIConverter;
@@ -22,8 +22,8 @@ final class OpenAPIToFlowConverterTest extends TestCase
             bool_schema('active', false)
         );
 
-        $openApiSpec = to_openapi_spec($originalSchema);
-        $convertedSchema = from_openapi_spec($openApiSpec);
+        $openApiSpec = schema_to_openapi_specification($originalSchema);
+        $convertedSchema = schema_from_openapi_specification($openApiSpec);
 
         self::assertCount(3, $convertedSchema->definitions());
         $definitions = \array_values($convertedSchema->definitions());
@@ -50,7 +50,7 @@ final class OpenAPIToFlowConverterTest extends TestCase
             ],
         ];
 
-        $schema = from_openapi_spec($openApiSpec);
+        $schema = schema_from_openapi_specification($openApiSpec);
 
         self::assertCount(2, $schema->definitions());
         $definitions = \array_values($schema->definitions());
@@ -203,7 +203,7 @@ final class OpenAPIToFlowConverterTest extends TestCase
             ],
         ];
 
-        $schema = from_openapi_spec($openApiSpec);
+        $schema = schema_from_openapi_specification($openApiSpec);
 
         self::assertCount(5, $schema->definitions());
         $definitions = \array_values($schema->definitions());

--- a/src/bridge/openapi/specification/tests/Flow/Bridge/OpenAPI/Specification/Tests/Unit/OpenAPIToFlowConverterTest.php
+++ b/src/bridge/openapi/specification/tests/Flow/Bridge/OpenAPI/Specification/Tests/Unit/OpenAPIToFlowConverterTest.php
@@ -1,0 +1,353 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\Bridge\OpenAPI\Specification\Tests\Unit;
+
+use function Flow\Bridge\OpenAPI\Specification\DSL\{from_openapi_spec, to_openapi_spec};
+use function Flow\ETL\DSL\{bool_schema, int_schema, schema, str_schema};
+use Flow\Bridge\OpenAPI\Specification\Exception\InvalidArgumentException;
+use Flow\Bridge\OpenAPI\Specification\OpenAPIConverter;
+use Flow\Types\Type\Logical\{DateTimeType, DateType, JsonType, ListType, MapType, StructureType, TimeType, UuidType, XMLType};
+use Flow\Types\Type\Native\{BooleanType, IntegerType, StringType};
+use PHPUnit\Framework\TestCase;
+
+final class OpenAPIToFlowConverterTest extends TestCase
+{
+    public function test_bidirectional_conversion_consistency() : void
+    {
+        $originalSchema = schema(
+            int_schema('id', false),
+            str_schema('name', true),
+            bool_schema('active', false)
+        );
+
+        $openApiSpec = to_openapi_spec($originalSchema);
+        $convertedSchema = from_openapi_spec($openApiSpec);
+
+        self::assertCount(3, $convertedSchema->definitions());
+        $definitions = \array_values($convertedSchema->definitions());
+        self::assertSame('id', $definitions[0]->entry()->name());
+        self::assertSame(IntegerType::class, $definitions[0]->type()::class);
+        self::assertFalse($definitions[0]->isNullable());
+
+        self::assertSame('name', $definitions[1]->entry()->name());
+        self::assertSame(StringType::class, $definitions[1]->type()::class);
+        self::assertTrue($definitions[1]->isNullable());
+
+        self::assertSame('active', $definitions[2]->entry()->name());
+        self::assertSame(BooleanType::class, $definitions[2]->type()::class);
+        self::assertFalse($definitions[2]->isNullable());
+    }
+
+    public function test_from_openapi_spec_dsl_function() : void
+    {
+        $openApiSpec = [
+            'type' => 'object',
+            'properties' => [
+                'id' => ['type' => 'integer', 'nullable' => false],
+                'name' => ['type' => 'string', 'nullable' => true],
+            ],
+        ];
+
+        $schema = from_openapi_spec($openApiSpec);
+
+        self::assertCount(2, $schema->definitions());
+        $definitions = \array_values($schema->definitions());
+        self::assertSame('id', $definitions[0]->entry()->name());
+        self::assertSame('name', $definitions[1]->entry()->name());
+    }
+
+    public function test_from_openapi_throws_exception_for_invalid_property_spec() : void
+    {
+        $converter = new OpenAPIConverter();
+        $openApiSpec = [
+            'type' => 'object',
+            'properties' => [
+                'invalid_prop' => 'not_an_array',
+            ],
+        ];
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("Property 'invalid_prop' specification must be an array");
+
+        $converter->fromOpenAPI($openApiSpec);
+    }
+
+    public function test_from_openapi_throws_exception_for_invalid_type() : void
+    {
+        $converter = new OpenAPIConverter();
+        $openApiSpec = [
+            'type' => 'array',
+            'properties' => [],
+        ];
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('OpenAPI specification must have type "object"');
+
+        $converter->fromOpenAPI($openApiSpec);
+    }
+
+    public function test_from_openapi_throws_exception_for_missing_properties() : void
+    {
+        $converter = new OpenAPIConverter();
+        $openApiSpec = [
+            'type' => 'object',
+        ];
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('OpenAPI specification must have properties array');
+
+        $converter->fromOpenAPI($openApiSpec);
+    }
+
+    public function test_from_openapi_throws_exception_for_missing_property_type() : void
+    {
+        $converter = new OpenAPIConverter();
+        $openApiSpec = [
+            'type' => 'object',
+            'properties' => [
+                'no_type' => ['nullable' => false],
+            ],
+        ];
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("Property 'no_type' must have a type");
+
+        $converter->fromOpenAPI($openApiSpec);
+    }
+
+    public function test_from_openapi_throws_exception_for_unsupported_type() : void
+    {
+        $converter = new OpenAPIConverter();
+        $openApiSpec = [
+            'type' => 'object',
+            'properties' => [
+                'unsupported' => ['type' => 'binary'],
+            ],
+        ];
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unsupported OpenAPI type: binary');
+
+        $converter->fromOpenAPI($openApiSpec);
+    }
+
+    public function test_from_openapi_with_array_type() : void
+    {
+        $converter = new OpenAPIConverter();
+        $openApiSpec = [
+            'type' => 'object',
+            'properties' => [
+                'tags' => [
+                    'type' => 'array',
+                    'items' => ['type' => 'string'],
+                    'nullable' => false,
+                ],
+            ],
+        ];
+
+        $schema = $converter->fromOpenAPI($openApiSpec);
+
+        self::assertCount(1, $schema->definitions());
+        $definitions = \array_values($schema->definitions());
+        $definition = $definitions[0];
+        self::assertSame('tags', $definition->entry()->name());
+        self::assertSame(ListType::class, $definition->type()::class);
+        self::assertFalse($definition->isNullable());
+    }
+
+    public function test_from_openapi_with_basic_types() : void
+    {
+        $converter = new OpenAPIConverter();
+        $openApiSpec = [
+            'type' => 'object',
+            'properties' => [
+                'id' => ['type' => 'integer', 'nullable' => false],
+                'name' => ['type' => 'string', 'nullable' => true],
+                'active' => ['type' => 'boolean', 'nullable' => false],
+                'price' => ['type' => 'number', 'nullable' => true],
+            ],
+        ];
+
+        $schema = $converter->fromOpenAPI($openApiSpec);
+
+        self::assertCount(4, $schema->definitions());
+        $definitions = \array_values($schema->definitions());
+        self::assertSame('id', $definitions[0]->entry()->name());
+        self::assertSame(IntegerType::class, $definitions[0]->type()::class);
+        self::assertFalse($definitions[0]->isNullable());
+
+        self::assertSame('name', $definitions[1]->entry()->name());
+        self::assertSame(StringType::class, $definitions[1]->type()::class);
+        self::assertTrue($definitions[1]->isNullable());
+    }
+
+    public function test_from_openapi_with_complex_schema() : void
+    {
+        $openApiSpec = [
+            'type' => 'object',
+            'properties' => [
+                'id' => ['type' => 'integer', 'nullable' => false],
+                'name' => ['type' => 'string', 'nullable' => true, 'description' => 'User name'],
+                'active' => ['type' => 'boolean', 'nullable' => false, 'example' => true],
+                'tags' => ['type' => 'array', 'items' => ['type' => 'string'], 'nullable' => true],
+                'address' => [
+                    'type' => 'object',
+                    'properties' => [
+                        'street' => ['type' => 'string', 'nullable' => false],
+                        'city' => ['type' => 'string', 'nullable' => true],
+                    ],
+                    'nullable' => false,
+                ],
+            ],
+        ];
+
+        $schema = from_openapi_spec($openApiSpec);
+
+        self::assertCount(5, $schema->definitions());
+        $definitions = \array_values($schema->definitions());
+
+        self::assertSame('id', $definitions[0]->entry()->name());
+        self::assertSame(IntegerType::class, $definitions[0]->type()::class);
+        self::assertFalse($definitions[0]->isNullable());
+
+        self::assertSame('name', $definitions[1]->entry()->name());
+        self::assertSame(StringType::class, $definitions[1]->type()::class);
+        self::assertTrue($definitions[1]->isNullable());
+        self::assertTrue($definitions[1]->metadata()->has('description'));
+        self::assertSame('User name', $definitions[1]->metadata()->get('description'));
+
+        self::assertSame('active', $definitions[2]->entry()->name());
+        self::assertSame(BooleanType::class, $definitions[2]->type()::class);
+        self::assertFalse($definitions[2]->isNullable());
+        self::assertTrue($definitions[2]->metadata()->has('example'));
+        self::assertTrue($definitions[2]->metadata()->get('example'));
+
+        self::assertSame('tags', $definitions[3]->entry()->name());
+        self::assertSame(ListType::class, $definitions[3]->type()::class);
+        self::assertTrue($definitions[3]->isNullable());
+
+        self::assertSame('address', $definitions[4]->entry()->name());
+        self::assertSame(StructureType::class, $definitions[4]->type()::class);
+        self::assertFalse($definitions[4]->isNullable());
+    }
+
+    public function test_from_openapi_with_empty_properties() : void
+    {
+        $converter = new OpenAPIConverter();
+        $openApiSpec = [
+            'type' => 'object',
+            'properties' => [],
+        ];
+
+        $schema = $converter->fromOpenAPI($openApiSpec);
+
+        self::assertCount(0, $schema->definitions());
+    }
+
+    public function test_from_openapi_with_metadata() : void
+    {
+        $converter = new OpenAPIConverter();
+        $openApiSpec = [
+            'type' => 'object',
+            'properties' => [
+                'name' => [
+                    'type' => 'string',
+                    'nullable' => false,
+                    'description' => 'User name',
+                    'example' => 'John Doe',
+                ],
+            ],
+        ];
+
+        $schema = $converter->fromOpenAPI($openApiSpec);
+
+        self::assertCount(1, $schema->definitions());
+        $definitions = \array_values($schema->definitions());
+        $definition = $definitions[0];
+        self::assertSame('name', $definition->entry()->name());
+        self::assertTrue($definition->metadata()->has('description'));
+        self::assertSame('User name', $definition->metadata()->get('description'));
+        self::assertTrue($definition->metadata()->has('example'));
+        self::assertSame('John Doe', $definition->metadata()->get('example'));
+    }
+
+    public function test_from_openapi_with_nested_structure() : void
+    {
+        $converter = new OpenAPIConverter();
+        $openApiSpec = [
+            'type' => 'object',
+            'properties' => [
+                'address' => [
+                    'type' => 'object',
+                    'properties' => [
+                        'street' => ['type' => 'string', 'nullable' => false],
+                        'city' => ['type' => 'string', 'nullable' => true],
+                    ],
+                    'nullable' => false,
+                ],
+            ],
+        ];
+
+        $schema = $converter->fromOpenAPI($openApiSpec);
+
+        self::assertCount(1, $schema->definitions());
+        $definitions = \array_values($schema->definitions());
+        $definition = $definitions[0];
+        self::assertSame('address', $definition->entry()->name());
+        self::assertSame(StructureType::class, $definition->type()::class);
+        self::assertFalse($definition->isNullable());
+    }
+
+    public function test_from_openapi_with_object_with_additional_properties() : void
+    {
+        $converter = new OpenAPIConverter();
+        $openApiSpec = [
+            'type' => 'object',
+            'properties' => [
+                'metadata' => [
+                    'type' => 'object',
+                    'additionalProperties' => ['type' => 'integer'],
+                    'nullable' => false,
+                ],
+            ],
+        ];
+
+        $schema = $converter->fromOpenAPI($openApiSpec);
+
+        self::assertCount(1, $schema->definitions());
+        $definitions = \array_values($schema->definitions());
+        $definition = $definitions[0];
+        self::assertSame('metadata', $definition->entry()->name());
+        self::assertSame(MapType::class, $definition->type()::class);
+        self::assertFalse($definition->isNullable());
+    }
+
+    public function test_from_openapi_with_special_string_formats() : void
+    {
+        $converter = new OpenAPIConverter();
+        $openApiSpec = [
+            'type' => 'object',
+            'properties' => [
+                'birth_date' => ['type' => 'string', 'format' => 'date', 'nullable' => false],
+                'created_at' => ['type' => 'string', 'format' => 'date-time', 'nullable' => false],
+                'duration' => ['type' => 'string', 'format' => 'time', 'nullable' => false],
+                'uuid' => ['type' => 'string', 'format' => 'uuid', 'nullable' => false],
+                'data' => ['type' => 'string', 'format' => 'json', 'nullable' => false],
+                'xml' => ['type' => 'string', 'format' => 'xml', 'nullable' => false],
+            ],
+        ];
+
+        $schema = $converter->fromOpenAPI($openApiSpec);
+
+        self::assertCount(6, $schema->definitions());
+        $definitions = \array_values($schema->definitions());
+        self::assertSame(DateType::class, $definitions[0]->type()::class);
+        self::assertSame(DateTimeType::class, $definitions[1]->type()::class);
+        self::assertSame(TimeType::class, $definitions[2]->type()::class);
+        self::assertSame(UuidType::class, $definitions[3]->type()::class);
+        self::assertSame(JsonType::class, $definitions[4]->type()::class);
+        self::assertSame(XMLType::class, $definitions[5]->type()::class);
+    }
+}

--- a/web/landing/templates/documentation/navigation_right.html.twig
+++ b/web/landing/templates/documentation/navigation_right.html.twig
@@ -114,6 +114,9 @@
             <li>
                 <a href="/documentation/components/bridges/monolog-http-bridge">Monolog Http</a>
             </li>
+            <li>
+                <a href="/documentation/components/bridges/oopenapi-specification-bridge">OpenApi Specification</a>
+            </li>
         </ul>
     </div>
 </div>


### PR DESCRIPTION
<!-- 
    Please replace #xxx with a GitHub issue id from flow-php/flow repository. For example #1234 
    If there is no item in a roadmap related to this PR, please check our contributing guidelines first. 
-->
Resolves: #1353
<!-- 
    Below section will be used to automatically generate changelog, please do not modify HTML code structure
    DO NOT REMOVE that HTML STRUCTURE, INSTEAD ADD YOUR CHANGES INSIDE THE LISTS 
    PULL REQUESTS WITHOUT CHANGELOG CAN'T BE MERGED 
-->
<h2>Change Log</h2>
<hr /> 
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <li>OpenAPI Specification Bridge</li>
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>

I might be wrong since I didn't had time yet to fully play with ApiPlatform but it seems it should be possible to register custom endpoints through something like this (pseudocode): 

```php
<?php

use ApiPlatform\OpenApi\Factory\OpenApiFactoryInterface;
use ApiPlatform\OpenApi\OpenApi;

class CustomApiOpenApiDecorator implements OpenApiFactoryInterface
{
    public function __construct(private OpenApiFactoryInterface $decorated) {}
    
    public function __invoke(array $context = []): OpenApi
    {
        $openApi = $this->decorated->__invoke($context);
        
        // Add your custom paths/schemas
        $openApi->getPaths()->addPath('/custom/endpoint', $customPathItem);
        
        return $openApi;
    }
}
```