### PR TITLE
Allow to chose encoding for parquet columns

### DIFF
--- a/documentation/components/libs/parquet.md
+++ b/documentation/components/libs/parquet.md
@@ -307,3 +307,217 @@ If you want to achieve the best compression, you should use `GZIP` or `SNAPPY` w
 
 For not yet supported algorithms, please check our [Roadmap](https://github.com/orgs/flow-php/projects/1) to understand when they will be supported.
 
+## Column Encodings
+
+Parquet supports various column encoding algorithms that can significantly impact file size and query performance. 
+You can specify custom encodings for individual columns using flat path notation.
+
+### Available Encodings
+
+#### PLAIN
+The default encoding that stores values as-is without any compression scheme.
+
+**When to use:**
+- Small datasets where compression overhead isn't justified
+- Columns with high cardinality and random distribution
+- When you need maximum compatibility with other Parquet readers
+
+**Supported types:** All column types
+
+```php
+use Flow\Parquet\Options;
+use Flow\Parquet\Option;
+
+$options = Options::default()->set(Option::COLUMNS_ENCODINGS, [
+    'description' => 'PLAIN',
+    'uuid' => 'PLAIN'
+]);
+```
+
+#### RLE_DICTIONARY
+Run Length Encoding with Dictionary compression. Values are stored in a dictionary and replaced with indices.
+
+**When to use:**
+- Columns with low cardinality (many repeated values)
+- String columns with repeated categories (status, country, department)
+- Enumeration-like data
+- Significant file size reduction (often 50-90% smaller)
+
+**Supported types:** All types except `FIXED_LEN_BYTE_ARRAY`
+
+```php
+$options = Options::default()->set(Option::COLUMNS_ENCODINGS, [
+    'status' => 'RLE_DICTIONARY',          // 'active', 'inactive', 'pending'  
+    'country_code' => 'RLE_DICTIONARY',    // 'US', 'UK', 'DE', 'FR'
+    'department' => 'RLE_DICTIONARY'       // 'engineering', 'sales', 'marketing'
+]);
+```
+
+#### DELTA_BINARY_PACKED
+Delta encoding with binary packing for integer columns. Stores differences between consecutive values.
+
+**When to use:**
+- Sequential or monotonic integer data (IDs, timestamps, counters)
+- Time series data with incremental values
+- Can achieve 70-95% compression for sequential data
+
+**Supported types:** Only `INT32` and `INT64`
+
+```php
+$options = Options::default()->set(Option::COLUMNS_ENCODINGS, [
+    'user_id' => 'DELTA_BINARY_PACKED',     // 1, 2, 3, 4, 5...
+    'timestamp_ms' => 'DELTA_BINARY_PACKED', // 1634567890123, 1634567890124...
+    'order_number' => 'DELTA_BINARY_PACKED'  // Sequential order IDs
+]);
+```
+
+### Using Custom Encodings
+
+#### Basic Column Encoding
+
+```php
+use Flow\Parquet\{Writer, Options, Option};
+use Flow\Parquet\ParquetFile\Schema;
+use Flow\Parquet\ParquetFile\Schema\FlatColumn;
+
+$schema = Schema::with(
+    FlatColumn::int64('user_id'),
+    FlatColumn::string('status'),
+    FlatColumn::string('description')
+);
+
+$options = Options::default()->set(Option::COLUMNS_ENCODINGS, [
+    'user_id' => 'DELTA_BINARY_PACKED',  // Sequential IDs
+    'status' => 'RLE_DICTIONARY',        // Limited set of values
+    'description' => 'PLAIN'             // High variance text
+]);
+
+$writer = new Writer(compressions: Compressions::SNAPPY, options: $options);
+```
+
+#### Nested Column Encoding (Flat Path Notation)
+
+For nested structures, use dot notation to specify the exact column path. 
+The flat path follows Parquet's internal structure conventions:
+
+**Flat Path Patterns:**
+- **Struct fields**: `parent.field_name` 
+- **List elements**: `list_name.list.element`
+- **Map keys**: `map_name.key_value.key`
+- **Map values**: `map_name.key_value.value`
+
+```php
+use Flow\Parquet\ParquetFile\Schema\{NestedColumn, ListElement, MapKey, MapValue};
+
+$schema = Schema::with(
+    NestedColumn::struct('user', [
+        FlatColumn::int64('id'),
+        FlatColumn::string('name'),
+        NestedColumn::struct('address', [
+            FlatColumn::string('street'),
+            FlatColumn::string('city'),
+            FlatColumn::string('country')
+        ])
+    ]),
+    NestedColumn::list('tags', ListElement::string()),
+    NestedColumn::map('metadata', MapKey::string(), MapValue::string())
+);
+```
+
+**Understanding Flat Paths:**
+
+```php
+// STRUCT: Direct field access with dot notation
+'user.id'              // user struct → id field
+'user.name'            // user struct → name field  
+'user.address.street'  // user struct → address struct → street field
+'user.address.city'    // user struct → address struct → city field
+'user.address.country' // user struct → address struct → country field
+
+// LIST: Always includes intermediate '.list.element' structure
+'tags.list.element'    // tags list → list wrapper → element (the actual string values)
+
+// MAP: Always includes intermediate '.key_value' structure  
+'metadata.key_value.key'   // metadata map → key_value wrapper → key (string keys)
+'metadata.key_value.value' // metadata map → key_value wrapper → value (string values)
+```
+
+**Applying Custom Encodings:**
+
+```php
+$options = Options::default()->set(Option::COLUMNS_ENCODINGS, [
+    // Struct fields - direct access
+    'user.id' => 'DELTA_BINARY_PACKED',
+    'user.name' => 'RLE_DICTIONARY', 
+    'user.address.street' => 'PLAIN',
+    'user.address.city' => 'RLE_DICTIONARY',
+    'user.address.country' => 'RLE_DICTIONARY',
+    
+    // List elements - note the '.list.element' suffix
+    'tags.list.element' => 'RLE_DICTIONARY',
+    
+    // Map key/value pairs - note the '.key_value.key/value' suffix
+    'metadata.key_value.key' => 'RLE_DICTIONARY',
+    'metadata.key_value.value' => 'PLAIN'
+]);
+```
+
+**Complex Nested Example:**
+
+```php
+// Complex nested structure with lists of structs and maps
+$schema = Schema::with(
+    NestedColumn::list('orders', ListElement::structure([
+        FlatColumn::int64('order_id'),
+        FlatColumn::string('status'),
+        NestedColumn::map('attributes', MapKey::string(), MapValue::string())
+    ]))
+);
+
+$options = Options::default()->set(Option::COLUMNS_ENCODINGS, [
+    // List of structs: list_name.list.element.field_name
+    'orders.list.element.order_id' => 'DELTA_BINARY_PACKED',
+    'orders.list.element.status' => 'RLE_DICTIONARY',
+    
+    // Map inside list element: list_name.list.element.map_name.key_value.key/value
+    'orders.list.element.attributes.key_value.key' => 'RLE_DICTIONARY',
+    'orders.list.element.attributes.key_value.value' => 'PLAIN'
+]);
+```
+
+#### Mixed Encoding Strategy
+
+```php
+$options = Options::default()->set(Option::COLUMNS_ENCODINGS, [
+    // High cardinality sequential data
+    'order_id' => 'DELTA_BINARY_PACKED',
+    'created_timestamp' => 'DELTA_BINARY_PACKED',
+    
+    // Low cardinality categorical data  
+    'order_status' => 'RLE_DICTIONARY',
+    'payment_method' => 'RLE_DICTIONARY',
+    'shipping_country' => 'RLE_DICTIONARY',
+    
+    // High variance descriptive data
+    'customer_notes' => 'PLAIN',
+    'product_description' => 'PLAIN'
+]);
+```
+
+### Encoding Compatibility
+
+| Encoding | INT32/INT64 | BYTE_ARRAY | BOOLEAN | FLOAT/DOUBLE | FIXED_LEN_BYTE_ARRAY |
+|----------|-------------|------------|---------|--------------|----------------------|
+| PLAIN | ✅ | ✅ | ✅ | ✅ | ✅ |
+| RLE_DICTIONARY | ✅ | ✅ | ✅ | ✅ | ❌ |
+| DELTA_BINARY_PACKED | ✅ | ❌ | ❌ | ❌ | ❌ |
+
+### Performance Guidelines
+
+1. **Analyze your data first** - Check cardinality and distribution patterns
+2. **Use RLE_DICTIONARY for categorical data** - Countries, statuses, departments
+3. **Use DELTA_BINARY_PACKED for sequential integers** - IDs, timestamps, counters  
+4. **Use PLAIN for high-variance data** - Descriptions, UUIDs, random data
+5. **Test different combinations** - Measure file size and query performance
+6. **Consider query patterns** - Frequently filtered columns benefit from dictionary encoding
+

--- a/src/lib/parquet/src/Flow/Parquet/Option.php
+++ b/src/lib/parquet/src/Flow/Parquet/Option.php
@@ -22,6 +22,22 @@ enum Option
     case BYTE_ARRAY_TO_STRING;
 
     /**
+     * Per-column encoding configuration using flat path notation.
+     * Accepts array<string, string> where key is column flat path and value is encoding name.
+     *
+     * Flat path examples:
+     * - Simple columns: 'column_name'
+     * - Nested structs: 'user.address.street'
+     * - List elements: 'items.list.element'
+     * - Map keys/values: 'metadata.key_value.key', 'metadata.key_value.value'
+     *
+     * Supported encodings: PLAIN, RLE_DICTIONARY, DELTA_BINARY_PACKED
+     *
+     * Default: null (use automatic encoding selection)
+     */
+    case COLUMNS_ENCODINGS;
+
+    /**
      * Whenever cardinality ratio of the dictionary goes below this value, PagesBuilders is going to fallback to PLAIN encoding.
      * Cardinality ration is calculated as distinct values / total values.
      * Please notice that even when cardinality ration is above this value, PageBuilder will still fallback to PLAIN encoding

--- a/src/lib/parquet/src/Flow/Parquet/Options.php
+++ b/src/lib/parquet/src/Flow/Parquet/Options.php
@@ -6,11 +6,13 @@ namespace Flow\Parquet;
 
 use Flow\Filesystem\SizeUnits;
 use Flow\Parquet\Exception\InvalidArgumentException;
+use Flow\Parquet\Options\ColumnsEncodings;
+use Flow\Parquet\ParquetFile\Encodings;
 
 final class Options
 {
     /**
-     * @var array<string, bool|float|int>
+     * @var array<string, null|array<mixed>|bool|ColumnsEncodings|float|int>
      */
     private array $options;
 
@@ -33,6 +35,7 @@ final class Options
             Option::ZSTD_COMPRESSION_LEVEL->name => 3,
             Option::WRITER_VERSION->name => 1,
             Option::VALIDATE_DATA->name => true,
+            Option::COLUMNS_ENCODINGS->name => null,
         ];
     }
 
@@ -41,7 +44,10 @@ final class Options
         return new self;
     }
 
-    public function get(Option $option) : bool|int|float
+    /**
+     * @return null|array<mixed>|bool|ColumnsEncodings|float|int
+     */
+    public function get(Option $option) : bool|int|float|array|ColumnsEncodings|null
     {
         return $this->options[$option->name];
     }
@@ -57,6 +63,21 @@ final class Options
         return $value;
     }
 
+    public function getColumnsEncodings() : ?ColumnsEncodings
+    {
+        $value = $this->options[Option::COLUMNS_ENCODINGS->name] ?? null;
+
+        if ($value === null) {
+            return null;
+        }
+
+        if ($value instanceof ColumnsEncodings) {
+            return $value;
+        }
+
+        throw new InvalidArgumentException('Option COLUMNS_ENCODINGS is not a ColumnsEncodings instance, but: ' . \gettype($value));
+    }
+
     public function getInt(Option $option) : int
     {
         $value = $this->options[$option->name];
@@ -68,9 +89,32 @@ final class Options
         return $value;
     }
 
-    public function set(Option $option, bool|int|float $value) : self
+    public function has(Option $option) : bool
     {
-        $this->options[$option->name] = $value;
+        $value = $this->options[$option->name] ?? null;
+
+        return $value !== null;
+    }
+
+    /**
+     * @param null|array<mixed>|bool|ColumnsEncodings|float|int $value
+     */
+    public function set(Option $option, bool|int|float|array|ColumnsEncodings|null $value) : self
+    {
+        if ($option === Option::COLUMNS_ENCODINGS) {
+            if ($value === null) {
+                $this->options[$option->name] = null;
+            } elseif ($value instanceof ColumnsEncodings) {
+                $this->options[$option->name] = $value;
+            } elseif (\is_array($value)) {
+                /** @var array<string, Encodings|string> $value */
+                $this->options[$option->name] = ColumnsEncodings::fromArray($value);
+            } else {
+                throw new InvalidArgumentException('Option COLUMNS_ENCODINGS must be an array, ColumnsEncodings instance, or null, got: ' . \gettype($value));
+            }
+        } else {
+            $this->options[$option->name] = $value;
+        }
 
         return $this;
     }

--- a/src/lib/parquet/src/Flow/Parquet/Options/ColumnsEncodings.php
+++ b/src/lib/parquet/src/Flow/Parquet/Options/ColumnsEncodings.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\Parquet\Options;
+
+use Flow\Parquet\Exception\InvalidArgumentException;
+use Flow\Parquet\ParquetFile\Encodings;
+
+final class ColumnsEncodings
+{
+    /**
+     * @param array<string, Encodings> $encodings
+     */
+    private function __construct(private array $encodings)
+    {
+    }
+
+    /**
+     * @param array<string, Encodings> $flatPathToEncodingMap
+     */
+    public static function create(array $flatPathToEncodingMap) : self
+    {
+        $encodings = [];
+
+        foreach ($flatPathToEncodingMap as $flatPath => $encoding) {
+            if (!\is_string($flatPath)) {
+                throw new InvalidArgumentException('Column flat path must be a string, got: ' . \gettype($flatPath));
+            }
+
+            if ($flatPath === '') {
+                throw new InvalidArgumentException('Column flat path cannot be empty');
+            }
+
+            if (!$encoding instanceof Encodings) {
+                throw new InvalidArgumentException('Encoding must be an Encodings enum, got: ' . \gettype($encoding));
+            }
+
+            $encodings[$flatPath] = $encoding;
+        }
+
+        return new self($encodings);
+    }
+
+    /**
+     * @param array<string, Encodings|string> $columnEncodings
+     */
+    public static function fromArray(array $columnEncodings) : self
+    {
+        $encodings = [];
+
+        foreach ($columnEncodings as $flatPath => $encoding) {
+            if (!\is_string($flatPath)) {
+                throw new InvalidArgumentException('Column flat path must be a string, got: ' . \gettype($flatPath));
+            }
+
+            if ($flatPath === '') {
+                throw new InvalidArgumentException('Column flat path cannot be empty');
+            }
+
+            if ($encoding instanceof Encodings) {
+                $encodings[$flatPath] = $encoding;
+            } elseif (\is_string($encoding)) {
+                $encodings[$flatPath] = self::parseEncodingName($encoding);
+            } else {
+                throw new InvalidArgumentException('Encoding must be an Encodings enum or string, got: ' . \gettype($encoding));
+            }
+        }
+
+        return new self($encodings);
+    }
+
+    public function count() : int
+    {
+        return \count($this->encodings);
+    }
+
+    public function getEncodingForFlatPath(string $flatPath) : ?Encodings
+    {
+        return $this->encodings[$flatPath] ?? null;
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function getFlatPaths() : array
+    {
+        return \array_keys($this->encodings);
+    }
+
+    public function hasFlatPath(string $flatPath) : bool
+    {
+        return \array_key_exists($flatPath, $this->encodings);
+    }
+
+    public function isEmpty() : bool
+    {
+        return empty($this->encodings);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function toArray() : array
+    {
+        $result = [];
+
+        foreach ($this->encodings as $flatPath => $encoding) {
+            $result[$flatPath] = $encoding->name;
+        }
+
+        return $result;
+    }
+
+    private static function parseEncodingName(string $encodingName) : Encodings
+    {
+        return match (\strtoupper(\trim($encodingName))) {
+            'PLAIN' => Encodings::PLAIN,
+            'RLE_DICTIONARY' => Encodings::RLE_DICTIONARY,
+            'DELTA_BINARY_PACKED' => Encodings::DELTA_BINARY_PACKED,
+            default => throw new InvalidArgumentException(
+                "Unsupported encoding: '{$encodingName}'. Supported encodings: PLAIN, RLE_DICTIONARY, DELTA_BINARY_PACKED"
+            ),
+        };
+    }
+}

--- a/src/lib/parquet/src/Flow/Parquet/Writer.php
+++ b/src/lib/parquet/src/Flow/Parquet/Writer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Flow\Parquet;
 
+use function Flow\Types\DSL\type_integer;
 use Composer\InstalledVersions;
 use Flow\Filesystem\{DestinationStream, Path};
 use Flow\Filesystem\Stream\{NativeLocalDestinationStream};
@@ -177,7 +178,7 @@ final class Writer
     public function writeRow(array $row) : void
     {
         $this->rowGroupBuilder()->addRow($row);
-        $interval = (int) $this->options->get(Option::ROW_GROUP_SIZE_CHECK_INTERVAL);
+        $interval = type_integer()->assert($this->options->get(Option::ROW_GROUP_SIZE_CHECK_INTERVAL));
 
         if (($this->rowGroupBuilder()->rowsCount() % $interval === 0) && $this->rowGroupBuilder()->isFull()) {
             $rowGroupContainer = $this->rowGroupBuilder()->flush($this->fileOffset);

--- a/src/lib/parquet/src/Flow/Parquet/Writer/ColumnChunkBuilderFactory.php
+++ b/src/lib/parquet/src/Flow/Parquet/Writer/ColumnChunkBuilderFactory.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\Parquet\Writer;
+
+use Flow\Parquet\Exception\InvalidArgumentException;
+use Flow\Parquet\{Option, Options};
+use Flow\Parquet\ParquetFile\{Compressions, Encodings};
+use Flow\Parquet\ParquetFile\Schema\{FlatColumn, PhysicalType};
+use Flow\Parquet\Writer\ColumnChunkBuilder\{DeltaBinaryPackedColumnChunkBuilder, PlainFlatColumnChunkBuilder, RLEDictionaryChunkBuilder};
+
+final class ColumnChunkBuilderFactory
+{
+    public static function createBuilder(FlatColumn $column, Options $options, Compressions $compressions) : ColumnChunkBuilder
+    {
+        if ($options->has(Option::COLUMNS_ENCODINGS)) {
+            $columnsEncodings = $options->getColumnsEncodings();
+            $flatPath = $column->flatPath();
+
+            if ($columnsEncodings !== null && $columnsEncodings->hasFlatPath($flatPath)) {
+                $encoding = $columnsEncodings->getEncodingForFlatPath($flatPath);
+
+                if ($encoding !== null) {
+                    return self::createForEncoding($column, $encoding, $options, $compressions);
+                }
+            }
+        }
+
+        if (($column->type() === PhysicalType::INT32 || $column->type() === PhysicalType::INT64) && $options->getInt(Option::WRITER_VERSION) === 2) {
+            return new DeltaBinaryPackedColumnChunkBuilder($column, $options, $compressions);
+        }
+
+        return new PlainFlatColumnChunkBuilder($column, $options, $compressions);
+    }
+
+    private static function createForEncoding(FlatColumn $column, Encodings $encoding, Options $options, Compressions $compressions) : ColumnChunkBuilder
+    {
+        self::validateEncodingForColumn($column, $encoding);
+
+        return match ($encoding) {
+            Encodings::PLAIN => new PlainFlatColumnChunkBuilder($column, $options, $compressions),
+            Encodings::RLE_DICTIONARY => new RLEDictionaryChunkBuilder($column, $options, $compressions),
+            Encodings::DELTA_BINARY_PACKED => new DeltaBinaryPackedColumnChunkBuilder($column, $options, $compressions),
+            default => throw new InvalidArgumentException("Unsupported encoding for column builder: {$encoding->name}"),
+        };
+    }
+
+    private static function validateEncodingForColumn(FlatColumn $column, Encodings $encoding) : void
+    {
+        $columnType = $column->type();
+        $encodingName = $encoding->name;
+        $flatPath = $column->flatPath();
+
+        switch ($encoding) {
+            case Encodings::DELTA_BINARY_PACKED:
+                if ($columnType !== PhysicalType::INT32 && $columnType !== PhysicalType::INT64) {
+                    throw new InvalidArgumentException(
+                        'DELTA_BINARY_PACKED encoding is only supported for INT32 and INT64 columns. ' .
+                        "Column '{$flatPath}' has type: {$columnType->name}"
+                    );
+                }
+
+                break;
+
+            case Encodings::RLE_DICTIONARY:
+                if ($columnType === PhysicalType::FIXED_LEN_BYTE_ARRAY) {
+                    throw new InvalidArgumentException(
+                        'RLE_DICTIONARY encoding is not supported for FIXED_LEN_BYTE_ARRAY columns. ' .
+                        "Column '{$flatPath}' has type: {$columnType->name}"
+                    );
+                }
+
+                break;
+
+            case Encodings::PLAIN:
+                break;
+
+            default:
+                throw new InvalidArgumentException(
+                    "Encoding '{$encodingName}' is not implemented. " .
+                    'Supported encodings: PLAIN, RLE_DICTIONARY, DELTA_BINARY_PACKED'
+                );
+        }
+    }
+}

--- a/src/lib/parquet/src/Flow/Parquet/Writer/ColumnChunkBuilders.php
+++ b/src/lib/parquet/src/Flow/Parquet/Writer/ColumnChunkBuilders.php
@@ -9,8 +9,10 @@ use Flow\Parquet\{Dremel\WriteColumnData,
     Options,
     Writer\ColumnChunkBuilder\DeltaBinaryPackedColumnChunkBuilder,
     Writer\ColumnChunkBuilder\NestedColumnChunkBuilder,
-    Writer\ColumnChunkBuilder\PlainFlatColumnChunkBuilder};
-use Flow\Parquet\ParquetFile\{Compressions, Schema};
+    Writer\ColumnChunkBuilder\PlainFlatColumnChunkBuilder,
+    Writer\ColumnChunkBuilder\RLEDictionaryChunkBuilder};
+use Flow\Parquet\Exception\InvalidArgumentException;
+use Flow\Parquet\ParquetFile\{Compressions, Encodings, Schema};
 use Flow\Parquet\ParquetFile\Schema\{FlatColumn, NestedColumn, PhysicalType};
 
 final class ColumnChunkBuilders
@@ -103,12 +105,66 @@ final class ColumnChunkBuilders
         return $size;
     }
 
+    private static function createBuilderForEncoding(FlatColumn $column, Encodings $encoding, Options $options, Compressions $compressions) : ColumnChunkBuilder
+    {
+        self::validateEncodingForColumn($column, $encoding);
+
+        return match ($encoding) {
+            Encodings::PLAIN => new PlainFlatColumnChunkBuilder($column, $options, $compressions),
+            Encodings::RLE_DICTIONARY => new RLEDictionaryChunkBuilder($column, $options, $compressions),
+            Encodings::DELTA_BINARY_PACKED => new DeltaBinaryPackedColumnChunkBuilder($column, $options, $compressions),
+            default => throw new InvalidArgumentException("Unsupported encoding for column builder: {$encoding->name}"),
+        };
+    }
+
     private static function createFlatColumnBuilder(FlatColumn $column, Options $options, Compressions $compressions) : ColumnChunkBuilder
     {
+        if ($options->has(Option::COLUMNS_ENCODINGS)) {
+            $columnsEncodings = $options->getColumnsEncodings();
+            $flatPath = $column->flatPath();
+
+            if ($columnsEncodings !== null && $columnsEncodings->hasFlatPath($flatPath)) {
+                $encoding = $columnsEncodings->getEncodingForFlatPath($flatPath);
+
+                if ($encoding !== null) {
+                    return self::createBuilderForEncoding($column, $encoding, $options, $compressions);
+                }
+            }
+        }
+
         if (($column->type() === PhysicalType::INT32 || $column->type() === PhysicalType::INT64) && $options->getInt(Option::WRITER_VERSION) === 2) {
             return new DeltaBinaryPackedColumnChunkBuilder($column, $options, $compressions);
         }
 
         return new PlainFlatColumnChunkBuilder($column, $options, $compressions);
+    }
+
+    private static function validateEncodingForColumn(FlatColumn $column, Encodings $encoding) : void
+    {
+        $columnType = $column->type();
+        $encodingName = $encoding->name;
+        $flatPath = $column->flatPath();
+
+        switch ($encoding) {
+            case Encodings::DELTA_BINARY_PACKED:
+                if ($columnType !== PhysicalType::INT32 && $columnType !== PhysicalType::INT64) {
+                    throw new InvalidArgumentException(
+                        'DELTA_BINARY_PACKED encoding is only supported for INT32 and INT64 columns. ' .
+                        "Column '{$flatPath}' has type: {$columnType->name}"
+                    );
+                }
+
+                break;
+
+            case Encodings::RLE_DICTIONARY:
+            case Encodings::PLAIN:
+                break;
+
+            default:
+                throw new InvalidArgumentException(
+                    "Encoding '{$encodingName}' is not implemented. " .
+                    'Supported encodings: PLAIN, RLE_DICTIONARY, DELTA_BINARY_PACKED'
+                );
+        }
     }
 }

--- a/src/lib/parquet/src/Flow/Parquet/Writer/ColumnChunkBuilders.php
+++ b/src/lib/parquet/src/Flow/Parquet/Writer/ColumnChunkBuilders.php
@@ -4,16 +4,10 @@ declare(strict_types=1);
 
 namespace Flow\Parquet\Writer;
 
-use Flow\Parquet\{Dremel\WriteColumnData,
-    Option,
-    Options,
-    Writer\ColumnChunkBuilder\DeltaBinaryPackedColumnChunkBuilder,
-    Writer\ColumnChunkBuilder\NestedColumnChunkBuilder,
-    Writer\ColumnChunkBuilder\PlainFlatColumnChunkBuilder,
-    Writer\ColumnChunkBuilder\RLEDictionaryChunkBuilder};
-use Flow\Parquet\Exception\InvalidArgumentException;
-use Flow\Parquet\ParquetFile\{Compressions, Encodings, Schema};
-use Flow\Parquet\ParquetFile\Schema\{FlatColumn, NestedColumn, PhysicalType};
+use Flow\Parquet\{Dremel\WriteColumnData, Options};
+use Flow\Parquet\ParquetFile\{Compressions, Schema};
+use Flow\Parquet\ParquetFile\Schema\{FlatColumn, NestedColumn};
+use Flow\Parquet\Writer\{ColumnChunkBuilder\NestedColumnChunkBuilder};
 
 final class ColumnChunkBuilders
 {
@@ -34,13 +28,13 @@ final class ColumnChunkBuilders
                 $builders[$column->name()] = new NestedColumnChunkBuilder(
                     $column,
                     array_map(
-                        fn (FlatColumn $childColumn) => self::createFlatColumnBuilder($childColumn, $options, $compressions),
+                        fn (FlatColumn $childColumn) => ColumnChunkBuilderFactory::createBuilder($childColumn, $options, $compressions),
                         $column->childrenFlat()
                     )
                 );
             } else {
                 /** @var FlatColumn $column */
-                $builders[$column->name()] = self::createFlatColumnBuilder($column, $options, $compressions);
+                $builders[$column->name()] = ColumnChunkBuilderFactory::createBuilder($column, $options, $compressions);
             }
         }
 
@@ -103,68 +97,5 @@ final class ColumnChunkBuilders
         }
 
         return $size;
-    }
-
-    private static function createBuilderForEncoding(FlatColumn $column, Encodings $encoding, Options $options, Compressions $compressions) : ColumnChunkBuilder
-    {
-        self::validateEncodingForColumn($column, $encoding);
-
-        return match ($encoding) {
-            Encodings::PLAIN => new PlainFlatColumnChunkBuilder($column, $options, $compressions),
-            Encodings::RLE_DICTIONARY => new RLEDictionaryChunkBuilder($column, $options, $compressions),
-            Encodings::DELTA_BINARY_PACKED => new DeltaBinaryPackedColumnChunkBuilder($column, $options, $compressions),
-            default => throw new InvalidArgumentException("Unsupported encoding for column builder: {$encoding->name}"),
-        };
-    }
-
-    private static function createFlatColumnBuilder(FlatColumn $column, Options $options, Compressions $compressions) : ColumnChunkBuilder
-    {
-        if ($options->has(Option::COLUMNS_ENCODINGS)) {
-            $columnsEncodings = $options->getColumnsEncodings();
-            $flatPath = $column->flatPath();
-
-            if ($columnsEncodings !== null && $columnsEncodings->hasFlatPath($flatPath)) {
-                $encoding = $columnsEncodings->getEncodingForFlatPath($flatPath);
-
-                if ($encoding !== null) {
-                    return self::createBuilderForEncoding($column, $encoding, $options, $compressions);
-                }
-            }
-        }
-
-        if (($column->type() === PhysicalType::INT32 || $column->type() === PhysicalType::INT64) && $options->getInt(Option::WRITER_VERSION) === 2) {
-            return new DeltaBinaryPackedColumnChunkBuilder($column, $options, $compressions);
-        }
-
-        return new PlainFlatColumnChunkBuilder($column, $options, $compressions);
-    }
-
-    private static function validateEncodingForColumn(FlatColumn $column, Encodings $encoding) : void
-    {
-        $columnType = $column->type();
-        $encodingName = $encoding->name;
-        $flatPath = $column->flatPath();
-
-        switch ($encoding) {
-            case Encodings::DELTA_BINARY_PACKED:
-                if ($columnType !== PhysicalType::INT32 && $columnType !== PhysicalType::INT64) {
-                    throw new InvalidArgumentException(
-                        'DELTA_BINARY_PACKED encoding is only supported for INT32 and INT64 columns. ' .
-                        "Column '{$flatPath}' has type: {$columnType->name}"
-                    );
-                }
-
-                break;
-
-            case Encodings::RLE_DICTIONARY:
-            case Encodings::PLAIN:
-                break;
-
-            default:
-                throw new InvalidArgumentException(
-                    "Encoding '{$encodingName}' is not implemented. " .
-                    'Supported encodings: PLAIN, RLE_DICTIONARY, DELTA_BINARY_PACKED'
-                );
-        }
     }
 }

--- a/src/lib/parquet/tests/Flow/Parquet/Tests/Unit/Options/ColumnsEncodingsTest.php
+++ b/src/lib/parquet/tests/Flow/Parquet/Tests/Unit/Options/ColumnsEncodingsTest.php
@@ -1,0 +1,271 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\Parquet\Tests\Unit\Options;
+
+use Flow\Parquet\Exception\InvalidArgumentException;
+use Flow\Parquet\Options\ColumnsEncodings;
+use Flow\Parquet\ParquetFile\Encodings;
+use PHPUnit\Framework\TestCase;
+
+final class ColumnsEncodingsTest extends TestCase
+{
+    public function test_accepts_case_insensitive_encoding_names() : void
+    {
+        $columnsEncodings = ColumnsEncodings::fromArray([
+            'col1' => 'plain',
+            'col2' => 'rle_dictionary',
+            'col3' => 'DELTA_BINARY_PACKED',
+            'col4' => 'Plain',
+            'col5' => 'RLE_Dictionary',
+        ]);
+
+        self::assertSame(Encodings::PLAIN, $columnsEncodings->getEncodingForFlatPath('col1'));
+        self::assertSame(Encodings::RLE_DICTIONARY, $columnsEncodings->getEncodingForFlatPath('col2'));
+        self::assertSame(Encodings::DELTA_BINARY_PACKED, $columnsEncodings->getEncodingForFlatPath('col3'));
+        self::assertSame(Encodings::PLAIN, $columnsEncodings->getEncodingForFlatPath('col4'));
+        self::assertSame(Encodings::RLE_DICTIONARY, $columnsEncodings->getEncodingForFlatPath('col5'));
+    }
+
+    public function test_accepts_encodings_enum_directly() : void
+    {
+        $columnsEncodings = ColumnsEncodings::fromArray([
+            'user_id' => Encodings::DELTA_BINARY_PACKED,
+            'status' => Encodings::RLE_DICTIONARY,
+            'description' => Encodings::PLAIN,
+        ]);
+
+        self::assertSame(Encodings::DELTA_BINARY_PACKED, $columnsEncodings->getEncodingForFlatPath('user_id'));
+        self::assertSame(Encodings::RLE_DICTIONARY, $columnsEncodings->getEncodingForFlatPath('status'));
+        self::assertSame(Encodings::PLAIN, $columnsEncodings->getEncodingForFlatPath('description'));
+    }
+
+    public function test_checks_if_flat_path_exists() : void
+    {
+        $columnsEncodings = ColumnsEncodings::fromArray([
+            'user_id' => 'DELTA_BINARY_PACKED',
+            'user.profile.name' => 'RLE_DICTIONARY',
+        ]);
+
+        self::assertTrue($columnsEncodings->hasFlatPath('user_id'));
+        self::assertTrue($columnsEncodings->hasFlatPath('user.profile.name'));
+        self::assertFalse($columnsEncodings->hasFlatPath('non_existing'));
+        self::assertFalse($columnsEncodings->hasFlatPath(''));
+    }
+
+    public function test_complex_nested_flat_paths() : void
+    {
+        $input = [
+            'struct_nested.struct_flat.list_of_ints.list.element' => 'DELTA_BINARY_PACKED',
+            'struct_nested.struct_flat.map_of_string_int.key_value.key' => 'RLE_DICTIONARY',
+            'struct_nested.struct_flat.map_of_string_int.key_value.value' => 'DELTA_BINARY_PACKED',
+            'struct_deeply_nested.struct_0.struct_1.struct_2.struct_3.struct_4.string' => 'RLE_DICTIONARY',
+        ];
+
+        $columnsEncodings = ColumnsEncodings::fromArray($input);
+
+        self::assertSame(4, $columnsEncodings->count());
+        self::assertSame(
+            Encodings::DELTA_BINARY_PACKED,
+            $columnsEncodings->getEncodingForFlatPath('struct_nested.struct_flat.list_of_ints.list.element')
+        );
+        self::assertSame(
+            Encodings::RLE_DICTIONARY,
+            $columnsEncodings->getEncodingForFlatPath('struct_nested.struct_flat.map_of_string_int.key_value.key')
+        );
+        self::assertSame(
+            Encodings::DELTA_BINARY_PACKED,
+            $columnsEncodings->getEncodingForFlatPath('struct_nested.struct_flat.map_of_string_int.key_value.value')
+        );
+        self::assertSame(
+            Encodings::RLE_DICTIONARY,
+            $columnsEncodings->getEncodingForFlatPath('struct_deeply_nested.struct_0.struct_1.struct_2.struct_3.struct_4.string')
+        );
+    }
+
+    public function test_create_method_throws_exception_for_non_enum() : void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Encoding must be an Encodings enum, got: string');
+
+        ColumnsEncodings::create([
+            'user_id' => 'DELTA_BINARY_PACKED',
+        ]);
+    }
+
+    public function test_create_method_with_encodings_enum() : void
+    {
+        $columnsEncodings = ColumnsEncodings::create([
+            'user_id' => Encodings::DELTA_BINARY_PACKED,
+            'status' => Encodings::RLE_DICTIONARY,
+            'description' => Encodings::PLAIN,
+        ]);
+
+        self::assertSame(3, $columnsEncodings->count());
+        self::assertSame(Encodings::DELTA_BINARY_PACKED, $columnsEncodings->getEncodingForFlatPath('user_id'));
+        self::assertSame(Encodings::RLE_DICTIONARY, $columnsEncodings->getEncodingForFlatPath('status'));
+        self::assertSame(Encodings::PLAIN, $columnsEncodings->getEncodingForFlatPath('description'));
+    }
+
+    public function test_creates_columns_encodings_from_valid_array() : void
+    {
+        $input = [
+            'user_id' => 'DELTA_BINARY_PACKED',
+            'status' => 'RLE_DICTIONARY',
+            'description' => 'PLAIN',
+        ];
+
+        $columnsEncodings = ColumnsEncodings::fromArray($input);
+
+        self::assertFalse($columnsEncodings->isEmpty());
+        self::assertSame(3, $columnsEncodings->count());
+        self::assertSame(['user_id', 'status', 'description'], $columnsEncodings->getFlatPaths());
+        self::assertSame($input, $columnsEncodings->toArray());
+    }
+
+    public function test_creates_columns_encodings_with_nested_flat_paths() : void
+    {
+        $input = [
+            'user.id' => 'DELTA_BINARY_PACKED',
+            'user.profile.name' => 'RLE_DICTIONARY',
+            'orders.list.element' => 'DELTA_BINARY_PACKED',
+            'metadata.key_value.key' => 'RLE_DICTIONARY',
+            'metadata.key_value.value' => 'PLAIN',
+        ];
+
+        $columnsEncodings = ColumnsEncodings::fromArray($input);
+
+        self::assertSame(5, $columnsEncodings->count());
+        self::assertSame(
+            ['user.id', 'user.profile.name', 'orders.list.element', 'metadata.key_value.key', 'metadata.key_value.value'],
+            $columnsEncodings->getFlatPaths()
+        );
+        self::assertSame($input, $columnsEncodings->toArray());
+    }
+
+    public function test_creates_empty_columns_encodings_from_empty_array() : void
+    {
+        $columnsEncodings = ColumnsEncodings::fromArray([]);
+
+        self::assertTrue($columnsEncodings->isEmpty());
+        self::assertSame(0, $columnsEncodings->count());
+        self::assertSame([], $columnsEncodings->getFlatPaths());
+        self::assertSame([], $columnsEncodings->toArray());
+    }
+
+    public function test_gets_encoding_for_existing_flat_path() : void
+    {
+        $columnsEncodings = ColumnsEncodings::fromArray([
+            'user_id' => 'DELTA_BINARY_PACKED',
+            'status' => 'RLE_DICTIONARY',
+        ]);
+
+        self::assertSame(Encodings::DELTA_BINARY_PACKED, $columnsEncodings->getEncodingForFlatPath('user_id'));
+        self::assertSame(Encodings::RLE_DICTIONARY, $columnsEncodings->getEncodingForFlatPath('status'));
+    }
+
+    public function test_handles_whitespace_in_encoding_names() : void
+    {
+        $columnsEncodings = ColumnsEncodings::fromArray([
+            'col1' => '  PLAIN  ',
+            'col2' => "\tRLE_DICTIONARY\n",
+            'col3' => ' DELTA_BINARY_PACKED ',
+        ]);
+
+        self::assertSame(Encodings::PLAIN, $columnsEncodings->getEncodingForFlatPath('col1'));
+        self::assertSame(Encodings::RLE_DICTIONARY, $columnsEncodings->getEncodingForFlatPath('col2'));
+        self::assertSame(Encodings::DELTA_BINARY_PACKED, $columnsEncodings->getEncodingForFlatPath('col3'));
+    }
+
+    public function test_mixed_enum_and_string_input() : void
+    {
+        $columnsEncodings = ColumnsEncodings::fromArray([
+            'user_id' => Encodings::DELTA_BINARY_PACKED,
+            'status' => 'RLE_DICTIONARY',
+            'description' => Encodings::PLAIN,
+        ]);
+
+        self::assertSame(Encodings::DELTA_BINARY_PACKED, $columnsEncodings->getEncodingForFlatPath('user_id'));
+        self::assertSame(Encodings::RLE_DICTIONARY, $columnsEncodings->getEncodingForFlatPath('status'));
+        self::assertSame(Encodings::PLAIN, $columnsEncodings->getEncodingForFlatPath('description'));
+    }
+
+    public function test_preserves_flat_path_order() : void
+    {
+        $input = [
+            'z_column' => 'PLAIN',
+            'a_column' => 'RLE_DICTIONARY',
+            'm_column' => 'DELTA_BINARY_PACKED',
+        ];
+
+        $columnsEncodings = ColumnsEncodings::fromArray($input);
+
+        self::assertSame(['z_column', 'a_column', 'm_column'], $columnsEncodings->getFlatPaths());
+        self::assertSame($input, $columnsEncodings->toArray());
+    }
+
+    public function test_returns_null_for_non_existing_flat_path() : void
+    {
+        $columnsEncodings = ColumnsEncodings::fromArray([
+            'user_id' => 'DELTA_BINARY_PACKED',
+        ]);
+
+        self::assertNull($columnsEncodings->getEncodingForFlatPath('non_existing'));
+        self::assertNull($columnsEncodings->getEncodingForFlatPath(''));
+    }
+
+    public function test_throws_exception_for_empty_flat_path() : void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Column flat path cannot be empty');
+
+        ColumnsEncodings::fromArray([
+            '' => 'PLAIN',
+        ]);
+    }
+
+    public function test_throws_exception_for_invalid_encoding_name() : void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("Unsupported encoding: 'INVALID_ENCODING'. Supported encodings: PLAIN, RLE_DICTIONARY, DELTA_BINARY_PACKED");
+
+        ColumnsEncodings::fromArray([
+            'user_id' => 'INVALID_ENCODING',
+        ]);
+    }
+
+    public function test_throws_exception_for_invalid_encoding_type() : void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Encoding must be an Encodings enum or string, got: integer');
+
+        ColumnsEncodings::fromArray([
+            'user_id' => 123,
+        ]);
+    }
+
+    public function test_throws_exception_for_non_string_flat_path() : void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Column flat path must be a string, got: integer');
+
+        ColumnsEncodings::fromArray([
+            123 => 'PLAIN',
+        ]);
+    }
+
+    public function test_to_array_returns_encoding_names() : void
+    {
+        $input = [
+            'user_id' => 'DELTA_BINARY_PACKED',
+            'status' => 'RLE_DICTIONARY',
+            'description' => 'PLAIN',
+        ];
+
+        $columnsEncodings = ColumnsEncodings::fromArray($input);
+        $result = $columnsEncodings->toArray();
+
+        self::assertSame($input, $result);
+    }
+}

--- a/src/lib/parquet/tests/Flow/Parquet/Tests/Unit/Writer/ColumnChunkBuilderFactoryTest.php
+++ b/src/lib/parquet/tests/Flow/Parquet/Tests/Unit/Writer/ColumnChunkBuilderFactoryTest.php
@@ -1,0 +1,207 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\Parquet\Tests\Unit\Writer;
+
+use Flow\Parquet\Exception\InvalidArgumentException;
+use Flow\Parquet\{Option, Options};
+use Flow\Parquet\ParquetFile\{Compressions};
+use Flow\Parquet\ParquetFile\Schema\{FlatColumn, LogicalType, PhysicalType};
+use Flow\Parquet\Writer\ColumnChunkBuilder\{DeltaBinaryPackedColumnChunkBuilder, PlainFlatColumnChunkBuilder, RLEDictionaryChunkBuilder};
+use Flow\Parquet\Writer\ColumnChunkBuilderFactory;
+use PHPUnit\Framework\TestCase;
+
+final class ColumnChunkBuilderFactoryTest extends TestCase
+{
+    public function test_create_builder_custom_encoding_overrides_automatic_selection() : void
+    {
+        $column = new FlatColumn('user_id', PhysicalType::INT32);
+        $options = Options::default()
+            ->set(Option::WRITER_VERSION, 2)
+            ->set(Option::COLUMNS_ENCODINGS, [
+                'user_id' => 'PLAIN',
+            ]);
+        $compressions = Compressions::UNCOMPRESSED;
+
+        $builder = ColumnChunkBuilderFactory::createBuilder($column, $options, $compressions);
+
+        self::assertInstanceOf(PlainFlatColumnChunkBuilder::class, $builder);
+    }
+
+    public function test_create_builder_for_int32_column_with_plain_encoding() : void
+    {
+        $column = new FlatColumn('user_id', PhysicalType::INT32);
+        $options = Options::default();
+        $compressions = Compressions::UNCOMPRESSED;
+
+        $builder = ColumnChunkBuilderFactory::createBuilder($column, $options, $compressions);
+
+        self::assertInstanceOf(PlainFlatColumnChunkBuilder::class, $builder);
+    }
+
+    public function test_create_builder_for_int32_column_with_writer_version_2() : void
+    {
+        $column = new FlatColumn('user_id', PhysicalType::INT32);
+        $options = Options::default()->set(Option::WRITER_VERSION, 2);
+        $compressions = Compressions::UNCOMPRESSED;
+
+        $builder = ColumnChunkBuilderFactory::createBuilder($column, $options, $compressions);
+
+        self::assertInstanceOf(DeltaBinaryPackedColumnChunkBuilder::class, $builder);
+    }
+
+    public function test_create_builder_for_int64_column_with_writer_version_2() : void
+    {
+        $column = new FlatColumn('timestamp', PhysicalType::INT64);
+        $options = Options::default()->set(Option::WRITER_VERSION, 2);
+        $compressions = Compressions::UNCOMPRESSED;
+
+        $builder = ColumnChunkBuilderFactory::createBuilder($column, $options, $compressions);
+
+        self::assertInstanceOf(DeltaBinaryPackedColumnChunkBuilder::class, $builder);
+    }
+
+    public function test_create_builder_for_string_column() : void
+    {
+        $column = new FlatColumn('name', PhysicalType::BYTE_ARRAY, logicalType: LogicalType::string());
+        $options = Options::default();
+        $compressions = Compressions::UNCOMPRESSED;
+
+        $builder = ColumnChunkBuilderFactory::createBuilder($column, $options, $compressions);
+
+        self::assertInstanceOf(PlainFlatColumnChunkBuilder::class, $builder);
+    }
+
+    public function test_create_builder_with_case_insensitive_encoding_names() : void
+    {
+        $column = new FlatColumn('status', PhysicalType::BYTE_ARRAY, logicalType: LogicalType::string());
+        $options = Options::default()->set(Option::COLUMNS_ENCODINGS, [
+            'status' => 'rle_dictionary',  // lowercase
+        ]);
+        $compressions = Compressions::UNCOMPRESSED;
+
+        $builder = ColumnChunkBuilderFactory::createBuilder($column, $options, $compressions);
+
+        self::assertInstanceOf(RLEDictionaryChunkBuilder::class, $builder);
+    }
+
+    public function test_create_builder_with_custom_delta_binary_packed_encoding() : void
+    {
+        $column = new FlatColumn('user_id', PhysicalType::INT32);
+        $options = Options::default()->set(Option::COLUMNS_ENCODINGS, [
+            'user_id' => 'DELTA_BINARY_PACKED',
+        ]);
+        $compressions = Compressions::UNCOMPRESSED;
+
+        $builder = ColumnChunkBuilderFactory::createBuilder($column, $options, $compressions);
+
+        self::assertInstanceOf(DeltaBinaryPackedColumnChunkBuilder::class, $builder);
+    }
+
+    public function test_create_builder_with_custom_plain_encoding() : void
+    {
+        $column = new FlatColumn('description', PhysicalType::BYTE_ARRAY, logicalType: LogicalType::string());
+        $options = Options::default()->set(Option::COLUMNS_ENCODINGS, [
+            'description' => 'PLAIN',
+        ]);
+        $compressions = Compressions::UNCOMPRESSED;
+
+        $builder = ColumnChunkBuilderFactory::createBuilder($column, $options, $compressions);
+
+        self::assertInstanceOf(PlainFlatColumnChunkBuilder::class, $builder);
+    }
+
+    public function test_create_builder_with_custom_rle_dictionary_encoding() : void
+    {
+        $column = new FlatColumn('status', PhysicalType::BYTE_ARRAY, logicalType: LogicalType::string());
+        $options = Options::default()->set(Option::COLUMNS_ENCODINGS, [
+            'status' => 'RLE_DICTIONARY',
+        ]);
+        $compressions = Compressions::UNCOMPRESSED;
+
+        $builder = ColumnChunkBuilderFactory::createBuilder($column, $options, $compressions);
+
+        self::assertInstanceOf(RLEDictionaryChunkBuilder::class, $builder);
+    }
+
+    public function test_create_builder_with_flat_path_encoding() : void
+    {
+        $column = new FlatColumn('user.id', PhysicalType::INT32);
+
+        $options = Options::default()->set(Option::COLUMNS_ENCODINGS, [
+            'user.id' => 'DELTA_BINARY_PACKED',
+        ]);
+        $compressions = Compressions::UNCOMPRESSED;
+
+        $builder = ColumnChunkBuilderFactory::createBuilder($column, $options, $compressions);
+
+        self::assertInstanceOf(DeltaBinaryPackedColumnChunkBuilder::class, $builder);
+    }
+
+    public function test_empty_columns_encodings_option() : void
+    {
+        $column = new FlatColumn('user_id', PhysicalType::INT32);
+        $options = Options::default()->set(Option::COLUMNS_ENCODINGS, []);
+        $compressions = Compressions::UNCOMPRESSED;
+
+        $builder = ColumnChunkBuilderFactory::createBuilder($column, $options, $compressions);
+
+        self::assertInstanceOf(PlainFlatColumnChunkBuilder::class, $builder);
+    }
+
+    public function test_fallback_to_plain_when_no_custom_encoding_specified() : void
+    {
+        $column = new FlatColumn('description', PhysicalType::BYTE_ARRAY, logicalType: LogicalType::string());
+        $options = Options::default()->set(Option::COLUMNS_ENCODINGS, [
+            'other_column' => 'RLE_DICTIONARY',
+        ]);
+        $compressions = Compressions::UNCOMPRESSED;
+
+        $builder = ColumnChunkBuilderFactory::createBuilder($column, $options, $compressions);
+
+        self::assertInstanceOf(PlainFlatColumnChunkBuilder::class, $builder);
+    }
+
+    public function test_invalid_delta_binary_packed_encoding_for_string_column_throws_exception() : void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("DELTA_BINARY_PACKED encoding is only supported for INT32 and INT64 columns. Column 'description' has type: BYTE_ARRAY");
+
+        $column = new FlatColumn('description', PhysicalType::BYTE_ARRAY, logicalType: LogicalType::string());
+        $options = Options::default()->set(Option::COLUMNS_ENCODINGS, [
+            'description' => 'DELTA_BINARY_PACKED',
+        ]);
+        $compressions = Compressions::UNCOMPRESSED;
+
+        ColumnChunkBuilderFactory::createBuilder($column, $options, $compressions);
+    }
+
+    public function test_invalid_rle_dictionary_encoding_for_fixed_len_byte_array_throws_exception() : void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("RLE_DICTIONARY encoding is not supported for FIXED_LEN_BYTE_ARRAY columns. Column 'fixed_data' has type: FIXED_LEN_BYTE_ARRAY");
+
+        $column = new FlatColumn('fixed_data', PhysicalType::FIXED_LEN_BYTE_ARRAY);
+        $options = Options::default()->set(Option::COLUMNS_ENCODINGS, [
+            'fixed_data' => 'RLE_DICTIONARY',
+        ]);
+        $compressions = Compressions::UNCOMPRESSED;
+
+        ColumnChunkBuilderFactory::createBuilder($column, $options, $compressions);
+    }
+
+    public function test_unsupported_encoding_name_throws_exception() : void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("Unsupported encoding: 'INVALID_ENCODING'. Supported encodings: PLAIN, RLE_DICTIONARY, DELTA_BINARY_PACKED");
+
+        $column = new FlatColumn('data', PhysicalType::BYTE_ARRAY);
+        $options = Options::default()->set(Option::COLUMNS_ENCODINGS, [
+            'data' => 'INVALID_ENCODING',
+        ]);
+        $compressions = Compressions::UNCOMPRESSED;
+
+        ColumnChunkBuilderFactory::createBuilder($column, $options, $compressions);
+    }
+}

--- a/src/lib/parquet/tests/Flow/Parquet/Tests/Unit/Writer/ColumnChunkBuildersTest.php
+++ b/src/lib/parquet/tests/Flow/Parquet/Tests/Unit/Writer/ColumnChunkBuildersTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Flow\Parquet\Tests\Unit\Writer;
 
 use Flow\Parquet\Dremel\{WriteColumnData};
-use Flow\Parquet\Exception\InvalidArgumentException;
 use Flow\Parquet\{Option, Options};
 use Flow\Parquet\ParquetFile\{Compressions, Schema};
 use Flow\Parquet\ParquetFile\Schema\{FlatColumn, ListElement, LogicalType, MapKey, MapValue, NestedColumn, PhysicalType};
@@ -657,22 +656,6 @@ final class ColumnChunkBuildersTest extends TestCase
         $builders = ColumnChunkBuilders::initialize($schema, $options, $compressions);
 
         self::assertInstanceOf(ColumnChunkBuilders::class, $builders);
-    }
-
-    public function test_invalid_encoding_for_column_type_throws_exception() : void
-    {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage("DELTA_BINARY_PACKED encoding is only supported for INT32 and INT64 columns. Column 'description' has type: BYTE_ARRAY");
-
-        $options = Options::default()->set(Option::COLUMNS_ENCODINGS, [
-            'description' => 'DELTA_BINARY_PACKED',
-        ]);
-        $compressions = Compressions::UNCOMPRESSED;
-
-        $flatColumn = new FlatColumn('description', PhysicalType::BYTE_ARRAY, logicalType: LogicalType::string());
-        $schema = Schema::with($flatColumn);
-
-        ColumnChunkBuilders::initialize($schema, $options, $compressions);
     }
 
     public function test_is_any_page_full_with_empty_builders() : void

--- a/src/lib/parquet/tests/Flow/Parquet/Tests/Unit/Writer/ColumnChunkBuildersTest.php
+++ b/src/lib/parquet/tests/Flow/Parquet/Tests/Unit/Writer/ColumnChunkBuildersTest.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace Flow\Parquet\Tests\Unit\Writer;
 
 use Flow\Parquet\Dremel\{WriteColumnData};
-use Flow\Parquet\Options;
+use Flow\Parquet\Exception\InvalidArgumentException;
+use Flow\Parquet\{Option, Options};
 use Flow\Parquet\ParquetFile\{Compressions, Schema};
-use Flow\Parquet\ParquetFile\Schema\{FlatColumn, LogicalType, NestedColumn, PhysicalType};
+use Flow\Parquet\ParquetFile\Schema\{FlatColumn, ListElement, LogicalType, MapKey, MapValue, NestedColumn, PhysicalType};
+use Flow\Parquet\Writer\ColumnChunkBuilder\{DeltaBinaryPackedColumnChunkBuilder, PlainFlatColumnChunkBuilder, RLEDictionaryChunkBuilder};
 use Flow\Parquet\Writer\{ColumnChunkBuilder, ColumnChunkBuilders, ColumnChunkContainer};
 use PHPUnit\Framework\TestCase;
 
@@ -80,6 +82,33 @@ final class ColumnChunkBuildersTest extends TestCase
         $builders->add($columnData);
 
         self::assertTrue(true);
+    }
+
+    public function test_case_insensitive_encoding_names_in_options() : void
+    {
+        $options = Options::default()->set(Option::COLUMNS_ENCODINGS, [
+            'col1' => 'plain',
+            'col2' => 'RLE_Dictionary',
+            'col3' => 'DELTA_BINARY_PACKED',
+        ]);
+        $compressions = Compressions::UNCOMPRESSED;
+
+        $col1 = new FlatColumn('col1', PhysicalType::BYTE_ARRAY, logicalType: LogicalType::string());
+        $col2 = new FlatColumn('col2', PhysicalType::BYTE_ARRAY, logicalType: LogicalType::string());
+        $col3 = new FlatColumn('col3', PhysicalType::INT32);
+        $schema = Schema::with($col1, $col2, $col3);
+
+        $builders = ColumnChunkBuilders::initialize($schema, $options, $compressions);
+
+        // Extract builders through reflection
+        $reflection = new \ReflectionClass($builders);
+        $buildersProperty = $reflection->getProperty('builders');
+        $buildersProperty->setAccessible(true);
+        $buildersArray = $buildersProperty->getValue($builders);
+
+        self::assertInstanceOf(PlainFlatColumnChunkBuilder::class, $buildersArray['col1']);
+        self::assertInstanceOf(RLEDictionaryChunkBuilder::class, $buildersArray['col2']);
+        self::assertInstanceOf(DeltaBinaryPackedColumnChunkBuilder::class, $buildersArray['col3']);
     }
 
     public function test_close_pages_before_flush() : void
@@ -162,6 +191,31 @@ final class ColumnChunkBuildersTest extends TestCase
         self::assertTrue(true);
     }
 
+    public function test_complex_nested_flat_paths_encoding_selection() : void
+    {
+        $options = Options::default()->set(Option::COLUMNS_ENCODINGS, [
+            'struct_nested.struct_flat.list_of_ints.list.element' => 'DELTA_BINARY_PACKED',
+            'struct_nested.struct_flat.map_of_string_int.key_value.key' => 'RLE_DICTIONARY',
+            'struct_nested.struct_flat.map_of_string_int.key_value.value' => 'DELTA_BINARY_PACKED',
+        ]);
+        $compressions = Compressions::UNCOMPRESSED;
+
+        // Create a complex nested structure
+        $listColumn = NestedColumn::list('list_of_ints', ListElement::int32());
+
+        $mapColumn = NestedColumn::map('map_of_string_int', MapKey::string(), MapValue::int32());
+
+        $structFlat = NestedColumn::create('struct_flat', [$listColumn, $mapColumn]);
+        $structNested = NestedColumn::create('struct_nested', [$structFlat]);
+
+        $schema = Schema::with($structNested);
+
+        $builders = ColumnChunkBuilders::initialize($schema, $options, $compressions);
+
+        // Verify the builders were created successfully (complex assertion would require deep reflection)
+        self::assertInstanceOf(ColumnChunkBuilders::class, $builders);
+    }
+
     public function test_constructor_with_builders_array() : void
     {
         $mockBuilder = $this->createMock(ColumnChunkBuilder::class);
@@ -175,6 +229,161 @@ final class ColumnChunkBuildersTest extends TestCase
         $builders = new ColumnChunkBuilders([]);
 
         self::assertInstanceOf(ColumnChunkBuilders::class, $builders);
+    }
+
+    public function test_custom_encoding_mixed_with_default_selection() : void
+    {
+        $options = Options::default()->set(Option::COLUMNS_ENCODINGS, [
+            'user_id' => 'DELTA_BINARY_PACKED',
+            'status' => 'RLE_DICTIONARY',
+        ]);
+        $compressions = Compressions::UNCOMPRESSED;
+
+        $userIdColumn = new FlatColumn('user_id', PhysicalType::INT32);
+        $statusColumn = new FlatColumn('status', PhysicalType::BYTE_ARRAY, logicalType: LogicalType::string());
+        $descriptionColumn = new FlatColumn('description', PhysicalType::BYTE_ARRAY, logicalType: LogicalType::string());
+        $schema = Schema::with($userIdColumn, $statusColumn, $descriptionColumn);
+
+        $builders = ColumnChunkBuilders::initialize($schema, $options, $compressions);
+
+        // Extract builders through reflection
+        $reflection = new \ReflectionClass($builders);
+        $buildersProperty = $reflection->getProperty('builders');
+        $buildersProperty->setAccessible(true);
+        $buildersArray = $buildersProperty->getValue($builders);
+
+        // Verify custom encodings
+        self::assertInstanceOf(DeltaBinaryPackedColumnChunkBuilder::class, $buildersArray['user_id']);
+        self::assertInstanceOf(RLEDictionaryChunkBuilder::class, $buildersArray['status']);
+
+        // Verify default encoding is used for description (not specified in custom encodings)
+        self::assertInstanceOf(PlainFlatColumnChunkBuilder::class, $buildersArray['description']);
+    }
+
+    public function test_custom_encoding_overrides_automatic_delta_selection() : void
+    {
+        // Writer version 2 would normally select DELTA_BINARY_PACKED for INT32/INT64
+        $options = Options::default()
+            ->set(Option::WRITER_VERSION, 2)
+            ->set(Option::COLUMNS_ENCODINGS, [
+                'user_id' => 'PLAIN',  // Override automatic DELTA selection
+            ]);
+        $compressions = Compressions::UNCOMPRESSED;
+
+        $flatColumn = new FlatColumn('user_id', PhysicalType::INT32);
+        $schema = Schema::with($flatColumn);
+
+        $builders = ColumnChunkBuilders::initialize($schema, $options, $compressions);
+
+        // Extract the builder through reflection to verify PLAIN is used instead of DELTA
+        $reflection = new \ReflectionClass($builders);
+        $buildersProperty = $reflection->getProperty('builders');
+        $buildersProperty->setAccessible(true);
+        $buildersArray = $buildersProperty->getValue($builders);
+
+        self::assertInstanceOf(PlainFlatColumnChunkBuilder::class, $buildersArray['user_id']);
+    }
+
+    // Custom encoding selection tests
+
+    public function test_custom_encoding_selection_with_delta_binary_packed() : void
+    {
+        $options = Options::default()->set(Option::COLUMNS_ENCODINGS, [
+            'user_id' => 'DELTA_BINARY_PACKED',
+        ]);
+        $compressions = Compressions::UNCOMPRESSED;
+
+        $flatColumn = new FlatColumn('user_id', PhysicalType::INT32);
+        $schema = Schema::with($flatColumn);
+
+        $builders = ColumnChunkBuilders::initialize($schema, $options, $compressions);
+
+        // Extract the builder through reflection to verify the correct type
+        $reflection = new \ReflectionClass($builders);
+        $buildersProperty = $reflection->getProperty('builders');
+        $buildersProperty->setAccessible(true);
+        $buildersArray = $buildersProperty->getValue($builders);
+
+        self::assertInstanceOf(DeltaBinaryPackedColumnChunkBuilder::class, $buildersArray['user_id']);
+    }
+
+    public function test_custom_encoding_selection_with_nested_columns() : void
+    {
+        $options = Options::default()->set(Option::COLUMNS_ENCODINGS, [
+            'user.id' => 'DELTA_BINARY_PACKED',
+            'user.name' => 'RLE_DICTIONARY',
+        ]);
+        $compressions = Compressions::UNCOMPRESSED;
+
+        $userIdColumn = new FlatColumn('id', PhysicalType::INT32);
+        $userNameColumn = new FlatColumn('name', PhysicalType::BYTE_ARRAY, logicalType: LogicalType::string());
+        $userColumn = NestedColumn::create('user', [$userIdColumn, $userNameColumn]);
+        $schema = Schema::with($userColumn);
+
+        $builders = ColumnChunkBuilders::initialize($schema, $options, $compressions);
+
+        // Extract the nested builder through reflection
+        $reflection = new \ReflectionClass($builders);
+        $buildersProperty = $reflection->getProperty('builders');
+        $buildersProperty->setAccessible(true);
+        $buildersArray = $buildersProperty->getValue($builders);
+
+        // Get the nested column builder
+        $nestedBuilder = $buildersArray['user'];
+        $nestedReflection = new \ReflectionClass($nestedBuilder);
+        $childBuildersProperty = $nestedReflection->getProperty('childrenColumnChunkBuilders');
+        $childBuildersProperty->setAccessible(true);
+        $childBuilders = $childBuildersProperty->getValue($nestedBuilder);
+
+        // Get the child builders as values array since they're keyed by flat path
+        $childBuilderValues = array_values($childBuilders);
+
+        // Verify the correct encoding builders were created
+        // Order: [0] = user.id (DELTA_BINARY_PACKED), [1] = user.name (RLE_DICTIONARY)
+        self::assertInstanceOf(DeltaBinaryPackedColumnChunkBuilder::class, $childBuilderValues[0]);
+        self::assertInstanceOf(RLEDictionaryChunkBuilder::class, $childBuilderValues[1]);
+    }
+
+    public function test_custom_encoding_selection_with_plain() : void
+    {
+        $options = Options::default()->set(Option::COLUMNS_ENCODINGS, [
+            'description' => 'PLAIN',
+        ]);
+        $compressions = Compressions::UNCOMPRESSED;
+
+        $flatColumn = new FlatColumn('description', PhysicalType::BYTE_ARRAY, logicalType: LogicalType::string());
+        $schema = Schema::with($flatColumn);
+
+        $builders = ColumnChunkBuilders::initialize($schema, $options, $compressions);
+
+        // Extract the builder through reflection to verify the correct type
+        $reflection = new \ReflectionClass($builders);
+        $buildersProperty = $reflection->getProperty('builders');
+        $buildersProperty->setAccessible(true);
+        $buildersArray = $buildersProperty->getValue($builders);
+
+        self::assertInstanceOf(PlainFlatColumnChunkBuilder::class, $buildersArray['description']);
+    }
+
+    public function test_custom_encoding_selection_with_rle_dictionary() : void
+    {
+        $options = Options::default()->set(Option::COLUMNS_ENCODINGS, [
+            'status' => 'RLE_DICTIONARY',
+        ]);
+        $compressions = Compressions::UNCOMPRESSED;
+
+        $flatColumn = new FlatColumn('status', PhysicalType::BYTE_ARRAY, logicalType: LogicalType::string());
+        $schema = Schema::with($flatColumn);
+
+        $builders = ColumnChunkBuilders::initialize($schema, $options, $compressions);
+
+        // Extract the builder through reflection to verify the correct type
+        $reflection = new \ReflectionClass($builders);
+        $buildersProperty = $reflection->getProperty('builders');
+        $buildersProperty->setAccessible(true);
+        $buildersArray = $buildersProperty->getValue($builders);
+
+        self::assertInstanceOf(RLEDictionaryChunkBuilder::class, $buildersArray['status']);
     }
 
     public function test_different_compression_types() : void
@@ -260,6 +469,26 @@ final class ColumnChunkBuildersTest extends TestCase
         self::assertIsArray($containers);
         self::assertCount(1, $containers);
         self::assertSame(0, $containers[0]->columnChunk->fileOffset());
+    }
+
+    public function test_empty_columns_encodings_option() : void
+    {
+        $options = Options::default()->set(Option::COLUMNS_ENCODINGS, []);
+        $compressions = Compressions::UNCOMPRESSED;
+
+        $flatColumn = new FlatColumn('user_id', PhysicalType::INT32);
+        $schema = Schema::with($flatColumn);
+
+        $builders = ColumnChunkBuilders::initialize($schema, $options, $compressions);
+
+        // Extract the builder through reflection to verify default behavior
+        $reflection = new \ReflectionClass($builders);
+        $buildersProperty = $reflection->getProperty('builders');
+        $buildersProperty->setAccessible(true);
+        $buildersArray = $buildersProperty->getValue($builders);
+
+        // Should use default PLAIN encoding since no custom encoding specified
+        self::assertInstanceOf(PlainFlatColumnChunkBuilder::class, $buildersArray['user_id']);
     }
 
     public function test_flush_calculates_offset_correctly() : void
@@ -428,6 +657,22 @@ final class ColumnChunkBuildersTest extends TestCase
         $builders = ColumnChunkBuilders::initialize($schema, $options, $compressions);
 
         self::assertInstanceOf(ColumnChunkBuilders::class, $builders);
+    }
+
+    public function test_invalid_encoding_for_column_type_throws_exception() : void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("DELTA_BINARY_PACKED encoding is only supported for INT32 and INT64 columns. Column 'description' has type: BYTE_ARRAY");
+
+        $options = Options::default()->set(Option::COLUMNS_ENCODINGS, [
+            'description' => 'DELTA_BINARY_PACKED',
+        ]);
+        $compressions = Compressions::UNCOMPRESSED;
+
+        $flatColumn = new FlatColumn('description', PhysicalType::BYTE_ARRAY, logicalType: LogicalType::string());
+        $schema = Schema::with($flatColumn);
+
+        ColumnChunkBuilders::initialize($schema, $options, $compressions);
     }
 
     public function test_is_any_page_full_with_empty_builders() : void


### PR DESCRIPTION
<!-- 
    Please replace #xxx with a GitHub issue id from flow-php/flow repository. For example #1234 
    If there is no item in a roadmap related to this PR, please check our contributing guidelines first. 
-->
Resolves: #1761

<!-- 
    Below section will be used to automatically generate changelog, please do not modify HTML code structure
    DO NOT REMOVE that HTML STRUCTURE, INSTEAD ADD YOUR CHANGES INSIDE THE LISTS 
    PULL REQUESTS WITHOUT CHANGELOG CAN'T BE MERGED 
-->
<h2>Change Log</h2>
<hr /> 
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <li>Allow to chose encoding for parquet columns</li>
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>