### PR TITLE
Allow to read only specific columns through CLI read command

### DIFF
--- a/src/cli/src/Flow/CLI/Command/FileReadCommand.php
+++ b/src/cli/src/Flow/CLI/Command/FileReadCommand.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Flow\CLI\Command;
 
-use function Flow\CLI\{option_bool, option_int, option_int_nullable};
+use function Flow\CLI\{option_bool, option_int, option_int_nullable, option_list_of_strings};
 use function Flow\ETL\DSL\{df};
 use Flow\CLI\Arguments\{FilePathArgument};
 use Flow\CLI\Command\Traits\{CSVOptions, ConfigOptions, ExcelOptions, JSONOptions, ParquetOptions, XMLOptions};
@@ -45,6 +45,7 @@ final class FileReadCommand extends Command
             ->addOption('input-file-batch-size', null, InputOption::VALUE_REQUIRED, 'Number of rows that are going to be read and displayed in one batch, when set to -1 whole dataset will be displayed at once', self::DEFAULT_BATCH_SIZE)
             ->addOption('input-file-limit', null, InputOption::VALUE_REQUIRED, 'Limit number of rows that are going to be used to infer file schema, when not set whole file is analyzed', null)
             ->addOption('output-truncate', null, InputOption::VALUE_REQUIRED, 'Truncate output to given number of characters, when set to -1 output is not truncated at all', 20)
+            ->addOption('output-columns', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Columns to include in output, when not set all columns are displayed', [])
             ->addOption('schema-auto-cast', null, InputOption::VALUE_OPTIONAL, 'When set Flow will try to automatically cast values to more precise data types, for example datetime strings will be casted to datetime type', false);
 
         $this->addConfigOptions($this);
@@ -80,6 +81,12 @@ final class FileReadCommand extends Command
 
         if ($limit !== null && $limit > 0) {
             $df->limit($limit);
+        }
+
+        $outputColumns = option_list_of_strings('output-columns', $input);
+
+        if (\count($outputColumns)) {
+            $df->select(...$outputColumns);
         }
 
         $formatter = new AsciiTableFormatter();

--- a/src/cli/tests/Flow/CLI/Tests/Integration/FileReadCommandTest.php
+++ b/src/cli/tests/Flow/CLI/Tests/Integration/FileReadCommandTest.php
@@ -137,6 +137,109 @@ OUTPUT,
         );
     }
 
+    public function test_read_rows_with_output_columns_empty_maintains_all_columns() : void
+    {
+        $tester = new CommandTester(new FileReadCommand('read'));
+
+        $tester->execute([
+            'input-file' => __DIR__ . '/Fixtures/orders.csv',
+            '--input-file-limit' => 2,
+        ]);
+
+        $tester->assertCommandIsSuccessful();
+
+        // Should contain all original columns (order_id, created_at, updated_at, discount, address, notes, items)
+        $output = $tester->getDisplay();
+        self::assertStringContainsString('order_id', $output);
+        self::assertStringContainsString('created_at', $output);
+        self::assertStringContainsString('updated_at', $output);
+        self::assertStringContainsString('discount', $output);
+        self::assertStringContainsString('address', $output);
+        self::assertStringContainsString('notes', $output);
+        self::assertStringContainsString('items', $output);
+        self::assertStringContainsString('2 rows', $output);
+    }
+
+    public function test_read_rows_with_output_columns_multiple_columns() : void
+    {
+        $tester = new CommandTester(new FileReadCommand('read'));
+
+        $tester->execute([
+            'input-file' => __DIR__ . '/Fixtures/orders.csv',
+            '--input-file-limit' => 3,
+            '--output-columns' => ['order_id', 'discount', 'created_at'],
+        ]);
+
+        $tester->assertCommandIsSuccessful();
+
+        self::assertStringContainsString(
+            <<<'OUTPUT'
++----------------------+----------+----------------------+
+|             order_id | discount |           created_at |
++----------------------+----------+----------------------+
+| e13d7098-5a78-3389-9 |    12.45 | 2024-06-17T19:24:49+ |
+| 947df050-3abb-3f5a-9 |          | 2024-02-23T19:18:53+ |
+| 6315f9e2-86bf-3321-a |     47.1 | 2024-04-02T11:30:25+ |
++----------------------+----------+----------------------+
+3 rows
+OUTPUT,
+            $tester->getDisplay()
+        );
+    }
+
+    public function test_read_rows_with_output_columns_nonexistent_column() : void
+    {
+        $tester = new CommandTester(new FileReadCommand('read'));
+
+        $tester->execute([
+            'input-file' => __DIR__ . '/Fixtures/orders.csv',
+            '--input-file-limit' => 2,
+            '--output-columns' => ['nonexistent_column'],
+        ]);
+
+        $tester->assertCommandIsSuccessful();
+
+        self::assertStringContainsString(
+            <<<'OUTPUT'
++--------------------+
+| nonexistent_column |
++--------------------+
+|                    |
+|                    |
++--------------------+
+2 rows
+OUTPUT,
+            $tester->getDisplay()
+        );
+    }
+
+    public function test_read_rows_with_output_columns_single_column() : void
+    {
+        $tester = new CommandTester(new FileReadCommand('read'));
+
+        $tester->execute([
+            'input-file' => __DIR__ . '/Fixtures/orders.csv',
+            '--input-file-limit' => 3,
+            '--output-columns' => ['order_id'],
+        ]);
+
+        $tester->assertCommandIsSuccessful();
+
+        self::assertStringContainsString(
+            <<<'OUTPUT'
++----------------------+
+|             order_id |
++----------------------+
+| e13d7098-5a78-3389-9 |
+| 947df050-3abb-3f5a-9 |
+| 6315f9e2-86bf-3321-a |
++----------------------+
+3 rows
+OUTPUT,
+            $tester->getDisplay()
+        );
+    }
+
     public function test_read_rows_xml() : void
     {
         $tester = new CommandTester(new FileReadCommand('read'));


### PR DESCRIPTION
<!-- 
    Please replace #xxx with a GitHub issue id from flow-php/flow repository. For example #1234 
    If there is no item in a roadmap related to this PR, please check our contributing guidelines first. 
-->
Resolves: #1786

<!-- 
    Below section will be used to automatically generate changelog, please do not modify HTML code structure
    DO NOT REMOVE that HTML STRUCTURE, INSTEAD ADD YOUR CHANGES INSIDE THE LISTS 
    PULL REQUESTS WITHOUT CHANGELOG CAN'T BE MERGED 
-->
<h2>Change Log</h2>
<hr /> 
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <li>--ouput-columns to CLI read command</li>
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>