### PR TITLE
Added head/tail/last method to Rows

### DIFF
--- a/src/core/etl/src/Flow/ETL/Rows.php
+++ b/src/core/etl/src/Flow/ETL/Rows.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Flow\ETL;
 
 use function Flow\ETL\DSL\{array_to_rows, row};
+use function Flow\Types\DSL\type_integer;
 use Flow\ETL\Exception\{DuplicatedEntriesException, InvalidArgumentException, RuntimeException};
 use Flow\ETL\Hash\{Algorithm, NativePHPHash};
 use Flow\ETL\Join\Expression;
@@ -12,6 +13,7 @@ use Flow\ETL\Row\{CartesianProduct, EntryFactory};
 use Flow\ETL\Row\Comparator\NativeComparator;
 use Flow\ETL\Row\{Comparator, Entries, Reference, References, SortOrder};
 use Flow\Filesystem\{Partition, Partitions};
+use Flow\Types\Exception\InvalidTypeException;
 
 /**
  * @implements \ArrayAccess<int, Row>
@@ -299,6 +301,26 @@ final class Rows implements \ArrayAccess, \Countable, \IteratorAggregate
         return $algorithm->hash($hash);
     }
 
+    /**
+     * @param int $count - Count of rows to return. Must be >= 0.
+     *
+     * @throws InvalidArgumentException When count is negative
+     * @throws InvalidTypeException When count is not an integer     */
+    public function head(int $count) : self
+    {
+        $count = type_integer()->assert($count);
+
+        if ($count < 0) {
+            throw new InvalidArgumentException('Count must be greater than or equal to 0');
+        }
+
+        if ($count === 0) {
+            return self::partitioned([], $this->partitions);
+        }
+
+        return self::partitioned(\array_slice($this->rows, 0, $count), $this->partitions);
+    }
+
     public function isPartitioned() : bool
     {
         return \count($this->partitions) > 0;
@@ -482,6 +504,15 @@ final class Rows implements \ArrayAccess, \Countable, \IteratorAggregate
         }
 
         return new self(...$joined);
+    }
+
+    public function last() : ?Row
+    {
+        if (empty($this->rows)) {
+            return null;
+        }
+
+        return $this->rows[\count($this->rows) - 1];
     }
 
     /**
@@ -737,6 +768,32 @@ final class Rows implements \ArrayAccess, \Countable, \IteratorAggregate
     public function sortEntries() : self
     {
         return $this->map(fn (Row $row) : Row => $row->sortEntries());
+    }
+
+    /**
+     * @param int $count - Count of rows to return. Must be >= 0.
+     *
+     * @throws InvalidArgumentException When count is negative
+     * @throws InvalidTypeException When count is not an integer     */
+    public function tail(int $count) : self
+    {
+        $count = type_integer()->assert($count);
+
+        if ($count < 0) {
+            throw new InvalidArgumentException('Count must be greater than or equal to 0');
+        }
+
+        if ($count === 0) {
+            return self::partitioned([], $this->partitions);
+        }
+
+        $rowsCount = \count($this->rows);
+
+        if ($count >= $rowsCount) {
+            return self::partitioned($this->rows, $this->partitions);
+        }
+
+        return self::partitioned(\array_slice($this->rows, -$count), $this->partitions);
     }
 
     public function take(int $size) : self

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/RowsTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/RowsTest.php
@@ -486,6 +486,122 @@ final class RowsTest extends FlowTestCase
         );
     }
 
+    public function test_head() : void
+    {
+        $rows = rows(
+            row(int_entry('id', 1)),
+            row(int_entry('id', 2)),
+            row(int_entry('id', 3)),
+            row(int_entry('id', 4)),
+            row(int_entry('id', 5)),
+        );
+
+        $head = $rows->head(3);
+
+        self::assertCount(3, $head);
+        self::assertSame(1, $head[0]->valueOf('id'));
+        self::assertSame(2, $head[1]->valueOf('id'));
+        self::assertSame(3, $head[2]->valueOf('id'));
+    }
+
+    public function test_head_on_empty_rows() : void
+    {
+        $head = (rows())->head(5);
+
+        self::assertCount(0, $head);
+    }
+
+    public function test_head_preserves_partitions() : void
+    {
+        $rows = rows_partitioned(
+            [
+                row(int_entry('id', 1), str_entry('group', 'a')),
+                row(int_entry('id', 2), str_entry('group', 'a')),
+                row(int_entry('id', 3), str_entry('group', 'a')),
+            ],
+            [partition('group', 'a')]
+        );
+
+        $head = $rows->head(2);
+
+        self::assertEquals(partitions(partition('group', 'a')), $head->partitions());
+        self::assertCount(2, $head);
+    }
+
+    public function test_head_with_count_larger_than_available() : void
+    {
+        $rows = rows(
+            row(int_entry('id', 1)),
+            row(int_entry('id', 2)),
+            row(int_entry('id', 3)),
+        );
+
+        $head = $rows->head(10);
+
+        self::assertCount(3, $head);
+        self::assertSame(1, $head[0]->valueOf('id'));
+        self::assertSame(2, $head[1]->valueOf('id'));
+        self::assertSame(3, $head[2]->valueOf('id'));
+    }
+
+    public function test_head_with_negative_count() : void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Count must be greater than or equal to 0');
+
+        $rows = rows(
+            row(int_entry('id', 1)),
+            row(int_entry('id', 2)),
+            row(int_entry('id', 3)),
+        );
+
+        $rows->head(-1);
+    }
+
+    public function test_head_with_zero_count() : void
+    {
+        $rows = rows(
+            row(int_entry('id', 1)),
+            row(int_entry('id', 2)),
+            row(int_entry('id', 3)),
+        );
+
+        $head = $rows->head(0);
+
+        self::assertCount(0, $head);
+    }
+
+    public function test_last() : void
+    {
+        $rows = rows(
+            row(int_entry('id', 1)),
+            row(int_entry('id', 2)),
+            row(int_entry('id', 3)),
+        );
+
+        $lastRow = $rows->last();
+
+        self::assertNotNull($lastRow);
+        self::assertSame(3, $lastRow->valueOf('id'));
+    }
+
+    public function test_last_on_empty_rows() : void
+    {
+        $lastRow = (rows())->last();
+
+        self::assertNull($lastRow);
+    }
+
+    public function test_last_on_single_row() : void
+    {
+        $rows = rows(row(int_entry('id', 42)));
+
+        $lastRow = $rows->last();
+
+        self::assertNotNull($lastRow);
+        self::assertSame(42, $lastRow->valueOf('id'));
+    }
+
     public function test_merge_empty_rows_with_partitioned_rows() : void
     {
         $rows1 = rows(row(int_entry('id', 1), str_entry('group', 'a')))->partitionBy(ref('group'))[0];
@@ -1004,6 +1120,108 @@ final class RowsTest extends FlowTestCase
             ),
             $sorted
         );
+    }
+
+    public function test_tail() : void
+    {
+        $rows = rows(
+            row(int_entry('id', 1)),
+            row(int_entry('id', 2)),
+            row(int_entry('id', 3)),
+            row(int_entry('id', 4)),
+            row(int_entry('id', 5)),
+        );
+
+        $tail = $rows->tail(3);
+
+        self::assertCount(3, $tail);
+        self::assertSame(3, $tail[0]->valueOf('id'));
+        self::assertSame(4, $tail[1]->valueOf('id'));
+        self::assertSame(5, $tail[2]->valueOf('id'));
+    }
+
+    public function test_tail_maintains_correct_order() : void
+    {
+        $rows = rows(
+            row(int_entry('id', 1)),
+            row(int_entry('id', 2)),
+            row(int_entry('id', 3)),
+            row(int_entry('id', 4)),
+            row(int_entry('id', 5)),
+        );
+
+        $tail = $rows->tail(2);
+
+        self::assertCount(2, $tail);
+        self::assertSame(4, $tail[0]->valueOf('id'));
+        self::assertSame(5, $tail[1]->valueOf('id'));
+    }
+
+    public function test_tail_on_empty_rows() : void
+    {
+        $tail = (rows())->tail(5);
+
+        self::assertCount(0, $tail);
+    }
+
+    public function test_tail_preserves_partitions() : void
+    {
+        $rows = rows_partitioned(
+            [
+                row(int_entry('id', 1), str_entry('group', 'a')),
+                row(int_entry('id', 2), str_entry('group', 'a')),
+                row(int_entry('id', 3), str_entry('group', 'a')),
+            ],
+            [partition('group', 'a')]
+        );
+
+        $tail = $rows->tail(2);
+
+        self::assertEquals(partitions(partition('group', 'a')), $tail->partitions());
+        self::assertCount(2, $tail);
+    }
+
+    public function test_tail_with_count_larger_than_available() : void
+    {
+        $rows = rows(
+            row(int_entry('id', 1)),
+            row(int_entry('id', 2)),
+            row(int_entry('id', 3)),
+        );
+
+        $tail = $rows->tail(10);
+
+        self::assertCount(3, $tail);
+        self::assertSame(1, $tail[0]->valueOf('id'));
+        self::assertSame(2, $tail[1]->valueOf('id'));
+        self::assertSame(3, $tail[2]->valueOf('id'));
+    }
+
+    public function test_tail_with_negative_count() : void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Count must be greater than or equal to 0');
+
+        $rows = rows(
+            row(int_entry('id', 1)),
+            row(int_entry('id', 2)),
+            row(int_entry('id', 3)),
+        );
+
+        $rows->tail(-1);
+    }
+
+    public function test_tail_with_zero_count() : void
+    {
+        $rows = rows(
+            row(int_entry('id', 1)),
+            row(int_entry('id', 2)),
+            row(int_entry('id', 3)),
+        );
+
+        $tail = $rows->tail(0);
+
+        self::assertCount(0, $tail);
     }
 
     public function test_take() : void


### PR DESCRIPTION
<!-- 
    Please replace #xxx with a GitHub issue id from flow-php/flow repository. For example #1234 
    If there is no item in a roadmap related to this PR, please check our contributing guidelines first. 
-->
Resolves: #1791

<!-- 
    Below section will be used to automatically generate changelog, please do not modify HTML code structure
    DO NOT REMOVE that HTML STRUCTURE, INSTEAD ADD YOUR CHANGES INSIDE THE LISTS 
    PULL REQUESTS WITHOUT CHANGELOG CAN'T BE MERGED 
-->
<h2>Change Log</h2>
<hr /> 
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <li>Rows::head()</li>
    <li>Rows::tail()</li>
    <li>Rows::last()</li>
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>