### PR TITLE
Added support for extra metadata reflected in the OpenApiSpecification

### DIFF
--- a/documentation/components/bridges/openapi-specification-bridge.md
+++ b/documentation/components/bridges/openapi-specification-bridge.md
@@ -24,19 +24,19 @@ This bridge allows you to convert Flow PHP schemas to OpenAPI specification form
 
 use function Flow\ETL\DSL\{schema, int_schema, str_schema, bool_schema};
 use function Flow\Bridge\OpenAPI\Specification\DSL\schema_to_openapi_specification;
-use Flow\ETL\Schema\Metadata;
+use Flow\Bridge\OpenAPI\Specification\OpenAPIMetadata;
 
 $userSchema = schema(
-    int_schema('id', false, Metadata::empty()
-        ->add('description', 'Unique user identifier')
-        ->add('example', 123)
+    int_schema('id', false, 
+        OpenAPIMetadata::description('Unique user identifier')
+            ->merge(OpenAPIMetadata::example(123))
     ),
-    str_schema('name', true, Metadata::empty()
-        ->add('description', 'User full name')
-        ->add('example', 'John Doe')
+    str_schema('name', true, 
+        OpenAPIMetadata::description('User full name')
+            ->merge(OpenAPIMetadata::example('John Doe'))
     ),
-    bool_schema('active', false, Metadata::empty()
-        ->add('description', 'Account status')
+    bool_schema('active', false, 
+        OpenAPIMetadata::description('Account status')
     )
 );
 
@@ -106,6 +106,155 @@ $flowSchema = schema_from_openapi_specification($openApiSpec);
 ```
 
 
+## OpenAPI Metadata
+
+The OpenAPI Specification Bridge provides specialized metadata handling through the `OpenAPIMetadata` enum, allowing you to add OpenAPI-specific properties to your Flow schema definitions. This metadata is used during schema conversion to generate rich OpenAPI specifications.
+
+### Available OpenAPI Metadata
+
+The `OpenAPIMetadata` enum provides the following metadata types:
+
+- `DESCRIPTION` - Human-readable description of the property
+- `FORMAT` - OpenAPI format specification (e.g., 'email', 'date-time', 'uuid')
+- `EXAMPLE` - Example value for the property
+- `EXAMPLES` - Multiple named examples
+- `DEPRECATED` - Mark property as deprecated
+- `TITLE` - Short title for the property
+- `DEFAULT` - Default value for the property
+- `READ_ONLY` - Mark property as read-only
+- `WRITE_ONLY` - Mark property as write-only
+- `NULLABLE` - Override schema nullability
+
+### Using OpenAPI Metadata
+
+```php
+<?php
+
+use function Flow\ETL\DSL\{schema, int_schema, str_schema};
+use Flow\Bridge\OpenAPI\Specification\{OpenAPIConverter, OpenAPIMetadata};
+
+$userSchema = schema(
+    int_schema('id', false, 
+        OpenAPIMetadata::description('Unique user identifier')
+            ->merge(OpenAPIMetadata::format('int64'))
+            ->merge(OpenAPIMetadata::example(12345))
+            ->merge(OpenAPIMetadata::readOnly())
+    ),
+    str_schema('email', false,
+        OpenAPIMetadata::description('User email address')
+            ->merge(OpenAPIMetadata::format('email'))
+            ->merge(OpenAPIMetadata::example('user@example.com'))
+            ->merge(OpenAPIMetadata::title('Email Address'))
+    ),
+    str_schema('password', false,
+        OpenAPIMetadata::description('User password')
+            ->merge(OpenAPIMetadata::format('password'))
+            ->merge(OpenAPIMetadata::writeOnly())
+    ),
+    str_schema('status', false,
+        OpenAPIMetadata::description('Account status')
+            ->merge(OpenAPIMetadata::default('active'))
+            ->merge(OpenAPIMetadata::examples([
+                'active' => 'active',
+                'inactive' => 'inactive',
+                'suspended' => 'suspended'
+            ]))
+    )
+);
+
+$converter = new OpenAPIConverter();
+$openApiSpec = $converter->toOpenAPI($userSchema);
+
+// Results in:
+// [
+//     'type' => 'object',
+//     'properties' => [
+//         'id' => [
+//             'type' => 'integer',
+//             'nullable' => false,
+//             'description' => 'Unique user identifier',
+//             'format' => 'int64',
+//             'example' => 12345,
+//             'readOnly' => true
+//         ],
+//         'email' => [
+//             'type' => 'string',
+//             'nullable' => false,
+//             'description' => 'User email address',
+//             'format' => 'email',
+//             'example' => 'user@example.com',
+//             'title' => 'Email Address'
+//         ],
+//         'password' => [
+//             'type' => 'string',
+//             'nullable' => false,
+//             'description' => 'User password',
+//             'format' => 'password',
+//             'writeOnly' => true
+//         ],
+//         'status' => [
+//             'type' => 'string',
+//             'nullable' => false,
+//             'description' => 'Account status',
+//             'default' => 'active',
+//             'examples' => [
+//                 'active' => 'active',
+//                 'inactive' => 'inactive',
+//                 'suspended' => 'suspended'
+//             ]
+//         ]
+//     ]
+// ]
+```
+
+### Metadata Priority System
+
+The OpenAPI bridge uses a priority system when handling metadata:
+
+1. **OpenAPI-specific metadata** (from `OpenAPIMetadata`) takes highest priority
+2. **Legacy metadata keys** are used as fallback when OpenAPI metadata is not present
+
+```php
+<?php
+
+use Flow\ETL\Schema\Metadata;
+use Flow\Bridge\OpenAPI\Specification\OpenAPIMetadata;
+
+// OpenAPI metadata takes priority over legacy metadata
+$metadata = Metadata::with('description', 'Legacy description')
+    ->merge(OpenAPIMetadata::description('OpenAPI description')) // This wins
+    ->merge(Metadata::with('example', 'Legacy example'))
+    ->merge(OpenAPIMetadata::example('OpenAPI example')); // This wins
+
+$schema = schema(
+    str_schema('field', false, $metadata)
+);
+
+// Result will use OpenAPI values: "OpenAPI description" and "OpenAPI example"
+```
+
+### Common OpenAPI Formats
+
+Here are some commonly used OpenAPI formats you can specify with `OpenAPIMetadata::format()`:
+
+**String formats:**
+- `email` - Email address
+- `uri` - URI/URL
+- `uuid` - UUID string
+- `date` - Date (YYYY-MM-DD)
+- `date-time` - Date and time (RFC 3339)
+- `password` - Password field
+- `byte` - Base64 encoded string
+- `binary` - Binary data
+
+**Integer formats:**
+- `int32` - 32-bit integer
+- `int64` - 64-bit integer
+
+**Number formats:**
+- `float` - Floating point number
+- `double` - Double precision number
+
 ### Usage Example
 
 ```php
@@ -114,17 +263,39 @@ $flowSchema = schema_from_openapi_specification($openApiSpec);
 use function Flow\ETL\DSL\{schema, int_schema, str_schema, list_schema, structure_schema};
 use function Flow\Types\DSL\{type_list, type_string, type_structure};
 use function Flow\Bridge\OpenAPI\Specification\DSL\schema_to_openapi_specification;
+use Flow\Bridge\OpenAPI\Specification\OpenAPIMetadata;
 
-// Define your data schema
+// Define your data schema with rich OpenAPI metadata
 $productSchema = schema(
-    int_schema('id', false),
-    str_schema('name', false),
-    str_schema('description', true),
+    int_schema('id', false, 
+        OpenAPIMetadata::description('Product identifier')
+            ->merge(OpenAPIMetadata::format('int64'))
+            ->merge(OpenAPIMetadata::example(123))
+            ->merge(OpenAPIMetadata::readOnly())
+    ),
+    str_schema('name', false,
+        OpenAPIMetadata::description('Product name')
+            ->merge(OpenAPIMetadata::title('Name'))
+            ->merge(OpenAPIMetadata::example('iPhone 15'))
+    ),
+    str_schema('description', true,
+        OpenAPIMetadata::description('Detailed product description')
+            ->merge(OpenAPIMetadata::example('Latest smartphone with advanced features'))
+    ),
     structure_schema('category', type_structure([
         'id' => type_string(),
         'name' => type_string()
-    ]), false),
-    list_schema('tags', type_list(type_string()), true)
+    ]), false, 
+        OpenAPIMetadata::description('Product category information')
+    ),
+    list_schema('tags', type_list(type_string()), true,
+        OpenAPIMetadata::description('Product tags for categorization')
+            ->merge(OpenAPIMetadata::examples([
+                'electronics' => 'electronics',
+                'smartphone' => 'smartphone',
+                'apple' => 'apple'
+            ]))
+    )
 );
 
 $apiSpec = schema_to_openapi_specification($productSchema);
@@ -158,14 +329,3 @@ $fullApiSpec = [
     ]
 ];
 ```
-
-## Supported OpenAPI Features
-
-### ✅ Supported
-- Basic types (boolean, integer, number, string)
-- String formats (date, date-time, time, uuid, json, xml)
-- Arrays with typed items
-- Objects with properties and additionalProperties
-- Nullable types
-- Descriptions and examples
-- Nested structures

--- a/src/bridge/openapi/specification/src/Flow/Bridge/OpenAPI/Specification/OpenAPIConverter.php
+++ b/src/bridge/openapi/specification/src/Flow/Bridge/OpenAPI/Specification/OpenAPIConverter.php
@@ -120,11 +120,51 @@ final class OpenAPIConverter
         $property = $this->convertTypeToOpenAPI($definition->type());
         $property['nullable'] = $definition->isNullable();
 
-        if ($definition->metadata()->has('description')) {
+        if ($definition->metadata()->has(OpenAPIMetadata::DESCRIPTION->value)) {
+            $property['description'] = $definition->metadata()->get(OpenAPIMetadata::DESCRIPTION->value);
+        }
+
+        if ($definition->metadata()->has(OpenAPIMetadata::FORMAT->value)) {
+            $property['format'] = $definition->metadata()->get(OpenAPIMetadata::FORMAT->value);
+        }
+
+        if ($definition->metadata()->has(OpenAPIMetadata::EXAMPLE->value)) {
+            $property['example'] = $definition->metadata()->get(OpenAPIMetadata::EXAMPLE->value);
+        }
+
+        if ($definition->metadata()->has(OpenAPIMetadata::EXAMPLES->value)) {
+            $property['examples'] = $definition->metadata()->get(OpenAPIMetadata::EXAMPLES->value);
+        }
+
+        if ($definition->metadata()->has(OpenAPIMetadata::DEPRECATED->value)) {
+            $property['deprecated'] = $definition->metadata()->get(OpenAPIMetadata::DEPRECATED->value);
+        }
+
+        if ($definition->metadata()->has(OpenAPIMetadata::TITLE->value)) {
+            $property['title'] = $definition->metadata()->get(OpenAPIMetadata::TITLE->value);
+        }
+
+        if ($definition->metadata()->has(OpenAPIMetadata::DEFAULT->value)) {
+            $property['default'] = $definition->metadata()->get(OpenAPIMetadata::DEFAULT->value);
+        }
+
+        if ($definition->metadata()->has(OpenAPIMetadata::READ_ONLY->value)) {
+            $property['readOnly'] = $definition->metadata()->get(OpenAPIMetadata::READ_ONLY->value);
+        }
+
+        if ($definition->metadata()->has(OpenAPIMetadata::WRITE_ONLY->value)) {
+            $property['writeOnly'] = $definition->metadata()->get(OpenAPIMetadata::WRITE_ONLY->value);
+        }
+
+        if ($definition->metadata()->has(OpenAPIMetadata::NULLABLE->value)) {
+            $property['nullable'] = $definition->metadata()->get(OpenAPIMetadata::NULLABLE->value);
+        }
+
+        if (!isset($property['description']) && $definition->metadata()->has('description')) {
             $property['description'] = $definition->metadata()->get('description');
         }
 
-        if ($definition->metadata()->has('example')) {
+        if (!isset($property['example']) && $definition->metadata()->has('example')) {
             $property['example'] = $definition->metadata()->get('example');
         }
 
@@ -238,7 +278,6 @@ final class OpenAPIConverter
             return type_map(type_string(), $valueType);
         }
 
-        // If it has properties, it's a structure
         if (isset($typeSpec['properties']) && \is_array($typeSpec['properties'])) {
             $elements = [];
             $optionalElements = [];
@@ -262,7 +301,6 @@ final class OpenAPIConverter
             return type_structure($elements, $optionalElements);
         }
 
-        // Default to empty map
         return type_map(type_string(), type_string());
     }
 

--- a/src/bridge/openapi/specification/src/Flow/Bridge/OpenAPI/Specification/OpenAPIMetadata.php
+++ b/src/bridge/openapi/specification/src/Flow/Bridge/OpenAPI/Specification/OpenAPIMetadata.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\Bridge\OpenAPI\Specification;
+
+use Flow\ETL\Schema\Metadata;
+
+enum OpenAPIMetadata : string
+{
+    case DEFAULT = 'openapi_default';
+    case DEPRECATED = 'openapi_deprecated';
+    case DESCRIPTION = 'openapi_description';
+    case EXAMPLE = 'openapi_example';
+    case EXAMPLES = 'openapi_examples';
+    case FORMAT = 'openapi_format';
+    case NULLABLE = 'openapi_nullable';
+    case READ_ONLY = 'openapi_read_only';
+    case TITLE = 'openapi_title';
+    case WRITE_ONLY = 'openapi_write_only';
+
+    /**
+     * @param array<mixed>|bool|float|int|string $default
+     */
+    public static function default($default) : Metadata
+    {
+        return Metadata::with(self::DEFAULT->value, $default);
+    }
+
+    public static function deprecated(bool $deprecated = true) : Metadata
+    {
+        return Metadata::with(self::DEPRECATED->value, $deprecated);
+    }
+
+    public static function description(string $description) : Metadata
+    {
+        return Metadata::with(self::DESCRIPTION->value, $description);
+    }
+
+    /**
+     * @param array<mixed>|bool|float|int|string $example
+     */
+    public static function example($example) : Metadata
+    {
+        return Metadata::with(self::EXAMPLE->value, $example);
+    }
+
+    /**
+     * @param array<string, mixed> $examples
+     */
+    public static function examples(array $examples) : Metadata
+    {
+        return Metadata::with(self::EXAMPLES->value, $examples);
+    }
+
+    public static function format(string $format) : Metadata
+    {
+        return Metadata::with(self::FORMAT->value, $format);
+    }
+
+    public static function nullable(bool $nullable = true) : Metadata
+    {
+        return Metadata::with(self::NULLABLE->value, $nullable);
+    }
+
+    public static function readOnly(bool $readOnly = true) : Metadata
+    {
+        return Metadata::with(self::READ_ONLY->value, $readOnly);
+    }
+
+    public static function title(string $title) : Metadata
+    {
+        return Metadata::with(self::TITLE->value, $title);
+    }
+
+    public static function writeOnly(bool $writeOnly = true) : Metadata
+    {
+        return Metadata::with(self::WRITE_ONLY->value, $writeOnly);
+    }
+}

--- a/src/bridge/openapi/specification/tests/Flow/Bridge/OpenAPI/Specification/Tests/Unit/OpenAPIMetadataIntegrationTest.php
+++ b/src/bridge/openapi/specification/tests/Flow/Bridge/OpenAPI/Specification/Tests/Unit/OpenAPIMetadataIntegrationTest.php
@@ -1,0 +1,450 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\Bridge\OpenAPI\Specification\Tests\Unit;
+
+use function Flow\ETL\DSL\{int_schema, schema, str_schema};
+use Flow\Bridge\OpenAPI\Specification\{OpenAPIConverter, OpenAPIMetadata};
+use Flow\ETL\Schema\Metadata;
+use PHPUnit\Framework\TestCase;
+
+final class OpenAPIMetadataIntegrationTest extends TestCase
+{
+    public function test_complex_example_with_all_metadata_types() : void
+    {
+        $converter = new OpenAPIConverter();
+        $schema = schema(
+            int_schema(
+                'id',
+                false,
+                OpenAPIMetadata::description('Unique identifier')
+                    ->merge(OpenAPIMetadata::title('ID'))
+                    ->merge(OpenAPIMetadata::example(12345))
+                    ->merge(OpenAPIMetadata::format('int64'))
+                    ->merge(OpenAPIMetadata::readOnly())
+            ),
+            str_schema(
+                'email',
+                true,
+                OpenAPIMetadata::description('User email address')
+                    ->merge(OpenAPIMetadata::format('email'))
+                    ->merge(OpenAPIMetadata::example('user@example.com'))
+                    ->merge(OpenAPIMetadata::title('Email Address'))
+            ),
+            str_schema(
+                'password',
+                false,
+                OpenAPIMetadata::description('User password')
+                    ->merge(OpenAPIMetadata::format('password'))
+                    ->merge(OpenAPIMetadata::writeOnly())
+                    ->merge(OpenAPIMetadata::title('Password'))
+            ),
+            str_schema(
+                'status',
+                false,
+                OpenAPIMetadata::description('Account status')
+                    ->merge(OpenAPIMetadata::deprecated(true))
+                    ->merge(OpenAPIMetadata::default('active'))
+                    ->merge(OpenAPIMetadata::examples([
+                        'active' => 'active',
+                        'inactive' => 'inactive',
+                        'suspended' => 'suspended',
+                    ]))
+                    ->merge(OpenAPIMetadata::title('Status'))
+            ),
+            str_schema(
+                'optional_field',
+                true,
+                OpenAPIMetadata::nullable(false) // Override schema nullability
+            )
+        );
+
+        $result = $converter->toOpenAPI($schema);
+
+        self::assertSame([
+            'type' => 'object',
+            'properties' => [
+                'id' => [
+                    'type' => 'integer',
+                    'nullable' => false,
+                    'description' => 'Unique identifier',
+                    'format' => 'int64',
+                    'example' => 12345,
+                    'title' => 'ID',
+                    'readOnly' => true,
+                ],
+                'email' => [
+                    'type' => 'string',
+                    'nullable' => true,
+                    'description' => 'User email address',
+                    'format' => 'email',
+                    'example' => 'user@example.com',
+                    'title' => 'Email Address',
+                ],
+                'password' => [
+                    'type' => 'string',
+                    'nullable' => false,
+                    'description' => 'User password',
+                    'format' => 'password',
+                    'title' => 'Password',
+                    'writeOnly' => true,
+                ],
+                'status' => [
+                    'type' => 'string',
+                    'nullable' => false,
+                    'description' => 'Account status',
+                    'examples' => [
+                        'active' => 'active',
+                        'inactive' => 'inactive',
+                        'suspended' => 'suspended',
+                    ],
+                    'deprecated' => true,
+                    'title' => 'Status',
+                    'default' => 'active',
+                ],
+                'optional_field' => [
+                    'type' => 'string',
+                    'nullable' => false,
+                ],
+            ],
+        ], $result);
+    }
+
+    public function test_converter_falls_back_to_legacy_metadata_when_openapi_not_present() : void
+    {
+        $converter = new OpenAPIConverter();
+        $metadata = Metadata::with('description', 'Legacy description')
+            ->merge(Metadata::with('example', 'Legacy example'));
+
+        $schema = schema(
+            str_schema('name', false, $metadata)
+        );
+
+        $result = $converter->toOpenAPI($schema);
+
+        /** @var array<string, mixed> $properties */
+        $properties = $result['properties'];
+        /** @var array<string, mixed> $nameProperty */
+        $nameProperty = $properties['name'];
+
+        self::assertSame('Legacy description', $nameProperty['description']);
+        self::assertSame('Legacy example', $nameProperty['example']);
+    }
+
+    public function test_converter_handles_mixed_legacy_and_openapi_metadata() : void
+    {
+        $converter = new OpenAPIConverter();
+        $metadata = Metadata::with('description', 'Legacy description')
+            ->merge(OpenAPIMetadata::format('email')) // Only format is OpenAPI-specific
+            ->merge(Metadata::with('example', 'Legacy example'));
+
+        $schema = schema(
+            str_schema('mixed', false, $metadata)
+        );
+
+        $result = $converter->toOpenAPI($schema);
+
+        /** @var array<string, mixed> $properties */
+        $properties = $result['properties'];
+        /** @var array<string, mixed> $mixedProperty */
+        $mixedProperty = $properties['mixed'];
+
+        self::assertSame('Legacy description', $mixedProperty['description']); // Fallback to legacy
+        self::assertSame('email', $mixedProperty['format']); // OpenAPI specific
+        self::assertSame('Legacy example', $mixedProperty['example']); // Fallback to legacy
+    }
+
+    public function test_converter_handles_multiple_openapi_metadata() : void
+    {
+        $converter = new OpenAPIConverter();
+        $metadata = OpenAPIMetadata::description('User email address')
+            ->merge(OpenAPIMetadata::format('email'))
+            ->merge(OpenAPIMetadata::example('user@example.com'))
+            ->merge(OpenAPIMetadata::title('Email Address'));
+
+        $schema = schema(
+            str_schema('email', false, $metadata)
+        );
+
+        $result = $converter->toOpenAPI($schema);
+
+        /** @var array<string, mixed> $properties */
+        $properties = $result['properties'];
+        /** @var array<string, mixed> $emailProperty */
+        $emailProperty = $properties['email'];
+
+        self::assertSame('User email address', $emailProperty['description']);
+        self::assertSame('email', $emailProperty['format']);
+        self::assertSame('user@example.com', $emailProperty['example']);
+        self::assertSame('Email Address', $emailProperty['title']);
+    }
+
+    public function test_converter_handles_openapi_default_metadata() : void
+    {
+        $converter = new OpenAPIConverter();
+        $schema = schema(
+            str_schema('status', false, OpenAPIMetadata::default('active'))
+        );
+
+        $result = $converter->toOpenAPI($schema);
+
+        /** @var array<string, mixed> $properties */
+        $properties = $result['properties'];
+        /** @var array<string, mixed> $statusProperty */
+        $statusProperty = $properties['status'];
+        self::assertSame('active', $statusProperty['default']);
+    }
+
+    public function test_converter_handles_openapi_deprecated_metadata() : void
+    {
+        $converter = new OpenAPIConverter();
+        $schema = schema(
+            str_schema('old_field', false, OpenAPIMetadata::deprecated())
+        );
+
+        $result = $converter->toOpenAPI($schema);
+
+        /** @var array<string, mixed> $properties */
+        $properties = $result['properties'];
+        /** @var array<string, mixed> $oldFieldProperty */
+        $oldFieldProperty = $properties['old_field'];
+        self::assertTrue($oldFieldProperty['deprecated']);
+    }
+
+    public function test_converter_handles_openapi_description_metadata() : void
+    {
+        $converter = new OpenAPIConverter();
+        $schema = schema(
+            str_schema('name', false, OpenAPIMetadata::description('User full name'))
+        );
+
+        $result = $converter->toOpenAPI($schema);
+
+        /** @var array<string, mixed> $properties */
+        $properties = $result['properties'];
+        /** @var array<string, mixed> $nameProperty */
+        $nameProperty = $properties['name'];
+        self::assertSame('User full name', $nameProperty['description']);
+    }
+
+    public function test_converter_handles_openapi_example_metadata() : void
+    {
+        $converter = new OpenAPIConverter();
+        $schema = schema(
+            str_schema('email', false, OpenAPIMetadata::example('user@example.com'))
+        );
+
+        $result = $converter->toOpenAPI($schema);
+
+        /** @var array<string, mixed> $properties */
+        $properties = $result['properties'];
+        /** @var array<string, mixed> $emailProperty */
+        $emailProperty = $properties['email'];
+        self::assertSame('user@example.com', $emailProperty['example']);
+    }
+
+    public function test_converter_handles_openapi_examples_metadata() : void
+    {
+        $converter = new OpenAPIConverter();
+        $examples = [
+            'active' => 'active',
+            'inactive' => 'inactive',
+            'pending' => 'pending',
+        ];
+        $schema = schema(
+            str_schema('status', false, OpenAPIMetadata::examples($examples))
+        );
+
+        $result = $converter->toOpenAPI($schema);
+
+        /** @var array<string, mixed> $properties */
+        $properties = $result['properties'];
+        /** @var array<string, mixed> $statusProperty */
+        $statusProperty = $properties['status'];
+        self::assertSame($examples, $statusProperty['examples']);
+    }
+
+    public function test_converter_handles_openapi_format_metadata() : void
+    {
+        $converter = new OpenAPIConverter();
+        $schema = schema(
+            str_schema('email', false, OpenAPIMetadata::format('email'))
+        );
+
+        $result = $converter->toOpenAPI($schema);
+
+        /** @var array<string, mixed> $properties */
+        $properties = $result['properties'];
+        /** @var array<string, mixed> $emailProperty */
+        $emailProperty = $properties['email'];
+        self::assertSame('email', $emailProperty['format']);
+    }
+
+    public function test_converter_handles_openapi_nullable_metadata_override() : void
+    {
+        $converter = new OpenAPIConverter();
+        $schema = schema(
+            str_schema('optional_field', false, OpenAPIMetadata::nullable(true)) // non-nullable schema definition but nullable in OpenAPI
+        );
+
+        $result = $converter->toOpenAPI($schema);
+
+        /** @var array<string, mixed> $properties */
+        $properties = $result['properties'];
+        /** @var array<string, mixed> $optionalFieldProperty */
+        $optionalFieldProperty = $properties['optional_field'];
+        self::assertTrue($optionalFieldProperty['nullable']); // Should be overridden
+    }
+
+    public function test_converter_handles_openapi_read_only_metadata() : void
+    {
+        $converter = new OpenAPIConverter();
+        $schema = schema(
+            str_schema('created_at', false, OpenAPIMetadata::readOnly())
+        );
+
+        $result = $converter->toOpenAPI($schema);
+
+        /** @var array<string, mixed> $properties */
+        $properties = $result['properties'];
+        /** @var array<string, mixed> $createdAtProperty */
+        $createdAtProperty = $properties['created_at'];
+        self::assertTrue($createdAtProperty['readOnly']);
+    }
+
+    public function test_converter_handles_openapi_title_metadata() : void
+    {
+        $converter = new OpenAPIConverter();
+        $schema = schema(
+            int_schema('id', false, OpenAPIMetadata::title('User ID'))
+        );
+
+        $result = $converter->toOpenAPI($schema);
+
+        /** @var array<string, mixed> $properties */
+        $properties = $result['properties'];
+        /** @var array<string, mixed> $idProperty */
+        $idProperty = $properties['id'];
+        self::assertSame('User ID', $idProperty['title']);
+    }
+
+    public function test_converter_handles_openapi_write_only_metadata() : void
+    {
+        $converter = new OpenAPIConverter();
+        $schema = schema(
+            str_schema('password', false, OpenAPIMetadata::writeOnly())
+        );
+
+        $result = $converter->toOpenAPI($schema);
+
+        /** @var array<string, mixed> $properties */
+        $properties = $result['properties'];
+        /** @var array<string, mixed> $passwordProperty */
+        $passwordProperty = $properties['password'];
+        self::assertTrue($passwordProperty['writeOnly']);
+    }
+
+    public function test_converter_prioritizes_openapi_metadata_over_legacy() : void
+    {
+        $converter = new OpenAPIConverter();
+        $metadata = Metadata::with('description', 'Legacy description') // Legacy metadata
+            ->merge(OpenAPIMetadata::description('OpenAPI description')) // OpenAPI metadata should take priority
+            ->merge(Metadata::with('example', 'Legacy example'))
+            ->merge(OpenAPIMetadata::example('OpenAPI example'));
+
+        $schema = schema(
+            str_schema('name', false, $metadata)
+        );
+
+        $result = $converter->toOpenAPI($schema);
+
+        /** @var array<string, mixed> $properties */
+        $properties = $result['properties'];
+        /** @var array<string, mixed> $nameProperty */
+        $nameProperty = $properties['name'];
+
+        self::assertSame('OpenAPI description', $nameProperty['description']);
+        self::assertSame('OpenAPI example', $nameProperty['example']);
+    }
+
+    public function test_openapi_metadata_usage_with_converter() : void
+    {
+        $converter = new OpenAPIConverter();
+        $schema = schema(
+            str_schema(
+                'user_email',
+                false,
+                OpenAPIMetadata::description('User email address')
+                    ->merge(OpenAPIMetadata::format('email'))
+                    ->merge(OpenAPIMetadata::example('user@example.com'))
+                    ->merge(OpenAPIMetadata::title('Email'))
+            ),
+            str_schema(
+                'password',
+                false,
+                OpenAPIMetadata::description('User password')
+                    ->merge(OpenAPIMetadata::format('password'))
+                    ->merge(OpenAPIMetadata::writeOnly())
+                    ->merge(OpenAPIMetadata::title('Password'))
+            ),
+            str_schema(
+                'created_at',
+                false,
+                OpenAPIMetadata::description('Account creation timestamp')
+                    ->merge(OpenAPIMetadata::format('date-time'))
+                    ->merge(OpenAPIMetadata::readOnly())
+                    ->merge(OpenAPIMetadata::example('2023-01-01T00:00:00Z'))
+            ),
+            str_schema(
+                'status',
+                false,
+                OpenAPIMetadata::description('Account status')
+                    ->merge(OpenAPIMetadata::deprecated())
+                    ->merge(OpenAPIMetadata::default('active'))
+                    ->merge(OpenAPIMetadata::examples([
+                        'active' => 'active',
+                        'inactive' => 'inactive',
+                        'suspended' => 'suspended',
+                    ]))
+            )
+        );
+
+        $result = $converter->toOpenAPI($schema);
+
+        /** @var array<string, mixed> $properties */
+        $properties = $result['properties'];
+
+        /** @var array<string, mixed> $email */
+        $email = $properties['user_email'];
+        self::assertSame('User email address', $email['description']);
+        self::assertSame('email', $email['format']);
+        self::assertSame('user@example.com', $email['example']);
+        self::assertSame('Email', $email['title']);
+
+        /** @var array<string, mixed> $password */
+        $password = $properties['password'];
+        self::assertSame('User password', $password['description']);
+        self::assertSame('password', $password['format']);
+        self::assertTrue($password['writeOnly']);
+        self::assertSame('Password', $password['title']);
+
+        /** @var array<string, mixed> $createdAt */
+        $createdAt = $properties['created_at'];
+        self::assertSame('Account creation timestamp', $createdAt['description']);
+        self::assertSame('date-time', $createdAt['format']);
+        self::assertTrue($createdAt['readOnly']);
+        self::assertSame('2023-01-01T00:00:00Z', $createdAt['example']);
+
+        /** @var array<string, mixed> $status */
+        $status = $properties['status'];
+        self::assertSame('Account status', $status['description']);
+        self::assertTrue($status['deprecated']);
+        self::assertSame('active', $status['default']);
+        self::assertSame([
+            'active' => 'active',
+            'inactive' => 'inactive',
+            'suspended' => 'suspended',
+        ], $status['examples']);
+    }
+}

--- a/src/bridge/openapi/specification/tests/Flow/Bridge/OpenAPI/Specification/Tests/Unit/OpenAPIMetadataTest.php
+++ b/src/bridge/openapi/specification/tests/Flow/Bridge/OpenAPI/Specification/Tests/Unit/OpenAPIMetadataTest.php
@@ -1,0 +1,199 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\Bridge\OpenAPI\Specification\Tests\Unit;
+
+use Flow\Bridge\OpenAPI\Specification\OpenAPIMetadata;
+use Flow\ETL\Schema\Metadata;
+use PHPUnit\Framework\TestCase;
+
+final class OpenAPIMetadataTest extends TestCase
+{
+    public function test_all_metadata_types_return_metadata_instances() : void
+    {
+        self::assertInstanceOf(Metadata::class, OpenAPIMetadata::description('test'));
+        self::assertInstanceOf(Metadata::class, OpenAPIMetadata::format('test'));
+        self::assertInstanceOf(Metadata::class, OpenAPIMetadata::example('test'));
+        self::assertInstanceOf(Metadata::class, OpenAPIMetadata::examples([]));
+        self::assertInstanceOf(Metadata::class, OpenAPIMetadata::deprecated());
+        self::assertInstanceOf(Metadata::class, OpenAPIMetadata::title('test'));
+        self::assertInstanceOf(Metadata::class, OpenAPIMetadata::default('test'));
+        self::assertInstanceOf(Metadata::class, OpenAPIMetadata::readOnly());
+        self::assertInstanceOf(Metadata::class, OpenAPIMetadata::writeOnly());
+        self::assertInstanceOf(Metadata::class, OpenAPIMetadata::nullable());
+    }
+
+    public function test_default_creates_metadata_with_correct_key_and_value() : void
+    {
+        $metadata = OpenAPIMetadata::default('default_value');
+
+        self::assertTrue($metadata->has(OpenAPIMetadata::DEFAULT->value));
+        self::assertSame('default_value', $metadata->get(OpenAPIMetadata::DEFAULT->value));
+    }
+
+    public function test_default_with_different_types() : void
+    {
+        $stringDefault = OpenAPIMetadata::default('test');
+        $intDefault = OpenAPIMetadata::default(0);
+        $boolDefault = OpenAPIMetadata::default(false);
+        $arrayDefault = OpenAPIMetadata::default([]);
+
+        self::assertSame('test', $stringDefault->get(OpenAPIMetadata::DEFAULT->value));
+        self::assertSame(0, $intDefault->get(OpenAPIMetadata::DEFAULT->value));
+        self::assertFalse($boolDefault->get(OpenAPIMetadata::DEFAULT->value));
+        self::assertSame([], $arrayDefault->get(OpenAPIMetadata::DEFAULT->value));
+    }
+
+    public function test_deprecated_creates_metadata_with_correct_key_and_default_value() : void
+    {
+        $metadata = OpenAPIMetadata::deprecated();
+
+        self::assertTrue($metadata->has(OpenAPIMetadata::DEPRECATED->value));
+        self::assertTrue($metadata->get(OpenAPIMetadata::DEPRECATED->value));
+    }
+
+    public function test_deprecated_creates_metadata_with_custom_value() : void
+    {
+        $metadata = OpenAPIMetadata::deprecated(false);
+
+        self::assertTrue($metadata->has(OpenAPIMetadata::DEPRECATED->value));
+        self::assertFalse($metadata->get(OpenAPIMetadata::DEPRECATED->value));
+    }
+
+    public function test_description_creates_metadata_with_correct_key_and_value() : void
+    {
+        $metadata = OpenAPIMetadata::description('User name');
+
+        self::assertTrue($metadata->has(OpenAPIMetadata::DESCRIPTION->value));
+        self::assertSame('User name', $metadata->get(OpenAPIMetadata::DESCRIPTION->value));
+    }
+
+    public function test_enum_values_are_consistent() : void
+    {
+        self::assertSame('openapi_description', OpenAPIMetadata::DESCRIPTION->value);
+        self::assertSame('openapi_format', OpenAPIMetadata::FORMAT->value);
+        self::assertSame('openapi_example', OpenAPIMetadata::EXAMPLE->value);
+        self::assertSame('openapi_examples', OpenAPIMetadata::EXAMPLES->value);
+        self::assertSame('openapi_deprecated', OpenAPIMetadata::DEPRECATED->value);
+        self::assertSame('openapi_title', OpenAPIMetadata::TITLE->value);
+        self::assertSame('openapi_default', OpenAPIMetadata::DEFAULT->value);
+        self::assertSame('openapi_read_only', OpenAPIMetadata::READ_ONLY->value);
+        self::assertSame('openapi_write_only', OpenAPIMetadata::WRITE_ONLY->value);
+        self::assertSame('openapi_nullable', OpenAPIMetadata::NULLABLE->value);
+    }
+
+    public function test_example_creates_metadata_with_correct_key_and_value() : void
+    {
+        $metadata = OpenAPIMetadata::example('john@example.com');
+
+        self::assertTrue($metadata->has(OpenAPIMetadata::EXAMPLE->value));
+        self::assertSame('john@example.com', $metadata->get(OpenAPIMetadata::EXAMPLE->value));
+    }
+
+    public function test_example_with_different_types() : void
+    {
+        $stringExample = OpenAPIMetadata::example('test');
+        $intExample = OpenAPIMetadata::example(42);
+        $arrayExample = OpenAPIMetadata::example(['a', 'b']);
+        $boolExample = OpenAPIMetadata::example(true);
+
+        self::assertSame('test', $stringExample->get(OpenAPIMetadata::EXAMPLE->value));
+        self::assertSame(42, $intExample->get(OpenAPIMetadata::EXAMPLE->value));
+        self::assertSame(['a', 'b'], $arrayExample->get(OpenAPIMetadata::EXAMPLE->value));
+        self::assertTrue($boolExample->get(OpenAPIMetadata::EXAMPLE->value));
+    }
+
+    public function test_examples_creates_metadata_with_correct_key_and_value() : void
+    {
+        $examples = [
+            'active' => 'active',
+            'inactive' => 'inactive',
+            'pending' => 'pending',
+        ];
+        $metadata = OpenAPIMetadata::examples($examples);
+
+        self::assertTrue($metadata->has(OpenAPIMetadata::EXAMPLES->value));
+        self::assertSame($examples, $metadata->get(OpenAPIMetadata::EXAMPLES->value));
+    }
+
+    public function test_format_creates_metadata_with_correct_key_and_value() : void
+    {
+        $metadata = OpenAPIMetadata::format('email');
+
+        self::assertTrue($metadata->has(OpenAPIMetadata::FORMAT->value));
+        self::assertSame('email', $metadata->get(OpenAPIMetadata::FORMAT->value));
+    }
+
+    public function test_metadata_can_be_combined() : void
+    {
+        $description = OpenAPIMetadata::description('User email');
+        $format = OpenAPIMetadata::format('email');
+        $example = OpenAPIMetadata::example('user@example.com');
+
+        $combined = $description->merge($format)->merge($example);
+
+        self::assertTrue($combined->has(OpenAPIMetadata::DESCRIPTION->value));
+        self::assertTrue($combined->has(OpenAPIMetadata::FORMAT->value));
+        self::assertTrue($combined->has(OpenAPIMetadata::EXAMPLE->value));
+        self::assertSame('User email', $combined->get(OpenAPIMetadata::DESCRIPTION->value));
+        self::assertSame('email', $combined->get(OpenAPIMetadata::FORMAT->value));
+        self::assertSame('user@example.com', $combined->get(OpenAPIMetadata::EXAMPLE->value));
+    }
+
+    public function test_nullable_creates_metadata_with_correct_key_and_default_value() : void
+    {
+        $metadata = OpenAPIMetadata::nullable();
+
+        self::assertTrue($metadata->has(OpenAPIMetadata::NULLABLE->value));
+        self::assertTrue($metadata->get(OpenAPIMetadata::NULLABLE->value));
+    }
+
+    public function test_nullable_creates_metadata_with_custom_value() : void
+    {
+        $metadata = OpenAPIMetadata::nullable(false);
+
+        self::assertTrue($metadata->has(OpenAPIMetadata::NULLABLE->value));
+        self::assertFalse($metadata->get(OpenAPIMetadata::NULLABLE->value));
+    }
+
+    public function test_read_only_creates_metadata_with_correct_key_and_default_value() : void
+    {
+        $metadata = OpenAPIMetadata::readOnly();
+
+        self::assertTrue($metadata->has(OpenAPIMetadata::READ_ONLY->value));
+        self::assertTrue($metadata->get(OpenAPIMetadata::READ_ONLY->value));
+    }
+
+    public function test_read_only_creates_metadata_with_custom_value() : void
+    {
+        $metadata = OpenAPIMetadata::readOnly(false);
+
+        self::assertTrue($metadata->has(OpenAPIMetadata::READ_ONLY->value));
+        self::assertFalse($metadata->get(OpenAPIMetadata::READ_ONLY->value));
+    }
+
+    public function test_title_creates_metadata_with_correct_key_and_value() : void
+    {
+        $metadata = OpenAPIMetadata::title('User ID');
+
+        self::assertTrue($metadata->has(OpenAPIMetadata::TITLE->value));
+        self::assertSame('User ID', $metadata->get(OpenAPIMetadata::TITLE->value));
+    }
+
+    public function test_write_only_creates_metadata_with_correct_key_and_default_value() : void
+    {
+        $metadata = OpenAPIMetadata::writeOnly();
+
+        self::assertTrue($metadata->has(OpenAPIMetadata::WRITE_ONLY->value));
+        self::assertTrue($metadata->get(OpenAPIMetadata::WRITE_ONLY->value));
+    }
+
+    public function test_write_only_creates_metadata_with_custom_value() : void
+    {
+        $metadata = OpenAPIMetadata::writeOnly(false);
+
+        self::assertTrue($metadata->has(OpenAPIMetadata::WRITE_ONLY->value));
+        self::assertFalse($metadata->get(OpenAPIMetadata::WRITE_ONLY->value));
+    }
+}


### PR DESCRIPTION
<!-- 
    Please replace #xxx with a GitHub issue id from flow-php/flow repository. For example #1234 
    If there is no item in a roadmap related to this PR, please check our contributing guidelines first. 
-->
Resolves: #1810

<!-- 
    Below section will be used to automatically generate changelog, please do not modify HTML code structure
    DO NOT REMOVE that HTML STRUCTURE, INSTEAD ADD YOUR CHANGES INSIDE THE LISTS 
    PULL REQUESTS WITHOUT CHANGELOG CAN'T BE MERGED 
-->
<h2>Change Log</h2>
<hr /> 
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <li>OpenApiMetadata allowing for passing extra details when generating open api specification from flow schema</li>
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>