### PR TITLE
Fix ordering by multiple columns in DbalLimitOffsetExtractor

### DIFF
--- a/src/adapter/etl-adapter-doctrine/src/Flow/ETL/Adapter/Doctrine/DbalLimitOffsetExtractor.php
+++ b/src/adapter/etl-adapter-doctrine/src/Flow/ETL/Adapter/Doctrine/DbalLimitOffsetExtractor.php
@@ -44,7 +44,7 @@ final class DbalLimitOffsetExtractor implements Extractor
             ->from($table->name);
 
         foreach ($orderBy as $order) {
-            $queryBuilder = $queryBuilder->orderBy($order->column, $order->order->name);
+            $queryBuilder = $queryBuilder->addOrderBy($order->column, $order->order->name);
         }
 
         return new self(

--- a/src/adapter/etl-adapter-doctrine/tests/Flow/ETL/Adapter/Doctrine/Tests/Integration/DbalLimitOffsetExtractorTest.php
+++ b/src/adapter/etl-adapter-doctrine/tests/Flow/ETL/Adapter/Doctrine/Tests/Integration/DbalLimitOffsetExtractorTest.php
@@ -5,12 +5,84 @@ declare(strict_types=1);
 namespace Flow\ETL\Adapter\Doctrine\Tests\Integration;
 
 use function Flow\ETL\Adapter\Doctrine\from_dbal_limit_offset;
-use Flow\ETL\Adapter\Doctrine\Table;
+use function Flow\ETL\DSL\{data_frame, flow_context, from_array};
+use Doctrine\DBAL\Schema\Column;
+use Doctrine\DBAL\Types\{TextType, Type, Types};
+use Flow\ETL\Adapter\Doctrine\{DbalLoader, DbalTypesDetector, Order, OrderBy, Table, TypesMap};
 use Flow\ETL\Adapter\Doctrine\Tests\IntegrationTestCase;
+use Flow\ETL\{Config, Rows};
+use Flow\Types\Type\Native\{IntegerType, StringType};
 
 final class DbalLimitOffsetExtractorTest extends IntegrationTestCase
 {
-    public function test_creating_limit_offset_extractor_for_table_without_oder_by() : void
+    public function test_creating_limit_offset_extractor_for_table() : void
+    {
+        $this->pgsqlDatabaseContext->createTable((new \Doctrine\DBAL\Schema\Table(
+            $table = 'flow_doctrine_order_by_test',
+            [
+                new Column('id', Type::getType(Types::INTEGER), ['notnull' => true]),
+                new Column('code', Type::getType(Types::INTEGER), ['notnull' => true]),
+            ],
+        ))
+            ->setPrimaryKey(['id']));
+
+        $customTypesMap = new TypesMap([
+            StringType::class => TextType::class,
+            IntegerType::class => \Doctrine\DBAL\Types\IntegerType::class,
+        ]);
+
+        $customConverter = new DbalTypesDetector($customTypesMap);
+
+        $loader = (new DbalLoader($table, $this->postgresqlConnectionParams()))
+            ->withTypesDetector($customConverter);
+
+        (data_frame())
+            ->read(from_array([
+                ['id' => 1, 'code' => 100],
+                ['id' => 2, 'code' => 100],
+                ['id' => 3, 'code' => 200],
+            ]))
+            ->load($loader)
+            ->run();
+
+        $extractor = from_dbal_limit_offset(
+            $this->pgsqlDatabaseContext->connection(),
+            new Table('flow_doctrine_order_by_test', ['id', 'code']),
+            [
+                new OrderBy('code', Order::DESC),
+                new OrderBy('id', Order::ASC),
+            ]
+        );
+
+        self::assertSame(
+            [
+                [
+                    [
+                        'id' => 3,
+                        'code' => 200,
+                    ],
+                ],
+                [
+                    [
+                        'id' => 1,
+                        'code' => 100,
+                    ],
+                ],
+                [
+                    [
+                        'id' => 2,
+                        'code' => 100,
+                    ],
+                ],
+            ],
+            \array_map(
+                static fn (Rows $r) => $r->toArray(),
+                \iterator_to_array($extractor->extract(flow_context(Config::builder()->putInputIntoRows()->build())))
+            )
+        );
+    }
+
+    public function test_creating_limit_offset_extractor_for_table_without_order_by() : void
     {
         $this->expectExceptionMessage('There must be at least one column to order by, zero given');
 


### PR DESCRIPTION
Currently DbalLimitOffsetExtractor only orders by the last given column instead of in order of all the given ordering columns.

<!-- 
    Please replace #xxx with a GitHub issue id from flow-php/flow repository. For example #1234 
    If there is no item in a roadmap related to this PR, please check our contributing guidelines first. 
-->
Resolves: #xxx

<!-- 
    Below section will be used to automatically generate changelog, please do not modify HTML code structure
    DO NOT REMOVE that HTML STRUCTURE, INSTEAD ADD YOUR CHANGES INSIDE THE LISTS 
    PULL REQUESTS WITHOUT CHANGELOG CAN'T BE MERGED 
-->
<h2>Change Log</h2>
<hr /> 
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
    <li>DbalLimitOffsetExtractor only orders by the last given column instead of in order of all the given ordering columns.</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>