### PR TITLE
Remove `Rows::fromArray()`, pass `EntryFactory` to the join methods

### DIFF
--- a/src/core/etl/src/Flow/ETL/Rows.php
+++ b/src/core/etl/src/Flow/ETL/Rows.php
@@ -383,7 +383,7 @@ final class Rows implements \ArrayAccess, \Countable, \IteratorAggregate
     /**
      * @throws InvalidArgumentException
      */
-    public function joinLeft(self $right, Expression $expression, EntryFactory $entryFactory = new EntryFactory()) : self
+    public function joinLeft(self $right, Expression $expression, EntryFactory $entryFactory) : self
     {
         /**
          * @var array<Row> $joined
@@ -455,7 +455,7 @@ final class Rows implements \ArrayAccess, \Countable, \IteratorAggregate
     /**
      * @throws InvalidArgumentException
      */
-    public function joinRight(self $right, Expression $expression, EntryFactory $entryFactory = new EntryFactory()) : self
+    public function joinRight(self $right, Expression $expression, EntryFactory $entryFactory) : self
     {
         /**
          * @var array<Row> $joined

--- a/src/core/etl/src/Flow/ETL/Rows.php
+++ b/src/core/etl/src/Flow/ETL/Rows.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Flow\ETL;
 
-use function Flow\ETL\DSL\{array_to_rows, row};
+use function Flow\ETL\DSL\row;
 use function Flow\Types\DSL\type_integer;
 use Flow\ETL\Exception\{DuplicatedEntriesException, InvalidArgumentException, RuntimeException};
 use Flow\ETL\Hash\{Algorithm, NativePHPHash};
@@ -32,14 +32,6 @@ final class Rows implements \ArrayAccess, \Countable, \IteratorAggregate
     {
         $this->rows = \array_values($rows);
         $this->partitions = new Partitions();
-    }
-
-    /**
-     * @param array<array-key, mixed> $data
-     */
-    public static function fromArray(array $data, EntryFactory $entryFactory = new EntryFactory()) : self
-    {
-        return array_to_rows($data, $entryFactory);
     }
 
     /**
@@ -391,7 +383,7 @@ final class Rows implements \ArrayAccess, \Countable, \IteratorAggregate
     /**
      * @throws InvalidArgumentException
      */
-    public function joinLeft(self $right, Expression $expression) : self
+    public function joinLeft(self $right, Expression $expression, EntryFactory $entryFactory = new EntryFactory()) : self
     {
         /**
          * @var array<Row> $joined
@@ -417,8 +409,6 @@ final class Rows implements \ArrayAccess, \Countable, \IteratorAggregate
             }
 
             if ($joinedRow === null) {
-                $entryFactory = new EntryFactory();
-
                 $entries = [];
 
                 foreach ($rightSchema->definitions() as $definition) {
@@ -465,7 +455,7 @@ final class Rows implements \ArrayAccess, \Countable, \IteratorAggregate
     /**
      * @throws InvalidArgumentException
      */
-    public function joinRight(self $right, Expression $expression) : self
+    public function joinRight(self $right, Expression $expression, EntryFactory $entryFactory = new EntryFactory()) : self
     {
         /**
          * @var array<Row> $joined
@@ -491,8 +481,6 @@ final class Rows implements \ArrayAccess, \Countable, \IteratorAggregate
             }
 
             if ($joinedRow === null) {
-                $entryFactory = new EntryFactory();
-
                 $entries = [];
 
                 foreach ($leftSchema->definitions() as $definition) {

--- a/src/core/etl/src/Flow/ETL/Transformer/JoinEachRowsTransformer.php
+++ b/src/core/etl/src/Flow/ETL/Transformer/JoinEachRowsTransformer.php
@@ -37,8 +37,6 @@ final readonly class JoinEachRowsTransformer implements Transformer
     }
 
     /**
-     * @param FlowContext $context
-     *
      * @throws InvalidArgumentException
      */
     public function transform(Rows $rows, FlowContext $context) : Rows
@@ -46,9 +44,9 @@ final readonly class JoinEachRowsTransformer implements Transformer
         $rightRows = $this->factory->from($rows)->fetch();
 
         return match ($this->type) {
-            Join::left => $rows->joinLeft($rightRows, $this->expression),
+            Join::left => $rows->joinLeft($rightRows, $this->expression, $context->entryFactory()),
             Join::left_anti => $rows->joinLeftAnti($rightRows, $this->expression),
-            Join::right => $rows->joinRight($rightRows, $this->expression),
+            Join::right => $rows->joinRight($rightRows, $this->expression, $context->entryFactory()),
             default => $rows->joinInner($rightRows, $this->expression),
         };
     }

--- a/src/core/etl/tests/Flow/ETL/Tests/Benchmark/RowsBench.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Benchmark/RowsBench.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Tests\Benchmark;
 
-use function Flow\ETL\DSL\{ref, string_entry};
+use function Flow\ETL\DSL\{array_to_rows, ref, string_entry};
 use Flow\ETL\{Row, Rows};
 use PhpBench\Attributes\{BeforeMethods, Groups, Revs};
 
@@ -19,7 +19,7 @@ final class RowsBench
 
     public function setUp() : void
     {
-        $this->rows = Rows::fromArray(
+        $this->rows = array_to_rows(
             \array_merge(...\array_map(static fn () : array => [
                 ['id' => 1, 'random' => false, 'text' => null, 'from' => 666],
                 ['id' => 2, 'random' => true, 'text' => null, 'from' => 666],
@@ -29,7 +29,7 @@ final class RowsBench
             ], \range(0, 10_000)))
         );
 
-        $this->reducedRows = Rows::fromArray(
+        $this->reducedRows = array_to_rows(
             \array_merge(...\array_map(static fn () : array => [
                 ['id' => 1, 'random' => false, 'text' => null, 'from' => 666],
                 ['id' => 2, 'random' => true, 'text' => null, 'from' => 666],

--- a/src/core/etl/tests/Flow/ETL/Tests/Benchmark/Transformer/RenameEachEntryTransformerBench.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Benchmark/Transformer/RenameEachEntryTransformerBench.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Tests\Benchmark\Transformer;
 
-use function Flow\ETL\DSL\{config, flow_context, rename_style};
+use function Flow\ETL\DSL\{array_to_rows, config, flow_context, rename_style};
 use Flow\ETL\{FlowContext, Rows, String\StringStyles, Transformer\RenameEachEntryTransformer};
 use PhpBench\Attributes\{BeforeMethods, Groups};
 
@@ -18,14 +18,14 @@ final class RenameEachEntryTransformerBench
 
     public function setUp() : void
     {
-        $this->rows = Rows::fromArray(
+        $this->rows = array_to_rows(
             \array_merge(...\array_map(static fn () : array => [
                 ['id' => 1, 'random text' => null, 'from' => 666],
                 ['id' => 2, 'random text' => null, 'from' => 666],
                 ['id' => 3, 'random text' => null, 'from' => 666],
                 ['id' => 4, 'random text' => null, 'from' => 666],
                 ['id' => 5, 'random text' => null, 'from' => 666],
-            ], \range(0, 1_000)))
+            ], \range(0, 1_000))),
         );
         $this->context = flow_context(config());
     }

--- a/src/core/etl/tests/Flow/ETL/Tests/Benchmark/Transformer/RenameEntryTransformerBench.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Benchmark/Transformer/RenameEntryTransformerBench.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Tests\Benchmark\Transformer;
 
-use function Flow\ETL\DSL\{config, flow_context};
+use function Flow\ETL\DSL\{array_to_rows, config, flow_context};
 use Flow\ETL\{FlowContext, Rows};
 use Flow\ETL\Transformer\RenameEntryTransformer;
 use PhpBench\Attributes\{BeforeMethods, Groups};
@@ -19,7 +19,7 @@ final class RenameEntryTransformerBench
 
     public function setUp() : void
     {
-        $this->rows = Rows::fromArray(
+        $this->rows = array_to_rows(
             \array_merge(...\array_map(static fn () : array => [
                 ['id' => 1, 'random' => false, 'text' => null, 'from' => 666],
                 ['id' => 2, 'random' => true, 'text' => null, 'from' => 666],

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/RowsJoinTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/RowsJoinTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Tests\Unit;
 
-use function Flow\ETL\DSL\{bool_entry, int_entry, join_on, row, rows, str_entry};
+use function Flow\ETL\DSL\{bool_entry, config, flow_context, int_entry, join_on, row, rows, str_entry};
 use Flow\ETL\Exception\{DuplicatedEntriesException, InvalidArgumentException};
 use Flow\ETL\Join\Expression;
 use Flow\ETL\Tests\FlowTestCase;
@@ -335,7 +335,8 @@ final class RowsJoinTest extends FlowTestCase
                 row(str_entry('code', 'US'), str_entry('name', 'United States')),
                 row(str_entry('code', 'GB'), str_entry('name', 'Great Britain')),
             ),
-            Expression::on(['country' => 'code'], 'joined_')
+            Expression::on(['country' => 'code'], 'joined_'),
+            flow_context(config())->entryFactory(),
         );
 
         self::assertEquals(
@@ -358,7 +359,8 @@ final class RowsJoinTest extends FlowTestCase
 
         $joined = $left->joinLeft(
             rows(),
-            Expression::on(['country' => 'code'])
+            Expression::on(['country' => 'code']),
+            flow_context(config())->entryFactory(),
         );
 
         self::assertEquals(
@@ -381,7 +383,8 @@ final class RowsJoinTest extends FlowTestCase
 
         $joined = $left->joinLeft(
             rows(),
-            Expression::on(['country_code' => 'country_code'])
+            Expression::on(['country_code' => 'country_code']),
+            flow_context(config())->entryFactory(),
         );
 
         self::assertEquals(
@@ -404,7 +407,8 @@ final class RowsJoinTest extends FlowTestCase
                 row(str_entry('code', 'US'), str_entry('name', 'United States')),
                 row(str_entry('code', 'GB'), str_entry('name', 'Great Britain')),
             ),
-            Expression::on(['country' => 'code'])
+            Expression::on(['country' => 'code']),
+            flow_context(config())->entryFactory(),
         );
 
         self::assertEquals(
@@ -430,7 +434,8 @@ final class RowsJoinTest extends FlowTestCase
                 row(int_entry('id', 101), str_entry('code', 'US'), str_entry('name', 'United States')),
                 row(int_entry('id', 102), str_entry('code', 'GB'), str_entry('name', 'Great Britain')),
             ),
-            Expression::on(['country' => 'code'], '')
+            Expression::on(['country' => 'code'], ''),
+            flow_context(config())->entryFactory(),
         );
     }
 
@@ -448,7 +453,8 @@ final class RowsJoinTest extends FlowTestCase
                 row(str_entry('country_code', 'US'), str_entry('name', 'United States')),
                 row(str_entry('country_code', 'GB'), str_entry('name', 'Great Britain')),
             ),
-            Expression::on(['country_code' => 'country_code'])
+            Expression::on(['country_code' => 'country_code']),
+            flow_context(config())->entryFactory(),
         );
 
         self::assertEquals(
@@ -476,7 +482,8 @@ final class RowsJoinTest extends FlowTestCase
                 row(str_entry('code', 'US'), str_entry('name', 'United States')),
                 row(str_entry('code', 'GB'), str_entry('name', 'Great Britain')),
             ),
-            Expression::on(['country' => 'code'], 'joined_')
+            Expression::on(['country' => 'code'], 'joined_'),
+            flow_context(config())->entryFactory(),
         );
 
         self::assertEquals(
@@ -501,7 +508,8 @@ final class RowsJoinTest extends FlowTestCase
 
         $joined = $left->joinRight(
             rows(),
-            Expression::on(['country' => 'code'])
+            Expression::on(['country' => 'code']),
+            flow_context(config())->entryFactory(),
         );
 
         self::assertEquals(
@@ -520,7 +528,8 @@ final class RowsJoinTest extends FlowTestCase
                 row(str_entry('code', 'US'), str_entry('name', 'United States')),
                 row(str_entry('code', 'GB'), str_entry('name', 'Great Britain')),
             ),
-            Expression::on(['country' => 'code'], 'joined_')
+            Expression::on(['country' => 'code'], 'joined_'),
+            flow_context(config())->entryFactory(),
         );
 
         self::assertEquals(
@@ -551,7 +560,8 @@ final class RowsJoinTest extends FlowTestCase
                 row(int_entry('id', 102), str_entry('code', 'US'), str_entry('name', 'United States')),
                 row(int_entry('id', 103), str_entry('code', 'GB'), str_entry('name', 'Great Britain')),
             ),
-            Expression::on(['country' => 'code'], '')
+            Expression::on(['country' => 'code'], ''),
+            flow_context(config())->entryFactory(),
         );
     }
 
@@ -570,7 +580,8 @@ final class RowsJoinTest extends FlowTestCase
                 row(str_entry('country_code', 'US'), str_entry('name', 'United States')),
                 row(str_entry('country_code', 'GB'), str_entry('name', 'Great Britain')),
             ),
-            Expression::on(['country_code' => 'country_code'])
+            Expression::on(['country_code' => 'country_code']),
+            flow_context(config())->entryFactory(),
         );
 
         self::assertEquals(


### PR DESCRIPTION
<!-- 
    Please replace #xxx with a GitHub issue id from flow-php/flow repository. For example #1234 
    If there is no item in a roadmap related to this PR, please check our contributing guidelines first. 
-->
Resolves: #1928

<!-- 
    Below section will be used to automatically generate changelog, please do not modify HTML code structure
    DO NOT REMOVE that HTML STRUCTURE, INSTEAD ADD YOUR CHANGES INSIDE THE LISTS 
    PULL REQUESTS WITHOUT CHANGELOG CAN'T BE MERGED 
-->
<h2>Change Log</h2>
<hr /> 
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Pass `EntryFactory` to the `Rows::join*()` methods</li>
    <li>Enforce instance of EntryFactory in the join methods</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <li>Remove `Rows::fromArray()`</li>
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>