### PR TITLE
Make `HTMLDocument` reliable

### DIFF
--- a/src/lib/types/src/Flow/Types/Type/Logical/HTMLType.php
+++ b/src/lib/types/src/Flow/Types/Type/Logical/HTMLType.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Flow\Types\Type\Logical;
 
-use Flow\Types\Exception\{CastingException, InvalidTypeException};
+use Flow\Types\Exception\{CastingException, InvalidArgumentException, InvalidTypeException};
 use Flow\Types\Type;
 use Flow\Types\Value\HTMLDocument;
 
@@ -28,19 +28,15 @@ final readonly class HTMLType implements Type
             return $value;
         }
 
-        if (\is_string($value)) {
-            return new HTMLDocument($value);
+        if (!is_string($value) && !is_object($value)) {
+            throw new CastingException($value, $this);
         }
 
-        if ($value instanceof \DOMDocument) {
+        try {
             return new HTMLDocument($value);
+        } catch (InvalidArgumentException $e) {
+            throw new CastingException($value, $this, $e);
         }
-
-        if (\is_object($value) && \is_a($value, 'Dom\HTMLDocument')) {
-            return new HTMLDocument($value);
-        }
-
-        throw new CastingException($value, $this);
     }
 
     public function isValid(mixed $value) : bool

--- a/src/lib/types/src/Flow/Types/Value/HTMLDocument.php
+++ b/src/lib/types/src/Flow/Types/Value/HTMLDocument.php
@@ -6,48 +6,39 @@ namespace Flow\Types\Value;
 
 use Flow\Types\Exception\InvalidArgumentException;
 
-final class HTMLDocument implements \Stringable
+final readonly class HTMLDocument implements \Stringable
 {
+    private const HTML_ALIKE_REGEX = <<<'REGXP'
+@^
+    <!DOCTYPE\s+html[^>]*>\s*      # must start with <!DOCTYPE html ...>
+    <html[^>]*>\s*                 # opening <html>
+    <head[^>]*>.*?<\/head>\s*      # exactly one <head> ... </head>
+    <body[^>]*>.*?<\/body>\s*      # exactly one <body> ... </body>
+    <\/html>\s*                    # closing </html>
+$@mix
+REGXP;
+
     private string $value;
 
     public function __construct(string|object $value)
     {
-        if ('' === $value) {
-            $this->value = $value;
-        } elseif (\is_string($value)) {
-            if (\class_exists('\Dom\HTMLDocument', false)) {
-                $options = \LIBXML_HTML_NOIMPLIED;
-
-                if (defined('Dom\HTML_NO_DEFAULT_NS')) {
-                    $options |= constant('\Dom\HTML_NO_DEFAULT_NS');
-                }
-
-                $document = \Dom\HTMLDocument::createFromString($value, $options);
-
-                $this->value = $document->saveHTML();
-            } else {
-                $document = new \DOMDocument();
-
-                $result = @$document->loadHTML($value, \LIBXML_HTML_NOIMPLIED | \LIBXML_HTML_NODEFDTD);
-
-                if ($result === false) {
-                    throw new InvalidArgumentException("Invalid value '{$value}'");
-                }
-
-                $value = $document->saveHTML() ?: throw new InvalidArgumentException("Invalid value '{$value}'");
-
-                $this->value = trim($value);
-            }
-        } elseif ($value instanceof \DOMDocument) {
-            $value = $value->saveHTML($value->documentElement) ?: throw new InvalidArgumentException('Invalid value ' . var_export($value, true));
-
-            $this->value = trim($value);
+        if ($value instanceof \DOMDocument) {
+            $value = $value->saveHTML($value) ?: '';
         } elseif (is_a($value, '\Dom\HTMLDocument', true)) {
             /* @phpstan-ignore-next-line */
-            $this->value = $value->saveHtml();
-        } else {
-            throw new InvalidArgumentException('Invalid value ' . var_export($value, true));
+            $value = $value->saveHtml();
+        } elseif (!is_string($value)) {
+            throw new InvalidArgumentException('Invalid HTML document type: ' . $value::class);
         }
+
+        // Cut all new lines and tabs
+        $value = trim(str_replace(["\n", "\t"], '', $value));
+
+        if (!$this->isValid($value)) {
+            throw new InvalidArgumentException('Invalid HTML document given: ' . var_export($value, true));
+        }
+
+        $this->value = $value;
     }
 
     public static function fromString(string $value) : self
@@ -68,5 +59,14 @@ final class HTMLDocument implements \Stringable
     public function toString() : string
     {
         return $this->value;
+    }
+
+    private function isValid(string $value) : bool
+    {
+        if ('' === $value) {
+            return false;
+        }
+
+        return \preg_match(self::HTML_ALIKE_REGEX, $value) === 1;
     }
 }

--- a/src/lib/types/tests/Flow/Types/Tests/Unit/Type/Logical/HTMLTypeTest.php
+++ b/src/lib/types/tests/Flow/Types/Tests/Unit/Type/Logical/HTMLTypeTest.php
@@ -84,6 +84,26 @@ final class HTMLTypeTest extends TestCase
             'exceptionClass' => null,
         ];
 
+        yield 'valid HTML with spaces' => [
+            'value' => '<!DOCTYPE html><html>   <head><title></title></head>    <body><p>invalid</p>  </body>  </html>',
+            'expected' => '<!DOCTYPE html><html>   <head><title></title></head>    <body><p>invalid</p>  </body>  </html>',
+            'exceptionClass' => null,
+        ];
+
+        yield 'valid HTML with new lines' => [
+            'value' => <<<'HTML'
+<!DOCTYPE html>
+<html>
+    <head><title></title></head>
+    <body>
+        <p> invalid</p>
+    </body>
+</html>
+HTML,
+            'expected' => '<!DOCTYPE html><html>    <head><title></title></head>    <body>        <p> invalid</p>    </body></html>',
+            'exceptionClass' => null,
+        ];
+
         yield 'missing doctype' => [
             'value' => '<html><body><div><span>bar</span></div></body></html>',
             'expected' => null,

--- a/src/lib/types/tests/Flow/Types/Tests/Unit/Type/Logical/HTMLTypeTest.php
+++ b/src/lib/types/tests/Flow/Types/Tests/Unit/Type/Logical/HTMLTypeTest.php
@@ -7,7 +7,7 @@ namespace Flow\Types\Tests\Unit\Type\Logical;
 use function Flow\Types\DSL\{type_from_array, type_html};
 use Flow\Types\Exception\{CastingException, InvalidTypeException};
 use Flow\Types\Value\HTMLDocument;
-use PHPUnit\Framework\Attributes\{DataProvider, RequiresPhp};
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class HTMLTypeTest extends TestCase
@@ -15,7 +15,7 @@ final class HTMLTypeTest extends TestCase
     public static function assert_data_provider() : \Generator
     {
         yield 'valid HTMLDocument' => [
-            'value' => new HTMLDocument(''),
+            'value' => new HTMLDocument('<!DOCTYPE html><html><head></head><body></body></html>'),
             'exceptionClass' => null,
         ];
 
@@ -58,51 +58,46 @@ final class HTMLTypeTest extends TestCase
             'value' => new \DateTimeImmutable(),
             'exceptionClass' => InvalidTypeException::class,
         ];
+
+        yield 'incomplete HTML' => [
+            'value' => '<div><span>1</span></div>',
+            'exceptionClass' => InvalidTypeException::class,
+        ];
+
+        yield 'random object' => [
+            'value' => new \stdClass(),
+            'exceptionClass' => InvalidTypeException::class,
+        ];
     }
 
-    public static function cast_data_provider_php82() : \Generator
+    public static function cast_data_provider() : \Generator
     {
-        yield 'string to HTML' => [
-            'value' => '<!DOCTYPE html><html lang="en"><body><div><span>1</span></div></body></html>',
-            'expected' => <<<'HTML'
-<!DOCTYPE html>
-<html lang="en"><body><div><span>1</span></div></body></html>
-HTML,
+        yield 'valid HTMLDocument' => [
+            'value' => new HTMLDocument($html = '<!DOCTYPE html><html lang="en"><head></head><body><div><span>1</span></div></body></html>'),
+            'expected' => $html,
             'exceptionClass' => null,
         ];
 
-        yield 'incomplete string to HTML' => [
-            'value' => '<div><span>1</span></div>',
-            'expected' => <<<'HTML'
-<div><span>1</span></div>
-HTML,
+        yield 'valid HTML string' => [
+            'value' => $html = '<!DOCTYPE html><html lang="en"><head></head><body><div><span>1</span></div></body></html>',
+            'expected' => $html,
             'exceptionClass' => null,
         ];
 
-        yield 'object to HTML' => [
-            'value' => new \stdClass(),
+        yield 'missing doctype' => [
+            'value' => '<html><body><div><span>bar</span></div></body></html>',
             'expected' => null,
             'exceptionClass' => CastingException::class,
         ];
-    }
 
-    public static function cast_data_provider_php84() : \Generator
-    {
-        yield 'string to HTML' => [
-            'value' => '<!DOCTYPE html><html lang="en"><body><div><span>1</span></div></body></html>',
-            'expected' => '<!DOCTYPE html><html lang="en"><body><div><span>1</span></div></body></html>',
-            'exceptionClass' => null,
+        yield 'missing head' => [
+            'value' => '<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">
+<html><body><p>invalid</p></body></html>',
+            'expected' => null,
+            'exceptionClass' => CastingException::class,
         ];
 
-        yield 'incomplete string to HTML' => [
-            'value' => '<div><span>1</span></div>',
-            'expected' => <<<'HTML'
-<div><span>1</span></div>
-HTML,
-            'exceptionClass' => null,
-        ];
-
-        yield 'object to HTML' => [
+        yield 'random object' => [
             'value' => new \stdClass(),
             'expected' => null,
             'exceptionClass' => CastingException::class,
@@ -112,22 +107,12 @@ HTML,
     public static function is_valid_data_provider() : \Generator
     {
         yield 'valid HTMLDocument' => [
-            'value' => new HTMLDocument(''),
+            'value' => new HTMLDocument('<!DOCTYPE html><html lang="en"><head></head><body><div><span>1</span></div></body></html>'),
             'expected' => true,
         ];
 
-        yield 'invalid HTML string' => [
-            'value' => '<html></html>',
-            'expected' => false,
-        ];
-
-        yield 'invalid date string' => [
-            'value' => '2020-01-01',
-            'expected' => false,
-        ];
-
-        yield 'invalid datetime string' => [
-            'value' => '2020-01-01 00:00:00',
+        yield 'valid HTML string' => [
+            'value' => '<!DOCTYPE html><html lang="en"><head></head><body><div><span>1</span></div></body></html>',
             'expected' => false,
         ];
     }
@@ -143,30 +128,15 @@ HTML,
         }
     }
 
-    #[RequiresPhp('< 8.4')]
-    #[DataProvider('cast_data_provider_php82')]
-    public function test_cast_php82(mixed $value, mixed $expected, ?string $exceptionClass) : void
+    #[DataProvider('cast_data_provider')]
+    public function test_cast(mixed $value, mixed $expected, ?string $exceptionClass = null) : void
     {
         if ($exceptionClass !== null) {
             $this->expectException($exceptionClass);
-            type_html()->cast($value);
-        } else {
-            $result = type_html()->cast($value);
-            self::assertSame($expected, $result->toString());
         }
-    }
 
-    #[RequiresPhp('>= 8.4')]
-    #[DataProvider('cast_data_provider_php84')]
-    public function test_cast_php84(mixed $value, mixed $expected, ?string $exceptionClass) : void
-    {
-        if ($exceptionClass !== null) {
-            $this->expectException($exceptionClass);
-            type_html()->cast($value);
-        } else {
-            $result = type_html()->cast($value);
-            self::assertSame($expected, $result->toString());
-        }
+        $result = type_html()->cast($value);
+        self::assertSame($expected, $result->toString());
     }
 
     #[DataProvider('is_valid_data_provider')]

--- a/src/lib/types/tests/Flow/Types/Tests/Unit/Type/TypeDetectorTest.php
+++ b/src/lib/types/tests/Flow/Types/Tests/Unit/Type/TypeDetectorTest.php
@@ -99,7 +99,7 @@ final class TypeDetectorTest extends TestCase
         ];
 
         yield 'html' => [
-            HTMLDocument::fromString('<html><div><span>1</span></div></html>'),
+            HTMLDocument::fromString('<!DOCTYPE html><html lang="en"><head></head><body><div><span>1</span></div></body></html>'),
             HTMLType::class,
             'html',
         ];

--- a/src/lib/types/tests/Flow/Types/Tests/Unit/Value/HTMLDocumentTest.php
+++ b/src/lib/types/tests/Flow/Types/Tests/Unit/Value/HTMLDocumentTest.php
@@ -102,6 +102,29 @@ final class HTMLDocumentTest extends TestCase
         new HTMLDocument($value);
     }
 
+    #[DataProvider('provide_valid')]
+    public function test_create_with_string(string $value) : void
+    {
+        $document = new HTMLDocument($value);
+
+        self::assertSame(
+            $value,
+            $document->toString(),
+        );
+    }
+
+    public function test_create_with_string_with_multiple_spaces() : void
+    {
+        $html = '<!DOCTYPE html><html>   <head><title></title></head>    <body><p>invalid</p>  </body>  </html>';
+
+        $document = new HTMLDocument($html);
+
+        self::assertSame(
+            $html,
+            $document->toString(),
+        );
+    }
+
     public function test_with_random_object() : void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/src/lib/types/tests/Flow/Types/Tests/Unit/Value/HTMLDocumentTest.php
+++ b/src/lib/types/tests/Flow/Types/Tests/Unit/Value/HTMLDocumentTest.php
@@ -94,18 +94,8 @@ final class HTMLDocumentTest extends TestCase
         );
     }
 
-    #[RequiresPhp('>= 8.4')]
     #[DataProvider('provide_invalid')]
-    public function test_create_with_invalid_html_on_newer(string $value) : void
-    {
-        $this->expectException(InvalidArgumentException::class);
-
-        new HTMLDocument($value);
-    }
-
-    #[RequiresPhp('< 8.4')]
-    #[DataProvider('provide_invalid')]
-    public function test_create_with_invalid_html_on_old(string $value) : void
+    public function test_create_with_invalid_html(string $value) : void
     {
         $this->expectException(InvalidArgumentException::class);
 

--- a/src/lib/types/tests/Flow/Types/Tests/Unit/Value/HTMLDocumentTest.php
+++ b/src/lib/types/tests/Flow/Types/Tests/Unit/Value/HTMLDocumentTest.php
@@ -6,66 +6,110 @@ namespace Flow\Types\Tests\Unit\Value;
 
 use Flow\Types\Exception\InvalidArgumentException;
 use Flow\Types\Value\HTMLDocument;
-use PHPUnit\Framework\Attributes\RequiresPhp;
+use PHPUnit\Framework\Attributes\{DataProvider, RequiresPhp};
 use PHPUnit\Framework\TestCase;
 
 final class HTMLDocumentTest extends TestCase
 {
-    #[RequiresPhp('>= 8.4')]
-    public function test_create_with_dom_document_html_on_newer() : void
+    public static function provide_invalid() : \Generator
     {
-        $doc = \Dom\HTMLDocument::createFromString('<html><body><div><span>bar</span></div></body></html>', \LIBXML_HTML_NOIMPLIED);
+        yield 'empty' => [
+            'value' => '',
+        ];
+
+        yield 'invalid' => [
+            'value' => 'invalid',
+        ];
+
+        yield 'missing doctype' => [
+            'value' => '<html><body><div><span>bar</span></div></body></html>',
+        ];
+
+        yield 'missing head' => [
+            'value' => '<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">
+<html><body><p>invalid</p></body></html>',
+        ];
+
+        yield 'missing body' => [
+            'value' => '<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">
+<html><head></head></html>',
+        ];
+
+        yield 'not closed html' => [
+            'value' => '<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">
+<html><head></head><body><p>invalid</p></body>',
+        ];
+
+        yield 'xml' => [
+            'value' => '<?xml version="1.0"?><items><item>1</item></items>',
+        ];
+
+        yield 'xml element' => [
+            'value' => '<items><item>1</item></items>',
+        ];
+    }
+
+    public static function provide_valid() : \Generator
+    {
+        yield 'empty head and body' => [
+            'value' => '<!DOCTYPE html><html><head></head><body></body></html>',
+        ];
+
+        yield 'empty head' => [
+            'value' => '<!DOCTYPE html><html><head></head><body><p>invalid</p></body></html>',
+        ];
+
+        yield 'empty body' => [
+            'value' => '<!DOCTYPE html><html><head><title></title></head><body></body></html>',
+        ];
+
+        yield 'full' => [
+            'value' => '<!DOCTYPE html><html><head><title></title></head><body><p>invalid</p></body></html>',
+        ];
+    }
+
+    #[RequiresPhp('>= 8.4')]
+    #[DataProvider('provide_valid')]
+    public function test_create_with_dom_document_html_on_newer(string $value) : void
+    {
+        $doc = \Dom\HTMLDocument::createFromString($value);
 
         $document = new HTMLDocument($doc);
 
-        self::assertSame('<html><body><div><span>bar</span></div></body></html>', (string) $document);
+        self::assertSame($value, $document->toString());
     }
 
     #[RequiresPhp('< 8.4')]
-    public function test_create_with_dom_document_html_on_old() : void
+    #[DataProvider('provide_valid')]
+    public function test_create_with_dom_document_html_on_old(string $value) : void
     {
         $doc = new \DOMDocument();
-        $doc->loadHTML($html = '<html><body><div><span>bar</span></div></body></html>');
+        $doc->loadHTML($value);
 
         $document = new HTMLDocument($doc);
 
-        self::assertSame($html, (string) $document);
+        self::assertSame(
+            $value,
+            $document->toString(),
+        );
     }
 
     #[RequiresPhp('>= 8.4')]
-    public function test_create_with_invalid_html_on_newer() : void
+    #[DataProvider('provide_invalid')]
+    public function test_create_with_invalid_html_on_newer(string $value) : void
     {
-        self::markTestSkipped('Skipping invalid test');
-        $document = new HTMLDocument('invalid');
+        $this->expectException(InvalidArgumentException::class);
 
-        self::assertSame('invalid', (string) $document);
+        new HTMLDocument($value);
     }
 
     #[RequiresPhp('< 8.4')]
-    public function test_create_with_invalid_html_on_old() : void
+    #[DataProvider('provide_invalid')]
+    public function test_create_with_invalid_html_on_old(string $value) : void
     {
-        self::markTestSkipped('Skipping invalid test');
-        $document = new HTMLDocument('invalid');
+        $this->expectException(InvalidArgumentException::class);
 
-        self::assertSame('<p>invalid</p>', (string) $document);
-    }
-
-    #[RequiresPhp('>= 8.4')]
-    public function test_create_with_proper_html_on_newer() : void
-    {
-        $html = '<html><body><div><span>bar</span></div></body></html>';
-        $document = new HTMLDocument($html);
-
-        self::assertSame($html, (string) $document);
-    }
-
-    #[RequiresPhp('< 8.4')]
-    public function test_create_with_proper_html_on_old() : void
-    {
-        $html = '<html><body><div><span>bar</span></div></body></html>';
-        $document = new HTMLDocument($html);
-
-        self::assertSame($html, (string) $document);
+        new HTMLDocument($value);
     }
 
     public function test_with_random_object() : void


### PR DESCRIPTION
<!-- 
    Please replace #xxx with a GitHub issue id from flow-php/flow repository. For example #1234 
    If there is no item in a roadmap related to this PR, please check our contributing guidelines first. 
-->
Resolves: #xxx

<!-- 
    Below section will be used to automatically generate changelog, please do not modify HTML code structure
    DO NOT REMOVE that HTML STRUCTURE, INSTEAD ADD YOUR CHANGES INSIDE THE LISTS 
    PULL REQUESTS WITHOUT CHANGELOG CAN'T BE MERGED 
-->
<h2>Change Log</h2>
<hr /> 
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Make `HTMLDocument` reliable</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>