### PR TITLE
Move JSON & Uuid validation out of `StringTypeNarrower`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,7 @@
         "psr/simple-cache": "^1.0 || ^2.0 || ^3.0",
         "symfony/console": "^5.4 || ^6.4 || ^7.0",
         "symfony/http-foundation": "~5.4.0 || ~6.4.0 || ~7",
+        "symfony/polyfill-php83": "^1.33",
         "symfony/string": "^5.4 || ^6.4 || ^7.0",
         "symfony/uid": "^6.3 || ^7.0",
         "webmozart/glob": "^3.0 || ^4.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4f28d3d05c5e2a276ddf83d716407aa9",
+    "content-hash": "706dd41a7edb6e4c80a5a0b299259772",
     "packages": [
         {
             "name": "async-aws/core",

--- a/src/lib/types/composer.json
+++ b/src/lib/types/composer.json
@@ -7,7 +7,8 @@
         "types"
     ],
     "require": {
-        "php": "~8.2.0 || ~8.3.0 || ~8.4.0"
+        "php": "~8.2.0 || ~8.3.0 || ~8.4.0",
+        "symfony/polyfill-php83": "^1.33"
     },
     "config": {
         "optimize-autoloader": true,

--- a/src/lib/types/src/Flow/Types/Type/Logical/JsonType.php
+++ b/src/lib/types/src/Flow/Types/Type/Logical/JsonType.php
@@ -7,7 +7,6 @@ namespace Flow\Types\Type\Logical;
 use function Flow\Types\DSL\type_json;
 use Flow\Types\Exception\{CastingException, InvalidTypeException};
 use Flow\Types\Type;
-use Flow\Types\Type\Native\String\StringTypeNarrower;
 
 /**
  * @implements Type<string>
@@ -46,7 +45,22 @@ final readonly class JsonType implements Type
             return false;
         }
 
-        return (new StringTypeNarrower())->narrow($value) instanceof self;
+        if ($value === '') {
+            return false;
+        }
+
+        if ('{' !== $value[0] && '[' !== $value[0]) {
+            return false;
+        }
+
+        if (
+            !(\str_starts_with($value, '{') && \str_ends_with($value, '}'))
+            && !(\str_starts_with($value, '[') && \str_ends_with($value, ']'))
+        ) {
+            return false;
+        }
+
+        return \json_validate($value);
     }
 
     public function normalize() : array

--- a/src/lib/types/src/Flow/Types/Type/Logical/UuidType.php
+++ b/src/lib/types/src/Flow/Types/Type/Logical/UuidType.php
@@ -49,10 +49,8 @@ final readonly class UuidType implements Type
 
     public function isValid(mixed $value) : bool
     {
-        if (\is_object($value)) {
-            if ($value instanceof Uuid) {
-                return true;
-            }
+        if ($value instanceof Uuid) {
+            return true;
         }
 
         return false;

--- a/src/lib/types/src/Flow/Types/Type/Native/String/StringTypeNarrower.php
+++ b/src/lib/types/src/Flow/Types/Type/Native/String/StringTypeNarrower.php
@@ -33,7 +33,7 @@ final class StringTypeNarrower implements TypeNarrower
             return type_string();
         }
 
-        $this->setString($value);
+        $this->string = \trim($value);
 
         if ($this->isNull()) {
             return type_null();
@@ -207,30 +207,7 @@ final class StringTypeNarrower implements TypeNarrower
 
     private function isJson() : bool
     {
-        if ($this->string === '') {
-            return false;
-        }
-
-        if ('{' !== $this->string[0] && '[' !== $this->string[0]) {
-            return false;
-        }
-
-        if (\function_exists('json_validate')) {
-            return \json_validate($this->string);
-        }
-
-        if (
-            (!\str_starts_with($this->string, '{') || !\str_ends_with($this->string, '}'))
-            && (!\str_starts_with($this->string, '[') || !\str_ends_with($this->string, ']'))
-        ) {
-            return false;
-        }
-
-        try {
-            return \is_array(\json_decode($this->string, true, flags: \JSON_THROW_ON_ERROR));
-        } catch (\Exception) {
-            return false;
-        }
+        return type_json()->isValid($this->string);
     }
 
     private function isNull() : bool
@@ -263,15 +240,7 @@ final class StringTypeNarrower implements TypeNarrower
 
     private function isUuid() : bool
     {
-        if ($this->string === '') {
-            return false;
-        }
-
-        if (\strlen($this->string) !== 36) {
-            return false;
-        }
-
-        return 0 !== \preg_match(Uuid::UUID_REGEXP, $this->string);
+        return Uuid::isValid($this->string);
     }
 
     private function isXML() : bool
@@ -301,10 +270,5 @@ final class StringTypeNarrower implements TypeNarrower
         }
 
         return false;
-    }
-
-    private function setString(string $string) : void
-    {
-        $this->string = \trim($string);
     }
 }

--- a/src/lib/types/src/Flow/Types/Value/Uuid.php
+++ b/src/lib/types/src/Flow/Types/Value/Uuid.php
@@ -13,7 +13,7 @@ final readonly class Uuid implements \Stringable
      * This regexp is a port of the Uuid library,
      * which is copyright Ben Ramsey, @see https://github.com/ramsey/uuid.
      */
-    public const UUID_REGEXP = '/\A[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\z/ms';
+    private const UUID_REGEXP = '/\A[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\z/ms';
 
     private string $value;
 
@@ -28,11 +28,13 @@ final readonly class Uuid implements \Stringable
                     $this->value = (string) \Ramsey\Uuid\Uuid::fromString($value);
                 } elseif (\class_exists(\Symfony\Component\Uid\Uuid::class)) {
                     $this->value = \Symfony\Component\Uid\Uuid::fromString($value)->toRfc4122();
+                } elseif (self::isValid($value)) {
+                    $this->value = $value;
                 } else {
                     throw new RuntimeException("\Ramsey\Uuid\Uuid nor \Symfony\Component\Uid\Uuid class not found, please add 'ramsey/uuid' or 'symfony/uid' as a dependency to the project first.");
                 }
             } catch (\InvalidArgumentException $e) {
-                throw new InvalidArgumentException("Invalid UUID: '{$value}'", 0, $e);
+                throw new InvalidArgumentException("Invalid UUID: '{$value}'", $e->getCode(), $e);
             }
         } elseif ($value instanceof UuidInterface) {
             $this->value = $value->toString();
@@ -44,6 +46,15 @@ final readonly class Uuid implements \Stringable
     public static function fromString(string $value) : self
     {
         return new self($value);
+    }
+
+    public static function isValid(string $value) : bool
+    {
+        if (\strlen($value) !== 36) {
+            return false;
+        }
+
+        return 1 === \preg_match(self::UUID_REGEXP, $value);
     }
 
     public function __toString() : string

--- a/src/lib/types/tests/Flow/Types/Tests/Unit/Value/UuidTest.php
+++ b/src/lib/types/tests/Flow/Types/Tests/Unit/Value/UuidTest.php
@@ -18,6 +18,12 @@ final class UuidTest extends TestCase
         new Uuid('invalid-uuid-string');
     }
 
+    public function test_construct_with_invalid_uuid_throws_exception() : void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new Uuid('********-****-****-****************');
+    }
+
     public function test_construct_with_ramsey_uuid_instance() : void
     {
         $ramseyUuid = RamseyUuid::uuid4();
@@ -47,7 +53,6 @@ final class UuidTest extends TestCase
         $uuidString = '123e4567-e89b-12d3-a456-426614174000';
         $uuid = Uuid::fromString($uuidString);
 
-        self::assertInstanceOf(Uuid::class, $uuid);
         self::assertSame($uuidString, $uuid->toString());
     }
 


### PR DESCRIPTION
<!-- 
    Please replace #xxx with a GitHub issue id from flow-php/flow repository. For example #1234 
    If there is no item in a roadmap related to this PR, please check our contributing guidelines first. 
-->
Resolves: #1952

<!-- 
    Below section will be used to automatically generate changelog, please do not modify HTML code structure
    DO NOT REMOVE that HTML STRUCTURE, INSTEAD ADD YOUR CHANGES INSIDE THE LISTS 
    PULL REQUESTS WITHOUT CHANGELOG CAN'T BE MERGED 
-->
<h2>Change Log</h2>
<hr /> 
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Move JSON & Uuid validation out of `StringTypeNarrower`</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>