### PR TITLE
chore: narrow phpstan class.notFound suppression to config only and specific classes only

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -87,20 +87,8 @@ parameters:
 
     ignoreErrors:
         -
+            message: '#Dom\\(HTMLDocument|Element)#i'
             identifier: class.notFound
-            path: src/core/etl/src/Flow/ETL/Row/Entry/HTMLEntry.php
-
-        -
-            identifier: class.notFound
-            path: src/core/etl/src/Flow/ETL/Function/HTMLQuerySelector.php
-
-        -
-            identifier: class.notFound
-            path: src/core/etl/src/Flow/ETL/Function/HTMLQuerySelectorAll.php
-
-        -
-            identifier: class.notFound
-            path: src/lib/types/src/Flow/Types/Type/Logical/HTMLType.php
 
 includes:
     - tools/phpstan/vendor/spaze/phpstan-disallowed-calls/extension.neon

--- a/src/core/etl/src/Flow/ETL/DSL/functions.php
+++ b/src/core/etl/src/Flow/ETL/DSL/functions.php
@@ -632,7 +632,7 @@ function xml_element_entry(string $name, \DOMElement|string|null $value, ?Metada
  * @return Entry<?HTMLDocument>
  */
 #[DocumentationDSL(module: Module::CORE, type: DSLType::ENTRY)]
-function html_entry(string $name, HTMLDocument|string|null $value, ?Metadata $metadata = null) : Entry // @phpstan-ignore class.notFound,class.notFound
+function html_entry(string $name, HTMLDocument|string|null $value, ?Metadata $metadata = null) : Entry
 {
     return new HTMLEntry($name, $value, $metadata);
 }
@@ -1973,7 +1973,7 @@ function json_schema(string $name, bool $nullable = false, ?Metadata $metadata =
  * @return Definition<HTMLDocument>
  */
 #[DocumentationDSL(module: Module::CORE, type: DSLType::SCHEMA)]
-function html_schema(string $name, bool $nullable = false, ?Metadata $metadata = null) : Definition // @phpstan-ignore class.notFound
+function html_schema(string $name, bool $nullable = false, ?Metadata $metadata = null) : Definition
 {
     return Definition::html($name, $nullable, $metadata);
 }

--- a/src/core/etl/src/Flow/ETL/Schema/Definition.php
+++ b/src/core/etl/src/Flow/ETL/Schema/Definition.php
@@ -143,7 +143,7 @@ final class Definition
     /**
      * @return Definition<HTMLDocument>
      */
-    public static function html(string|Reference $entry, bool $nullable = false, ?Metadata $metadata = null) : self // @phpstan-ignore class.notFound
+    public static function html(string|Reference $entry, bool $nullable = false, ?Metadata $metadata = null) : self
     {
         return new self($entry, type_html(), $nullable, $metadata);
     }

--- a/src/lib/types/src/Flow/Types/DSL/functions.php
+++ b/src/lib/types/src/Flow/Types/DSL/functions.php
@@ -441,7 +441,7 @@ function type_literal(bool|float|int|string $value) : LiteralType
  * @return Type<HTMLDocument>
  */
 #[DocumentationDSL(module: Module::TYPES, type: DSLType::TYPE)]
-function type_html() : Type // @phpstan-ignore class.notFound
+function type_html() : Type
 {
     return new HTMLType();
 }

--- a/src/lib/types/src/Flow/Types/Type/Logical/HTMLType.php
+++ b/src/lib/types/src/Flow/Types/Type/Logical/HTMLType.php
@@ -23,7 +23,7 @@ final readonly class HTMLType implements Type
 $@isx
 REGXP;
 
-    public function assert(mixed $value) : HTMLDocument // @phpstan-ignore class.notFound
+    public function assert(mixed $value) : HTMLDocument
     {
         if ($this->isValid($value)) {
             return $value;
@@ -32,7 +32,7 @@ REGXP;
         throw InvalidTypeException::value($value, $this);
     }
 
-    public function cast(mixed $value) : HTMLDocument // @phpstan-ignore class.notFound
+    public function cast(mixed $value) : HTMLDocument
     {
         if (!$this->isValid($value)) {
             throw new CastingException($value, $this);
@@ -40,7 +40,6 @@ REGXP;
 
         /* @phpstan-ignore-next-line */
         if (\is_string($value)) {
-            /* @phpstan-ignore-next-line class.notFound */
             return HTMLDocument::createFromString($value);
         }
 


### PR DESCRIPTION
<!-- 
    Below section will be used to automatically generate changelog, please do not modify HTML code structure
    DO NOT REMOVE that HTML STRUCTURE, INSTEAD ADD YOUR CHANGES INSIDE THE LISTS 
    PULL REQUESTS WITHOUT CHANGELOG CAN'T BE MERGED 
-->
<h2>Change Log</h2>
<hr /> 
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>narrow phpstan class.notFound suppression to config only and specific classes only</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>

Regarding #1960 