### PR TITLE
Make HTTP Adapter aware of HTML & XML entry types

### DIFF
--- a/src/adapter/etl-adapter-http/src/Flow/ETL/Adapter/Http/ContentTypeDetector.php
+++ b/src/adapter/etl-adapter-http/src/Flow/ETL/Adapter/Http/ContentTypeDetector.php
@@ -8,22 +8,22 @@ use Psr\Http\Message\ResponseInterface;
 
 final class ContentTypeDetector
 {
-    public static function detectFromResponse(ResponseInterface $response) : string
+    public static function detectFromResponse(ResponseInterface $response) : ResponseType
     {
         foreach ($response->getHeader('Content-Type') as $header) {
             if (\str_contains($header, 'application/json')) {
-                return 'json';
+                return ResponseType::JSON;
             }
 
             if (\str_contains($header, 'application/xml')) {
-                return 'xml';
+                return ResponseType::XML;
             }
 
             if (\str_contains($header, 'text/html')) {
-                return 'html';
+                return ResponseType::HTML;
             }
         }
 
-        return 'text';
+        return ResponseType::TEXT;
     }
 }

--- a/src/adapter/etl-adapter-http/src/Flow/ETL/Adapter/Http/ContentTypeDetector.php
+++ b/src/adapter/etl-adapter-http/src/Flow/ETL/Adapter/Http/ContentTypeDetector.php
@@ -4,14 +4,13 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Adapter\Http;
 
+use Psr\Http\Message\ResponseInterface;
+
 final class ContentTypeDetector
 {
-    /**
-     * @param array<string> $headers
-     */
-    public static function detectFromHeaders(array $headers) : string
+    public static function detectFromHeaders(ResponseInterface $response) : string
     {
-        foreach ($headers as $header) {
+        foreach ($response->getHeader('Content-Type') as $header) {
             if (\str_contains($header, 'application/json')) {
                 return 'json';
             }

--- a/src/adapter/etl-adapter-http/src/Flow/ETL/Adapter/Http/ContentTypeDetector.php
+++ b/src/adapter/etl-adapter-http/src/Flow/ETL/Adapter/Http/ContentTypeDetector.php
@@ -8,7 +8,7 @@ use Psr\Http\Message\ResponseInterface;
 
 final class ContentTypeDetector
 {
-    public static function detectFromHeaders(ResponseInterface $response) : string
+    public static function detectFromResponse(ResponseInterface $response) : string
     {
         foreach ($response->getHeader('Content-Type') as $header) {
             if (\str_contains($header, 'application/json')) {

--- a/src/adapter/etl-adapter-http/src/Flow/ETL/Adapter/Http/ContentTypeDetector.php
+++ b/src/adapter/etl-adapter-http/src/Flow/ETL/Adapter/Http/ContentTypeDetector.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Adapter\Http;
+
+final class ContentTypeDetector
+{
+    /**
+     * @param array<string> $headers
+     */
+    public static function detectFromHeaders(array $headers) : string
+    {
+        foreach ($headers as $header) {
+            if (\str_contains($header, 'application/json')) {
+                return 'json';
+            }
+
+            if (\str_contains($header, 'application/xml')) {
+                return 'xml';
+            }
+
+            if (\str_contains($header, 'text/html')) {
+                return 'html';
+            }
+        }
+
+        return 'text';
+    }
+}

--- a/src/adapter/etl-adapter-http/src/Flow/ETL/Adapter/Http/ResponseEntriesFactory.php
+++ b/src/adapter/etl-adapter-http/src/Flow/ETL/Adapter/Http/ResponseEntriesFactory.php
@@ -38,14 +38,11 @@ final class ResponseEntriesFactory
             }
 
             $responseBodyEntry = match ($responseType) {
-                'json' => json_entry('response_body', (array) \json_decode($responseBodyContent, true, 512, JSON_THROW_ON_ERROR)),
-                'xml' => xml_entry('response_body', $responseBodyContent),
+                ResponseType::JSON => json_entry('response_body', (array) \json_decode($responseBodyContent, true, 512, JSON_THROW_ON_ERROR)),
+                ResponseType::XML => xml_entry('response_body', $responseBodyContent),
+                ResponseType::HTML => class_exists('\Dom\HTMLDocument') ? html_entry('response_body', $responseBodyContent) : string_entry('response_body', $responseBodyContent),
                 default => string_entry('response_body', $responseBodyContent),
             };
-
-            if (class_exists('\Dom\HTMLDocument') && 'html' === $responseType) {
-                $responseBodyEntry = html_entry('response_body', $responseBodyContent);
-            }
         } else {
             $responseBodyEntry = string_entry('response_body', null);
         }

--- a/src/adapter/etl-adapter-http/src/Flow/ETL/Adapter/Http/ResponseEntriesFactory.php
+++ b/src/adapter/etl-adapter-http/src/Flow/ETL/Adapter/Http/ResponseEntriesFactory.php
@@ -4,11 +4,10 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Adapter\Http;
 
-use function Flow\ETL\DSL\string_entry;
+use function Flow\ETL\DSL\{html_entry, int_entry, json_entry, string_entry, xml_entry};
 use Flow\ETL\Exception\InvalidArgumentException;
 use Flow\ETL\Row;
 use Flow\ETL\Row\Entries;
-use Flow\ETL\Row\Entry\{IntegerEntry, JsonEntry};
 use Psr\Http\Message\ResponseInterface;
 
 final class ResponseEntriesFactory
@@ -23,17 +22,11 @@ final class ResponseEntriesFactory
      */
     public function create(ResponseInterface $response) : Entries
     {
-        $responseType = 'html';
-
-        foreach ($response->getHeader('Content-Type') as $header) {
-            if (\str_contains($header, 'application/json')) {
-                $responseType = 'json';
-            }
-        }
-
         $responseBody = $response->getBody();
 
         if ($responseBody->isReadable()) {
+            $responseType = ContentTypeDetector::detectFromHeaders($response->getHeader('Content-Type'));
+
             if ($responseBody->isSeekable()) {
                 $responseBody->seek(0);
             }
@@ -44,26 +37,14 @@ final class ResponseEntriesFactory
                 $responseBody->seek(0);
             }
 
-            switch ($responseType) {
-                case 'json':
-                    if (\class_exists(JsonEntry::class)) {
-                        $decodedJson = \json_decode($responseBodyContent, true, 512, JSON_THROW_ON_ERROR);
+            $responseBodyEntry = match ($responseType) {
+                'json' => json_entry('response_body', (array) \json_decode($responseBodyContent, true, 512, JSON_THROW_ON_ERROR)),
+                'xml' => xml_entry('response_body', $responseBodyContent),
+                default => string_entry('response_body', $responseBodyContent),
+            };
 
-                        if (!\is_array($decodedJson)) {
-                            throw new InvalidArgumentException('Invalid JSON response body, expected array or object');
-                        }
-
-                        $responseBodyEntry = new JsonEntry('response_body', $decodedJson);
-                    } else {
-                        $responseBodyEntry = string_entry('response_body', $responseBodyContent);
-                    }
-
-                    break;
-
-                default:
-                    $responseBodyEntry = string_entry('response_body', $responseBodyContent);
-
-                    break;
+            if (class_exists('\Dom\HTMLDocument') && 'html' === $responseType) {
+                $responseBodyEntry = html_entry('response_body', $responseBodyContent);
             }
         } else {
             $responseBodyEntry = string_entry('response_body', null);
@@ -71,8 +52,8 @@ final class ResponseEntriesFactory
 
         return new Entries(
             $responseBodyEntry,
-            new JsonEntry('response_headers', $response->getHeaders()),
-            new IntegerEntry('response_status_code', $response->getStatusCode()),
+            json_entry('response_headers', $response->getHeaders()),
+            int_entry('response_status_code', $response->getStatusCode()),
             string_entry('response_protocol_version', $response->getProtocolVersion()),
             string_entry('response_reason_phrase', $response->getReasonPhrase()),
         );

--- a/src/adapter/etl-adapter-http/src/Flow/ETL/Adapter/Http/ResponseEntriesFactory.php
+++ b/src/adapter/etl-adapter-http/src/Flow/ETL/Adapter/Http/ResponseEntriesFactory.php
@@ -25,7 +25,7 @@ final class ResponseEntriesFactory
         $responseBody = $response->getBody();
 
         if ($responseBody->isReadable()) {
-            $responseType = ContentTypeDetector::detectFromHeaders($response);
+            $responseType = ContentTypeDetector::detectFromResponse($response);
 
             if ($responseBody->isSeekable()) {
                 $responseBody->seek(0);

--- a/src/adapter/etl-adapter-http/src/Flow/ETL/Adapter/Http/ResponseEntriesFactory.php
+++ b/src/adapter/etl-adapter-http/src/Flow/ETL/Adapter/Http/ResponseEntriesFactory.php
@@ -25,7 +25,7 @@ final class ResponseEntriesFactory
         $responseBody = $response->getBody();
 
         if ($responseBody->isReadable()) {
-            $responseType = ContentTypeDetector::detectFromHeaders($response->getHeader('Content-Type'));
+            $responseType = ContentTypeDetector::detectFromHeaders($response);
 
             if ($responseBody->isSeekable()) {
                 $responseBody->seek(0);

--- a/src/adapter/etl-adapter-http/src/Flow/ETL/Adapter/Http/ResponseType.php
+++ b/src/adapter/etl-adapter-http/src/Flow/ETL/Adapter/Http/ResponseType.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Adapter\Http;
+
+enum ResponseType : string
+{
+    case HTML = 'html';
+    case JSON = 'json';
+    case TEXT = 'text';
+    case XML = 'xml';
+}

--- a/src/adapter/etl-adapter-http/tests/Flow/ETL/Adapter/HTTP/Tests/Unit/ContentTypeDetectorTest.php
+++ b/src/adapter/etl-adapter-http/tests/Flow/ETL/Adapter/HTTP/Tests/Unit/ContentTypeDetectorTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Adapter\HTTP\Tests\Unit;
 
-use Flow\ETL\Adapter\Http\ContentTypeDetector;
+use Flow\ETL\Adapter\Http\{ContentTypeDetector, ResponseType};
 use Nyholm\Psr7\Response;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -16,32 +16,32 @@ final class ContentTypeDetectorTest extends TestCase
     {
         yield 'application/json' => [
             new Response(headers: ['Content-Type' => 'application/json']),
-            'json',
+            ResponseType::JSON,
         ];
 
         yield 'application/xml' => [
             new Response(headers: ['Content-Type' => 'application/xml']),
-            'xml',
+            ResponseType::XML,
         ];
 
         yield 'text/html' => [
             new Response(headers: ['Content-Type' => 'text/html']),
-            'html',
+            ResponseType::HTML,
         ];
 
         yield 'unknown' => [
             new Response(headers: ['Content-Type' => 'unknown']),
-            'text',
+            ResponseType::TEXT,
         ];
 
         yield 'missing' => [
             new Response(),
-            'text',
+            ResponseType::TEXT,
         ];
     }
 
     #[DataProvider('responses')]
-    public function test_detects_content_type_from_response(ResponseInterface $response, string $expected) : void
+    public function test_detects_content_type_from_response(ResponseInterface $response, ResponseType $expected) : void
     {
         self::assertSame(
             $expected,

--- a/src/adapter/etl-adapter-http/tests/Flow/ETL/Adapter/HTTP/Tests/Unit/ContentTypeDetectorTest.php
+++ b/src/adapter/etl-adapter-http/tests/Flow/ETL/Adapter/HTTP/Tests/Unit/ContentTypeDetectorTest.php
@@ -45,7 +45,7 @@ final class ContentTypeDetectorTest extends TestCase
     {
         self::assertSame(
             $expected,
-            ContentTypeDetector::detectFromHeaders($response),
+            ContentTypeDetector::detectFromResponse($response),
         );
     }
 }

--- a/src/adapter/etl-adapter-http/tests/Flow/ETL/Adapter/HTTP/Tests/Unit/ContentTypeDetectorTest.php
+++ b/src/adapter/etl-adapter-http/tests/Flow/ETL/Adapter/HTTP/Tests/Unit/ContentTypeDetectorTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Adapter\HTTP\Tests\Unit;
+
+use Flow\ETL\Adapter\Http\ContentTypeDetector;
+use Nyholm\Psr7\Response;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+
+final class ContentTypeDetectorTest extends TestCase
+{
+    public static function responses() : \Generator
+    {
+        yield 'application/json' => [
+            new Response(headers: ['Content-Type' => 'application/json']),
+            'json',
+        ];
+
+        yield 'application/xml' => [
+            new Response(headers: ['Content-Type' => 'application/xml']),
+            'xml',
+        ];
+
+        yield 'text/html' => [
+            new Response(headers: ['Content-Type' => 'text/html']),
+            'html',
+        ];
+
+        yield 'unknown' => [
+            new Response(headers: ['Content-Type' => 'unknown']),
+            'text',
+        ];
+
+        yield 'missing' => [
+            new Response(),
+            'text',
+        ];
+    }
+
+    #[DataProvider('responses')]
+    public function test_detects_content_type_from_response(ResponseInterface $response, string $expected) : void
+    {
+        self::assertSame(
+            $expected,
+            ContentTypeDetector::detectFromHeaders($response),
+        );
+    }
+}

--- a/src/adapter/etl-adapter-http/tests/Flow/ETL/Adapter/HTTP/Tests/Unit/ResponseEntriesFactoryTest.php
+++ b/src/adapter/etl-adapter-http/tests/Flow/ETL/Adapter/HTTP/Tests/Unit/ResponseEntriesFactoryTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Adapter\HTTP\Tests\Unit;
+
+use Flow\ETL\Adapter\Http\ResponseEntriesFactory;
+use Flow\ETL\Row\Entry\{HTMLEntry, JsonEntry, StringEntry, XMLEntry};
+use Flow\ETL\Tests\FlowTestCase;
+use Nyholm\Psr7\Response;
+use PHPUnit\Framework\Attributes\{DataProvider, RequiresPhp};
+use Psr\Http\Message\ResponseInterface;
+
+final class ResponseEntriesFactoryTest extends FlowTestCase
+{
+    public static function responses() : \Generator
+    {
+        yield 'uses JsonEntry for response body when Content-Type header is application/json' => [
+            JsonEntry::class,
+            new Response(
+                headers: ['Content-Type' => 'application/json'],
+                body: \json_encode(['status' => 'success'], JSON_THROW_ON_ERROR),
+            ),
+        ];
+
+        yield 'uses XmlEntry for response body when Content-Type header is application/xml' => [
+            XMLEntry::class,
+            new Response(
+                headers: ['Content-Type' => 'application/xml'],
+                body: '<root><foo baz="buz">bar</foo></root>',
+            ),
+        ];
+
+        yield 'uses StringEntry for response body when no Content-Type header was provided' => [
+            StringEntry::class,
+            new Response(
+                body: '<!DOCTYPE html><html lang="en"><head></head><body><div>2</div><p>3</p></body></html>',
+            ),
+        ];
+    }
+
+    /**
+     * @param class-string $entryClass
+     */
+    #[DataProvider('responses')]
+    public function test_uses_expected_entry_for_response_body(string $entryClass, ResponseInterface $response) : void
+    {
+        $entryFactory = new ResponseEntriesFactory();
+
+        self::assertInstanceOf(
+            $entryClass,
+            $entryFactory->create($response)->get('response_body')
+        );
+    }
+
+    #[RequiresPhp('>= 8.4')]
+    public function test_uses_html_entry_for_response_body_on_newer_php() : void
+    {
+        $entryFactory = new ResponseEntriesFactory();
+
+        $response = new Response(
+            headers: ['Content-Type' => 'text/html'],
+            body: '<!DOCTYPE html><html lang="en"><head></head><body><div>2</div><p>3</p></body></html>',
+        );
+
+        self::assertInstanceOf(
+            HTMLEntry::class,
+            $entryFactory->create($response)->get('response_body')
+        );
+    }
+
+    #[RequiresPhp('< 8.4')]
+    public function test_uses_string_entry_for_response_body_on_older_php() : void
+    {
+        $entryFactory = new ResponseEntriesFactory();
+
+        $response = new Response(
+            headers: ['Content-Type' => 'text/html'],
+            body: '<!DOCTYPE html><html lang="en"><head></head><body><div>2</div><p>3</p></body></html>',
+        );
+
+        self::assertInstanceOf(
+            StringEntry::class,
+            $entryFactory->create($response)->get('response_body')
+        );
+    }
+}


### PR DESCRIPTION
<!-- 
    Please replace #xxx with a GitHub issue id from flow-php/flow repository. For example #1234 
    If there is no item in a roadmap related to this PR, please check our contributing guidelines first. 
-->
Resolves: #1979 

<!-- 
    Below section will be used to automatically generate changelog, please do not modify HTML code structure
    DO NOT REMOVE that HTML STRUCTURE, INSTEAD ADD YOUR CHANGES INSIDE THE LISTS 
    PULL REQUESTS WITHOUT CHANGELOG CAN'T BE MERGED 
-->
<h2>Change Log</h2>
<hr /> 
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <li>Make HTTP Adapter aware of HTML & XML entry types</li>
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>