### PR TITLE
chore: Unify and bump minimal Symfony requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,11 +38,11 @@
         "psr/http-message": "^1.0 || ^2.0",
         "psr/log": "^2.0 || ^3.0",
         "psr/simple-cache": "^1.0 || ^2.0 || ^3.0",
-        "symfony/console": "^5.4 || ^6.4 || ^7.0",
-        "symfony/http-foundation": "~5.4.0 || ~6.4.0 || ~7",
+        "symfony/console": "^6.4 || ^7.3 || ^8.0",
+        "symfony/http-foundation": "^6.4 || ^7.3 || ^8.0",
         "symfony/polyfill-php83": "^1.33",
-        "symfony/string": "^5.4 || ^6.4 || ^7.0",
-        "symfony/uid": "^6.3 || ^7.0",
+        "symfony/string": "^6.4 || ^7.3 || ^8.0",
+        "symfony/uid": "^6.4 || ^7.3 || ^8.0",
         "webmozart/glob": "^3.0 || ^4.0"
     },
     "require-dev": {
@@ -55,11 +55,11 @@
         "php-http/curl-client": "^2.2",
         "php-http/mock-client": "^1.5",
         "ramsey/uuid": "^4.5",
-        "symfony/cache": "^6.2 || ^7.0",
-        "symfony/dotenv": "^6.2 || ^7.0",
-        "symfony/finder": "^6.3 || ^7.0",
-        "symfony/http-client": "^5.4.47 || ^6.4 || ^7.0",
-        "symfony/process": "^7.2"
+        "symfony/cache": "^6.4 || ^7.3 || ^8.0",
+        "symfony/dotenv": "^6.4 || ^7.3 || ^8.0",
+        "symfony/finder": "^6.4 || ^7.3 || ^8.0",
+        "symfony/http-client": "^6.4 || ^7.3 || ^8.0",
+        "symfony/process": "^7.3 || ^8.0"
     },
     "replace": {
         "flow-php/array-dot": "self.version",

--- a/src/bridge/symfony/http-foundation/composer.json
+++ b/src/bridge/symfony/http-foundation/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": "~8.2.0 || ~8.3.0 || ~8.4.0",
-        "symfony/http-foundation": "~5.4.0 || ~6.4.0 || ~7",
+        "symfony/http-foundation": "^6.4 || ^7.3 || ^8.0",
         "flow-php/etl": "self.version"
     },
     "require-dev": {

--- a/src/cli/composer.json
+++ b/src/cli/composer.json
@@ -9,8 +9,8 @@
     ],
     "require": {
         "php": "~8.2.0 || ~8.3.0 || ~8.4.0",
-        "symfony/console": "^5.4 || ^6.4 || ^7.0",
-        "symfony/uid": "^6.3 || ^7.0",
+        "symfony/console": "^6.4 || ^7.3 || ^8.0",
+        "symfony/uid": "^6.4 || ^7.3 || ^8.0",
         "flow-php/etl": "self.version",
         "flow-php/etl-adapter-csv": "self.version",
         "flow-php/etl-adapter-parquet": "self.version",

--- a/src/core/etl/composer.json
+++ b/src/core/etl/composer.json
@@ -19,14 +19,14 @@
         "flow-php/filesystem": "self.version",
         "psr/simple-cache": "^1.0 || ^2.0 || ^3.0",
         "webmozart/glob": "^3.0 || ^4.0",
-        "symfony/string": "^5.4 || ^6.4 || ^7.0"
+        "symfony/string": "^6.4 || ^7.3 || ^8.0"
     },
     "suggest": {
         "ext-bcmath": "BCMath extension for PHP for more precise calculations"
     },
     "require-dev": {
         "ramsey/uuid": "^4.5",
-        "symfony/uid": "^6.3 || ^7.0"
+        "symfony/uid": "^6.4 || ^7.3 || ^8.0"
     },
     "config": {
         "optimize-autoloader": true,

--- a/src/lib/parquet-viewer/composer.json
+++ b/src/lib/parquet-viewer/composer.json
@@ -15,7 +15,7 @@
         "coduo/php-humanizer": "^5.0",
         "flow-php/etl": "self.version",
         "flow-php/parquet": "self.version",
-        "symfony/console": "^5.4 || ^6.4 || ^7.0"
+        "symfony/console": "^6.4 || ^7.3 || ^8.0"
     },
     "config": {
         "optimize-autoloader": true,


### PR DESCRIPTION
This PR:
- removes Symfony 5.4 support (which is for years in security bugfix mode only),
- adjust minimal 6 to 6.4, which is the LTS release,
- bumps 7 to 7.3, which is the latest supported right now,
- and allows 8.0 for testing purposes

<!-- 
    Below section will be used to automatically generate changelog, please do not modify HTML code structure
    DO NOT REMOVE that HTML STRUCTURE, INSTEAD ADD YOUR CHANGES INSIDE THE LISTS 
    PULL REQUESTS WITHOUT CHANGELOG CAN'T BE MERGED 
-->
<h2>Change Log</h2>
<hr /> 
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Unify and bump minimal Symfony requirements</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>