### PR TITLE
Allow usage of `HTMLElement` in `HTMLQuerySelector*`

### DIFF
--- a/src/core/etl/src/Flow/ETL/Function/HTMLQuerySelector.php
+++ b/src/core/etl/src/Flow/ETL/Function/HTMLQuerySelector.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Function;
 
-use Dom\{Element, HTMLDocument};
+use function Flow\Types\DSL\type_instance_of;
+use Dom\{Element, HTMLDocument, HTMLElement};
 use Flow\ETL\Exception\RequiredPHPVersionException;
 use Flow\ETL\Row;
 
@@ -21,7 +22,7 @@ final class HTMLQuerySelector extends ScalarFunctionChain
 
     public function eval(Row $row) : ?Element
     {
-        $value = (new Parameter($this->value))->asInstanceOf($row, HTMLDocument::class);
+        $value = (new Parameter($this->value))->as($row, type_instance_of(HTMLDocument::class), type_instance_of(HTMLElement::class));
         $selector = (new Parameter($this->selector))->asString($row);
 
         if (null === $value || null === $selector) {

--- a/src/core/etl/src/Flow/ETL/Function/HTMLQuerySelectorAll.php
+++ b/src/core/etl/src/Flow/ETL/Function/HTMLQuerySelectorAll.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Function;
 
+use function Flow\Types\DSL\type_instance_of;
 use DOM\{Element, HTMLDocument};
+use Dom\HTMLElement;
 use Flow\ETL\Exception\RequiredPHPVersionException;
 use Flow\ETL\Row;
 
@@ -24,7 +26,7 @@ final class HTMLQuerySelectorAll extends ScalarFunctionChain
      */
     public function eval(Row $row) : ?array
     {
-        $value = (new Parameter($this->value))->asInstanceOf($row, HTMLDocument::class);
+        $value = (new Parameter($this->value))->as($row, type_instance_of(HTMLDocument::class), type_instance_of(HTMLElement::class));
         $selector = (new Parameter($this->selector))->asString($row);
 
         if (null === $value || null === $selector) {

--- a/src/core/etl/tests/Flow/ETL/Tests/Integration/Function/HTMLQuerySelectorTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Integration/Function/HTMLQuerySelectorTest.php
@@ -33,20 +33,41 @@ final class HTMLQuerySelectorTest extends TestCase
 
     public function test_valid_query_on_html_document() : void
     {
-        $html = HTMLDocument::createFromString('<!DOCTYPE html><html lang="en"><head></head><body><div><span>foobar</span></div></body></html>');
-
-        $element = HTMLDocument::createFromString('<span>foobar</span>', \LIBXML_HTML_NOIMPLIED | \LIBXML_NOERROR);
+        $html = HTMLDocument::createFromString(
+            <<<'HTML'
+<!DOCTYPE html>
+<html lang="en">
+<head></head>
+<body>
+<div><span>foo</span></div>
+<div><p>bar</p></div>
+<div><p>baz</p></div>
+</body>
+</html>
+HTML
+        );
 
         self::assertEquals(
             [
                 [
-                    'html_element' => $element->documentElement,
+                    'span_element' => 'foo',
+                    'p_element' => null,
+                ],
+                [
+                    'span_element' => null,
+                    'p_element' => 'bar',
+                ],
+                [
+                    'span_element' => null,
+                    'p_element' => 'baz',
                 ],
             ],
             df()
                 ->read(from_rows(rows(row(html_entry('html_raw', $html)))))
-                ->withEntry('html_element', ref('html_raw')->htmlQuerySelector('body div span'))
-                ->drop('html_raw')
+                ->withEntry('containers', ref('html_raw')->htmlQuerySelectorAll('body div')->expand())
+                ->withEntry('span_element', ref('containers')->htmlQuerySelector('body span')->domElementValue())
+                ->withEntry('p_element', ref('containers')->htmlQuerySelector('p')->domElementValue())
+                ->select('span_element', 'p_element')
                 ->fetch()
                 ->toArray()
         );


### PR DESCRIPTION
<!-- 
    Please replace #xxx with a GitHub issue id from flow-php/flow repository. For example #1234 
    If there is no item in a roadmap related to this PR, please check our contributing guidelines first. 
-->
Resolves: #xxx

<!-- 
    Below section will be used to automatically generate changelog, please do not modify HTML code structure
    DO NOT REMOVE that HTML STRUCTURE, INSTEAD ADD YOUR CHANGES INSIDE THE LISTS 
    PULL REQUESTS WITHOUT CHANGELOG CAN'T BE MERGED 
-->
<h2>Change Log</h2>
<hr /> 
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Allow usage of `HTMLElement` in `HTMLQuerySelector*`</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>