### PR TITLE
Bugfix for `XMLElementEntry` losing parent relation

### DIFF
--- a/src/core/etl/src/Flow/ETL/Row/Entry/XMLElementEntry.php
+++ b/src/core/etl/src/Flow/ETL/Row/Entry/XMLElementEntry.php
@@ -40,9 +40,6 @@ final class XMLElementEntry implements Entry
             }
 
             $value = $doc->documentElement;
-        } elseif ($value instanceof \DOMElement) {
-            /** @var \DOMElement $value */
-            $value = (new \DOMDocument())->importNode($value, true);
         }
 
         $this->metadata = $metadata ?: Metadata::empty();

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Entry/XMLElementEntryTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Row/Entry/XMLElementEntryTest.php
@@ -12,12 +12,25 @@ use Flow\ETL\Tests\FlowTestCase;
 
 final class XMLElementEntryTest extends FlowTestCase
 {
+    public function test_create_from_dom_document() : void
+    {
+        $document = new \DOMDocument();
+        $document->loadXML('<root><name>User Name</name><id>01</id></root>');
+
+        /* @phpstan-ignore-next-line */
+        $entry = xml_element_entry('node', $document->documentElement->firstChild);
+
+        self::assertInstanceOf(\DOMElement::class, $entry->value());
+        self::assertSame('<name>User Name</name>', $entry->toString());
+        self::assertSame($document->documentElement, $entry->value()->parentNode);
+    }
+
     public function test_create_from_string() : void
     {
         $entry = xml_element_entry('node', '<node attr="test">value</node>');
 
         self::assertInstanceOf(\DOMElement::class, $entry->value());
-        self::assertEquals('<node attr="test">value</node>', $entry->toString());
+        self::assertSame('<node attr="test">value</node>', $entry->toString());
     }
 
     public function test_create_from_string_fails_with_invalid_xml() : void
@@ -34,7 +47,7 @@ final class XMLElementEntryTest extends FlowTestCase
         $duplicated = $entry->duplicate();
 
         self::assertNotSame($entry, $duplicated);
-        self::assertEquals($entry->toString(), $duplicated->toString());
+        self::assertSame($entry->toString(), $duplicated->toString());
     }
 
     public function test_serialization() : void


### PR DESCRIPTION
<!-- 
    Please replace #xxx with a GitHub issue id from flow-php/flow repository. For example #1234 
    If there is no item in a roadmap related to this PR, please check our contributing guidelines first. 
-->
Resolves: #xxx

<!-- 
    Below section will be used to automatically generate changelog, please do not modify HTML code structure
    DO NOT REMOVE that HTML STRUCTURE, INSTEAD ADD YOUR CHANGES INSIDE THE LISTS 
    PULL REQUESTS WITHOUT CHANGELOG CAN'T BE MERGED 
-->
<h2>Change Log</h2>
<hr /> 
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>Bugfix for `XMLElementEntry` losing parent relation</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>