### PR TITLE
chore: Replace "cocur/slugify" with Symfony String on website

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,6 @@
         "webmozart/glob": "^3.0 || ^4.0"
     },
     "require-dev": {
-        "cocur/slugify": "^4.5",
         "composer/semver": "^3.4",
         "fakerphp/faker": "^1.23",
         "fig/log-test": "^1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c04606bd77f46466de1310dd65ec2502",
+    "content-hash": "6903ea785014f457442da551242cc609",
     "packages": [
         {
             "name": "async-aws/core",
@@ -4104,80 +4104,6 @@
                 }
             ],
             "time": "2023-12-20T15:40:13+00:00"
-        },
-        {
-            "name": "cocur/slugify",
-            "version": "v4.6.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/cocur/slugify.git",
-                "reference": "1d674022e9cbefa80b4f51aa3e2375b6e3c14fdb"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/cocur/slugify/zipball/1d674022e9cbefa80b4f51aa3e2375b6e3c14fdb",
-                "reference": "1d674022e9cbefa80b4f51aa3e2375b6e3c14fdb",
-                "shasum": ""
-            },
-            "require": {
-                "ext-mbstring": "*",
-                "php": "~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0"
-            },
-            "conflict": {
-                "symfony/config": "<3.4 || >=4,<4.3",
-                "symfony/dependency-injection": "<3.4 || >=4,<4.3",
-                "symfony/http-kernel": "<3.4 || >=4,<4.3",
-                "twig/twig": "<2.12.1"
-            },
-            "require-dev": {
-                "laravel/framework": "^5.0|^6.0|^7.0|^8.0",
-                "latte/latte": "~2.2",
-                "league/container": "^2.2.0",
-                "mikey179/vfsstream": "~1.6.8",
-                "mockery/mockery": "^1.3",
-                "nette/di": "~2.4",
-                "pimple/pimple": "~1.1",
-                "plumphp/plum": "~0.1",
-                "symfony/config": "^3.4 || ^4.3 || ^5.0 || ^6.0",
-                "symfony/dependency-injection": "^3.4 || ^4.3 || ^5.0 || ^6.0",
-                "symfony/http-kernel": "^3.4 || ^4.3 || ^5.0 || ^6.0",
-                "symfony/phpunit-bridge": "^5.4 || ^6.0",
-                "twig/twig": "^2.12.1 || ~3.0",
-                "zendframework/zend-modulemanager": "~2.2",
-                "zendframework/zend-servicemanager": "~2.2",
-                "zendframework/zend-view": "~2.2"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Cocur\\Slugify\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Florian Eckerstorfer",
-                    "email": "florian@eckerstorfer.co",
-                    "homepage": "https://florian.ec"
-                },
-                {
-                    "name": "Ivo Bathke",
-                    "email": "ivo.bathke@gmail.com"
-                }
-            ],
-            "description": "Converts a string into a slug.",
-            "keywords": [
-                "slug",
-                "slugify"
-            ],
-            "support": {
-                "issues": "https://github.com/cocur/slugify/issues",
-                "source": "https://github.com/cocur/slugify/tree/v4.6.0"
-            },
-            "time": "2024-09-10T14:09:25+00:00"
         },
         {
             "name": "composer/semver",

--- a/src/tools/documentation/src/Flow/Documentation/Models/FunctionModel.php
+++ b/src/tools/documentation/src/Flow/Documentation/Models/FunctionModel.php
@@ -75,7 +75,7 @@ final readonly class FunctionModel
         return new self(
             $relativePath,
             $reflectionFunction->getStartLine(),
-            (new AsciiSlugger())->slug($reflectionFunction->getShortName())->toString(),
+            (new AsciiSlugger())->slug($reflectionFunction->getShortName())->lower()->toString(),
             $reflectionFunction->getShortName(),
             $reflectionFunction->getNamespaceName(),
             ParametersModel::fromFunctionReflection($reflectionFunction),

--- a/src/tools/documentation/src/Flow/Documentation/Models/FunctionModel.php
+++ b/src/tools/documentation/src/Flow/Documentation/Models/FunctionModel.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Flow\Documentation\Models;
 
 use function Flow\Types\DSL\{type_array, type_boolean, type_integer, type_optional, type_string, type_structure};
-use Cocur\Slugify\Slugify;
 use Flow\ETL\Function\ScalarFunctionChain;
+use Symfony\Component\String\Slugger\AsciiSlugger;
 
 final readonly class FunctionModel
 {
@@ -75,7 +75,7 @@ final readonly class FunctionModel
         return new self(
             $relativePath,
             $reflectionFunction->getStartLine(),
-            (new Slugify())->slugify($reflectionFunction->getShortName()),
+            (new AsciiSlugger())->slug($reflectionFunction->getShortName())->toString(),
             $reflectionFunction->getShortName(),
             $reflectionFunction->getNamespaceName(),
             ParametersModel::fromFunctionReflection($reflectionFunction),

--- a/src/tools/documentation/src/Flow/Documentation/Models/MethodModel.php
+++ b/src/tools/documentation/src/Flow/Documentation/Models/MethodModel.php
@@ -72,12 +72,12 @@ final readonly class MethodModel
         $returnTypeReflection = $reflectionMethod->getReturnType();
         $declaringClass = $reflectionMethod->getDeclaringClass();
         $className = $declaringClass->getName();
-        $classSlug = (new AsciiSlugger())->slug($declaringClass->getShortName())->toString();
+        $classSlug = (new AsciiSlugger())->slug($declaringClass->getShortName())->lower()->toString();
 
         return new self(
             $relativePath,
             $reflectionMethod->getStartLine(),
-            (new AsciiSlugger())->slug($reflectionMethod->getShortName())->toString(),
+            (new AsciiSlugger())->slug($reflectionMethod->getShortName())->lower()->toString(),
             $reflectionMethod->getShortName(),
             $className,
             $classSlug,

--- a/src/tools/documentation/src/Flow/Documentation/Models/MethodModel.php
+++ b/src/tools/documentation/src/Flow/Documentation/Models/MethodModel.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Flow\Documentation\Models;
 
 use function Flow\Types\DSL\{type_array, type_boolean, type_integer, type_optional, type_string, type_structure};
-use Cocur\Slugify\Slugify;
 use Flow\ETL\Function\ScalarFunctionChain;
+use Symfony\Component\String\Slugger\AsciiSlugger;
 
 final readonly class MethodModel
 {
@@ -72,12 +72,12 @@ final readonly class MethodModel
         $returnTypeReflection = $reflectionMethod->getReturnType();
         $declaringClass = $reflectionMethod->getDeclaringClass();
         $className = $declaringClass->getName();
-        $classSlug = (new Slugify())->slugify($declaringClass->getShortName());
+        $classSlug = (new AsciiSlugger())->slug($declaringClass->getShortName())->toString();
 
         return new self(
             $relativePath,
             $reflectionMethod->getStartLine(),
-            (new Slugify())->slugify($reflectionMethod->getShortName()),
+            (new AsciiSlugger())->slug($reflectionMethod->getShortName())->toString(),
             $reflectionMethod->getShortName(),
             $className,
             $classSlug,

--- a/web/landing/composer.json
+++ b/web/landing/composer.json
@@ -28,9 +28,9 @@
         "twig/markdown-extra": "^3.11",
         "twig/extra-bundle": "^3.8",
         "league/commonmark": "^2.4",
-        "cocur/slugify": "^4.5",
         "presta/sitemap-bundle": "^4.1",
-        "symfony/mime": "^7.2"
+        "symfony/mime": "^7.2",
+        "symfony/string": "^7.3"
     },
     "require-dev": {
         "symfony/web-profiler-bundle": "^6.4",

--- a/web/landing/composer.lock
+++ b/web/landing/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b349ac2973701b855f56dd85866f0122",
+    "content-hash": "afba3dce3b396f7523fcbf86917d9267",
     "packages": [
         {
             "name": "brick/math",
@@ -131,80 +131,6 @@
                 }
             ],
             "time": "2023-12-20T15:40:13+00:00"
-        },
-        {
-            "name": "cocur/slugify",
-            "version": "v4.6.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/cocur/slugify.git",
-                "reference": "1d674022e9cbefa80b4f51aa3e2375b6e3c14fdb"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/cocur/slugify/zipball/1d674022e9cbefa80b4f51aa3e2375b6e3c14fdb",
-                "reference": "1d674022e9cbefa80b4f51aa3e2375b6e3c14fdb",
-                "shasum": ""
-            },
-            "require": {
-                "ext-mbstring": "*",
-                "php": "~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0"
-            },
-            "conflict": {
-                "symfony/config": "<3.4 || >=4,<4.3",
-                "symfony/dependency-injection": "<3.4 || >=4,<4.3",
-                "symfony/http-kernel": "<3.4 || >=4,<4.3",
-                "twig/twig": "<2.12.1"
-            },
-            "require-dev": {
-                "laravel/framework": "^5.0|^6.0|^7.0|^8.0",
-                "latte/latte": "~2.2",
-                "league/container": "^2.2.0",
-                "mikey179/vfsstream": "~1.6.8",
-                "mockery/mockery": "^1.3",
-                "nette/di": "~2.4",
-                "pimple/pimple": "~1.1",
-                "plumphp/plum": "~0.1",
-                "symfony/config": "^3.4 || ^4.3 || ^5.0 || ^6.0",
-                "symfony/dependency-injection": "^3.4 || ^4.3 || ^5.0 || ^6.0",
-                "symfony/http-kernel": "^3.4 || ^4.3 || ^5.0 || ^6.0",
-                "symfony/phpunit-bridge": "^5.4 || ^6.0",
-                "twig/twig": "^2.12.1 || ~3.0",
-                "zendframework/zend-modulemanager": "~2.2",
-                "zendframework/zend-servicemanager": "~2.2",
-                "zendframework/zend-view": "~2.2"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Cocur\\Slugify\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Florian Eckerstorfer",
-                    "email": "florian@eckerstorfer.co",
-                    "homepage": "https://florian.ec"
-                },
-                {
-                    "name": "Ivo Bathke",
-                    "email": "ivo.bathke@gmail.com"
-                }
-            ],
-            "description": "Converts a string into a slug.",
-            "keywords": [
-                "slug",
-                "slugify"
-            ],
-            "support": {
-                "issues": "https://github.com/cocur/slugify/issues",
-                "source": "https://github.com/cocur/slugify/tree/v4.6.0"
-            },
-            "time": "2024-09-10T14:09:25+00:00"
         },
         {
             "name": "coduo/php-humanizer",
@@ -427,7 +353,7 @@
         },
         {
             "name": "flow-php/array-dot",
-            "version": "0.26.1",
+            "version": "0.27.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/flow-php/array-dot.git",
@@ -469,7 +395,7 @@
             ],
             "support": {
                 "issues": "https://github.com/flow-php/array-dot/issues",
-                "source": "https://github.com/flow-php/array-dot/tree/0.26.1"
+                "source": "https://github.com/flow-php/array-dot/tree/0.27.0"
             },
             "funding": [
                 {
@@ -485,16 +411,16 @@
         },
         {
             "name": "flow-php/etl",
-            "version": "0.26.1",
+            "version": "0.27.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/flow-php/etl.git",
-                "reference": "11e5fd92ba89b171912ef5862c2f4556e99abac8"
+                "reference": "d6de8db4584fffcc57bdc24e080c8b6b6afd6a04"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/flow-php/etl/zipball/11e5fd92ba89b171912ef5862c2f4556e99abac8",
-                "reference": "11e5fd92ba89b171912ef5862c2f4556e99abac8",
+                "url": "https://api.github.com/repos/flow-php/etl/zipball/d6de8db4584fffcc57bdc24e080c8b6b6afd6a04",
+                "reference": "d6de8db4584fffcc57bdc24e080c8b6b6afd6a04",
                 "shasum": ""
             },
             "require": {
@@ -507,12 +433,12 @@
                 "php": "~8.2.0 || ~8.3.0 || ~8.4.0",
                 "psr/clock": "^1.0",
                 "psr/simple-cache": "^1.0 || ^2.0 || ^3.0",
-                "symfony/string": "^5.4 || ^6.4 || ^7.0",
+                "symfony/string": "^6.4 || ^7.3 || ^8.0",
                 "webmozart/glob": "^3.0 || ^4.0"
             },
             "require-dev": {
                 "ramsey/uuid": "^4.5",
-                "symfony/uid": "^6.3 || ^7.0"
+                "symfony/uid": "^6.4 || ^7.3 || ^8.0"
             },
             "suggest": {
                 "ext-bcmath": "BCMath extension for PHP for more precise calculations"
@@ -541,7 +467,7 @@
             ],
             "support": {
                 "issues": "https://github.com/flow-php/etl/issues",
-                "source": "https://github.com/flow-php/etl/tree/0.26.1"
+                "source": "https://github.com/flow-php/etl/tree/0.27.0"
             },
             "funding": [
                 {
@@ -553,20 +479,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-10-28T12:28:38+00:00"
+            "time": "2025-11-10T18:48:07+00:00"
         },
         {
             "name": "flow-php/etl-adapter-http",
-            "version": "0.26.1",
+            "version": "0.27.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/flow-php/etl-adapter-http.git",
-                "reference": "69effa10835a7ce0acf19c586fc7cd7b57a6354d"
+                "reference": "807ca1fad7808ae8370e1766c4366a7fccfee86e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/flow-php/etl-adapter-http/zipball/69effa10835a7ce0acf19c586fc7cd7b57a6354d",
-                "reference": "69effa10835a7ce0acf19c586fc7cd7b57a6354d",
+                "url": "https://api.github.com/repos/flow-php/etl-adapter-http/zipball/807ca1fad7808ae8370e1766c4366a7fccfee86e",
+                "reference": "807ca1fad7808ae8370e1766c4366a7fccfee86e",
                 "shasum": ""
             },
             "require": {
@@ -604,7 +530,7 @@
             ],
             "support": {
                 "issues": "https://github.com/flow-php/etl-adapter-http/issues",
-                "source": "https://github.com/flow-php/etl-adapter-http/tree/0.26.1"
+                "source": "https://github.com/flow-php/etl-adapter-http/tree/0.27.0"
             },
             "funding": [
                 {
@@ -616,23 +542,24 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-10-27T17:41:11+00:00"
+            "time": "2025-11-09T20:01:29+00:00"
         },
         {
             "name": "flow-php/filesystem",
-            "version": "0.26.1",
+            "version": "0.27.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/flow-php/filesystem.git",
-                "reference": "6fca263e996e4a06544c40bc958b72657d6b6821"
+                "reference": "eeebf5e9a707afb67f8b1820766b1a2a2a84e5c8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/flow-php/filesystem/zipball/6fca263e996e4a06544c40bc958b72657d6b6821",
-                "reference": "6fca263e996e4a06544c40bc958b72657d6b6821",
+                "url": "https://api.github.com/repos/flow-php/filesystem/zipball/eeebf5e9a707afb67f8b1820766b1a2a2a84e5c8",
+                "reference": "eeebf5e9a707afb67f8b1820766b1a2a2a84e5c8",
                 "shasum": ""
             },
             "require": {
+                "flow-php/types": "self.version",
                 "php": "~8.2.0 || ~8.3.0 || ~8.4.0",
                 "webmozart/glob": "^3.0 || ^4.0"
             },
@@ -665,7 +592,7 @@
             ],
             "support": {
                 "issues": "https://github.com/flow-php/filesystem/issues",
-                "source": "https://github.com/flow-php/filesystem/tree/0.26.1"
+                "source": "https://github.com/flow-php/filesystem/tree/0.27.0"
             },
             "funding": [
                 {
@@ -677,24 +604,25 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-10-21T12:21:54+00:00"
+            "time": "2025-11-10T11:25:06+00:00"
         },
         {
             "name": "flow-php/types",
-            "version": "0.26.1",
+            "version": "0.27.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/flow-php/types.git",
-                "reference": "505233757edc87c636461c023b2314d5693ff1df"
+                "reference": "8106aece43dc54a2794229223da0431b81079186"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/flow-php/types/zipball/505233757edc87c636461c023b2314d5693ff1df",
-                "reference": "505233757edc87c636461c023b2314d5693ff1df",
+                "url": "https://api.github.com/repos/flow-php/types/zipball/8106aece43dc54a2794229223da0431b81079186",
+                "reference": "8106aece43dc54a2794229223da0431b81079186",
                 "shasum": ""
             },
             "require": {
-                "php": "~8.2.0 || ~8.3.0 || ~8.4.0"
+                "php": "~8.2.0 || ~8.3.0 || ~8.4.0",
+                "symfony/polyfill-php83": "^1.33"
             },
             "type": "library",
             "autoload": {
@@ -718,7 +646,7 @@
             ],
             "support": {
                 "issues": "https://github.com/flow-php/types/issues",
-                "source": "https://github.com/flow-php/types/tree/0.26.1"
+                "source": "https://github.com/flow-php/types/tree/0.27.0"
             },
             "funding": [
                 {
@@ -730,7 +658,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-10-28T12:29:18+00:00"
+            "time": "2025-11-09T17:18:09+00:00"
         },
         {
             "name": "league/commonmark",
@@ -3559,16 +3487,16 @@
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v7.3.6",
+            "version": "v7.3.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "6379e490d6ecfc5c4224ff3a754b90495ecd135c"
+                "reference": "db488a62f98f7a81d5746f05eea63a74e55bb7c4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/6379e490d6ecfc5c4224ff3a754b90495ecd135c",
-                "reference": "6379e490d6ecfc5c4224ff3a754b90495ecd135c",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/db488a62f98f7a81d5746f05eea63a74e55bb7c4",
+                "reference": "db488a62f98f7a81d5746f05eea63a74e55bb7c4",
                 "shasum": ""
             },
             "require": {
@@ -3618,7 +3546,7 @@
             "description": "Defines an object-oriented layer for the HTTP specification",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-foundation/tree/v7.3.6"
+                "source": "https://github.com/symfony/http-foundation/tree/v7.3.7"
             },
             "funding": [
                 {
@@ -3638,20 +3566,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-11-06T11:05:57+00:00"
+            "time": "2025-11-08T16:41:12+00:00"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v6.4.28",
+            "version": "v6.4.29",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "bbccadab358e236fcf13cc02a01fc0115d09d787"
+                "reference": "18818b48f54c1d2bd92b41d82d8345af50b15658"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/bbccadab358e236fcf13cc02a01fc0115d09d787",
-                "reference": "bbccadab358e236fcf13cc02a01fc0115d09d787",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/18818b48f54c1d2bd92b41d82d8345af50b15658",
+                "reference": "18818b48f54c1d2bd92b41d82d8345af50b15658",
                 "shasum": ""
             },
             "require": {
@@ -3736,7 +3664,7 @@
             "description": "Provides a structured process for converting a Request into a Response",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-kernel/tree/v6.4.28"
+                "source": "https://github.com/symfony/http-kernel/tree/v6.4.29"
             },
             "funding": [
                 {
@@ -3756,7 +3684,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-11-06T20:52:25+00:00"
+            "time": "2025-11-12T11:22:59+00:00"
         },
         {
             "name": "symfony/mime",
@@ -5715,22 +5643,22 @@
         },
         {
             "name": "twig/extra-bundle",
-            "version": "v3.22.0",
+            "version": "v3.22.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/twig-extra-bundle.git",
-                "reference": "6d253f0fe28a83a045497c8fb3ea9bfe84e82cf4"
+                "reference": "b6534bc925bec930004facca92fccebd0c809247"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/twig-extra-bundle/zipball/6d253f0fe28a83a045497c8fb3ea9bfe84e82cf4",
-                "reference": "6d253f0fe28a83a045497c8fb3ea9bfe84e82cf4",
+                "url": "https://api.github.com/repos/twigphp/twig-extra-bundle/zipball/b6534bc925bec930004facca92fccebd0c809247",
+                "reference": "b6534bc925bec930004facca92fccebd0c809247",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.1.0",
-                "symfony/framework-bundle": "^5.4|^6.4|^7.0",
-                "symfony/twig-bundle": "^5.4|^6.4|^7.0",
+                "symfony/framework-bundle": "^5.4|^6.4|^7.0|^8.0",
+                "symfony/twig-bundle": "^5.4|^6.4|^7.0|^8.0",
                 "twig/twig": "^3.2|^4.0"
             },
             "require-dev": {
@@ -5773,7 +5701,7 @@
                 "twig"
             ],
             "support": {
-                "source": "https://github.com/twigphp/twig-extra-bundle/tree/v3.22.0"
+                "source": "https://github.com/twigphp/twig-extra-bundle/tree/v3.22.1"
             },
             "funding": [
                 {
@@ -5785,7 +5713,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-09-15T05:57:37+00:00"
+            "time": "2025-11-02T11:00:49+00:00"
         },
         {
             "name": "twig/markdown-extra",

--- a/web/landing/src/Flow/Website/Twig/SlugifyExtension.php
+++ b/web/landing/src/Flow/Website/Twig/SlugifyExtension.php
@@ -19,6 +19,6 @@ final class SlugifyExtension extends AbstractExtension
 
     public function slugify(string $text) : string
     {
-        return (new AsciiSlugger())->slug($text)->toString();
+        return (new AsciiSlugger())->slug($text)->lower()->toString();
     }
 }

--- a/web/landing/src/Flow/Website/Twig/SlugifyExtension.php
+++ b/web/landing/src/Flow/Website/Twig/SlugifyExtension.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Flow\Website\Twig;
 
-use Cocur\Slugify\Slugify;
+use Symfony\Component\String\Slugger\AsciiSlugger;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFilter;
 
 final class SlugifyExtension extends AbstractExtension
 {
-    public function getFilters()
+    public function getFilters() : array
     {
         return [
             new TwigFilter('slugify', $this->slugify(...)),
@@ -19,6 +19,6 @@ final class SlugifyExtension extends AbstractExtension
 
     public function slugify(string $text) : string
     {
-        return (new Slugify())->slugify($text);
+        return (new AsciiSlugger())->slug($text)->toString();
     }
 }


### PR DESCRIPTION
<!-- 
    Please replace #xxx with a GitHub issue id from flow-php/flow repository. For example #1234 
    If there is no item in a roadmap related to this PR, please check our contributing guidelines first. 
-->
That library is not too active in maintenance, and we already use Symfony String across Flow, which provides us support for slugger.

<!-- 
    Below section will be used to automatically generate changelog, please do not modify HTML code structure
    DO NOT REMOVE that HTML STRUCTURE, INSTEAD ADD YOUR CHANGES INSIDE THE LISTS 
    PULL REQUESTS WITHOUT CHANGELOG CAN'T BE MERGED 
-->
<h2>Change Log</h2>
<hr /> 
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Replace "cocur/slugify" with Symfony String on website</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>