### PR TITLE
fix: cast thrift encoded values to ints to preven issues with 32 systems

### DIFF
--- a/src/lib/parquet/src/Flow/Parquet/ParquetFile/Metadata.php
+++ b/src/lib/parquet/src/Flow/Parquet/ParquetFile/Metadata.php
@@ -24,8 +24,8 @@ final readonly class Metadata
         return new self(
             Schema::fromThrift($thrift->schema),
             RowGroups::fromThrift($thrift->row_groups, $options),
-            $thrift->num_rows,
-            $thrift->version,
+            (int) $thrift->num_rows,
+            (int) $thrift->version,
             $thrift->created_by
         );
     }

--- a/src/lib/parquet/src/Flow/Parquet/ParquetFile/Page/Header/DataPageHeader.php
+++ b/src/lib/parquet/src/Flow/Parquet/ParquetFile/Page/Header/DataPageHeader.php
@@ -22,7 +22,7 @@ final readonly class DataPageHeader
             Encodings::from($thrift->encoding),
             Encodings::from($thrift->repetition_level_encoding),
             Encodings::from($thrift->definition_level_encoding),
-            $thrift->num_values
+            (int) $thrift->num_values
         );
     }
 

--- a/src/lib/parquet/src/Flow/Parquet/ParquetFile/Page/Header/DataPageHeaderV2.php
+++ b/src/lib/parquet/src/Flow/Parquet/ParquetFile/Page/Header/DataPageHeaderV2.php
@@ -25,12 +25,12 @@ final readonly class DataPageHeaderV2
     public static function fromThrift(\Flow\Parquet\ThriftModel\DataPageHeaderV2 $thrift, Options $options) : self
     {
         return new self(
-            $thrift->num_values,
-            $thrift->num_nulls,
-            $thrift->num_rows,
+            (int) $thrift->num_values,
+            (int) $thrift->num_nulls,
+            (int) $thrift->num_rows,
             Encodings::from($thrift->encoding),
-            $thrift->definition_levels_byte_length,
-            $thrift->repetition_levels_byte_length,
+            (int) $thrift->definition_levels_byte_length,
+            (int) $thrift->repetition_levels_byte_length,
             /** @phpstan-ignore-next-line */
             $thrift->is_compressed ?? null,
             $thrift->statistics ? Statistics::fromThrift($thrift->statistics) : null,

--- a/src/lib/parquet/src/Flow/Parquet/ParquetFile/Page/Header/DictionaryPageHeader.php
+++ b/src/lib/parquet/src/Flow/Parquet/ParquetFile/Page/Header/DictionaryPageHeader.php
@@ -18,7 +18,7 @@ final readonly class DictionaryPageHeader
     {
         return new self(
             Encodings::from($thrift->encoding),
-            $thrift->num_values
+            (int) $thrift->num_values
         );
     }
 

--- a/src/lib/parquet/src/Flow/Parquet/ParquetFile/Page/PageHeader.php
+++ b/src/lib/parquet/src/Flow/Parquet/ParquetFile/Page/PageHeader.php
@@ -24,8 +24,8 @@ final readonly class PageHeader
     {
         return new self(
             Type::from($thrift->type),
-            $thrift->compressed_page_size,
-            $thrift->uncompressed_page_size,
+            (int) $thrift->compressed_page_size,
+            (int) $thrift->uncompressed_page_size,
             $thrift->data_page_header !== null ? DataPageHeader::fromThrift($thrift->data_page_header) : null,
             $thrift->data_page_header_v2 !== null ? DataPageHeaderV2::fromThrift($thrift->data_page_header_v2, $options) : null,
             $thrift->dictionary_page_header !== null ? DictionaryPageHeader::fromThrift($thrift->dictionary_page_header) : null

--- a/src/lib/parquet/src/Flow/Parquet/ParquetFile/RowGroup.php
+++ b/src/lib/parquet/src/Flow/Parquet/ParquetFile/RowGroup.php
@@ -25,7 +25,7 @@ final class RowGroup
     {
         return new self(
             \array_map(static fn (\Flow\Parquet\ThriftModel\ColumnChunk $columnChunk) => ColumnChunk::fromThrift($columnChunk, $options), $thrift->columns),
-            $thrift->num_rows
+            (int) $thrift->num_rows
         );
     }
 

--- a/src/lib/parquet/src/Flow/Parquet/ParquetFile/RowGroup/ColumnChunk.php
+++ b/src/lib/parquet/src/Flow/Parquet/ParquetFile/RowGroup/ColumnChunk.php
@@ -46,15 +46,15 @@ final readonly class ColumnChunk
         return new self(
             PhysicalType::from($thrift->meta_data->type),
             Compressions::from($thrift->meta_data->codec),
-            $thrift->meta_data->num_values,
-            $thrift->file_offset,
+            (int) $thrift->meta_data->num_values,
+            (int) $thrift->file_offset,
             $thrift->meta_data->path_in_schema,
             \array_map(static fn ($encoding) => Encodings::from($encoding), $thrift->meta_data->encodings),
-            $thrift->meta_data->total_compressed_size,
-            $thrift->meta_data->total_uncompressed_size,
-            $thrift->meta_data->dictionary_page_offset,
-            $thrift->meta_data->data_page_offset,
-            $thrift->meta_data->index_page_offset,
+            (int) $thrift->meta_data->total_compressed_size,
+            (int) $thrift->meta_data->total_uncompressed_size,
+            $thrift->meta_data->dictionary_page_offset !== null ? (int) $thrift->meta_data->dictionary_page_offset : null,
+            $thrift->meta_data->data_page_offset !== null ? (int) $thrift->meta_data->data_page_offset : null,
+            $thrift->meta_data->index_page_offset !== null ? (int) $thrift->meta_data->index_page_offset : null,
             $thrift->meta_data->statistics ? Statistics::fromThrift($thrift->meta_data->statistics) : null,
             $options
         );

--- a/src/lib/parquet/src/Flow/Parquet/ParquetFile/Schema/FlatColumn.php
+++ b/src/lib/parquet/src/Flow/Parquet/ParquetFile/Schema/FlatColumn.php
@@ -95,9 +95,9 @@ final class FlatColumn implements Column
             $thrift->converted_type === null ? null : ConvertedType::from($thrift->converted_type),
             $thrift->logicalType === null ? null : LogicalType::fromThrift($thrift->logicalType),
             $thrift->repetition_type === null ? null : Repetition::from($thrift->repetition_type),
-            $thrift->precision,
-            $thrift->scale,
-            $thrift->type_length,
+            $thrift->precision !== null ? (int) $thrift->precision : null,
+            $thrift->scale !== null ? (int) $thrift->scale : null,
+            $thrift->type_length !== null ? (int) $thrift->type_length : null,
         );
     }
 

--- a/src/lib/parquet/src/Flow/Parquet/ParquetFile/Schema/LogicalType/Decimal.php
+++ b/src/lib/parquet/src/Flow/Parquet/ParquetFile/Schema/LogicalType/Decimal.php
@@ -17,8 +17,8 @@ final readonly class Decimal
     public static function fromThrift(DecimalType $thrift) : self
     {
         return new self(
-            $thrift->scale,
-            $thrift->precision
+            (int) $thrift->scale,
+            (int) $thrift->precision
         );
     }
 

--- a/src/lib/parquet/src/Flow/Parquet/ParquetFile/Statistics.php
+++ b/src/lib/parquet/src/Flow/Parquet/ParquetFile/Statistics.php
@@ -24,8 +24,8 @@ final readonly class Statistics
         return new self(
             $thrift->max,
             $thrift->min,
-            $thrift->null_count,
-            $thrift->distinct_count,
+            $thrift->null_count !== null ? (int) $thrift->null_count : null,
+            $thrift->distinct_count !== null ? (int) $thrift->distinct_count : null,
             $thrift->max_value,
             $thrift->min_value,
             $thrift->is_max_value_exact,


### PR DESCRIPTION
<!-- 
    Please replace #xxx with a GitHub issue id from flow-php/flow repository. For example #1234 
    If there is no item in a roadmap related to this PR, please check our contributing guidelines first. 
-->
Resolves: #xxx

<!-- 
    Below section will be used to automatically generate changelog, please do not modify HTML code structure
    DO NOT REMOVE that HTML STRUCTURE, INSTEAD ADD YOUR CHANGES INSIDE THE LISTS 
    PULL REQUESTS WITHOUT CHANGELOG CAN'T BE MERGED 
-->
<h2>Change Log</h2>
<hr /> 
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>cast thrift encoded values to ints to preven issues with 32 systems</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>

Without this we might not be able to run parquet based examples in playground which is compiled to 32bit architecture 