### PR TITLE
fix: installation of libpg when installing pg-query-ext through pie

### DIFF
--- a/src/extension/pg-query-ext/README.md
+++ b/src/extension/pg-query-ext/README.md
@@ -33,25 +33,16 @@ sudo dnf install protobuf-c-devel git make gcc
 **Install the extension:**
 
 ```bash
-# Simple installation (auto-downloads libpg_query for PostgreSQL 17)
+# Simple installation (auto-downloads libpg_query)
 pie install flow-php/pg-query-ext
 
-# Install with a specific PostgreSQL grammar version (15, 16, or 17)
-pie install flow-php/pg-query-ext --with-pg-version=16
-
-# Or with a pre-installed libpg_query
+# Or with a pre-installed libpg_query (must be version 17+)
 pie install flow-php/pg-query-ext --with-pg-query=/usr/local
 ```
 
-The extension will automatically download and build the appropriate libpg_query version if not found on your system.
+The extension will automatically download and build libpg_query 17-latest if not found on your system.
 
-**Supported PostgreSQL versions:**
-
-| PostgreSQL | libpg_query version |
-|------------|---------------------|
-| 17         | 17-6.1.0 (default)  |
-| 16         | 16-5.2.0            |
-| 15         | 15-4.2.4            |
+> **Note:** This extension uses PostgreSQL 17 grammar (libpg_query 17-latest). It requires `postgres_deparse.h` which is only available in libpg_query 17+.
 
 ### Requirements
 

--- a/src/extension/pg-query-ext/composer.json
+++ b/src/extension/pg-query-ext/composer.json
@@ -27,11 +27,6 @@
                 "name": "with-pg-query",
                 "needs-value": false,
                 "description": "Path to libpg_query installation (optional - will auto-download if not found)"
-            },
-            {
-                "name": "with-pg-version",
-                "needs-value": true,
-                "description": "PostgreSQL grammar version: 15, 16, or 17 (default: 17)"
             }
         ],
         "support-zts": true,

--- a/src/extension/pg-query-ext/ext/config.m4
+++ b/src/extension/pg-query-ext/ext/config.m4
@@ -5,30 +5,10 @@ PHP_ARG_WITH([pg-query],
   [AS_HELP_STRING([--with-pg-query@<:@=DIR@:>@],
     [Include pg_query support. DIR is the libpg_query install prefix (optional - will download if not found)])])
 
-PHP_ARG_WITH([pg-version],
-  [PostgreSQL grammar version],
-  [AS_HELP_STRING([--with-pg-version@<:@=VERSION@:>@],
-    [PostgreSQL grammar version: 15, 16, or 17 (default: 17)])], [17], [no])
-
 if test "$PHP_PG_QUERY" != "no"; then
-  dnl Map PostgreSQL version to libpg_query version
-  case "$PHP_PG_VERSION" in
-    15)
-      LIBPG_QUERY_VERSION="15-4.2.4"
-      ;;
-    16)
-      LIBPG_QUERY_VERSION="16-5.2.0"
-      ;;
-    17|yes|"")
-      LIBPG_QUERY_VERSION="17-latest"
-      PHP_PG_VERSION="17"
-      ;;
-    *)
-      AC_MSG_ERROR([Unsupported PostgreSQL version: $PHP_PG_VERSION. Supported versions: 15, 16, 17])
-      ;;
-  esac
-
-  AC_MSG_NOTICE([Using PostgreSQL $PHP_PG_VERSION grammar (libpg_query $LIBPG_QUERY_VERSION)])
+  dnl libpg_query 17-latest is required for postgres_deparse.h support
+  LIBPG_QUERY_VERSION="17-latest"
+  AC_MSG_NOTICE([Using libpg_query $LIBPG_QUERY_VERSION (PostgreSQL 17 grammar)])
 
   PG_QUERY_DIR=""
 
@@ -42,12 +22,14 @@ if test "$PHP_PG_QUERY" != "no"; then
   AC_MSG_CHECKING([for libpg_query])
 
   for i in $SEARCH_PATH ; do
-    if test -r "$i/pg_query.h" && test -r "$i/libpg_query.a"; then
+    dnl Check flat directory structure (headers and lib in same dir)
+    if test -r "$i/pg_query.h" && test -r "$i/postgres_deparse.h" && test -r "$i/libpg_query.a"; then
       PG_QUERY_DIR=$i
       AC_MSG_RESULT([found in $i])
       break
     fi
-    if test -r "$i/include/pg_query.h" && test -r "$i/lib/libpg_query.a"; then
+    dnl Check standard include/lib directory structure
+    if test -r "$i/include/pg_query.h" && test -r "$i/include/postgres_deparse.h" && test -r "$i/lib/libpg_query.a"; then
       PG_QUERY_DIR=$i
       PG_QUERY_INCLUDE_DIR="$i/include"
       PG_QUERY_LIB_DIR="$i/lib"
@@ -61,7 +43,7 @@ if test "$PHP_PG_QUERY" != "no"; then
 
   dnl Check bundled directory
   if test -z "$PG_QUERY_DIR"; then
-    if test -r "$EXT_DIR/libpg_query/pg_query.h" && test -r "$EXT_DIR/libpg_query/libpg_query.a"; then
+    if test -r "$EXT_DIR/libpg_query/pg_query.h" && test -r "$EXT_DIR/libpg_query/postgres_deparse.h" && test -r "$EXT_DIR/libpg_query/libpg_query.a"; then
       PG_QUERY_DIR="$EXT_DIR/libpg_query"
       AC_MSG_RESULT([using bundled libpg_query])
     fi


### PR DESCRIPTION
<!-- 
    Please replace #xxx with a GitHub issue id from flow-php/flow repository. For example #1234 
    If there is no item in a roadmap related to this PR, please check our contributing guidelines first. 
-->
Resolves: #xxx

<!-- 
    Below section will be used to automatically generate changelog, please do not modify HTML code structure
    DO NOT REMOVE that HTML STRUCTURE, INSTEAD ADD YOUR CHANGES INSIDE THE LISTS 
    PULL REQUESTS WITHOUT CHANGELOG CAN'T BE MERGED 
-->
<h2>Change Log</h2>
<hr /> 
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>installation of libpg when installing pg-query-ext through pie</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>