### PR TITLE
feature: expose tables through from statement of select statement

### DIFF
--- a/src/lib/postgresql/src/Flow/PostgreSql/AST/Nodes/From.php
+++ b/src/lib/postgresql/src/Flow/PostgreSql/AST/Nodes/From.php
@@ -73,6 +73,21 @@ final readonly class From implements \Countable
         return $this->count() === 0;
     }
 
+    public function tables() : Tables
+    {
+        $tables = [];
+
+        foreach ($this->nodes as $node) {
+            $rangeVar = $node->getRangeVar();
+
+            if ($rangeVar !== null) {
+                $tables[] = new Table($rangeVar);
+            }
+        }
+
+        return new Tables($tables);
+    }
+
     private function isValidFromNode(Node $node) : bool
     {
         return $node->getRangeVar() !== null

--- a/src/lib/postgresql/src/Flow/PostgreSql/AST/Nodes/Tables.php
+++ b/src/lib/postgresql/src/Flow/PostgreSql/AST/Nodes/Tables.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\PostgreSql\AST\Nodes;
+
+/**
+ * @implements \IteratorAggregate<int, Table>
+ */
+final readonly class Tables implements \Countable, \IteratorAggregate
+{
+    /**
+     * @param array<int, Table> $tables
+     */
+    public function __construct(
+        private array $tables,
+    ) {
+    }
+
+    /**
+     * @return array<int, Table>
+     */
+    public function all() : array
+    {
+        return $this->tables;
+    }
+
+    public function count() : int
+    {
+        return \count($this->tables);
+    }
+
+    public function first() : ?Table
+    {
+        return $this->tables[0] ?? null;
+    }
+
+    public function get(int $index) : ?Table
+    {
+        return $this->tables[$index] ?? null;
+    }
+
+    /**
+     * @return \Traversable<int, Table>
+     */
+    public function getIterator() : \Traversable
+    {
+        return new \ArrayIterator($this->tables);
+    }
+
+    /**
+     * @phpstan-assert-if-false Table $this->first()
+     * @phpstan-assert-if-false Table $this->last()
+     */
+    public function isEmpty() : bool
+    {
+        return \count($this->tables) === 0;
+    }
+
+    /**
+     * @phpstan-assert-if-true Table $this->first()
+     * @phpstan-assert-if-true Table $this->last()
+     */
+    public function isSingle() : bool
+    {
+        return \count($this->tables) === 1;
+    }
+
+    public function last() : ?Table
+    {
+        if (\count($this->tables) === 0) {
+            return null;
+        }
+
+        return $this->tables[\count($this->tables) - 1];
+    }
+}

--- a/src/lib/postgresql/tests/Flow/PostgreSql/Tests/Unit/AST/Nodes/FromTest.php
+++ b/src/lib/postgresql/tests/Flow/PostgreSql/Tests/Unit/AST/Nodes/FromTest.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Flow\PostgreSql\Tests\Unit\AST\Nodes;
 
-use function Flow\PostgreSql\DSL\sql_parse;
+use function Flow\PostgreSql\DSL\{col, derived, eq, func, literal, select, sql_parse, star, table, table_func};
 
 use Flow\PostgreSql\AST\Nodes\Exception\InvalidFromNodeException;
-use Flow\PostgreSql\AST\Nodes\From;
+use Flow\PostgreSql\AST\Nodes\{From, Tables};
 use Flow\PostgreSql\AST\Nodes\Statement\SelectStatement;
 use Flow\PostgreSql\Protobuf\AST\Node;
 use PHPUnit\Framework\TestCase;
@@ -23,7 +23,12 @@ final class FromTest extends TestCase
 
     public function test_accepts_join_expr_node() : void
     {
-        $statement = sql_parse('SELECT * FROM users JOIN orders ON users.id = orders.user_id')->statements()->first();
+        $statement = sql_parse(
+            select(star())
+                ->from(table('users'))
+                ->join(table('orders'), eq(col('id', 'users'), col('user_id', 'orders')))
+                ->toSql()
+        )->statements()->first();
         self::assertInstanceOf(SelectStatement::class, $statement);
 
         $from = $statement->from();
@@ -32,7 +37,11 @@ final class FromTest extends TestCase
 
     public function test_accepts_range_function_node() : void
     {
-        $statement = sql_parse('SELECT * FROM generate_series(1, 10)')->statements()->first();
+        $statement = sql_parse(
+            select(star())
+                ->from(table_func(func('generate_series', [literal(1), literal(10)])))
+                ->toSql()
+        )->statements()->first();
         self::assertInstanceOf(SelectStatement::class, $statement);
 
         $from = $statement->from();
@@ -41,7 +50,11 @@ final class FromTest extends TestCase
 
     public function test_accepts_range_subselect_node() : void
     {
-        $statement = sql_parse('SELECT * FROM (SELECT 1) AS t')->statements()->first();
+        $statement = sql_parse(
+            select(star())
+                ->from(derived(select(literal(1)), 't'))
+                ->toSql()
+        )->statements()->first();
         self::assertInstanceOf(SelectStatement::class, $statement);
 
         $from = $statement->from();
@@ -50,7 +63,9 @@ final class FromTest extends TestCase
 
     public function test_accepts_range_var_node() : void
     {
-        $statement = sql_parse('SELECT * FROM users')->statements()->first();
+        $statement = sql_parse(
+            select(star())->from(table('users'))->toSql()
+        )->statements()->first();
         self::assertInstanceOf(SelectStatement::class, $statement);
 
         $from = $statement->from();
@@ -59,7 +74,9 @@ final class FromTest extends TestCase
 
     public function test_count_returns_number_of_from_nodes() : void
     {
-        $statement = sql_parse('SELECT * FROM users, orders')->statements()->first();
+        $statement = sql_parse(
+            select(star())->from(table('users'), table('orders'))->toSql()
+        )->statements()->first();
         self::assertInstanceOf(SelectStatement::class, $statement);
 
         self::assertCount(2, $statement->from());
@@ -79,7 +96,9 @@ final class FromTest extends TestCase
 
     public function test_has_function_returns_false_for_regular_table() : void
     {
-        $statement = sql_parse('SELECT * FROM users')->statements()->first();
+        $statement = sql_parse(
+            select(star())->from(table('users'))->toSql()
+        )->statements()->first();
         self::assertInstanceOf(SelectStatement::class, $statement);
 
         self::assertFalse($statement->from()->hasFunction());
@@ -87,7 +106,11 @@ final class FromTest extends TestCase
 
     public function test_has_function_returns_true_for_function_in_from() : void
     {
-        $statement = sql_parse('SELECT * FROM generate_series(1, 10)')->statements()->first();
+        $statement = sql_parse(
+            select(star())
+                ->from(table_func(func('generate_series', [literal(1), literal(10)])))
+                ->toSql()
+        )->statements()->first();
         self::assertInstanceOf(SelectStatement::class, $statement);
 
         self::assertTrue($statement->from()->hasFunction());
@@ -99,6 +122,86 @@ final class FromTest extends TestCase
         self::assertInstanceOf(SelectStatement::class, $statement);
 
         self::assertTrue($statement->from()->hasFunction());
+    }
+
+    public function test_tables_returns_empty_collection_for_empty_from() : void
+    {
+        $from = new From([]);
+
+        $tables = $from->tables();
+
+        self::assertInstanceOf(Tables::class, $tables);
+        self::assertTrue($tables->isEmpty());
+    }
+
+    public function test_tables_returns_empty_collection_for_function() : void
+    {
+        $statement = sql_parse(
+            select(star())
+                ->from(table_func(func('generate_series', [literal(1), literal(10)])))
+                ->toSql()
+        )->statements()->first();
+        self::assertInstanceOf(SelectStatement::class, $statement);
+
+        $tables = $statement->from()->tables();
+
+        self::assertTrue($tables->isEmpty());
+    }
+
+    public function test_tables_returns_empty_collection_for_join() : void
+    {
+        $statement = sql_parse(
+            select(star())
+                ->from(table('users'))
+                ->join(table('orders'), eq(col('id', 'users'), col('user_id', 'orders')))
+                ->toSql()
+        )->statements()->first();
+        self::assertInstanceOf(SelectStatement::class, $statement);
+
+        $tables = $statement->from()->tables();
+
+        self::assertTrue($tables->isEmpty());
+    }
+
+    public function test_tables_returns_empty_collection_for_subquery() : void
+    {
+        $statement = sql_parse(
+            select(star())
+                ->from(derived(select(literal(1)), 't'))
+                ->toSql()
+        )->statements()->first();
+        self::assertInstanceOf(SelectStatement::class, $statement);
+
+        $tables = $statement->from()->tables();
+
+        self::assertTrue($tables->isEmpty());
+    }
+
+    public function test_tables_returns_multiple_tables() : void
+    {
+        $statement = sql_parse(
+            select(star())->from(table('users'), table('orders'))->toSql()
+        )->statements()->first();
+        self::assertInstanceOf(SelectStatement::class, $statement);
+
+        $tables = $statement->from()->tables();
+
+        self::assertCount(2, $tables);
+        self::assertSame('users', $tables->first()?->name());
+        self::assertSame('orders', $tables->last()?->name());
+    }
+
+    public function test_tables_returns_single_table() : void
+    {
+        $statement = sql_parse(
+            select(star())->from(table('users'))->toSql()
+        )->statements()->first();
+        self::assertInstanceOf(SelectStatement::class, $statement);
+
+        $tables = $statement->from()->tables();
+
+        self::assertTrue($tables->isSingle());
+        self::assertSame('users', $tables->first()?->name());
     }
 
     public function test_throws_exception_for_invalid_node() : void

--- a/src/lib/postgresql/tests/Flow/PostgreSql/Tests/Unit/AST/Nodes/TablesTest.php
+++ b/src/lib/postgresql/tests/Flow/PostgreSql/Tests/Unit/AST/Nodes/TablesTest.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\PostgreSql\Tests\Unit\AST\Nodes;
+
+use Flow\PostgreSql\AST\Nodes\{Table, Tables};
+use Flow\PostgreSql\Protobuf\AST\RangeVar;
+use PHPUnit\Framework\TestCase;
+
+final class TablesTest extends TestCase
+{
+    protected function setUp() : void
+    {
+        if (!\extension_loaded('pg_query')) {
+            self::markTestSkipped('pg_query extension is not loaded. For local development use `nix-shell --arg with-pg-query-ext true` to enable it in the shell.');
+        }
+    }
+
+    public function test_all_returns_all_tables() : void
+    {
+        $table1 = new Table($this->createRangeVar('users'));
+        $table2 = new Table($this->createRangeVar('orders'));
+
+        $tables = new Tables([$table1, $table2]);
+
+        self::assertSame([$table1, $table2], $tables->all());
+    }
+
+    public function test_count_returns_number_of_tables() : void
+    {
+        $tables = new Tables([
+            new Table($this->createRangeVar('users')),
+            new Table($this->createRangeVar('orders')),
+        ]);
+
+        self::assertCount(2, $tables);
+    }
+
+    public function test_count_returns_zero_for_empty_collection() : void
+    {
+        $tables = new Tables([]);
+
+        self::assertCount(0, $tables);
+    }
+
+    public function test_first_returns_first_table() : void
+    {
+        $table1 = new Table($this->createRangeVar('users'));
+        $table2 = new Table($this->createRangeVar('orders'));
+
+        $tables = new Tables([$table1, $table2]);
+
+        self::assertSame($table1, $tables->first());
+    }
+
+    public function test_first_returns_null_for_empty_collection() : void
+    {
+        $tables = new Tables([]);
+
+        self::assertNull($tables->first());
+    }
+
+    public function test_get_returns_null_for_invalid_index() : void
+    {
+        $tables = new Tables([new Table($this->createRangeVar('users'))]);
+
+        self::assertNull($tables->get(5));
+    }
+
+    public function test_get_returns_table_at_index() : void
+    {
+        $table1 = new Table($this->createRangeVar('users'));
+        $table2 = new Table($this->createRangeVar('orders'));
+
+        $tables = new Tables([$table1, $table2]);
+
+        self::assertSame($table1, $tables->get(0));
+        self::assertSame($table2, $tables->get(1));
+    }
+
+    public function test_is_empty_returns_false_for_non_empty_collection() : void
+    {
+        $tables = new Tables([new Table($this->createRangeVar('users'))]);
+
+        self::assertFalse($tables->isEmpty());
+    }
+
+    public function test_is_empty_returns_true_for_empty_collection() : void
+    {
+        $tables = new Tables([]);
+
+        self::assertTrue($tables->isEmpty());
+    }
+
+    public function test_is_iterable() : void
+    {
+        $table1 = new Table($this->createRangeVar('users'));
+        $table2 = new Table($this->createRangeVar('orders'));
+
+        $tables = new Tables([$table1, $table2]);
+
+        $result = [];
+
+        foreach ($tables as $table) {
+            $result[] = $table;
+        }
+
+        self::assertSame([$table1, $table2], $result);
+    }
+
+    public function test_is_single_returns_false_for_empty_collection() : void
+    {
+        $tables = new Tables([]);
+
+        self::assertFalse($tables->isSingle());
+    }
+
+    public function test_is_single_returns_false_for_multiple_tables() : void
+    {
+        $tables = new Tables([
+            new Table($this->createRangeVar('users')),
+            new Table($this->createRangeVar('orders')),
+        ]);
+
+        self::assertFalse($tables->isSingle());
+    }
+
+    public function test_is_single_returns_true_for_single_table() : void
+    {
+        $tables = new Tables([new Table($this->createRangeVar('users'))]);
+
+        self::assertTrue($tables->isSingle());
+    }
+
+    public function test_last_returns_last_table() : void
+    {
+        $table1 = new Table($this->createRangeVar('users'));
+        $table2 = new Table($this->createRangeVar('orders'));
+
+        $tables = new Tables([$table1, $table2]);
+
+        self::assertSame($table2, $tables->last());
+    }
+
+    public function test_last_returns_null_for_empty_collection() : void
+    {
+        $tables = new Tables([]);
+
+        self::assertNull($tables->last());
+    }
+
+    private function createRangeVar(string $tableName) : RangeVar
+    {
+        $rangeVar = new RangeVar();
+        $rangeVar->setRelname($tableName);
+
+        return $rangeVar;
+    }
+}


### PR DESCRIPTION
<!-- 
    Please replace #xxx with a GitHub issue id from flow-php/flow repository. For example #1234 
    If there is no item in a roadmap related to this PR, please check our contributing guidelines first. 
-->
Resolves: #xxx

<!-- 
    Below section will be used to automatically generate changelog, please do not modify HTML code structure
    DO NOT REMOVE that HTML STRUCTURE, INSTEAD ADD YOUR CHANGES INSIDE THE LISTS 
    PULL REQUESTS WITHOUT CHANGELOG CAN'T BE MERGED 
-->
<h2>Change Log</h2>
<hr /> 
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <li>expose tables through from statement of select statement</li>
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>