### PR TITLE
Allow preserving existing values during DBAL upsert

### DIFF
--- a/src/lib/doctrine-dbal-bulk/src/Flow/Doctrine/Bulk/Dialect/MySQLDialect.php
+++ b/src/lib/doctrine-dbal-bulk/src/Flow/Doctrine/Bulk/Dialect/MySQLDialect.php
@@ -78,7 +78,7 @@ final readonly class MySQLDialect implements Dialect
                 \implode(',', \array_map(fn (string $column) : string => $this->platform->quoteIdentifier($column), $bulkData->columns()->all())),
                 $bulkData->toSqlPlaceholders(),
                 \count($options->updateColumns)
-                    ? $this->updateSelectedColumns($options->updateColumns, $bulkData->columns())
+                    ? $this->updateSelectedColumns($options->updateColumns, $bulkData->columns(), $table->name(), $options->preserveExistingValues)
                     : $this->updateAllColumns($bulkData->columns())
             );
         }
@@ -129,10 +129,18 @@ final readonly class MySQLDialect implements Dialect
      *
      * @return string
      */
-    private function updateSelectedColumns(array $updateColumns, Columns $columns) : string
+    private function updateSelectedColumns(array $updateColumns, Columns $columns, string $tableName, ?bool $preserveExistingValues = null) : string
     {
         return \count($updateColumns)
-            ? \implode(',', \array_map(fn (string $column) : string => "{$this->platform->quoteIdentifier($column)} = VALUES({$this->platform->quoteIdentifier($column)})", $updateColumns))
+            ? \implode(',', \array_map(function (string $column) use ($tableName, $preserveExistingValues) : string {
+                $clause = "{$this->platform->quoteIdentifier($column)} = ";
+
+                if (true === $preserveExistingValues) {
+                    return $clause . "COALESCE(VALUES({$this->platform->quoteIdentifier($column)}), {$tableName}.{$this->platform->quoteIdentifier($column)})";
+                }
+
+                return $clause . "VALUES({$this->platform->quoteIdentifier($column)})";
+            }, $updateColumns))
             : $this->updateAllColumns($columns);
     }
 }

--- a/src/lib/doctrine-dbal-bulk/src/Flow/Doctrine/Bulk/Dialect/MySQLDialect.php
+++ b/src/lib/doctrine-dbal-bulk/src/Flow/Doctrine/Bulk/Dialect/MySQLDialect.php
@@ -24,17 +24,6 @@ final readonly class MySQLDialect implements Dialect
     {
         $columns = $bulkData->columns()->all();
 
-        if (count($columns) === 1) {
-            $column = $columns[0];
-
-            return \sprintf(
-                'DELETE FROM %s WHERE %s IN (%s)',
-                $table->name(),
-                $this->platform->quoteIdentifier($column),
-                $bulkData->toSqlPlaceholders()
-            );
-        }
-
         return \sprintf(
             'DELETE FROM %s WHERE (%s) IN (%s)',
             $table->name(),

--- a/src/lib/doctrine-dbal-bulk/src/Flow/Doctrine/Bulk/Dialect/MySQLInsertOptions.php
+++ b/src/lib/doctrine-dbal-bulk/src/Flow/Doctrine/Bulk/Dialect/MySQLInsertOptions.php
@@ -18,6 +18,7 @@ final readonly class MySQLInsertOptions implements InsertOptions
         public ?bool $skipConflicts = null,
         public ?bool $upsert = null,
         public array $updateColumns = [],
+        public ?bool $preserveExistingValues = null,
     ) {
     }
 
@@ -29,6 +30,7 @@ final readonly class MySQLInsertOptions implements InsertOptions
                 'skip_conflicts' => type_optional(type_boolean()),
                 'upsert' => type_optional(type_boolean()),
                 'update_columns' => type_list(type_string()),
+                'preserve_existing_values' => type_optional(type_boolean()),
             ]
         )->assert($options);
 
@@ -36,6 +38,7 @@ final readonly class MySQLInsertOptions implements InsertOptions
             $options['skip_conflicts'] ?? null,
             $options['upsert'] ?? null,
             $options['update_columns'] ?? [],
+            $options['preserve_existing_values'] ?? null,
         );
     }
 
@@ -52,9 +55,9 @@ final readonly class MySQLInsertOptions implements InsertOptions
     /**
      * @param array<string> $updateColumns
      */
-    public function updateColumns(array $updateColumns) : self
+    public function updateColumns(array $updateColumns, ?bool $preserveExistingValues = null) : self
     {
-        return new self($this->skipConflicts, $this->upsert, $updateColumns);
+        return new self($this->skipConflicts, $this->upsert, $updateColumns, $preserveExistingValues);
     }
 
     public function upsert(bool $upsert = true) : self

--- a/src/lib/doctrine-dbal-bulk/src/Flow/Doctrine/Bulk/Dialect/PostgreSQLDialect.php
+++ b/src/lib/doctrine-dbal-bulk/src/Flow/Doctrine/Bulk/Dialect/PostgreSQLDialect.php
@@ -67,7 +67,7 @@ final readonly class PostgreSQLDialect implements Dialect
                 $bulkData->toSqlPlaceholders(),
                 \implode(',', $options->conflictColumns),
                 \count($options->updateColumns)
-                    ? $this->updatedSelectedColumns($options->updateColumns, $bulkData->columns())
+                    ? $this->updatedSelectedColumns($options->updateColumns, $bulkData->columns(), $table->name(), $options->preserveExistingValues)
                     : $this->updateAllColumns($bulkData->columns())
             );
         }
@@ -80,7 +80,7 @@ final readonly class PostgreSQLDialect implements Dialect
                 $bulkData->toSqlPlaceholders(),
                 $options->constraint,
                 \count($options->updateColumns)
-                    ? $this->updatedSelectedColumns($options->updateColumns, $bulkData->columns())
+                    ? $this->updatedSelectedColumns($options->updateColumns, $bulkData->columns(), $table->name(), $options->preserveExistingValues)
                     : $this->updateAllColumns($bulkData->columns())
             );
         }
@@ -132,7 +132,7 @@ final readonly class PostgreSQLDialect implements Dialect
             'UPDATE %s as existing_table SET %s FROM (VALUES %s) as excluded (%s) WHERE %s',
             $table->name(),
             \count($options->updateColumns)
-                ? $this->updatedSelectedColumns($options->updateColumns, $bulkData->columns()->without(...$options->primaryKeyColumns))
+                ? $this->updatedSelectedColumns($options->updateColumns, $bulkData->columns()->without(...$options->primaryKeyColumns), $table->name(), $options->preserveExistingValues)
                 : $this->updateAllColumns($bulkData->columns()->without(...$options->primaryKeyColumns)),
             $bulkData->toSqlCastedPlaceholders($table),
             \implode(',', \array_map(fn (string $column) : string => $this->platform->quoteIdentifier($column), $bulkData->columns()->all())),
@@ -140,11 +140,6 @@ final readonly class PostgreSQLDialect implements Dialect
         );
     }
 
-    /**
-     * @param Columns $columns
-     *
-     * @return string
-     */
     private function updateAllColumns(Columns $columns) : string
     {
         /**
@@ -162,8 +157,6 @@ final readonly class PostgreSQLDialect implements Dialect
 
     /**
      * @param array<string> $updateColumns
-     *
-     * @return string
      */
     private function updatedIndexColumns(array $updateColumns) : string
     {
@@ -172,11 +165,8 @@ final readonly class PostgreSQLDialect implements Dialect
 
     /**
      * @param array<string> $updateColumns
-     * @param Columns $columns
-     *
-     * @return string
      */
-    private function updatedSelectedColumns(array $updateColumns, Columns $columns) : string
+    private function updatedSelectedColumns(array $updateColumns, Columns $columns, string $tableName, ?bool $preserveExistingValues = null) : string
     {
         /**
          * https://www.postgresql.org/docs/9.5/sql-insert.html#SQL-ON-CONFLICT
@@ -184,7 +174,15 @@ final readonly class PostgreSQLDialect implements Dialect
          * table's name (or an alias), and to rows proposed for insertion using the special EXCLUDED table.
          */
         return \count($updateColumns)
-            ? \implode(',', \array_map(fn (string $column) : string => "{$this->platform->quoteIdentifier($column)} = {$this->platform->quoteIdentifier('excluded.' . $column)}", $updateColumns))
+            ? \implode(',', \array_map(function (string $column) use ($tableName, $preserveExistingValues) : string {
+                $clause = "{$this->platform->quoteIdentifier($column)} = ";
+
+                if (true === $preserveExistingValues) {
+                    return $clause . "COALESCE({$this->platform->quoteIdentifier('excluded.' . $column)}, {$tableName}.{$this->platform->quoteIdentifier($column)})";
+                }
+
+                return $clause . "{$this->platform->quoteIdentifier('excluded.' . $column)}";
+            }, $updateColumns))
             : $this->updateAllColumns($columns);
     }
 }

--- a/src/lib/doctrine-dbal-bulk/src/Flow/Doctrine/Bulk/Dialect/PostgreSQLDialect.php
+++ b/src/lib/doctrine-dbal-bulk/src/Flow/Doctrine/Bulk/Dialect/PostgreSQLDialect.php
@@ -24,17 +24,6 @@ final readonly class PostgreSQLDialect implements Dialect
     {
         $columns = $bulkData->columns()->all();
 
-        if (count($columns) === 1) {
-            $column = $columns[0];
-
-            return \sprintf(
-                'DELETE FROM %s WHERE %s IN (%s)',
-                $table->name(),
-                $this->platform->quoteIdentifier($column),
-                $bulkData->toSqlPlaceholders()
-            );
-        }
-
         return \sprintf(
             'DELETE FROM %s WHERE (%s) IN (%s)',
             $table->name(),

--- a/src/lib/doctrine-dbal-bulk/src/Flow/Doctrine/Bulk/Dialect/PostgreSQLInsertOptions.php
+++ b/src/lib/doctrine-dbal-bulk/src/Flow/Doctrine/Bulk/Dialect/PostgreSQLInsertOptions.php
@@ -18,6 +18,7 @@ final readonly class PostgreSQLInsertOptions implements InsertOptions
         public ?string $constraint = null,
         public array $conflictColumns = [],
         public array $updateColumns = [],
+        public ?bool $preserveExistingValues = null,
     ) {
     }
 
@@ -27,11 +28,13 @@ final readonly class PostgreSQLInsertOptions implements InsertOptions
     public static function fromArray(array $options) : InsertOptions
     {
         $options = type_structure(
-            optional_elements: [
+            [],
+            [
                 'skip_conflicts' => type_optional(type_boolean()),
                 'constraint' => type_optional(type_string()),
                 'conflict_columns' => type_list(type_string()),
                 'update_columns' => type_list(type_string()),
+                'preserve_existing_values' => type_optional(type_boolean()),
             ]
         )->assert($options);
 
@@ -40,6 +43,7 @@ final readonly class PostgreSQLInsertOptions implements InsertOptions
             $options['constraint'] ?? null,
             $options['conflict_columns'] ?? [],
             $options['update_columns'] ?? [],
+            $options['preserve_existing_values'] ?? null,
         );
     }
 
@@ -69,8 +73,8 @@ final readonly class PostgreSQLInsertOptions implements InsertOptions
     /**
      * @param array<string> $updateColumns
      */
-    public function updateColumns(array $updateColumns) : self
+    public function updateColumns(array $updateColumns, ?bool $preserveExistingValues = null) : self
     {
-        return new self($this->skipConflicts, $this->constraint, $this->conflictColumns, $updateColumns);
+        return new self($this->skipConflicts, $this->constraint, $this->conflictColumns, $updateColumns, $preserveExistingValues);
     }
 }

--- a/src/lib/doctrine-dbal-bulk/src/Flow/Doctrine/Bulk/Dialect/PostgreSQLUpdateOptions.php
+++ b/src/lib/doctrine-dbal-bulk/src/Flow/Doctrine/Bulk/Dialect/PostgreSQLUpdateOptions.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Flow\Doctrine\Bulk\Dialect;
 
-use function Flow\Types\DSL\{type_list, type_string, type_structure};
+use function Flow\Types\DSL\{type_boolean, type_list, type_optional, type_string, type_structure};
 use Flow\Doctrine\Bulk\UpdateOptions;
 
 final readonly class PostgreSQLUpdateOptions implements UpdateOptions
@@ -16,6 +16,7 @@ final readonly class PostgreSQLUpdateOptions implements UpdateOptions
     public function __construct(
         public array $primaryKeyColumns = [],
         public array $updateColumns = [],
+        public ?bool $preserveExistingValues = null,
     ) {
     }
 
@@ -28,12 +29,14 @@ final readonly class PostgreSQLUpdateOptions implements UpdateOptions
             optional_elements: [
                 'primary_key_columns' => type_list(type_string()),
                 'update_columns' => type_list(type_string()),
+                'preserve_existing_values' => type_optional(type_boolean()),
             ]
         )->assert($options);
 
         return new self(
             $options['primary_key_columns'] ?? [],
             $options['update_columns'] ?? [],
+            $options['preserve_existing_values'] ?? null,
         );
     }
 

--- a/src/lib/doctrine-dbal-bulk/src/Flow/Doctrine/Bulk/Dialect/SqliteDialect.php
+++ b/src/lib/doctrine-dbal-bulk/src/Flow/Doctrine/Bulk/Dialect/SqliteDialect.php
@@ -23,17 +23,6 @@ final readonly class SqliteDialect implements Dialect
     {
         $columns = $bulkData->columns()->all();
 
-        if (count($columns) === 1) {
-            $column = $columns[0];
-
-            return \sprintf(
-                'DELETE FROM %s WHERE %s IN (%s)',
-                $table->name(),
-                $this->platform->quoteIdentifier($column),
-                $bulkData->toSqlPlaceholders()
-            );
-        }
-
         return \sprintf(
             'DELETE FROM %s WHERE (%s) IN (%s)',
             $table->name(),

--- a/src/lib/doctrine-dbal-bulk/src/Flow/Doctrine/Bulk/Dialect/SqliteDialect.php
+++ b/src/lib/doctrine-dbal-bulk/src/Flow/Doctrine/Bulk/Dialect/SqliteDialect.php
@@ -60,7 +60,7 @@ final readonly class SqliteDialect implements Dialect
                 $bulkData->toSqlPlaceholders(),
                 \implode(',', $options->conflictColumns),
                 \count($options->updateColumns)
-                    ? $this->updateSelectedColumns($options->updateColumns, $bulkData->columns())
+                    ? $this->updateSelectedColumns($options->updateColumns, $bulkData->columns(), $table->name(), $options->preserveExistingValues)
                     : $this->updateAllColumns($bulkData->columns())
             );
         }
@@ -82,7 +82,7 @@ final readonly class SqliteDialect implements Dialect
         );
     }
 
-    public function prepareUpdate(TableDefinition $table, BulkData $bulkData, ?UpdateOptions $updateOptions = null) : string
+    public function prepareUpdate(TableDefinition $table, BulkData $bulkData, ?UpdateOptions $options = null) : string
     {
         return \sprintf(
             'REPLACE INTO %s (%s) VALUES %s',
@@ -105,10 +105,18 @@ final readonly class SqliteDialect implements Dialect
     /**
      * @param array<string> $updateColumns
      */
-    private function updateSelectedColumns(array $updateColumns, Columns $columns) : string
+    private function updateSelectedColumns(array $updateColumns, Columns $columns, string $tableName, ?bool $preserveExistingValues = null) : string
     {
         return [] !== $updateColumns
-            ? \implode(',', \array_map(fn (string $column) : string => "{$this->platform->quoteIdentifier($column)} = {$this->platform->quoteIdentifier('excluded.' . $column)}", $updateColumns))
+            ? \implode(',', \array_map(function (string $column) use ($tableName, $preserveExistingValues) : string {
+                $clause = "{$this->platform->quoteIdentifier($column)} = ";
+
+                if (true === $preserveExistingValues) {
+                    return $clause . "COALESCE({$this->platform->quoteIdentifier('excluded.' . $column)}, {$tableName}.{$this->platform->quoteIdentifier($column)})";
+                }
+
+                return $clause . "{$this->platform->quoteIdentifier('excluded.' . $column)}";
+            }, $updateColumns))
             : $this->updateAllColumns($columns);
     }
 }

--- a/src/lib/doctrine-dbal-bulk/src/Flow/Doctrine/Bulk/Dialect/SqliteInsertOptions.php
+++ b/src/lib/doctrine-dbal-bulk/src/Flow/Doctrine/Bulk/Dialect/SqliteInsertOptions.php
@@ -17,6 +17,7 @@ final readonly class SqliteInsertOptions implements InsertOptions
         public ?bool $skipConflicts = null,
         public array $conflictColumns = [],
         public array $updateColumns = [],
+        public ?bool $preserveExistingValues = null,
     ) {
     }
 
@@ -31,6 +32,7 @@ final readonly class SqliteInsertOptions implements InsertOptions
                 'skip_conflicts' => type_optional(type_boolean()),
                 'conflict_columns' => type_list(type_string()),
                 'update_columns' => type_list(type_string()),
+                'preserve_existing_values' => type_optional(type_boolean()),
             ]
         )->assert($options);
 
@@ -38,6 +40,7 @@ final readonly class SqliteInsertOptions implements InsertOptions
             $options['skip_conflicts'] ?? null,
             $options['conflict_columns'] ?? [],
             $options['update_columns'] ?? [],
+            $options['preserve_existing_values'] ?? null,
         );
     }
 
@@ -62,8 +65,8 @@ final readonly class SqliteInsertOptions implements InsertOptions
     /**
      * @param array<string> $updateColumns
      */
-    public function updateColumns(array $updateColumns) : self
+    public function updateColumns(array $updateColumns, ?bool $preserveExistingValues = null) : self
     {
-        return new self($this->skipConflicts, $this->conflictColumns, $updateColumns);
+        return new self($this->skipConflicts, $this->conflictColumns, $updateColumns, $preserveExistingValues);
     }
 }

--- a/src/lib/doctrine-dbal-bulk/tests/Flow/Doctrine/Bulk/Tests/Integration/MySqlBulkInsertTest.php
+++ b/src/lib/doctrine-dbal-bulk/tests/Flow/Doctrine/Bulk/Tests/Integration/MySqlBulkInsertTest.php
@@ -155,6 +155,57 @@ final class MySqlBulkInsertTest extends MysqlIntegrationTestCase
         );
     }
 
+    public function test_inserts_new_rows_and_update_selected_columns_and_preserve_existing_values() : void
+    {
+        $this->databaseContext->createTable(
+            (new Table(
+                $table = 'flow_doctrine_bulk_test',
+                [
+                    new Column('id', Type::getType(Types::INTEGER), ['notnull' => true]),
+                    new Column('name', Type::getType(Types::STRING), ['notnull' => false, 'length' => 255]),
+                    new Column('description', Type::getType(Types::STRING), ['notnull' => false, 'length' => 255]),
+                    new Column('active', Type::getType(Types::BOOLEAN), ['notnull' => true]),
+                ],
+            ))
+                ->setPrimaryKey(['id'])
+        );
+
+        Bulk::create()->insert(
+            $this->databaseContext->connection(),
+            $table,
+            new BulkData([
+                ['id' => 1, 'name' => 'Name One', 'description' => 'Description One', 'active' => true],
+                ['id' => 2, 'name' => 'Name Two', 'description' => 'Description Two', 'active' => true],
+                ['id' => 3, 'name' => 'Name Three', 'description' => 'Description Three', 'active' => true],
+            ])
+        );
+
+        Bulk::create()->insert(
+            $this->databaseContext->connection(),
+            $table,
+            new BulkData([
+                ['id' => 2, 'name' => 'New Name Two', 'description' => null, 'active' => true],
+                ['id' => 3, 'name' => null, 'description' => 'DESCRIPTION', 'active' => true],
+            ]),
+            MySQLInsertOptions::fromArray([
+                'upsert' => true,
+                'update_columns' => ['name', 'description'],
+                'preserve_existing_values' => true,
+            ])
+        );
+
+        self::assertEquals(3, $this->databaseContext->tableCount($table));
+        self::assertEquals(2, $this->executedQueriesCount());
+        self::assertEquals(
+            [
+                ['id' => 1, 'name' => 'Name One', 'description' => 'Description One', 'active' => true],
+                ['id' => 2, 'name' => 'New Name Two', 'description' => 'Description Two', 'active' => true],
+                ['id' => 3, 'name' => 'Name Three', 'description' => 'DESCRIPTION', 'active' => true],
+            ],
+            $this->databaseContext->selectAll($table)
+        );
+    }
+
     public function test_inserts_new_rows_and_update_selected_columns_only_of_already_existed() : void
     {
         $this->databaseContext->createTable(

--- a/src/lib/doctrine-dbal-bulk/tests/Flow/Doctrine/Bulk/Tests/Integration/PostgreSqlBulkInsertTest.php
+++ b/src/lib/doctrine-dbal-bulk/tests/Flow/Doctrine/Bulk/Tests/Integration/PostgreSqlBulkInsertTest.php
@@ -204,6 +204,56 @@ final class PostgreSqlBulkInsertTest extends PostgreSqlIntegrationTestCase
         );
     }
 
+    public function test_inserts_new_rows_or_updates_already_existed_based_on_columns_with_update_only_specific_columns_and_preserve_existing_values() : void
+    {
+        $this->databaseContext->createTable(
+            (new Table(
+                $table = 'flow_doctrine_bulk_test',
+                [
+                    new Column('id', Type::getType(Types::INTEGER), ['notnull' => true]),
+                    new Column('name', Type::getType(Types::STRING), ['notnull' => false, 'length' => 255]),
+                    new Column('description', Type::getType(Types::STRING), ['notnull' => false, 'length' => 255]),
+                    new Column('active', Type::getType(Types::BOOLEAN), ['notnull' => true]),
+                ],
+            ))
+                ->setPrimaryKey(['id'])
+        );
+        Bulk::create()->insert(
+            $this->databaseContext->connection(),
+            $table,
+            new BulkData([
+                ['id' => 1, 'name' => 'Name One', 'description' => 'Description One', 'active' => true],
+                ['id' => 2, 'name' => 'Name Two', 'description' => 'Description Two', 'active' => false],
+                ['id' => 3, 'name' => 'Name Three', 'description' => 'Description Three', 'active' => true],
+            ])
+        );
+
+        Bulk::create()->insert(
+            $this->databaseContext->connection(),
+            $table,
+            new BulkData([
+                ['id' => 2, 'name' => 'New Name Two', 'description' => null, 'active' => true],
+                ['id' => 3, 'name' => null, 'description' => 'DESCRIPTION', 'active' => true],
+            ]),
+            PostgreSQLInsertOptions::fromArray([
+                'conflict_columns' => ['id'],
+                'update_columns' => ['name', 'description'],
+                'preserve_existing_values' => true,
+            ])
+        );
+
+        self::assertEquals(3, $this->databaseContext->tableCount($table));
+        self::assertEquals(2, $this->executedQueriesCount());
+        self::assertEquals(
+            [
+                ['id' => 1, 'name' => 'Name One', 'description' => 'Description One', 'active' => true],
+                ['id' => 2, 'name' => 'New Name Two', 'description' => 'Description Two', 'active' => false],
+                ['id' => 3, 'name' => 'Name Three', 'description' => 'DESCRIPTION', 'active' => true],
+            ],
+            $this->databaseContext->selectAll($table)
+        );
+    }
+
     public function test_inserts_new_rows_or_updates_already_existed_based_on_primary_key() : void
     {
         $this->databaseContext->createTable(

--- a/src/lib/doctrine-dbal-bulk/tests/Flow/Doctrine/Bulk/Tests/Integration/SqliteBulkInsertTest.php
+++ b/src/lib/doctrine-dbal-bulk/tests/Flow/Doctrine/Bulk/Tests/Integration/SqliteBulkInsertTest.php
@@ -200,4 +200,54 @@ final class SqliteBulkInsertTest extends SqliteIntegrationTestCase
             $this->databaseContext->selectAll($table)
         );
     }
+
+    public function test_inserts_new_rows_or_updates_already_existed_based_on_columns_with_update_only_specific_columns_and_preserve_existing_values() : void
+    {
+        $this->databaseContext->createTable(
+            (new Table(
+                $table = 'flow_doctrine_bulk_test',
+                [
+                    new Column('id', Type::getType(Types::INTEGER), ['notnull' => true]),
+                    new Column('name', Type::getType(Types::STRING), ['notnull' => false, 'length' => 255]),
+                    new Column('description', Type::getType(Types::STRING), ['notnull' => false, 'length' => 255]),
+                    new Column('active', Type::getType(Types::BOOLEAN), ['notnull' => true]),
+                ],
+            ))
+                ->setPrimaryKey(['id'])
+        );
+        Bulk::create()->insert(
+            $this->databaseContext->connection(),
+            $table,
+            new BulkData([
+                ['id' => 1, 'name' => 'Name One', 'description' => 'Description One', 'active' => true],
+                ['id' => 2, 'name' => 'Name Two', 'description' => 'Description Two', 'active' => false],
+                ['id' => 3, 'name' => 'Name Three', 'description' => 'Description Three', 'active' => true],
+            ])
+        );
+
+        Bulk::create()->insert(
+            $this->databaseContext->connection(),
+            $table,
+            new BulkData([
+                ['id' => 2, 'name' => 'New Name Two', 'description' => null, 'active' => true],
+                ['id' => 3, 'name' => null, 'description' => 'DESCRIPTION', 'active' => true],
+            ]),
+            SqliteInsertOptions::fromArray([
+                'conflict_columns' => ['id'],
+                'update_columns' => ['name', 'description'],
+                'preserve_existing_values' => true,
+            ])
+        );
+
+        self::assertEquals(3, $this->databaseContext->tableCount($table));
+        self::assertEquals(2, $this->executedQueriesCount());
+        self::assertEquals(
+            [
+                ['id' => 1, 'name' => 'Name One', 'description' => 'Description One', 'active' => true],
+                ['id' => 2, 'name' => 'New Name Two', 'description' => 'Description Two', 'active' => false],
+                ['id' => 3, 'name' => 'Name Three', 'description' => 'DESCRIPTION', 'active' => true],
+            ],
+            $this->databaseContext->selectAll($table)
+        );
+    }
 }


### PR DESCRIPTION
<!-- 
    Please replace #xxx with a GitHub issue id from flow-php/flow repository. For example #1234 
    If there is no item in a roadmap related to this PR, please check our contributing guidelines first. 
-->
Resolves: #2128 

<!-- 
    Below section will be used to automatically generate changelog, please do not modify HTML code structure
    DO NOT REMOVE that HTML STRUCTURE, INSTEAD ADD YOUR CHANGES INSIDE THE LISTS 
    PULL REQUESTS WITHOUT CHANGELOG CAN'T BE MERGED 
-->
<h2>Change Log</h2>
<hr /> 
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <li>Allow preserving existing values during DBAL upsert</li>
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>