### PR TITLE
feature: move benchmarks to dedicated runner

### DIFF
--- a/.github/workflows/baseline.yml
+++ b/.github/workflows/baseline.yml
@@ -91,7 +91,7 @@ jobs:
           overwrite: true
 
   benchmark-baseline:
-    runs-on: ubuntu-latest
+    runs-on: flow-php-runner
 
     services:
       postgres:

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,5 +1,11 @@
+name: Benchmark Tests
+
 on:
-  workflow_call:
+  workflow_dispatch:
+  pull_request_target:
+    paths:
+      - 'src/**'
+      - 'phpbench.json.dist'
 
 jobs:
   benchmark-tests:
@@ -26,6 +32,8 @@ jobs:
     steps:
       - name: "Checkout"
         uses: "actions/checkout@v5"
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: "Setup PHP Environment"
         uses: "./.github/actions/setup-php-env"

--- a/.github/workflows/job-benchmark-tests.yml
+++ b/.github/workflows/job-benchmark-tests.yml
@@ -3,7 +3,7 @@ on:
 
 jobs:
   benchmark-tests:
-    runs-on: ${{ matrix.operating-system }}
+    runs-on: flow-php-runner
     strategy:
       fail-fast: false
       matrix:
@@ -11,8 +11,6 @@ jobs:
           - "locked"
         php-version:
           - "8.3"
-        operating-system:
-          - "ubuntu-latest"
 
     services:
       postgres:

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -56,6 +56,3 @@ jobs:
 
   mutation-tests:
     uses: ./.github/workflows/job-mutation-tests.yml
-
-  benchmark-tests:
-    uses: ./.github/workflows/job-benchmark-tests.yml

--- a/documentation/benchmarks.md
+++ b/documentation/benchmarks.md
@@ -33,9 +33,11 @@ Baseline generation is triggered by:
 
 ### Pull Request Comparison
 
-When a pull request is opened, benchmarks run on the same dedicated runner and compare results against the stored `1.x`
-baseline. This comparison is posted as a summary in the PR, allowing reviewers to identify any performance regressions
-or improvements.
+When a pull request is opened, benchmarks run on the dedicated runner and compare results against the stored `1.x`
+baseline. The comparison is posted as a job summary.
+
+The workflow uses `pull_request_target` trigger, which means the workflow code always comes from the `1.x` branch.
+This prevents attackers from modifying the workflow file in their PR to execute malicious code on the self-hosted runner.
 
 ## Benchmark Categories
 

--- a/documentation/benchmarks.md
+++ b/documentation/benchmarks.md
@@ -1,0 +1,78 @@
+# Benchmarks
+
+- [⬅️️ Back](/documentation/introduction.md)
+
+[TOC]
+
+## Infrastructure
+
+All benchmarks run on a dedicated self-hosted GitHub Actions runner hosted on [Digital Ocean](/sponsor):
+
+| Specification   | Value                  |
+|-----------------|------------------------|
+| **Runner Name** | `flow-php-runner`      |
+| **vCPUs**       | 2                      |
+| **Memory**      | 2 GB                   |
+| **OS**          | Ubuntu 24.04 (LTS) x64 |
+
+Using a dedicated runner ensures benchmark results are consistent and not affected by varying loads on shared
+GitHub-hosted runners.
+
+## How Benchmarks Work
+
+### Baseline Generation
+
+When code is merged to the `1.x` branch, the baseline workflow automatically runs all benchmarks and stores the results
+as artifacts. This baseline serves as the reference point for all future comparisons.
+
+Baseline generation is triggered by:
+
+- Push to `1.x` branch
+- Daily schedule (3 AM UTC)
+- Manual workflow dispatch
+
+### Pull Request Comparison
+
+When a pull request is opened, benchmarks run on the same dedicated runner and compare results against the stored `1.x`
+baseline. This comparison is posted as a summary in the PR, allowing reviewers to identify any performance regressions
+or improvements.
+
+## Benchmark Categories
+
+Benchmarks are organized into five categories:
+
+| Category            | Description                                                                    |
+|---------------------|--------------------------------------------------------------------------------|
+| **Extractors**      | Performance of data extraction from various sources (CSV, JSON, Parquet, etc.) |
+| **Transformers**    | Performance of data transformation operations                                  |
+| **Loaders**         | Performance of data loading to various destinations                            |
+| **Building Blocks** | Core framework operations (rows, entries, schema, etc.)                        |
+| **Parquet Library** | Low-level Parquet file operations                                              |
+
+## Running Benchmarks Locally
+
+To run benchmarks locally:
+
+```bash
+# Run all benchmarks
+composer test:benchmark
+
+# Run specific category
+composer test:benchmark:extractor
+composer test:benchmark:transformer
+composer test:benchmark:loader
+composer test:benchmark:building_blocks
+composer test:benchmark:parquet-library
+```
+
+## Interpreting Results
+
+Benchmark results show timing comparisons between your changes and the baseline. Key metrics include:
+
+- **Mean time** - Average execution time
+- **Mode** - Most frequent execution time
+- **Best/Worst** - Range of execution times
+- **Memory** - Peak memory usage
+
+A significant increase in execution time or memory usage may indicate a performance regression that should be
+investigated before merging.

--- a/web/landing/templates/documentation/navigation_left.html.twig
+++ b/web/landing/templates/documentation/navigation_left.html.twig
@@ -27,6 +27,9 @@
                     <a href="/documentation/dsl#dsl-functions">DSL References</a>
                 </li>
                 <li>
+                    <a href="/documentation/benchmarks">Benchmarks</a>
+                </li>
+                <li>
                     <a href="/documentation/adrs">Architecture Decision Records</a>
                 </li>
                 <li>


### PR DESCRIPTION
- added: Benchmark documentation explaining infrastructure, workflow, and how to run benchmarks
- changed: GitHub Actions benchmarks now run on dedicated self-hosted runner (flow-php-runner) for consistent results

<!-- 
    Please replace #xxx with a GitHub issue id from flow-php/flow repository. For example #1234 
    If there is no item in a roadmap related to this PR, please check our contributing guidelines first. 
-->
Resolves: #xxx

<!-- 
    Below section will be used to automatically generate changelog, please do not modify HTML code structure
    DO NOT REMOVE that HTML STRUCTURE, INSTEAD ADD YOUR CHANGES INSIDE THE LISTS 
    PULL REQUESTS WITHOUT CHANGELOG CAN'T BE MERGED 
-->
<h2>Change Log</h2>
<hr />
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <li>Benchmark documentation explaining infrastructure, workflow, and how to run benchmarks</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>GitHub Actions benchmarks now run on dedicated self-hosted runner (flow-php-runner) for consistent results</li>
  </ul>
</div>
