### PR TITLE
Adjust `Parameter::asNumber()` behaviour to match closer the PHP one

### DIFF
--- a/src/core/etl/src/Flow/ETL/Function/Parameter.php
+++ b/src/core/etl/src/Flow/ETL/Function/Parameter.php
@@ -153,11 +153,17 @@ final readonly class Parameter
     {
         $result = $this->eval($row, $context);
 
-        if (\is_string($result)) {
+        if (!\is_numeric($result)) {
             return $default;
         }
 
-        return \is_numeric($result) ? $result : $default;
+        return match (true) {
+            \is_int($result),
+            \is_float($result) => $result,
+            ($result == (int) $result) => (int) $result,
+            ($result == (float) $result) => (float) $result,
+            default => $default,
+        };
     }
 
     public function asObject(Row $row, FlowContext $context) : ?object

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Function/ParameterTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Function/ParameterTest.php
@@ -67,6 +67,10 @@ final class ParameterTest extends FlowTestCase
         yield 'zero' => [0, null, 0];
         yield 'negative integer' => [-42, null, -42];
         yield 'negative float' => [-3.14, null, -3.14];
+        yield 'integer as string' => ['99', null, 99];
+        yield 'float as string' => ['99.5', null, 99.5];
+        yield 'negative integer as string' => ['-42', null, -42];
+        yield 'negative float as string' => ['-3.14', null, -3.14];
         yield 'string with default' => ['not numeric', 99, 99];
         yield 'string with float default' => ['not numeric', 99.5, 99.5];
         yield 'boolean with default' => [true, 99, 99];


### PR DESCRIPTION
<!-- 
    Please replace #xxx with a GitHub issue id from flow-php/flow repository. For example #1234 
    If there is no item in a roadmap related to this PR, please check our contributing guidelines first. 
-->
Resolves: #2142

<!-- 
    Below section will be used to automatically generate changelog, please do not modify HTML code structure
    DO NOT REMOVE that HTML STRUCTURE, INSTEAD ADD YOUR CHANGES INSIDE THE LISTS 
    PULL REQUESTS WITHOUT CHANGELOG CAN'T BE MERGED 
-->
<h2>Change Log</h2>
<hr /> 
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Adjust `Parameter::asNumber()` behaviour to match closer the PHP one</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>