### PR TITLE
fix: transformation loader use loader through pipeline

### DIFF
--- a/src/core/etl/src/Flow/ETL/Loader/TransformerLoader.php
+++ b/src/core/etl/src/Flow/ETL/Loader/TransformerLoader.php
@@ -25,12 +25,10 @@ final readonly class TransformerLoader implements Closure, Loader, OverridingLoa
     public function load(Rows $rows, FlowContext $context) : void
     {
         if ($this->transformer instanceof Transformer) {
-            $rows = $this->transformer->transform($rows, $context);
+            $this->loader->load($this->transformer->transform($rows, $context), $context);
         } else {
-            $rows = df()->from(from_rows($rows))->with($this->transformer)->fetch();
+            df($context->config)->from(from_rows($rows))->with($this->transformer)->load($this->loader)->run();
         }
-
-        $this->loader->load($rows, $context);
     }
 
     public function loaders() : array

--- a/src/core/etl/tests/Flow/ETL/Tests/Integration/Loader/TransformerLoaderTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Integration/Loader/TransformerLoaderTest.php
@@ -1,0 +1,173 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Tests\Integration\Loader;
+
+use function Flow\ETL\DSL\{add_row_index, batch_size, df, drop, from_array, limit, mask_columns, select, to_memory, to_transformation};
+use Flow\ETL\Loader;
+use Flow\ETL\Memory\ArrayMemory;
+use Flow\ETL\Tests\Double\FakeStaticOrdersExtractor;
+use Flow\ETL\Tests\FlowTestCase;
+use Flow\ETL\Transformation\AddRowIndex\StartFrom;
+
+final class TransformerLoaderTest extends FlowTestCase
+{
+    public function test_transformer_loader_with_add_row_index_transformation() : void
+    {
+        $memory = new ArrayMemory();
+
+        df()
+            ->read(from_array([
+                ['name' => 'Alice', 'age' => 30],
+                ['name' => 'Bob', 'age' => 25],
+                ['name' => 'Charlie', 'age' => 35],
+            ]))
+            ->collect()
+            ->write(
+                to_transformation(
+                    add_row_index('row_num', StartFrom::ONE),
+                    to_memory($memory)
+                )
+            )
+            ->run();
+
+        self::assertSame(
+            [
+                ['name' => 'Alice', 'age' => 30, 'row_num' => 1],
+                ['name' => 'Bob', 'age' => 25, 'row_num' => 2],
+                ['name' => 'Charlie', 'age' => 35, 'row_num' => 3],
+            ],
+            $memory->dump()
+        );
+    }
+
+    public function test_transformer_loader_with_batch_size_transformation() : void
+    {
+        $loader = $this->createMock(Loader::class);
+        $loader->expects(self::exactly(2))
+            ->method('load');
+
+        df()
+             ->read(
+                 new FakeStaticOrdersExtractor(1000)
+             )
+             ->collect()
+             ->write(
+                 to_transformation(
+                     batch_size(500),
+                     $loader
+                 )
+             )
+             ->run();
+    }
+
+    public function test_transformer_loader_with_drop_transformation() : void
+    {
+        $memory = new ArrayMemory();
+
+        df()
+            ->read(from_array([
+                ['id' => 1, 'name' => 'Alice', 'email' => 'alice@example.com', 'password' => 'secret123'],
+                ['id' => 2, 'name' => 'Bob', 'email' => 'bob@example.com', 'password' => 'secret456'],
+            ]))
+            ->write(
+                to_transformation(
+                    drop('password', 'email'),
+                    to_memory($memory)
+                )
+            )
+            ->run();
+
+        self::assertSame(
+            [
+                ['id' => 1, 'name' => 'Alice'],
+                ['id' => 2, 'name' => 'Bob'],
+            ],
+            $memory->dump()
+        );
+    }
+
+    public function test_transformer_loader_with_limit_transformation() : void
+    {
+        $memory = new ArrayMemory();
+
+        df()
+            ->read(from_array([
+                ['id' => 1, 'name' => 'Alice'],
+                ['id' => 2, 'name' => 'Bob'],
+                ['id' => 3, 'name' => 'Charlie'],
+                ['id' => 4, 'name' => 'Diana'],
+                ['id' => 5, 'name' => 'Eve'],
+            ]))
+            ->collect()
+            ->write(
+                to_transformation(
+                    limit(3),
+                    to_memory($memory)
+                )
+            )
+            ->run();
+
+        self::assertSame(
+            [
+                ['id' => 1, 'name' => 'Alice'],
+                ['id' => 2, 'name' => 'Bob'],
+                ['id' => 3, 'name' => 'Charlie'],
+            ],
+            $memory->dump()
+        );
+    }
+
+    public function test_transformer_loader_with_mask_columns_transformation() : void
+    {
+        $memory = new ArrayMemory();
+
+        df()
+            ->read(from_array([
+                ['id' => 1, 'name' => 'Alice', 'ssn' => '123-45-6789', 'email' => 'alice@example.com'],
+                ['id' => 2, 'name' => 'Bob', 'ssn' => '987-65-4321', 'email' => 'bob@example.com'],
+            ]))
+            ->write(
+                to_transformation(
+                    mask_columns(['ssn', 'email'], '***'),
+                    to_memory($memory)
+                )
+            )
+            ->run();
+
+        self::assertSame(
+            [
+                ['id' => 1, 'name' => 'Alice', 'ssn' => '***', 'email' => '***'],
+                ['id' => 2, 'name' => 'Bob', 'ssn' => '***', 'email' => '***'],
+            ],
+            $memory->dump()
+        );
+    }
+
+    public function test_transformer_loader_with_select_transformation() : void
+    {
+        $memory = new ArrayMemory();
+
+        df()
+            ->read(from_array([
+                ['id' => 1, 'name' => 'Alice', 'email' => 'alice@example.com', 'age' => 30],
+                ['id' => 2, 'name' => 'Bob', 'email' => 'bob@example.com', 'age' => 25],
+            ]))
+            ->write(
+                to_transformation(
+                    select('name', 'email'),
+                    to_memory($memory)
+                )
+            )
+            ->run();
+
+        self::assertSame(
+            [
+                ['name' => 'Alice', 'email' => 'alice@example.com'],
+                ['name' => 'Bob', 'email' => 'bob@example.com'],
+            ],
+            $memory->dump()
+        );
+    }
+}

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Loader/TransformerLoaderTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Loader/TransformerLoaderTest.php
@@ -7,9 +7,7 @@ namespace Flow\ETL\Tests\Unit\Loader;
 use function Flow\ETL\DSL\{config, df, flow_context, from_array, ref, rows, to_memory, to_transformation};
 use function Flow\Types\DSL\type_string;
 use Flow\ETL\{DataFrame,
-    FlowContext,
     Loader,
-    Loader\Closure,
     Memory\ArrayMemory,
     Tests\FlowTestCase,
     Transformation,
@@ -34,44 +32,6 @@ final class TransformerLoaderTest extends FlowTestCase
         );
 
         $transformer->load(rows(), flow_context(config()));
-    }
-
-    /**
-     * Tests that the closure method is called when using a Closure loader.
-     */
-    public function test_transformer_loader_with_closure() : void
-    {
-        $closure_loader = $this->createMockForIntersectionOfInterfaces([Loader::class, Closure::class]);
-
-        $closure_loader->expects(self::once())
-            ->method('closure')
-            ->with(self::isInstanceOf(FlowContext::class));
-
-        \assert($closure_loader instanceof Loader);
-        $transformer = to_transformation(
-            new class implements Transformation {
-                public function transform(DataFrame $data_frame) : DataFrame
-                {
-                    return $data_frame;
-                }
-            },
-            $closure_loader
-        );
-
-        df()
-            ->read(
-                from_array(
-                    [
-                        ['id' => 1],
-                        ['id' => 2],
-                        ['id' => 3],
-                    ]
-                )
-            )
-            ->write(
-                $transformer
-            )
-            ->run();
     }
 
     public function test_transformer_loader_with_transformation() : void


### PR DESCRIPTION
<!-- 
    Please replace #xxx with a GitHub issue id from flow-php/flow repository. For example #1234 
    If there is no item in a roadmap related to this PR, please check our contributing guidelines first. 
-->
Resolves: #xxx

<!-- 
    Below section will be used to automatically generate changelog, please do not modify HTML code structure
    DO NOT REMOVE that HTML STRUCTURE, INSTEAD ADD YOUR CHANGES INSIDE THE LISTS 
    PULL REQUESTS WITHOUT CHANGELOG CAN'T BE MERGED 
-->
<h2>Change Log</h2>
<hr /> 
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>TransformerLoader</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>