### PR TITLE
Remove part of unnecessary recursion calls from `array_dot_get()` method

### DIFF
--- a/src/lib/array-dot/src/Flow/ArrayDot/array_dot.php
+++ b/src/lib/array-dot/src/Flow/ArrayDot/array_dot.php
@@ -19,14 +19,8 @@ function array_dot_steps(string $path) : array
         throw new InvalidPathException("Path can't be empty.");
     }
 
-    if (\str_contains($path, '{')) {
-        if (!\str_contains($path, '}')) {
-            throw new InvalidPathException('Multimatch syntax not closed');
-        }
-
-        if (\strpos($path, '}') !== \strlen($path) - 1) {
-            throw new InvalidPathException('Multimatch must be used at the end of path');
-        }
+    if (\str_contains($path, '{') && !\str_ends_with($path, '}')) {
+        throw new InvalidPathException('Multimatch must be used at the end of path');
     }
 
     $path = \str_replace('\\.', '__ESCAPED_DOT__', $path);
@@ -45,8 +39,7 @@ function array_dot_steps(string $path) : array
         $pathSteps[$index] = \str_replace('__ESCAPED_DOT__', '.', $step);
 
         if ($step === '__MULTIMATCH_PATH__') {
-            /** @phpstan-ignore-next-line */
-            $pathSteps[$index] = $multiMatchPath[2];
+            $pathSteps[$index] = $multiMatchPath[2] ?? throw new InvalidPathException('Multimatch not found');
         }
     }
 
@@ -247,33 +240,29 @@ function array_dot_get(array $array, string $path) : mixed
 
         if (\in_array($step, ['*', '?*'], true)) {
             $stepsLeft = \array_slice($pathSteps, \count($takenSteps), \count($pathSteps));
+
+            if (!\count($stepsLeft)) {
+                return $arraySlice;
+            }
+
             $results = [];
 
-            foreach (\array_keys($arraySlice) as $key) {
-                if (!\count($stepsLeft)) {
-                    return $arraySlice;
+            foreach ($arraySlice as $value) {
+                if (!\is_array($value)) {
+                    $pathTaken = \implode('.', $takenSteps);
+                    $type = \gettype($value);
+
+                    throw new InvalidPathException("Expected array under path, \"{$pathTaken}\", but got: {$type}");
                 }
 
-                if ($step === '?*') {
-                    if (!\is_array($arraySlice[$key])) {
-                        $pathTaken = \implode('.', $takenSteps);
-                        $type = \gettype($arraySlice[$key]);
-
-                        throw new InvalidPathException("Expected array under path, \"{$pathTaken}\", but got: {$type}");
+                try {
+                    $results[] = array_dot_get($value, \implode('.', $stepsLeft));
+                } catch (InvalidPathException $e) {
+                    if ($step === '?*') {
+                        continue;
                     }
 
-                    if (array_dot_exists($arraySlice[$key], \implode('.', $stepsLeft))) {
-                        $results[] = array_dot_get($arraySlice[$key], \implode('.', $stepsLeft));
-                    }
-                } else {
-                    if (!\is_array($arraySlice[$key])) {
-                        $pathTaken = \implode('.', $takenSteps);
-                        $type = \gettype($arraySlice[$key]);
-
-                        throw new InvalidPathException("Expected array under path, \"{$pathTaken}\", but got: {$type}");
-                    }
-
-                    $results[] = array_dot_get($arraySlice[$key], \implode('.', $stepsLeft));
+                    throw $e;
                 }
             }
 

--- a/src/lib/array-dot/tests/Flow/ArrayDot/Tests/Unit/ArrayDotStepsTest.php
+++ b/src/lib/array-dot/tests/Flow/ArrayDot/Tests/Unit/ArrayDotStepsTest.php
@@ -45,7 +45,7 @@ final class ArrayDotStepsTest extends TestCase
     public function test_multimatch_not_closed() : void
     {
         $this->expectException(InvalidPathException::class);
-        $this->expectExceptionMessage('Multimatch syntax not closed');
+        $this->expectExceptionMessage('Multimatch must be used at the end of path');
 
         self::assertSame(
             ['foo', 'bar', '{bas, bai}'],
@@ -61,6 +61,14 @@ final class ArrayDotStepsTest extends TestCase
         self::assertSame(
             ['foo', 'bar', '{bas, bai}'],
             array_dot_steps('foo.bar.{bas, bai}.id')
+        );
+    }
+
+    public function test_simple_multimatch() : void
+    {
+        self::assertSame(
+            ['{foo}'],
+            array_dot_steps('{foo}')
         );
     }
 


### PR DESCRIPTION
<!-- 
    Please replace #xxx with a GitHub issue id from flow-php/flow repository. For example #1234 
    If there is no item in a roadmap related to this PR, please check our contributing guidelines first. 
-->
Resolves: #2156

Cleaner to review [without whitespace visible](https://github.com/flow-php/flow/pull/2157/files?w=1).

<!-- 
    Below section will be used to automatically generate changelog, please do not modify HTML code structure
    DO NOT REMOVE that HTML STRUCTURE, INSTEAD ADD YOUR CHANGES INSIDE THE LISTS 
    PULL REQUESTS WITHOUT CHANGELOG CAN'T BE MERGED 
-->
<h2>Change Log</h2>
<hr /> 
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Remove part of unnecessary recursion calls from `array_dot_get()` method</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>