### PR TITLE
test: trivial docblock for benchmark stability verification

### DIFF
--- a/src/core/etl/src/Flow/ETL/RandomValueGenerator.php
+++ b/src/core/etl/src/Flow/ETL/RandomValueGenerator.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Flow\ETL;
 
+/**
+ * Random value generator interface for producing random integers and strings.
+ */
 interface RandomValueGenerator
 {
     public function int(int $min, int $max) : int;


### PR DESCRIPTION
This is a test commit to verify benchmark variance after increasing iterations from 2 to 3 in phpbench configuration.

<!-- 
    Please replace #xxx with a GitHub issue id from flow-php/flow repository. For example #1234 
    If there is no item in a roadmap related to this PR, please check our contributing guidelines first. 
-->
Resolves: #xxx

<!-- 
    Below section will be used to automatically generate changelog, please do not modify HTML code structure
    DO NOT REMOVE that HTML STRUCTURE, INSTEAD ADD YOUR CHANGES INSIDE THE LISTS 
    PULL REQUESTS WITHOUT CHANGELOG CAN'T BE MERGED 
-->
<h2>Change Log</h2>
<hr /> 
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>test pr</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>