### PR TITLE
fix: support any regex delimiter and modifiers in compiler pass pattern matching

### DIFF
--- a/src/bridge/symfony/telemetry-bundle/src/Flow/Bridge/Symfony/TelemetryBundle/DependencyInjection/Compiler/CacheTelemetryPass.php
+++ b/src/bridge/symfony/telemetry-bundle/src/Flow/Bridge/Symfony/TelemetryBundle/DependencyInjection/Compiler/CacheTelemetryPass.php
@@ -81,8 +81,10 @@ final class CacheTelemetryPass implements CompilerPassInterface
 
     private function matchesPattern(string $serviceId, string $pattern) : bool
     {
-        if (\str_starts_with($pattern, '/') && \str_ends_with($pattern, '/')) {
-            return (bool) \preg_match($pattern, $serviceId);
+        $result = @\preg_match($pattern, $serviceId);
+
+        if ($result !== false) {
+            return (bool) $result;
         }
 
         return $serviceId === $pattern;

--- a/src/bridge/symfony/telemetry-bundle/src/Flow/Bridge/Symfony/TelemetryBundle/DependencyInjection/Compiler/DBALTelemetryPass.php
+++ b/src/bridge/symfony/telemetry-bundle/src/Flow/Bridge/Symfony/TelemetryBundle/DependencyInjection/Compiler/DBALTelemetryPass.php
@@ -99,8 +99,10 @@ final class DBALTelemetryPass implements CompilerPassInterface
 
     private function matchesPattern(string $connectionName, string $pattern) : bool
     {
-        if (\str_starts_with($pattern, '/') && \str_ends_with($pattern, '/')) {
-            return (bool) \preg_match($pattern, $connectionName);
+        $result = @\preg_match($pattern, $connectionName);
+
+        if ($result !== false) {
+            return (bool) $result;
         }
 
         return $connectionName === $pattern;

--- a/src/bridge/symfony/telemetry-bundle/src/Flow/Bridge/Symfony/TelemetryBundle/DependencyInjection/Compiler/HttpClientTelemetryPass.php
+++ b/src/bridge/symfony/telemetry-bundle/src/Flow/Bridge/Symfony/TelemetryBundle/DependencyInjection/Compiler/HttpClientTelemetryPass.php
@@ -62,8 +62,10 @@ final class HttpClientTelemetryPass implements CompilerPassInterface
 
     private function matchesPattern(string $serviceId, string $pattern) : bool
     {
-        if (\str_starts_with($pattern, '/') && \str_ends_with($pattern, '/')) {
-            return (bool) \preg_match($pattern, $serviceId);
+        $result = @\preg_match($pattern, $serviceId);
+
+        if ($result !== false) {
+            return (bool) $result;
         }
 
         return $serviceId === $pattern;

--- a/src/bridge/symfony/telemetry-bundle/src/Flow/Bridge/Symfony/TelemetryBundle/DependencyInjection/Compiler/Psr18ClientTelemetryPass.php
+++ b/src/bridge/symfony/telemetry-bundle/src/Flow/Bridge/Symfony/TelemetryBundle/DependencyInjection/Compiler/Psr18ClientTelemetryPass.php
@@ -83,8 +83,10 @@ final class Psr18ClientTelemetryPass implements CompilerPassInterface
 
     private function matchesPattern(string $serviceId, string $pattern) : bool
     {
-        if (\str_starts_with($pattern, '/') && \str_ends_with($pattern, '/')) {
-            return (bool) \preg_match($pattern, $serviceId);
+        $result = @\preg_match($pattern, $serviceId);
+
+        if ($result !== false) {
+            return (bool) $result;
         }
 
         return $serviceId === $pattern;


### PR DESCRIPTION
Use @preg_match with error suppression to detect valid regex patterns instead of checking for '/' delimiters, supporting any delimiter and modifiers, consistent with the rest of the telemetry-bundle.

<h2>Change Log</h2>
  <hr />
  <div id="change-log">
    <h4>Added</h4>
    <ul id="added">
      <!-- <li>Feature making everything better</li> -->
    </ul>
    <h4>Fixed</h4>
    <ul id="fixed">
      <li>Support any regex delimiter and modifiers in compiler pass pattern matching</li>
    </ul>
    <h4>Changed</h4>
    <ul id="changed">
      <!-- <li>Something into something new</li> -->
    </ul>
    <h4>Removed</h4>
    <ul id="removed">
      <!-- <li>Something</li> -->
    </ul>
    <h4>Deprecated</h4>
    <ul id="deprecated">
      <!-- <li>Something is from now deprecated</li> -->
    </ul>
    <h4>Security</h4>
    <ul id="security">
      <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
    </ul>
  </div