### PR TITLE
Don't remove already existing file when doing partitioning

### DIFF
--- a/src/core/etl/src/Flow/ETL/Filesystem/FilesystemStreams.php
+++ b/src/core/etl/src/Flow/ETL/Filesystem/FilesystemStreams.php
@@ -41,7 +41,7 @@ final class FilesystemStreams implements \Countable, \IteratorAggregate
 
                     if ($this->saveMode === SaveMode::Overwrite) {
                         if ($fileStream->path()->partitions()->count()) {
-                            $partitionFilesPatter = \Flow\Filesystem\DSL\path($fileStream->path()->parentDirectory()->uri() . '/*', $fileStream->path()->options());
+                            $partitionFilesPatter = Path::from($fileStream->path()->parentDirectory()->uri() . '/' . $fileStream->path()->basename(), $fileStream->path()->options());
 
                             foreach ($fs->list($partitionFilesPatter) as $partitionFile) {
                                 if (\str_contains($partitionFile->path->path(), self::FLOW_TMP_FILE_PREFIX)) {
@@ -54,7 +54,7 @@ final class FilesystemStreams implements \Countable, \IteratorAggregate
 
                         $fs->mv(
                             $fileStream->path(),
-                            \Flow\Filesystem\DSL\path(
+                            Path::from(
                                 \str_replace(self::FLOW_TMP_FILE_PREFIX, '', $fileStream->path()->uri()),
                                 $fileStream->path()->options()
                             )

--- a/src/core/etl/tests/Flow/ETL/Tests/Integration/Filesystem/FilesystemStreams/Partitioned/OverwriteModeTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Integration/Filesystem/FilesystemStreams/Partitioned/OverwriteModeTest.php
@@ -27,6 +27,7 @@ final class OverwriteModeTest extends FilesystemStreamsTestCase
         $this->setupFiles([
             __FUNCTION__ => [
                 'partition=value' => [
+                    'existing.txt' => 'file content',
                     'file.txt' => 'file content',
                 ],
             ],
@@ -39,10 +40,10 @@ final class OverwriteModeTest extends FilesystemStreamsTestCase
 
         $files = \iterator_to_array($this->fs()->list(path($file->parentDirectory()->path() . '/**/*.txt')));
 
-        self::assertCount(1, $files);
+        self::assertCount(2, $files);
 
-        self::assertStringStartsWith('file.txt', $files[0]->path->basename());
-        self::assertSame('new content', \file_get_contents($files[0]->path->path()));
+        self::assertStringStartsWith('file.txt', $files[1]->path->basename());
+        self::assertSame('new content', \file_get_contents($files[1]->path->path()));
     }
 
     public function test_open_stream_for_existing_partition_without_existing_file() : void


### PR DESCRIPTION
<!-- 
    Please replace #xxx with a GitHub issue id from flow-php/flow repository. For example #1234 
    If there is no item in a roadmap related to this PR, please check our contributing guidelines first. 
-->
Resolves: #2239 

<!-- 
    Below section will be used to automatically generate changelog, please do not modify HTML code structure
    DO NOT REMOVE that HTML STRUCTURE, INSTEAD ADD YOUR CHANGES INSIDE THE LISTS 
    PULL REQUESTS WITHOUT CHANGELOG CAN'T BE MERGED 
-->
<h2>Change Log</h2>
<hr /> 
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>Don't remove already existing file when doing partitioning</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>