### PR TITLE
Prevent fatal error when fetching Google sheet rows without values

### DIFF
--- a/src/adapter/etl-adapter-google-sheet/src/Flow/ETL/Adapter/GoogleSheet/GoogleSheetExtractor.php
+++ b/src/adapter/etl-adapter-google-sheet/src/Flow/ETL/Adapter/GoogleSheet/GoogleSheetExtractor.php
@@ -70,7 +70,7 @@ final class GoogleSheetExtractor implements Extractor, LimitableExtractor
         $response = $this->service->spreadsheets_values->batchGet($this->spreadsheetId, array_merge($this->options, ['ranges' => $ranges]));
 
         foreach ($response->getValueRanges() as $valueRange) {
-            foreach ($valueRange->getValues() as $rowData) {
+            foreach ($valueRange->getValues() ?: [] as $rowData) {
                 $rowDataCount = \count($rowData);
 
                 if ($this->withHeader) {

--- a/src/adapter/etl-adapter-google-sheet/tests/Flow/ETL/Adapter/GoogleSheet/Tests/Fixtures/batch-empty-rows.json
+++ b/src/adapter/etl-adapter-google-sheet/tests/Flow/ETL/Adapter/GoogleSheet/Tests/Fixtures/batch-empty-rows.json
@@ -1,0 +1,26 @@
+{
+  "spreadsheetId": "eae3913a86de8d5ccfe841fd3c7ec50dba3902045232",
+  "valueRanges": [
+    {
+      "range": "Sheet!A1:C10",
+      "majorDimension": "ROWS",
+      "values": [
+        ["Header 1", "Header 2", "Header 3"],
+        ["A2", "B2", "C2"],
+        ["A3", "B3", "C3"],
+        ["A4", "B4", "C4"],
+        ["A5", "B5", "C5"],
+        ["A6", "B6", "C6"],
+        ["A7", "B7", "C7"],
+        ["A8", "B8", "C8"],
+        ["A9", "B9", "C9"],
+        ["A10", "B10", "C10"]
+      ]
+    },
+    {
+      "range": "Sheet!A11:C20",
+      "majorDimension": "ROWS",
+      "values": null
+    }
+  ]
+}

--- a/src/adapter/etl-adapter-google-sheet/tests/Flow/ETL/Adapter/GoogleSheet/Tests/Integration/GoogleSheetExtractorTest.php
+++ b/src/adapter/etl-adapter-google-sheet/tests/Flow/ETL/Adapter/GoogleSheet/Tests/Integration/GoogleSheetExtractorTest.php
@@ -100,6 +100,23 @@ final class GoogleSheetExtractorTest extends FlowTestCase
         self::assertCount(19, $rows);
     }
 
+    public function test_extract_with_batches_containing_empty_rows() : void
+    {
+        $extractor = from_google_sheet(
+            $this->context->sheets(__DIR__ . '/../Fixtures/batch-empty-rows.json'),
+            '1234567890',
+            'Sheet',
+        );
+        $extractor->withRowsPerPage(10);
+
+        $rows = df()
+            ->extract($extractor)
+            ->fetch()
+            ->toArray();
+
+        self::assertCount(9, $rows);
+    }
+
     public function test_extract_with_batches_without_header() : void
     {
         $extractor = from_google_sheet(


### PR DESCRIPTION
<!-- 
    Please replace #xxx with a GitHub issue id from flow-php/flow repository. For example #1234 
    If there is no item in a roadmap related to this PR, please check our contributing guidelines first. 
-->
Resolves: #2243

<!-- 
    Below section will be used to automatically generate changelog, please do not modify HTML code structure
    DO NOT REMOVE that HTML STRUCTURE, INSTEAD ADD YOUR CHANGES INSIDE THE LISTS 
    PULL REQUESTS WITHOUT CHANGELOG CAN'T BE MERGED 
-->
<h2>Change Log</h2>
<hr /> 
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>Prevent fatal error when fetching Google sheet rows without values</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>