### PR TITLE
fix: support for explicit schemas in update/merge/delete query builders

### DIFF
--- a/src/lib/postgresql/src/Flow/PostgreSql/QueryBuilder/Delete/DeleteBuilder.php
+++ b/src/lib/postgresql/src/Flow/PostgreSql/QueryBuilder/Delete/DeleteBuilder.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Flow\PostgreSql\QueryBuilder\Delete;
 
 use Flow\PostgreSql\Protobuf\AST\{Alias, DeleteStmt, Node, RangeVar, ResTarget};
-use Flow\PostgreSql\QueryBuilder\AstToSql;
+use Flow\PostgreSql\QueryBuilder\{AstToSql, QualifiedIdentifier};
 use Flow\PostgreSql\QueryBuilder\Clause\WithClause;
 use Flow\PostgreSql\QueryBuilder\Condition\{Condition, ConditionFactory};
 use Flow\PostgreSql\QueryBuilder\Exception\InvalidAstException;
@@ -33,6 +33,7 @@ final readonly class DeleteBuilder implements DeleteFromStep, DeleteUsingStep
     private function __construct(
         private ?WithClause $with = null,
         private ?string $table = null,
+        private ?string $schema = null,
         private ?string $alias = null,
         private array $using = [],
         private ?Condition $where = null,
@@ -57,6 +58,12 @@ final readonly class DeleteBuilder implements DeleteFromStep, DeleteUsingStep
 
         if ($tableName === '') {
             throw InvalidAstException::missingRequiredField('relname', 'RangeVar');
+        }
+
+        $schema = $relation->getSchemaname();
+
+        if ($schema === '') {
+            $schema = null;
         }
 
         $alias = $relation->getAlias();
@@ -125,6 +132,7 @@ final readonly class DeleteBuilder implements DeleteFromStep, DeleteUsingStep
         return new self(
             with: $withClause,
             table: $tableName,
+            schema: $schema,
             alias: $aliasName,
             using: $using,
             where: $whereCondition,
@@ -139,9 +147,12 @@ final readonly class DeleteBuilder implements DeleteFromStep, DeleteUsingStep
 
     public function from(string $table, ?string $alias = null) : DeleteUsingStep
     {
+        $identifier = QualifiedIdentifier::parse($table);
+
         return new self(
             with: $this->with,
-            table: $table,
+            table: $identifier->name(),
+            schema: $identifier->schema(),
             alias: $alias,
             using: $this->using,
             where: $this->where,
@@ -154,6 +165,7 @@ final readonly class DeleteBuilder implements DeleteFromStep, DeleteUsingStep
         return new self(
             with: $this->with,
             table: $this->table,
+            schema: $this->schema,
             alias: $this->alias,
             using: $this->using,
             where: $this->where,
@@ -166,6 +178,7 @@ final readonly class DeleteBuilder implements DeleteFromStep, DeleteUsingStep
         return new self(
             with: $this->with,
             table: $this->table,
+            schema: $this->schema,
             alias: $this->alias,
             using: $this->using,
             where: $this->where,
@@ -185,6 +198,10 @@ final readonly class DeleteBuilder implements DeleteFromStep, DeleteUsingStep
             'relname' => $this->table,
             'inh' => true,
         ]);
+
+        if ($this->schema !== null) {
+            $rangeVar->setSchemaname($this->schema);
+        }
 
         if ($this->alias !== null) {
             $alias = new Alias([
@@ -242,6 +259,7 @@ final readonly class DeleteBuilder implements DeleteFromStep, DeleteUsingStep
         return new self(
             with: $this->with,
             table: $this->table,
+            schema: $this->schema,
             alias: $this->alias,
             using: $tables,
             where: $this->where,
@@ -254,6 +272,7 @@ final readonly class DeleteBuilder implements DeleteFromStep, DeleteUsingStep
         return new self(
             with: $this->with,
             table: $this->table,
+            schema: $this->schema,
             alias: $this->alias,
             using: $this->using,
             where: $condition,

--- a/src/lib/postgresql/src/Flow/PostgreSql/QueryBuilder/Merge/MergeBuilder.php
+++ b/src/lib/postgresql/src/Flow/PostgreSql/QueryBuilder/Merge/MergeBuilder.php
@@ -27,6 +27,7 @@ final readonly class MergeBuilder implements MergeIntoStep, MergeOnStep, MergeUs
         private ?string $schema = null,
         private ?string $tableAlias = null,
         private ?string $sourceTable = null,
+        private ?string $sourceSchema = null,
         private ?SelectFinalStep $sourceSelect = null,
         private ?string $sourceAlias = null,
         private ?Condition $joinCondition = null,
@@ -52,6 +53,7 @@ final readonly class MergeBuilder implements MergeIntoStep, MergeOnStep, MergeUs
             $this->schema,
             $this->tableAlias,
             $this->sourceTable,
+            $this->sourceSchema,
             $this->sourceSelect,
             $this->sourceAlias,
             $this->joinCondition,
@@ -69,6 +71,7 @@ final readonly class MergeBuilder implements MergeIntoStep, MergeOnStep, MergeUs
             $identifier->schema(),
             $alias,
             $this->sourceTable,
+            $this->sourceSchema,
             $this->sourceSelect,
             $this->sourceAlias,
             $this->joinCondition,
@@ -84,6 +87,7 @@ final readonly class MergeBuilder implements MergeIntoStep, MergeOnStep, MergeUs
             $this->schema,
             $this->tableAlias,
             $this->sourceTable,
+            $this->sourceSchema,
             $this->sourceSelect,
             $this->sourceAlias,
             $condition,
@@ -148,6 +152,11 @@ final readonly class MergeBuilder implements MergeIntoStep, MergeOnStep, MergeUs
                 'relname' => $this->sourceTable ?? '',
                 'inh' => true,
             ]);
+
+            if ($this->sourceSchema !== null) {
+                $sourceRangeVar->setSchemaname($this->sourceSchema);
+            }
+
             $alias = new Alias();
             $alias->setAliasname($this->sourceAlias);
             $sourceRangeVar->setAlias($alias);
@@ -187,6 +196,7 @@ final readonly class MergeBuilder implements MergeIntoStep, MergeOnStep, MergeUs
                 $this->schema,
                 $this->tableAlias,
                 null,
+                null,
                 $source,
                 $alias,
                 $this->joinCondition,
@@ -194,12 +204,15 @@ final readonly class MergeBuilder implements MergeIntoStep, MergeOnStep, MergeUs
             );
         }
 
+        $identifier = QualifiedIdentifier::parse($source);
+
         return new self(
             $this->with,
             $this->table,
             $this->schema,
             $this->tableAlias,
-            $source,
+            $identifier->name(),
+            $identifier->schema(),
             null,
             $alias,
             $this->joinCondition,

--- a/src/lib/postgresql/src/Flow/PostgreSql/QueryBuilder/Update/UpdateBuilder.php
+++ b/src/lib/postgresql/src/Flow/PostgreSql/QueryBuilder/Update/UpdateBuilder.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Flow\PostgreSql\QueryBuilder\Update;
 
 use Flow\PostgreSql\Protobuf\AST\{Alias, Node, RangeVar, ResTarget, UpdateStmt};
-use Flow\PostgreSql\QueryBuilder\AstToSql;
+use Flow\PostgreSql\QueryBuilder\{AstToSql, QualifiedIdentifier};
 use Flow\PostgreSql\QueryBuilder\Clause\WithClause;
 use Flow\PostgreSql\QueryBuilder\Condition\{Condition, ConditionFactory};
 use Flow\PostgreSql\QueryBuilder\Exception\{InvalidAstException, InvalidExpressionException};
@@ -27,6 +27,7 @@ final readonly class UpdateBuilder implements UpdateSetStep, UpdateTableStep
     private function __construct(
         private ?WithClause $with = null,
         private ?string $table = null,
+        private ?string $schema = null,
         private ?string $alias = null,
         private array $assignments = [],
         private array $from = [],
@@ -60,6 +61,12 @@ final readonly class UpdateBuilder implements UpdateSetStep, UpdateTableStep
 
         if ($table === '') {
             throw InvalidAstException::missingRequiredField('relname', 'RangeVar');
+        }
+
+        $schema = $relation->getSchemaname();
+
+        if ($schema === '') {
+            $schema = null;
         }
 
         $alias = null;
@@ -127,7 +134,7 @@ final readonly class UpdateBuilder implements UpdateSetStep, UpdateTableStep
             }
         }
 
-        return new self($with, $table, $alias, $assignments, $from, $where, $returning);
+        return new self($with, $table, $schema, $alias, $assignments, $from, $where, $returning);
     }
 
     public static function with(WithClause $with) : UpdateTableStep
@@ -140,6 +147,7 @@ final readonly class UpdateBuilder implements UpdateSetStep, UpdateTableStep
         return new self(
             with: $this->with,
             table: $this->table,
+            schema: $this->schema,
             alias: $this->alias,
             assignments: $this->assignments,
             from: $tables,
@@ -153,6 +161,7 @@ final readonly class UpdateBuilder implements UpdateSetStep, UpdateTableStep
         return new self(
             with: $this->with,
             table: $this->table,
+            schema: $this->schema,
             alias: $this->alias,
             assignments: $this->assignments,
             from: $this->from,
@@ -171,6 +180,7 @@ final readonly class UpdateBuilder implements UpdateSetStep, UpdateTableStep
         return new self(
             with: $this->with,
             table: $this->table,
+            schema: $this->schema,
             alias: $this->alias,
             assignments: [...$this->assignments, $column => $value],
             from: $this->from,
@@ -184,6 +194,7 @@ final readonly class UpdateBuilder implements UpdateSetStep, UpdateTableStep
         return new self(
             with: $this->with,
             table: $this->table,
+            schema: $this->schema,
             alias: $this->alias,
             assignments: [...$this->assignments, ...$assignments],
             from: $this->from,
@@ -205,6 +216,10 @@ final readonly class UpdateBuilder implements UpdateSetStep, UpdateTableStep
         $updateStmt = new UpdateStmt();
 
         $rangeVar = new RangeVar(['relname' => $this->table, 'inh' => true]);
+
+        if ($this->schema !== null) {
+            $rangeVar->setSchemaname($this->schema);
+        }
 
         if ($this->alias !== null) {
             $aliasProto = new Alias(['aliasname' => $this->alias]);
@@ -271,9 +286,12 @@ final readonly class UpdateBuilder implements UpdateSetStep, UpdateTableStep
 
     public function update(string $table, ?string $alias = null) : UpdateSetStep
     {
+        $identifier = QualifiedIdentifier::parse($table);
+
         return new self(
             with: $this->with,
-            table: $table,
+            table: $identifier->name(),
+            schema: $identifier->schema(),
             alias: $alias,
             assignments: $this->assignments,
             from: $this->from,
@@ -287,6 +305,7 @@ final readonly class UpdateBuilder implements UpdateSetStep, UpdateTableStep
         return new self(
             with: $this->with,
             table: $this->table,
+            schema: $this->schema,
             alias: $this->alias,
             assignments: $this->assignments,
             from: $this->from,

--- a/src/lib/postgresql/tests/Flow/PostgreSql/Tests/Integration/QueryBuilder/Database/DeleteDatabaseTest.php
+++ b/src/lib/postgresql/tests/Flow/PostgreSql/Tests/Integration/QueryBuilder/Database/DeleteDatabaseTest.php
@@ -27,6 +27,10 @@ use function Flow\PostgreSql\DSL\{
 
 final class DeleteDatabaseTest extends DatabaseTestCase
 {
+    private const SCHEMA_NAME = 'flow_postgres_test_delete_schema';
+
+    private const SCHEMA_TABLE = 'flow_postgres_schema_logs';
+
     private const TABLE_ARCHIVE = 'flow_postgres_log_archive';
 
     private const TABLE_LOGS = 'flow_postgres_logs';
@@ -79,6 +83,7 @@ final class DeleteDatabaseTest extends DatabaseTestCase
     {
         $this->dropTableIfExists(self::TABLE_ARCHIVE);
         $this->dropTableIfExists(self::TABLE_LOGS);
+        $this->execute('DROP SCHEMA IF EXISTS ' . self::SCHEMA_NAME . ' CASCADE');
 
         parent::tearDown();
     }
@@ -157,6 +162,46 @@ final class DeleteDatabaseTest extends DatabaseTestCase
         self::assertArrayHasKey('level', $row);
         self::assertArrayHasKey('message', $row);
         self::assertArrayHasKey('created_at', $row);
+    }
+
+    public function test_delete_with_schema_qualified_table() : void
+    {
+        $this->execute('CREATE SCHEMA IF NOT EXISTS ' . self::SCHEMA_NAME);
+
+        $this->execute(
+            create()->table(self::SCHEMA_TABLE, self::SCHEMA_NAME)
+                ->column(column('id', data_type_serial()))
+                ->column(column('level', data_type_varchar(20))->notNull())
+                ->column(column('message', data_type_text()))
+                ->constraint(primary_key('id'))
+                ->toSql()
+        );
+
+        $this->execute(
+            insert()
+                ->into(self::SCHEMA_NAME . '.' . self::SCHEMA_TABLE)
+                ->columns('level', 'message')
+                ->values(literal('DEBUG'), literal('Test message'))
+                ->values(literal('INFO'), literal('Info message'))
+                ->toSql()
+        );
+
+        $query = delete()
+            ->from(self::SCHEMA_NAME . '.' . self::SCHEMA_TABLE)
+            ->where(eq(col('level'), literal('DEBUG')));
+
+        $result = $this->execute($query->toSql());
+
+        self::assertNotFalse($result);
+        self::assertSame(1, $this->affectedRows($result));
+
+        $check = $this->execute(
+            select(agg_count(star())->as('cnt'))
+                ->from(table(self::SCHEMA_TABLE, self::SCHEMA_NAME))
+                ->toSql()
+        );
+        $row = $this->fetchOne($check);
+        self::assertSame('1', $row['cnt']);
     }
 
     public function test_delete_with_using() : void

--- a/src/lib/postgresql/tests/Flow/PostgreSql/Tests/Integration/QueryBuilder/Database/InsertDatabaseTest.php
+++ b/src/lib/postgresql/tests/Flow/PostgreSql/Tests/Integration/QueryBuilder/Database/InsertDatabaseTest.php
@@ -26,6 +26,10 @@ use function Flow\PostgreSql\DSL\{
 
 final class InsertDatabaseTest extends DatabaseTestCase
 {
+    private const SCHEMA_NAME = 'flow_postgres_test_insert_schema';
+
+    private const SCHEMA_TABLE = 'flow_postgres_schema_products';
+
     private const TABLE_PRODUCTS = 'flow_postgres_products';
 
     protected function setUp() : void
@@ -48,6 +52,7 @@ final class InsertDatabaseTest extends DatabaseTestCase
     protected function tearDown() : void
     {
         $this->dropTableIfExists(self::TABLE_PRODUCTS);
+        $this->execute('DROP SCHEMA IF EXISTS ' . self::SCHEMA_NAME . ' CASCADE');
 
         parent::tearDown();
     }
@@ -188,5 +193,38 @@ final class InsertDatabaseTest extends DatabaseTestCase
         self::assertArrayHasKey('name', $row);
         self::assertArrayHasKey('price', $row);
         self::assertArrayHasKey('stock', $row);
+    }
+
+    public function test_insert_with_schema_qualified_table() : void
+    {
+        $this->execute('CREATE SCHEMA IF NOT EXISTS ' . self::SCHEMA_NAME);
+
+        $this->execute(
+            create()->table(self::SCHEMA_TABLE, self::SCHEMA_NAME)
+                ->column(column('id', data_type_serial()))
+                ->column(column('sku', data_type_varchar(50))->notNull())
+                ->column(column('name', data_type_varchar(100))->notNull())
+                ->constraint(primary_key('id'))
+                ->toSql()
+        );
+
+        $query = insert()
+            ->into(self::SCHEMA_NAME . '.' . self::SCHEMA_TABLE)
+            ->columns('sku', 'name')
+            ->values(literal('SCHEMA-SKU'), literal('Schema Product'));
+
+        $result = $this->execute($query->toSql());
+
+        self::assertNotFalse($result);
+        self::assertSame(1, $this->affectedRows($result));
+
+        $check = $this->execute(
+            select(col('name'))
+                ->from(table(self::SCHEMA_TABLE, self::SCHEMA_NAME))
+                ->where(eq(col('sku'), literal('SCHEMA-SKU')))
+                ->toSql()
+        );
+        $row = $this->fetchOne($check);
+        self::assertSame('Schema Product', $row['name']);
     }
 }

--- a/src/lib/postgresql/tests/Flow/PostgreSql/Tests/Integration/QueryBuilder/Database/MergeDatabaseTest.php
+++ b/src/lib/postgresql/tests/Flow/PostgreSql/Tests/Integration/QueryBuilder/Database/MergeDatabaseTest.php
@@ -25,6 +25,12 @@ use function Flow\PostgreSql\DSL\{
 
 final class MergeDatabaseTest extends DatabaseTestCase
 {
+    private const SCHEMA_NAME = 'flow_postgres_test_merge_schema';
+
+    private const SCHEMA_SOURCE = 'flow_postgres_schema_merge_source';
+
+    private const SCHEMA_TARGET = 'flow_postgres_schema_merge_target';
+
     private const TABLE_SOURCE = 'flow_postgres_merge_source';
 
     private const TABLE_TARGET = 'flow_postgres_merge_target';
@@ -75,6 +81,7 @@ final class MergeDatabaseTest extends DatabaseTestCase
     {
         $this->dropTableIfExists(self::TABLE_SOURCE);
         $this->dropTableIfExists(self::TABLE_TARGET);
+        $this->execute('DROP SCHEMA IF EXISTS ' . self::SCHEMA_NAME . ' CASCADE');
 
         parent::tearDown();
     }
@@ -271,5 +278,79 @@ final class MergeDatabaseTest extends DatabaseTestCase
         self::assertCount(2, $rows);
         self::assertSame('100', $rows[0]['value']);
         self::assertSame('250', $rows[1]['value']);
+    }
+
+    public function test_merge_with_schema_qualified_tables() : void
+    {
+        $this->execute('CREATE SCHEMA IF NOT EXISTS ' . self::SCHEMA_NAME);
+
+        $this->execute(
+            create()->table(self::SCHEMA_TARGET, self::SCHEMA_NAME)
+                ->column(column('id', data_type_serial()))
+                ->column(column('name', data_type_varchar(100))->notNull())
+                ->column(column('value', data_type_integer())->default(0))
+                ->constraint(primary_key('id'))
+                ->toSql()
+        );
+
+        $this->execute(
+            create()->table(self::SCHEMA_SOURCE, self::SCHEMA_NAME)
+                ->column(column('id', data_type_integer())->notNull())
+                ->column(column('name', data_type_varchar(100))->notNull())
+                ->column(column('value', data_type_integer())->default(0))
+                ->constraint(primary_key('id'))
+                ->toSql()
+        );
+
+        $this->execute(
+            insert()
+                ->into(self::SCHEMA_NAME . '.' . self::SCHEMA_TARGET)
+                ->columns('name', 'value')
+                ->values(literal('Target Row'), literal(100))
+                ->toSql()
+        );
+
+        $this->execute(
+            insert()
+                ->into(self::SCHEMA_NAME . '.' . self::SCHEMA_SOURCE)
+                ->columns('id', 'name', 'value')
+                ->values(literal(1), literal('Updated Row'), literal(200))
+                ->values(literal(2), literal('New Row'), literal(300))
+                ->toSql()
+        );
+
+        $query = merge(self::SCHEMA_NAME . '.' . self::SCHEMA_TARGET, 't')
+            ->using(self::SCHEMA_NAME . '.' . self::SCHEMA_SOURCE, 's')
+            ->on(eq(col('t.id'), col('s.id')))
+            ->whenMatched()
+            ->thenUpdate([
+                'name' => col('s.name'),
+                'value' => col('s.value'),
+            ])
+            ->whenNotMatched()
+            ->thenInsertValues([
+                'name' => col('s.name'),
+                'value' => col('s.value'),
+            ]);
+
+        $result = $this->execute($query->toSql());
+
+        self::assertNotFalse($result);
+        self::assertSame(2, $this->affectedRows($result));
+
+        $rows = $this->fetchAll(
+            $this->execute(
+                select(star())
+                    ->from(table(self::SCHEMA_TARGET, self::SCHEMA_NAME))
+                    ->orderBy(order_by(col('id')))
+                    ->toSql()
+            )
+        );
+
+        self::assertCount(2, $rows);
+        self::assertSame('Updated Row', $rows[0]['name']);
+        self::assertSame('200', $rows[0]['value']);
+        self::assertSame('New Row', $rows[1]['name']);
+        self::assertSame('300', $rows[1]['value']);
     }
 }

--- a/src/lib/postgresql/tests/Flow/PostgreSql/Tests/Integration/QueryBuilder/Database/SelectDatabaseTest.php
+++ b/src/lib/postgresql/tests/Flow/PostgreSql/Tests/Integration/QueryBuilder/Database/SelectDatabaseTest.php
@@ -29,6 +29,10 @@ use function Flow\PostgreSql\DSL\{
 
 final class SelectDatabaseTest extends DatabaseTestCase
 {
+    private const SCHEMA_NAME = 'flow_postgres_test_select_schema';
+
+    private const SCHEMA_TABLE = 'flow_postgres_schema_users';
+
     private const TABLE_ORDERS = 'flow_postgres_orders';
 
     private const TABLE_USERS = 'flow_postgres_users';
@@ -83,6 +87,7 @@ final class SelectDatabaseTest extends DatabaseTestCase
     {
         $this->dropTableIfExists(self::TABLE_ORDERS);
         $this->dropTableIfExists(self::TABLE_USERS);
+        $this->execute('DROP SCHEMA IF EXISTS ' . self::SCHEMA_NAME . ' CASCADE');
 
         parent::tearDown();
     }
@@ -206,6 +211,39 @@ final class SelectDatabaseTest extends DatabaseTestCase
         self::assertCount(2, $rows);
         self::assertSame('Bob Wilson', $rows[0]['name']);
         self::assertSame('John Doe', $rows[1]['name']);
+    }
+
+    public function test_select_with_schema_qualified_table() : void
+    {
+        $this->execute('CREATE SCHEMA IF NOT EXISTS ' . self::SCHEMA_NAME);
+
+        $this->execute(
+            create()->table(self::SCHEMA_TABLE, self::SCHEMA_NAME)
+                ->column(column('id', data_type_serial()))
+                ->column(column('name', data_type_varchar(100))->notNull())
+                ->column(column('email', data_type_varchar(255)))
+                ->constraint(primary_key('id'))
+                ->toSql()
+        );
+
+        $this->execute(
+            insert()
+                ->into(self::SCHEMA_NAME . '.' . self::SCHEMA_TABLE)
+                ->columns('name', 'email')
+                ->values(literal('Schema User'), literal('schema@example.com'))
+                ->toSql()
+        );
+
+        $query = select(star())
+            ->from(table(self::SCHEMA_TABLE, self::SCHEMA_NAME));
+
+        $result = $this->execute($query->toSql());
+
+        self::assertNotFalse($result);
+        $rows = $this->fetchAll($result);
+        self::assertCount(1, $rows);
+        self::assertSame('Schema User', $rows[0]['name']);
+        self::assertSame('schema@example.com', $rows[0]['email']);
     }
 
     public function test_select_with_where() : void

--- a/src/lib/postgresql/tests/Flow/PostgreSql/Tests/Integration/QueryBuilder/Database/TruncateDatabaseTest.php
+++ b/src/lib/postgresql/tests/Flow/PostgreSql/Tests/Integration/QueryBuilder/Database/TruncateDatabaseTest.php
@@ -22,6 +22,10 @@ use function Flow\PostgreSql\DSL\{
 
 final class TruncateDatabaseTest extends DatabaseTestCase
 {
+    private const SCHEMA_NAME = 'flow_postgres_test_truncate_schema';
+
+    private const SCHEMA_TABLE = 'flow_postgres_schema_truncate';
+
     private const TABLE_ONE = 'flow_postgres_truncate_one';
 
     private const TABLE_TWO = 'flow_postgres_truncate_two';
@@ -70,6 +74,7 @@ final class TruncateDatabaseTest extends DatabaseTestCase
     {
         $this->dropTableIfExists(self::TABLE_TWO);
         $this->dropTableIfExists(self::TABLE_ONE);
+        $this->execute('DROP SCHEMA IF EXISTS ' . self::SCHEMA_NAME . ' CASCADE');
 
         parent::tearDown();
     }
@@ -239,5 +244,47 @@ final class TruncateDatabaseTest extends DatabaseTestCase
         );
 
         self::assertSame('1', $row['id']);
+    }
+
+    public function test_truncate_with_schema_qualified_table() : void
+    {
+        $this->execute('CREATE SCHEMA IF NOT EXISTS ' . self::SCHEMA_NAME);
+
+        $this->execute(
+            create()->table(self::SCHEMA_TABLE, self::SCHEMA_NAME)
+                ->column(column('id', data_type_serial()))
+                ->column(column('name', data_type_varchar(100))->notNull())
+                ->constraint(primary_key('id'))
+                ->toSql()
+        );
+
+        $this->execute(
+            insert()
+                ->into(self::SCHEMA_NAME . '.' . self::SCHEMA_TABLE)
+                ->columns('name')
+                ->values(literal('Row 1'))
+                ->values(literal('Row 2'))
+                ->toSql()
+        );
+
+        $rows = $this->fetchAll(
+            $this->execute(
+                select(star())->from(table(self::SCHEMA_TABLE, self::SCHEMA_NAME))->toSql()
+            )
+        );
+        self::assertCount(2, $rows);
+
+        $result = $this->execute(
+            truncate_table(self::SCHEMA_NAME . '.' . self::SCHEMA_TABLE)->toSql()
+        );
+
+        self::assertNotFalse($result);
+
+        $rows = $this->fetchAll(
+            $this->execute(
+                select(star())->from(table(self::SCHEMA_TABLE, self::SCHEMA_NAME))->toSql()
+            )
+        );
+        self::assertCount(0, $rows);
     }
 }

--- a/src/lib/postgresql/tests/Flow/PostgreSql/Tests/Integration/QueryBuilder/Database/UpdateDatabaseTest.php
+++ b/src/lib/postgresql/tests/Flow/PostgreSql/Tests/Integration/QueryBuilder/Database/UpdateDatabaseTest.php
@@ -27,6 +27,10 @@ use function Flow\PostgreSql\DSL\{
 
 final class UpdateDatabaseTest extends DatabaseTestCase
 {
+    private const SCHEMA_NAME = 'flow_postgres_test_update_schema';
+
+    private const SCHEMA_TABLE = 'flow_postgres_schema_employees';
+
     private const TABLE_DEPARTMENTS = 'flow_postgres_departments';
 
     private const TABLE_EMPLOYEES = 'flow_postgres_employees';
@@ -81,6 +85,7 @@ final class UpdateDatabaseTest extends DatabaseTestCase
     {
         $this->dropTableIfExists(self::TABLE_EMPLOYEES);
         $this->dropTableIfExists(self::TABLE_DEPARTMENTS);
+        $this->execute('DROP SCHEMA IF EXISTS ' . self::SCHEMA_NAME . ' CASCADE');
 
         parent::tearDown();
     }
@@ -185,6 +190,47 @@ final class UpdateDatabaseTest extends DatabaseTestCase
         self::assertArrayHasKey('department_id', $row);
         self::assertArrayHasKey('status', $row);
         self::assertSame('reviewed', $row['status']);
+    }
+
+    public function test_update_with_schema_qualified_table() : void
+    {
+        $this->execute('CREATE SCHEMA IF NOT EXISTS ' . self::SCHEMA_NAME);
+
+        $this->execute(
+            create()->table(self::SCHEMA_TABLE, self::SCHEMA_NAME)
+                ->column(column('id', data_type_serial()))
+                ->column(column('name', data_type_varchar(100))->notNull())
+                ->column(column('status', data_type_varchar(50))->default('active'))
+                ->constraint(primary_key('id'))
+                ->toSql()
+        );
+
+        $this->execute(
+            insert()
+                ->into(self::SCHEMA_NAME . '.' . self::SCHEMA_TABLE)
+                ->columns('name', 'status')
+                ->values(literal('Alice'), literal('active'))
+                ->toSql()
+        );
+
+        $query = update()
+            ->update(self::SCHEMA_NAME . '.' . self::SCHEMA_TABLE)
+            ->set('status', literal('updated'))
+            ->where(eq(col('name'), literal('Alice')));
+
+        $result = $this->execute($query->toSql());
+
+        self::assertNotFalse($result);
+        self::assertSame(1, $this->affectedRows($result));
+
+        $check = $this->execute(
+            select(col('status'))
+                ->from(table(self::SCHEMA_TABLE, self::SCHEMA_NAME))
+                ->where(eq(col('name'), literal('Alice')))
+                ->toSql()
+        );
+        $row = $this->fetchOne($check);
+        self::assertSame('updated', $row['status']);
     }
 
     public function test_update_with_where() : void

--- a/src/lib/postgresql/tests/Flow/PostgreSql/Tests/Unit/QueryBuilder/Delete/DeleteBuilderTest.php
+++ b/src/lib/postgresql/tests/Flow/PostgreSql/Tests/Unit/QueryBuilder/Delete/DeleteBuilderTest.php
@@ -284,6 +284,51 @@ final class DeleteBuilderTest extends TestCase
         self::assertSame('DELETE FROM sessions WHERE expired = true RETURNING id', $deparsed);
     }
 
+    public function test_delete_with_schema() : void
+    {
+        $query = DeleteBuilder::create()
+            ->from('myschema.users');
+
+        $ast = $query->toAst();
+
+        $relation = $ast->getRelation();
+        self::assertNotNull($relation);
+        self::assertSame('users', $relation->getRelname());
+        self::assertSame('myschema', $relation->getSchemaname());
+    }
+
+    public function test_delete_with_schema_deparsed_output() : void
+    {
+        if (!\function_exists('pg_query_deparse')) {
+            self::markTestSkipped('pg_query_deparse function not available.');
+        }
+
+        $query = DeleteBuilder::create()
+            ->from('public.users');
+
+        $deparsed = $this->deparse($query->toAst());
+        self::assertSame('DELETE FROM public.users', $deparsed);
+    }
+
+    public function test_delete_with_schema_round_trip() : void
+    {
+        $original = DeleteBuilder::create()
+            ->from('myschema.users');
+
+        $ast = $original->toAst();
+        $restored = DeleteBuilder::fromAst($ast);
+        $restoredAst = $restored->toAst();
+
+        $originalRelation = $ast->getRelation();
+        self::assertNotNull($originalRelation);
+
+        $restoredRelation = $restoredAst->getRelation();
+        self::assertNotNull($restoredRelation);
+
+        self::assertSame($originalRelation->getRelname(), $restoredRelation->getRelname());
+        self::assertSame($originalRelation->getSchemaname(), $restoredRelation->getSchemaname());
+    }
+
     public function test_delete_with_using() : void
     {
         $query = DeleteBuilder::create()

--- a/src/lib/postgresql/tests/Flow/PostgreSql/Tests/Unit/QueryBuilder/Merge/MergeBuilderTest.php
+++ b/src/lib/postgresql/tests/Flow/PostgreSql/Tests/Unit/QueryBuilder/Merge/MergeBuilderTest.php
@@ -144,6 +144,30 @@ final class MergeBuilderTest extends TestCase
         self::assertSame(3, MergeMatchKind::NOT_MATCHED_BY_TARGET->value);
     }
 
+    public function test_merge_using_parses_schema_and_table() : void
+    {
+        $query = MergeBuilder::create()
+            ->into('target', 't')
+            ->using('myschema.source', 's')
+            ->on(new Comparison(Column::tableColumn('t', 'id'), ComparisonOperator::EQ, Column::tableColumn('s', 'id')))
+            ->whenMatched()
+            ->thenDoNothing();
+
+        $ast = $query->toAst();
+
+        $sourceRelation = $ast->getSourceRelation();
+        self::assertNotNull($sourceRelation);
+
+        $rangeVar = $sourceRelation->getRangeVar();
+        self::assertNotNull($rangeVar);
+        self::assertSame('source', $rangeVar->getRelname());
+        self::assertSame('myschema', $rangeVar->getSchemaname());
+
+        $alias = $rangeVar->getAlias();
+        self::assertNotNull($alias);
+        self::assertSame('s', $alias->getAliasname());
+    }
+
     public function test_merge_when_clause_data_structure() : void
     {
         $condition = new Comparison(Column::name('id'), ComparisonOperator::EQ, Literal::int(1));

--- a/src/lib/postgresql/tests/Flow/PostgreSql/Tests/Unit/QueryBuilder/Update/UpdateBuilderTest.php
+++ b/src/lib/postgresql/tests/Flow/PostgreSql/Tests/Unit/QueryBuilder/Update/UpdateBuilderTest.php
@@ -588,6 +588,57 @@ final class UpdateBuilderTest extends TestCase
         self::assertSame('UPDATE users SET last_login = now() WHERE id = 1 RETURNING id, last_login', $deparsed);
     }
 
+    public function test_update_with_schema() : void
+    {
+        $query = UpdateBuilder::create()
+            ->update('myschema.users')
+            ->set('name', Literal::string('John'))
+            ->setAll([]);
+
+        $ast = $query->toAst();
+
+        $relation = $ast->getRelation();
+        self::assertNotNull($relation);
+        self::assertSame('users', $relation->getRelname());
+        self::assertSame('myschema', $relation->getSchemaname());
+    }
+
+    public function test_update_with_schema_deparsed_output() : void
+    {
+        if (!\function_exists('pg_query_deparse')) {
+            self::markTestSkipped('pg_query_deparse function not available.');
+        }
+
+        $query = UpdateBuilder::create()
+            ->update('public.users')
+            ->set('name', Literal::string('John'))
+            ->setAll([]);
+
+        $deparsed = $this->deparse($query->toAst());
+        self::assertSame("UPDATE public.users SET name = 'John'", $deparsed);
+    }
+
+    public function test_update_with_schema_round_trip() : void
+    {
+        $original = UpdateBuilder::create()
+            ->update('myschema.users')
+            ->set('name', Literal::string('John'))
+            ->setAll([]);
+
+        $ast = $original->toAst();
+        $restored = UpdateBuilder::fromAst($ast);
+        $restoredAst = $restored->toAst();
+
+        $originalRelation = $ast->getRelation();
+        self::assertNotNull($originalRelation);
+
+        $restoredRelation = $restoredAst->getRelation();
+        self::assertNotNull($restoredRelation);
+
+        self::assertSame($originalRelation->getRelname(), $restoredRelation->getRelname());
+        self::assertSame($originalRelation->getSchemaname(), $restoredRelation->getSchemaname());
+    }
+
     public function test_update_with_where() : void
     {
         $query = UpdateBuilder::create()


### PR DESCRIPTION
<!-- 
    Please replace #xxx with a GitHub issue id from flow-php/flow repository. For example #1234 
    If there is no item in a roadmap related to this PR, please check our contributing guidelines first. 
-->
Resolves: #xxx

<!-- 
    Below section will be used to automatically generate changelog, please do not modify HTML code structure
    DO NOT REMOVE that HTML STRUCTURE, INSTEAD ADD YOUR CHANGES INSIDE THE LISTS 
    PULL REQUESTS WITHOUT CHANGELOG CAN'T BE MERGED 
-->
<h2>Change Log</h2>
<hr /> 
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>support for explicit schemas in update/merge/delete query builders</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>