### PR TITLE
fix: readLines() dropping falsy values in S3 and Azure source streams

### DIFF
--- a/src/bridge/filesystem/async-aws/src/Flow/Filesystem/Bridge/AsyncAWS/AsyncAWSS3SourceStream.php
+++ b/src/bridge/filesystem/async-aws/src/Flow/Filesystem/Bridge/AsyncAWS/AsyncAWSS3SourceStream.php
@@ -72,18 +72,16 @@ final class AsyncAWSS3SourceStream implements SourceStream
             }
 
             if (\substr_count($content, $separator) > 1) {
-                /**
-                 * @phpstan-ignore-next-line
-                 */
-                $lines = \array_filter(\explode($separator, $content));
+                /** @phpstan-ignore argument.type */
+                $lines = \explode($separator, $content);
 
-                // Yield all lines except the last one
-                foreach (\array_slice($lines, 0, -1) as $line) {
-                    yield $line;
+                $lastIndex = \count($lines) - 1;
+
+                for ($i = 0; $i < $lastIndex; $i++) {
+                    yield $lines[$i];
                 }
 
-                // The last line is incomplete, so we need to keep it for the next iteration
-                $content = \end($lines);
+                $content = $lines[$lastIndex];
             } elseif (\substr_count($content, $separator) === 1) {
                 // Split the content by the separator
                 /**

--- a/src/bridge/filesystem/async-aws/tests/Flow/Filesystem/Bridge/AsyncAWS/Tests/Integration/AsyncAWSS3SourceStreamTest.php
+++ b/src/bridge/filesystem/async-aws/tests/Flow/Filesystem/Bridge/AsyncAWS/Tests/Integration/AsyncAWSS3SourceStreamTest.php
@@ -85,4 +85,18 @@ TEXT;
 
         $stream->close();
     }
+
+    public function test_reading_lines_with_falsy_values_preserves_all_lines() : void
+    {
+        $content = "header\n0\n\nvalue\n0\nlast";
+        $this->givenFileExists(path('aws-s3://falsy.csv'), $content);
+
+        $stream = aws_s3_filesystem($this->bucket(), $this->s3Client())->readFrom(path('aws-s3://falsy.csv'));
+
+        $lines = \iterator_to_array($stream->readLines());
+
+        self::assertSame(['header', '0', '', 'value', '0', 'last'], $lines);
+
+        $stream->close();
+    }
 }

--- a/src/bridge/filesystem/azure/src/Flow/Filesystem/Bridge/Azure/AzureBlobSourceStream.php
+++ b/src/bridge/filesystem/azure/src/Flow/Filesystem/Bridge/Azure/AzureBlobSourceStream.php
@@ -74,18 +74,16 @@ final class AzureBlobSourceStream implements SourceStream
             }
 
             if (\substr_count($content, $separator) > 1) {
-                /**
-                 * @phpstan-ignore-next-line
-                 */
-                $lines = \array_filter(\explode($separator, $content));
+                /** @phpstan-ignore argument.type */
+                $lines = \explode($separator, $content);
 
-                // Yield all lines except the last one
-                foreach (\array_slice($lines, 0, -1) as $line) {
-                    yield $line;
+                $lastIndex = \count($lines) - 1;
+
+                for ($i = 0; $i < $lastIndex; $i++) {
+                    yield $lines[$i];
                 }
 
-                // The last line is incomplete, so we need to keep it for the next iteration
-                $content = \end($lines);
+                $content = $lines[$lastIndex];
             } elseif (\substr_count($content, $separator) === 1) {
                 // Split the content by the separator
                 /**

--- a/src/bridge/filesystem/azure/tests/Flow/Filesystem/Bridge/Azure/Tests/Integration/AzureBlobSourceStreamTest.php
+++ b/src/bridge/filesystem/azure/tests/Flow/Filesystem/Bridge/Azure/Tests/Integration/AzureBlobSourceStreamTest.php
@@ -85,4 +85,18 @@ TEXT;
 
         $stream->close();
     }
+
+    public function test_reading_lines_with_falsy_values_preserves_all_lines() : void
+    {
+        $content = "header\n0\n\nvalue\n0\nlast";
+        $this->givenFileExists('flow-php', 'falsy.csv', $content);
+
+        $stream = azure_filesystem($this->blobService('flow-php'))->readFrom(path('azure-blob://falsy.csv'));
+
+        $lines = \iterator_to_array($stream->readLines());
+
+        self::assertSame(['header', '0', '', 'value', '0', 'last'], $lines);
+
+        $stream->close();
+    }
 }


### PR DESCRIPTION
<!-- 
    Below section will be used to automatically generate changelog, please do not modify HTML code structure
    DO NOT REMOVE that HTML STRUCTURE, INSTEAD ADD YOUR CHANGES INSIDE THE LISTS 
    PULL REQUESTS WITHOUT CHANGELOG CAN'T BE MERGED 
-->
<h2>Change Log</h2>
<hr /> 
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>readLines() dropping falsy values in S3 and Azure source streams</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>

--- 

array_filter() without callback was removing lines containing '0' or empty strings, causing schema detection to produce different results compared to local filesystem.