### PR TITLE
fix: arrow-ext installation through pie

### DIFF
--- a/src/extension/arrow-ext/ext/Makefile.frag
+++ b/src/extension/arrow-ext/ext/Makefile.frag
@@ -1,0 +1,16 @@
+# Build the actual extension via Cargo (Rust) and replace the dummy .so
+# This runs after PHP's build system compiles the dummy arrow.c
+
+ARROW_CARGO_DIR = $(srcdir)/..
+
+all: cargo_build_arrow
+
+.PHONY: cargo_build_arrow
+cargo_build_arrow: $(phplibdir)/arrow.so
+	cd "$(ARROW_CARGO_DIR)" && cargo build --release
+	@if [ "$$(uname)" = "Darwin" ]; then \
+		cp "$(ARROW_CARGO_DIR)/target/release/libarrow.dylib" "$(phplibdir)/arrow.so"; \
+	else \
+		cp "$(ARROW_CARGO_DIR)/target/release/libarrow.so" "$(phplibdir)/arrow.so"; \
+	fi
+	@echo "Replaced dummy arrow.so with Rust-built extension"

--- a/src/extension/arrow-ext/ext/Makefile.frag
+++ b/src/extension/arrow-ext/ext/Makefile.frag
@@ -7,7 +7,7 @@ all: cargo_build_arrow
 
 .PHONY: cargo_build_arrow
 cargo_build_arrow: $(phplibdir)/arrow.so
-	cd "$(ARROW_CARGO_DIR)" && cargo build --release
+	cd "$(ARROW_CARGO_DIR)" && PHP_CONFIG="$$(which php-config)" PHP="$$(which php)" cargo build --release
 	@if [ "$$(uname)" = "Darwin" ]; then \
 		cp "$(ARROW_CARGO_DIR)/target/release/libarrow.dylib" "$(phplibdir)/arrow.so"; \
 	else \

--- a/src/extension/arrow-ext/ext/config.m4
+++ b/src/extension/arrow-ext/ext/config.m4
@@ -1,5 +1,4 @@
 dnl config.m4 for extension arrow (Rust-based via ext-php-rs)
-dnl This is a best-effort PIE compatibility shim delegating to cargo
 
 PHP_ARG_ENABLE([arrow],
   [whether to enable arrow support],
@@ -8,41 +7,37 @@ PHP_ARG_ENABLE([arrow],
 
 if test "$PHP_ARROW" != "no"; then
   AC_MSG_CHECKING([for cargo (Rust build tool)])
-  AC_PATH_PROG(CARGO, cargo, no)
-  if test "$CARGO" = "no"; then
+  AC_PATH_PROG(CARGO, cargo)
+  if test -z "$CARGO"; then
+    RUSTUP_CARGO=$(rustup which cargo 2>/dev/null)
+    if test -n "$RUSTUP_CARGO"; then
+      CARGO=$RUSTUP_CARGO
+    fi
+  fi
+  if test -z "$CARGO"; then
     AC_MSG_ERROR([cargo is required to build the arrow extension. Install Rust from https://rustup.rs/])
   fi
   AC_MSG_RESULT([$CARGO])
 
-  dnl Build via cargo in the parent directory (where Cargo.toml lives)
-  EXT_DIR=$(pwd)
-  ARROW_SRC_DIR=$(dirname "$EXT_DIR")
-
-  AC_MSG_NOTICE([Building arrow extension via cargo...])
-  (cd "$ARROW_SRC_DIR" && $CARGO build --release) || AC_MSG_ERROR([cargo build failed])
-
-  dnl Detect the built library
-  case $host_os in
-    darwin*)
-      ARROW_LIB="$ARROW_SRC_DIR/target/release/libarrow.dylib"
-      ;;
-    *)
-      ARROW_LIB="$ARROW_SRC_DIR/target/release/libarrow.so"
-      ;;
-  esac
-
-  if test ! -f "$ARROW_LIB"; then
-    AC_MSG_ERROR([Built library not found at $ARROW_LIB])
+  AC_MSG_CHECKING([for rustc (Rust compiler)])
+  AC_PATH_PROG(RUSTC, rustc)
+  if test -z "$RUSTC"; then
+    RUSTUP_RUSTC=$(rustup which rustc 2>/dev/null)
+    if test -n "$RUSTUP_RUSTC"; then
+      RUSTC=$RUSTUP_RUSTC
+    fi
   fi
-
-  dnl Copy built library to expected location
-  mkdir -p "$EXT_DIR/modules"
-  cp "$ARROW_LIB" "$EXT_DIR/modules/arrow.so"
+  if test -z "$RUSTC"; then
+    AC_MSG_ERROR([rustc is required to build the arrow extension. Install Rust from https://rustup.rs/])
+  fi
+  AC_MSG_RESULT([$RUSTC])
 
   dnl Create a dummy C file so phpize/configure infrastructure does not complain
-  if test ! -f "$EXT_DIR/arrow.c"; then
-    echo "/* Dummy - actual extension built by Rust/cargo */" > "$EXT_DIR/arrow.c"
+  ARROW_EXT_DIR=$(pwd)
+  if test ! -f "$ARROW_EXT_DIR/arrow.c"; then
+    echo "/* Dummy - actual extension built by Rust/cargo */" > "$ARROW_EXT_DIR/arrow.c"
   fi
 
   PHP_NEW_EXTENSION(arrow, arrow.c, $ext_shared)
+  PHP_ADD_MAKEFILE_FRAGMENT
 fi


### PR DESCRIPTION
<!-- 
    Below section will be used to automatically generate changelog, please do not modify HTML code structure
    DO NOT REMOVE that HTML STRUCTURE, INSTEAD ADD YOUR CHANGES INSIDE THE LISTS 
    PULL REQUESTS WITHOUT CHANGELOG CAN'T BE MERGED 
-->
<h2>Change Log</h2>
<hr /> 
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>arrow-ext installation through pie</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>

The solutions is based on `masakielastic/php-ext-hello-rust` and and `ptondereau/biscuit-php` 