### PR TITLE
fix: missing interfaces/exceptions in arrow-ext

### DIFF
--- a/src/extension/arrow-ext/Cargo.lock
+++ b/src/extension/arrow-ext/Cargo.lock
@@ -519,9 +519,9 @@ dependencies = [
 
 [[package]]
 name = "ext-php-rs"
-version = "0.15.7"
+version = "0.15.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83b57e00633bee412187a6c91888906c34a4dc11901b7c978fdcf572591c59b1"
+checksum = "4cac21b7a62e6b23f4b14241cdda38ef8a321da093ac2cad3fd66775324baa20"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -548,7 +548,7 @@ dependencies = [
  "bitflags",
  "cexpr",
  "ext-php-rs-clang-sys",
- "itertools 0.13.0",
+ "itertools",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -581,13 +581,13 @@ dependencies = [
 
 [[package]]
 name = "ext-php-rs-derive"
-version = "0.11.9"
+version = "0.11.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6f16a7ba2aa9026014c70402fafc0782f3ed3144a0e09eacfca8ed21bbadc1"
+checksum = "67eabe5d508fde240a60d9e4476e9dfab25d6320e32949a3102e509347460864"
 dependencies = [
  "convert_case",
  "darling",
- "itertools 0.14.0",
+ "itertools",
  "proc-macro2",
  "quote",
  "syn",
@@ -829,15 +829,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "009ae045c87e7082cb72dab0ccd01ae075dd00141ddc108f43a0ea150a9e7227"
 dependencies = [
  "rustversion",
-]
-
-[[package]]
-name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
 ]
 
 [[package]]

--- a/src/extension/arrow-ext/php/Flow/Arrow/OutputStream.php
+++ b/src/extension/arrow-ext/php/Flow/Arrow/OutputStream.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace Flow\Arrow;
 
+if (\extension_loaded('arrow')) {
+    return;
+}
+
 interface OutputStream
 {
     public function append(string $data) : self;

--- a/src/extension/arrow-ext/php/Flow/Arrow/Parquet/Exception.php
+++ b/src/extension/arrow-ext/php/Flow/Arrow/Parquet/Exception.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace Flow\Arrow\Parquet;
 
-final class Exception extends \RuntimeException
+if (\extension_loaded('arrow')) {
+    return;
+}
+
+final class Exception extends \Exception
 {
 }

--- a/src/extension/arrow-ext/php/Flow/Arrow/RandomAccessFile.php
+++ b/src/extension/arrow-ext/php/Flow/Arrow/RandomAccessFile.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace Flow\Arrow;
 
+if (\extension_loaded('arrow')) {
+    return;
+}
+
 interface RandomAccessFile
 {
     public function read(int $length, int $offset) : string;

--- a/src/extension/arrow-ext/src/lib.rs
+++ b/src/extension/arrow-ext/src/lib.rs
@@ -21,7 +21,24 @@ pub extern "C" fn php_module_info(_module: *mut ModuleEntry) {
     info_table_end!();
 }
 
+pub unsafe extern "C" fn module_startup(_type: i32, _module_number: i32) -> i32 {
+    if let Err(e) = stream::output_stream::register() {
+        eprintln!("arrow: failed to register Flow\\Arrow\\OutputStream: {e}");
+        return -1;
+    }
+    if let Err(e) = stream::random_access_file::register() {
+        eprintln!("arrow: failed to register Flow\\Arrow\\RandomAccessFile: {e}");
+        return -1;
+    }
+    if let Err(e) = parquet::exception::register() {
+        eprintln!("arrow: failed to register Flow\\Arrow\\Parquet\\Exception: {e}");
+        return -1;
+    }
+    0
+}
+
 #[php_module]
+#[php(startup = "module_startup")]
 pub fn get_module(module: ModuleBuilder) -> ModuleBuilder {
     module
         .info_function(php_module_info)

--- a/src/extension/arrow-ext/src/parquet/exception.rs
+++ b/src/extension/arrow-ext/src/parquet/exception.rs
@@ -1,5 +1,20 @@
+use ext_php_rs::builders::ClassBuilder;
+use ext_php_rs::error::Result;
 use ext_php_rs::exception::PhpException;
+use ext_php_rs::flags::ClassFlags;
 use ext_php_rs::zend::{ce, ClassEntry};
+
+fn noop(_ce: &'static mut ClassEntry) {}
+
+pub fn register() -> Result<()> {
+    ClassBuilder::new("Flow\\Arrow\\Parquet\\Exception")
+        .extends((ce::exception, "Exception"))
+        .flags(ClassFlags::Final)
+        .registration(noop)
+        .register()?;
+
+    Ok(())
+}
 
 fn parquet_exception_ce() -> &'static ClassEntry {
     ClassEntry::try_find("Flow\\Arrow\\Parquet\\Exception")

--- a/src/extension/arrow-ext/src/stream/mod.rs
+++ b/src/extension/arrow-ext/src/stream/mod.rs
@@ -1,2 +1,4 @@
+pub mod output_stream;
 pub mod php_destination_stream;
 pub mod php_source_stream;
+pub mod random_access_file;

--- a/src/extension/arrow-ext/src/stream/output_stream.rs
+++ b/src/extension/arrow-ext/src/stream/output_stream.rs
@@ -1,0 +1,22 @@
+use ext_php_rs::args::Arg;
+use ext_php_rs::builders::{ClassBuilder, FunctionBuilder};
+use ext_php_rs::error::Result;
+use ext_php_rs::flags::{ClassFlags, DataType, MethodFlags};
+use ext_php_rs::zend::ClassEntry;
+
+fn noop(_ce: &'static mut ClassEntry) {}
+
+pub fn register() -> Result<()> {
+    ClassBuilder::new("Flow\\Arrow\\OutputStream")
+        .flags(ClassFlags::Interface)
+        .registration(noop)
+        .method(
+            FunctionBuilder::new_abstract("append")
+                .arg(Arg::new("data", DataType::String))
+                .returns(DataType::Object(Some("self")), false, false),
+            MethodFlags::Public | MethodFlags::Abstract,
+        )
+        .register()?;
+
+    Ok(())
+}

--- a/src/extension/arrow-ext/src/stream/random_access_file.rs
+++ b/src/extension/arrow-ext/src/stream/random_access_file.rs
@@ -1,0 +1,28 @@
+use ext_php_rs::args::Arg;
+use ext_php_rs::builders::{ClassBuilder, FunctionBuilder};
+use ext_php_rs::error::Result;
+use ext_php_rs::flags::{ClassFlags, DataType, MethodFlags};
+use ext_php_rs::zend::ClassEntry;
+
+fn noop(_ce: &'static mut ClassEntry) {}
+
+pub fn register() -> Result<()> {
+    ClassBuilder::new("Flow\\Arrow\\RandomAccessFile")
+        .flags(ClassFlags::Interface)
+        .registration(noop)
+        .method(
+            FunctionBuilder::new_abstract("read")
+                .arg(Arg::new("length", DataType::Long))
+                .arg(Arg::new("offset", DataType::Long))
+                .returns(DataType::String, false, false),
+            MethodFlags::Public | MethodFlags::Abstract,
+        )
+        .method(
+            FunctionBuilder::new_abstract("size")
+                .returns(DataType::Long, false, true),
+            MethodFlags::Public | MethodFlags::Abstract,
+        )
+        .register()?;
+
+    Ok(())
+}

--- a/src/extension/arrow-ext/tests/phpt/036_interfaces_and_exception_registered.phpt
+++ b/src/extension/arrow-ext/tests/phpt/036_interfaces_and_exception_registered.phpt
@@ -1,0 +1,30 @@
+--TEST--
+arrow extension registers OutputStream, RandomAccessFile interfaces and Parquet\Exception class
+--SKIPIF--
+<?php if (!extension_loaded("arrow")) die("skip arrow extension not loaded"); ?>
+--FILE--
+<?php
+var_dump(interface_exists('Flow\Arrow\OutputStream', false));
+var_dump(interface_exists('Flow\Arrow\RandomAccessFile', false));
+var_dump(class_exists('Flow\Arrow\Parquet\Exception', false));
+var_dump(is_subclass_of('Flow\Arrow\Parquet\Exception', \Exception::class));
+
+$r = new ReflectionClass('Flow\Arrow\OutputStream');
+var_dump($r->isInterface());
+var_dump($r->hasMethod('append'));
+
+$r = new ReflectionClass('Flow\Arrow\RandomAccessFile');
+var_dump($r->isInterface());
+var_dump($r->hasMethod('read'));
+var_dump($r->hasMethod('size'));
+?>
+--EXPECT--
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)


### PR DESCRIPTION
<h2>Change Log</h2>
<hr /> 
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>missing interfaces/exceptions in arrow-ext</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>updated ext-php-rs in arrow-ext</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>