### PR TITLE
fix: using type_array for structure array like assertions

### DIFF
--- a/src/lib/types/src/Flow/Types/Type/Comparator.php
+++ b/src/lib/types/src/Flow/Types/Type/Comparator.php
@@ -14,7 +14,7 @@ use Flow\Types\Type\Logical\{DateTimeType,
     OptionalType,
     StructureType,
     TimeType};
-use Flow\Types\Type\Native\{FloatType, IntegerType, NullType, StringType, UnionType};
+use Flow\Types\Type\Native\{ArrayType, FloatType, IntegerType, NullType, StringType, UnionType};
 
 final class Comparator
 {
@@ -66,6 +66,14 @@ final class Comparator
 
         if (\in_array($left::class, [StringType::class, JsonType::class], true) && \in_array($right::class, [StringType::class, JsonType::class], true)) {
             return true;
+        }
+
+        if ($left instanceof ArrayType) {
+            return $right instanceof ArrayType || $right instanceof ListType || $right instanceof MapType || $right instanceof StructureType;
+        }
+
+        if ($right instanceof ArrayType) {
+            return $left instanceof ListType || $left instanceof MapType || $left instanceof StructureType;
         }
 
         return type_equals($left, $right);

--- a/src/lib/types/tests/Flow/Types/Tests/Unit/Type/ComparatorTest.php
+++ b/src/lib/types/tests/Flow/Types/Tests/Unit/Type/ComparatorTest.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 
 namespace Flow\Types\Tests\Unit\Type;
 
-use function Flow\Types\DSL\{type_boolean,
+use function Flow\Types\DSL\{type_array,
+    type_boolean,
     type_equals,
     type_float,
     type_integer,
@@ -41,6 +42,14 @@ final class ComparatorTest extends TestCase
         yield [type_union(type_integer(), type_null()), type_integer()];
         yield [type_union(type_integer(), type_null()), type_float()];
         yield [type_integer(), type_string()];
+
+        yield [type_array(), type_array()];
+        yield [type_array(), type_list(type_string())];
+        yield [type_array(), type_map(type_string(), type_integer())];
+        yield [type_array(), type_structure(['id' => type_integer()])];
+        yield [type_list(type_string()), type_array()];
+        yield [type_map(type_string(), type_integer()), type_array()];
+        yield [type_structure(['id' => type_integer()]), type_array()];
     }
 
     public static function type_comparison_data_provider() : \Generator
@@ -70,6 +79,10 @@ final class ComparatorTest extends TestCase
     {
         yield [type_integer(), type_union(type_float(), type_integer())];
         yield [type_integer(), type_boolean()];
+        yield [type_array(), type_string()];
+        yield [type_array(), type_integer()];
+        yield [type_array(), type_boolean()];
+        yield [type_string(), type_array()];
     }
 
     /**

--- a/src/lib/types/tests/Flow/Types/Tests/Unit/Type/Logical/StructureTypeTest.php
+++ b/src/lib/types/tests/Flow/Types/Tests/Unit/Type/Logical/StructureTypeTest.php
@@ -4,13 +4,15 @@ declare(strict_types=1);
 
 namespace Flow\Types\Tests\Unit\Type\Logical;
 
-use function Flow\Types\DSL\{type_boolean,
+use function Flow\Types\DSL\{type_array,
+    type_boolean,
     type_datetime,
     type_float,
     type_from_array,
     type_integer,
     type_list,
     type_map,
+    type_mixed,
     type_optional,
     type_string,
     type_structure};
@@ -103,6 +105,52 @@ final class StructureTypeTest extends TestCase
         yield 'valid structure with extra field when allow_extra is true' => [
             'value' => ['id' => 1, 'name' => 'test', 'active' => false],
             'structureType' => type_structure(['id' => type_integer(), 'name' => type_string()], [], true),
+            'exceptionClass' => null,
+        ];
+
+        yield 'valid structure with type_array field containing a list of structures' => [
+            'value' => [
+                'id' => 'test-id',
+                'size' => 123,
+                'schema' => [
+                    ['ref' => 'col1', 'type' => ['key' => 'value'], 'metadata' => [], 'nullable' => true],
+                    ['ref' => 'col2', 'type' => ['key2' => 'value2'], 'metadata' => [], 'nullable' => false],
+                ],
+                'rows_count' => 10,
+                'processed_rows' => 5,
+                'synchronization_id' => 'sync-123',
+            ],
+            'structureType' => type_structure([
+                'id' => type_string(),
+                'size' => type_integer(),
+                'schema' => type_array(),
+                'rows_count' => type_integer(),
+                'processed_rows' => type_integer(),
+                'synchronization_id' => type_string(),
+            ]),
+            'exceptionClass' => null,
+        ];
+
+        yield 'valid structure with type_list(type_mixed()) field containing a list of structures' => [
+            'value' => [
+                'id' => 'test-id',
+                'size' => 123,
+                'schema' => [
+                    ['ref' => 'col1', 'type' => ['key' => 'value'], 'metadata' => [], 'nullable' => true],
+                    ['ref' => 'col2', 'type' => ['key2' => 'value2'], 'metadata' => [], 'nullable' => false],
+                ],
+                'rows_count' => 10,
+                'processed_rows' => 5,
+                'synchronization_id' => 'sync-123',
+            ],
+            'structureType' => type_structure([
+                'id' => type_string(),
+                'size' => type_integer(),
+                'schema' => type_list(type_mixed()),
+                'rows_count' => type_integer(),
+                'processed_rows' => type_integer(),
+                'synchronization_id' => type_string(),
+            ]),
             'exceptionClass' => null,
         ];
 


### PR DESCRIPTION

<!-- 
    Below section will be used to automatically generate changelog, please do not modify HTML code structure
    DO NOT REMOVE that HTML STRUCTURE, INSTEAD ADD YOUR CHANGES INSIDE THE LISTS 
    PULL REQUESTS WITHOUT CHANGELOG CAN'T BE MERGED 
-->
<h2>Change Log</h2>
<hr /> 
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>using type_array for structure array like assertions</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>