### PR TITLE
fix: preserve XML namespace declarations when capturing subtrees

### DIFF
--- a/src/adapter/etl-adapter-xml/src/Flow/ETL/Adapter/XML/XMLParserExtractor.php
+++ b/src/adapter/etl-adapter-xml/src/Flow/ETL/Adapter/XML/XMLParserExtractor.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Flow\ETL\Adapter\XML;
 
 use function Flow\ETL\DSL\array_to_rows;
+use function Flow\Types\DSL\type_string;
 use Flow\ETL\Exception\RuntimeException;
 use Flow\ETL\Extractor\{FileExtractor, Limitable, LimitableExtractor, PathFiltering, Signal};
 use Flow\ETL\{Extractor, FlowContext, Schema};
@@ -31,6 +32,11 @@ final class XMLParserExtractor implements Extractor, FileExtractor, LimitableExt
      * @var array<string>
      */
     private array $elements = [];
+
+    /**
+     * @var list<array<string, string>>
+     */
+    private array $namespaceStack = [];
 
     private ?\XMLParser $parser = null;
 
@@ -79,6 +85,7 @@ final class XMLParserExtractor implements Extractor, FileExtractor, LimitableExt
         }
 
         array_pop($this->currentPath);
+        array_pop($this->namespaceStack);
     }
 
     public function extract(FlowContext $context) : \Generator
@@ -165,21 +172,39 @@ final class XMLParserExtractor implements Extractor, FileExtractor, LimitableExt
     public function startElementHandler(\XMLParser $parser, string $name, array $attrs) : void
     {
         $this->currentPath[] = $name;
-        $currentPathString = implode('/', $this->currentPath);
 
-        if ($currentPathString === $this->xmlNodePath || ($this->xmlNodePath === '' && \count($this->currentPath) === 1)) {
+        $namespaceDeclarations = [];
+        $otherAttributes = [];
+
+        foreach ($attrs as $key => $value) {
+            if ($key === 'xmlns' || str_starts_with($key, 'xmlns:')) {
+                $namespaceDeclarations[$key] = \is_scalar($value) ? type_string()->cast($value) : '';
+            } else {
+                $otherAttributes[$key] = $value;
+            }
+        }
+
+        $this->namespaceStack[] = $namespaceDeclarations;
+
+        $isCapturedRoot = implode('/', $this->currentPath) === $this->xmlNodePath || ($this->xmlNodePath === '' && \count($this->currentPath) === 1);
+
+        if ($isCapturedRoot) {
             $this->capturing = true;
-            $this->writer()->startElement($name);
-
-            foreach ($attrs as $key => $value) {
-                $this->writer()->writeAttribute($key, \is_scalar($value) ? (string) $value : '');
-            }
+            $namespacesToEmit = array_merge(...$this->namespaceStack);
         } elseif ($this->capturing) {
-            $this->writer()->startElement($name);
+            $namespacesToEmit = $namespaceDeclarations;
+        } else {
+            return;
+        }
 
-            foreach ($attrs as $key => $value) {
-                $this->writer()->writeAttribute($key, \is_scalar($value) ? (string) $value : '');
-            }
+        $this->writer()->startElement($name);
+
+        foreach ($namespacesToEmit as $nsKey => $nsValue) {
+            $this->writer()->writeAttribute($nsKey, $nsValue);
+        }
+
+        foreach ($otherAttributes as $key => $value) {
+            $this->writer()->writeAttribute($key, \is_scalar($value) ? type_string()->cast($value) : '');
         }
     }
 
@@ -221,6 +246,9 @@ final class XMLParserExtractor implements Extractor, FileExtractor, LimitableExt
             xml_parser_free($this->parser);
             $this->parser = null;
         }
+
+        $this->namespaceStack = [];
+        $this->currentPath = [];
     }
 
     private function parser() : \XMLParser

--- a/src/adapter/etl-adapter-xml/tests/Flow/ETL/Adapter/XML/Tests/Fixtures/namespaced_default.xml
+++ b/src/adapter/etl-adapter-xml/tests/Flow/ETL/Adapter/XML/Tests/Fixtures/namespaced_default.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<feed xmlns="http://example.com/default">
+    <entry>
+        <title>Product 1</title>
+    </entry>
+</feed>

--- a/src/adapter/etl-adapter-xml/tests/Flow/ETL/Adapter/XML/Tests/Fixtures/namespaced_feed.xml
+++ b/src/adapter/etl-adapter-xml/tests/Flow/ETL/Adapter/XML/Tests/Fixtures/namespaced_feed.xml
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<feed xmlns:g="http://base.google.com/ns/1.0" xmlns:c="http://example.com/custom">
+    <entry>
+        <g:id>1</g:id>
+        <g:title>Product 1</g:title>
+        <c:tag>alpha</c:tag>
+    </entry>
+    <entry>
+        <g:id>2</g:id>
+        <g:title>Product 2</g:title>
+        <c:tag>beta</c:tag>
+    </entry>
+</feed>

--- a/src/adapter/etl-adapter-xml/tests/Flow/ETL/Adapter/XML/Tests/Fixtures/namespaced_multi_ancestor.xml
+++ b/src/adapter/etl-adapter-xml/tests/Flow/ETL/Adapter/XML/Tests/Fixtures/namespaced_multi_ancestor.xml
@@ -1,0 +1,9 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<feed xmlns:a="http://example.com/a">
+    <group xmlns:b="http://example.com/b">
+        <entry>
+            <a:alpha>A</a:alpha>
+            <b:beta>B</b:beta>
+        </entry>
+    </group>
+</feed>

--- a/src/adapter/etl-adapter-xml/tests/Flow/ETL/Adapter/XML/Tests/Fixtures/namespaced_nested.xml
+++ b/src/adapter/etl-adapter-xml/tests/Flow/ETL/Adapter/XML/Tests/Fixtures/namespaced_nested.xml
@@ -1,0 +1,9 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<feed xmlns:g="http://base.google.com/ns/1.0">
+    <group xmlns:g="http://example.com/override" xmlns:x="http://example.com/extra">
+        <entry>
+            <g:id>1</g:id>
+            <x:note>hello</x:note>
+        </entry>
+    </group>
+</feed>

--- a/src/adapter/etl-adapter-xml/tests/Flow/ETL/Adapter/XML/Tests/Fixtures/namespaced_on_captured_root.xml
+++ b/src/adapter/etl-adapter-xml/tests/Flow/ETL/Adapter/XML/Tests/Fixtures/namespaced_on_captured_root.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<feed>
+    <entry xmlns:g="http://base.google.com/ns/1.0">
+        <g:title>Product 1</g:title>
+    </entry>
+</feed>

--- a/src/adapter/etl-adapter-xml/tests/Flow/ETL/Adapter/XML/Tests/Fixtures/namespaced_prefixed_attribute.xml
+++ b/src/adapter/etl-adapter-xml/tests/Flow/ETL/Adapter/XML/Tests/Fixtures/namespaced_prefixed_attribute.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<feed xmlns:g="http://base.google.com/ns/1.0">
+    <entry xml:lang="en" g:priority="high">
+        <g:title>Product 1</g:title>
+    </entry>
+</feed>

--- a/src/adapter/etl-adapter-xml/tests/Flow/ETL/Adapter/XML/Tests/Fixtures/namespaced_sibling_isolation.xml
+++ b/src/adapter/etl-adapter-xml/tests/Flow/ETL/Adapter/XML/Tests/Fixtures/namespaced_sibling_isolation.xml
@@ -1,0 +1,9 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<feed>
+    <entry xmlns:g="http://example.com/first">
+        <g:note>first</g:note>
+    </entry>
+    <entry>
+        <plain>second</plain>
+    </entry>
+</feed>

--- a/src/adapter/etl-adapter-xml/tests/Flow/ETL/Adapter/XML/Tests/Integration/XMLParserExtractorTest.php
+++ b/src/adapter/etl-adapter-xml/tests/Flow/ETL/Adapter/XML/Tests/Integration/XMLParserExtractorTest.php
@@ -6,7 +6,7 @@ namespace Flow\ETL\Adapter\XML\Tests\Integration;
 
 use function Flow\ETL\Adapter\XML\from_xml;
 use function Flow\ETL\DSL\config;
-use function Flow\ETL\DSL\{df, flow_context, schema, xml_schema};
+use function Flow\ETL\DSL\{df, flow_context, ref, schema, xml_schema};
 use function Flow\Filesystem\DSL\path_real;
 use function Flow\Types\DSL\type_string;
 use Flow\ETL\Extractor\Signal;
@@ -111,6 +111,71 @@ XML,
         );
     }
 
+    public function test_reading_xml_with_ancestor_namespace_declaration() : void
+    {
+        $rows = df()
+            ->read(from_xml(__DIR__ . '/../Fixtures/namespaced_feed.xml', 'feed/entry'))
+            ->withEntry('title', ref('node')->xpath('/entry/g:title')->domElementValue())
+            ->fetch();
+
+        self::assertSame(
+            ['Product 1', 'Product 2'],
+            [$rows[0]->valueOf('title'), $rows[1]->valueOf('title')],
+        );
+
+        $node = type_string()->cast($rows[0]->valueOf('node'));
+
+        self::assertStringContainsString('xmlns:g="http://base.google.com/ns/1.0"', $node);
+        self::assertStringContainsString('xmlns:c="http://example.com/custom"', $node);
+    }
+
+    public function test_reading_xml_with_default_namespace_declaration() : void
+    {
+        $node = type_string()->cast(df()
+            ->read(from_xml(__DIR__ . '/../Fixtures/namespaced_default.xml', 'feed/entry'))
+            ->fetch()[0]
+            ->valueOf('node'));
+
+        self::assertStringContainsString('xmlns="http://example.com/default"', $node);
+    }
+
+    public function test_reading_xml_with_multi_ancestor_namespace_merge() : void
+    {
+        $node = type_string()->cast(df()
+            ->read(from_xml(__DIR__ . '/../Fixtures/namespaced_multi_ancestor.xml', 'feed/group/entry'))
+            ->fetch()[0]
+            ->valueOf('node'));
+
+        self::assertStringContainsString('xmlns:a="http://example.com/a"', $node);
+        self::assertStringContainsString('xmlns:b="http://example.com/b"', $node);
+    }
+
+    public function test_reading_xml_with_namespace_on_captured_root() : void
+    {
+        $rows = df()
+            ->read(from_xml(__DIR__ . '/../Fixtures/namespaced_on_captured_root.xml', 'feed/entry'))
+            ->withEntry('title', ref('node')->xpath('/entry/g:title')->domElementValue())
+            ->fetch();
+
+        self::assertSame('Product 1', $rows[0]->valueOf('title'));
+        self::assertStringContainsString(
+            'xmlns:g="http://base.google.com/ns/1.0"',
+            type_string()->cast($rows[0]->valueOf('node')),
+        );
+    }
+
+    public function test_reading_xml_with_prefixed_attribute() : void
+    {
+        $node = type_string()->cast(df()
+            ->read(from_xml(__DIR__ . '/../Fixtures/namespaced_prefixed_attribute.xml', 'feed/entry'))
+            ->fetch()[0]
+            ->valueOf('node'));
+
+        self::assertStringContainsString('xmlns:g="http://base.google.com/ns/1.0"', $node);
+        self::assertStringContainsString('xml:lang="en"', $node);
+        self::assertStringContainsString('g:priority="high"', $node);
+    }
+
     public function test_reading_xml_with_schema() : void
     {
         $rows = df()
@@ -131,6 +196,50 @@ XML,
             self::assertNotNull($row['node']);
             self::assertNull($row['missing']);
         }
+    }
+
+    public function test_reading_xml_with_shadowed_namespace_declaration() : void
+    {
+        $node = type_string()->cast(df()
+            ->read(from_xml(__DIR__ . '/../Fixtures/namespaced_nested.xml', 'feed/group/entry'))
+            ->fetch()[0]
+            ->valueOf('node'));
+
+        self::assertStringContainsString('xmlns:g="http://example.com/override"', $node);
+        self::assertStringContainsString('xmlns:x="http://example.com/extra"', $node);
+        self::assertStringNotContainsString('http://base.google.com/ns/1.0', $node);
+    }
+
+    public function test_reading_xml_with_sibling_namespace_isolation() : void
+    {
+        $rows = df()
+            ->read(from_xml(__DIR__ . '/../Fixtures/namespaced_sibling_isolation.xml', 'feed/entry'))
+            ->fetch()
+            ->toArray();
+
+        $firstNode = type_string()->cast($rows[0]['node']);
+        $secondNode = type_string()->cast($rows[1]['node']);
+
+        self::assertStringContainsString('xmlns:g="http://example.com/first"', $firstNode);
+        self::assertStringNotContainsString('xmlns:g', $secondNode);
+        self::assertStringNotContainsString('http://example.com/first', $secondNode);
+    }
+
+    public function test_reading_xml_without_namespaces_is_unchanged() : void
+    {
+        self::assertXmlStringEqualsXmlString(
+            <<<'XML'
+<item item_attribute_01="1">
+  <id id_attribute_01="1">1</id>
+</item>
+XML,
+            type_string()->cast(
+                df()
+                    ->read(from_xml(__DIR__ . '/../Fixtures/simple_items_flat.xml', 'root/items/item'))
+                    ->fetch()[0]
+                    ->valueOf('node')
+            )
+        );
     }
 
     public function test_signal_stop() : void


### PR DESCRIPTION
<!-- 
    Please replace #xxx with a GitHub issue id from flow-php/flow repository. For example #1234 
    If there is no item in a roadmap related to this PR, please check our contributing guidelines first. 
-->
Resolves: #2328 

<!-- 
    Below section will be used to automatically generate changelog, please do not modify HTML code structure
    DO NOT REMOVE that HTML STRUCTURE, INSTEAD ADD YOUR CHANGES INSIDE THE LISTS 
    PULL REQUESTS WITHOUT CHANGELOG CAN'T BE MERGED 
-->
<h2>Change Log</h2>
<hr /> 
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>preserve XML namespace declarations when capturing subtrees</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>