### PR TITLE
refactor: dont list remote storages when precise file path is used

### DIFF
--- a/src/bridge/filesystem/async-aws/src/Flow/Filesystem/Bridge/AsyncAWS/AsyncAWSS3Filesystem.php
+++ b/src/bridge/filesystem/async-aws/src/Flow/Filesystem/Bridge/AsyncAWS/AsyncAWSS3Filesystem.php
@@ -47,6 +47,34 @@ final readonly class AsyncAWSS3Filesystem implements Filesystem
     {
         $this->mount->supports($path) || throw new InvalidSchemeException($path->protocol(), $this->mount->protocol);
 
+        if (!$path->isPattern()
+            && $this->options->fileFastPath()
+            && $path->extension() !== false
+            && !\str_ends_with($path->path(), DIRECTORY_SEPARATOR)) {
+            try {
+                $headObject = $this->s3Client->headObject([
+                    'Bucket' => $this->bucket,
+                    'Key' => \ltrim($path->path(), DIRECTORY_SEPARATOR),
+                ]);
+                $headObject->resolve();
+
+                $fileStatus = new FileStatus(
+                    $path,
+                    true,
+                    $headObject->getContentLength(),
+                    $headObject->getLastModified(),
+                );
+
+                if ($pathFilter->accept($fileStatus)) {
+                    yield $fileStatus;
+                }
+
+                return;
+            } catch (NoSuchKeyException) {
+                // Not a single object - fall through to listing.
+            }
+        }
+
         if ($path->isPattern()) {
             $prefix = \ltrim($path->staticPart()->path(), DIRECTORY_SEPARATOR);
         } else {

--- a/src/bridge/filesystem/async-aws/src/Flow/Filesystem/Bridge/AsyncAWS/Options.php
+++ b/src/bridge/filesystem/async-aws/src/Flow/Filesystem/Bridge/AsyncAWS/Options.php
@@ -14,6 +14,8 @@ final class Options
 {
     private readonly BlockFactory $blockFactory;
 
+    private bool $fileFastPath = true;
+
     private int $partSize = 1024 * 1024 * 5;
 
     private readonly Path $tmpDir;
@@ -27,6 +29,11 @@ final class Options
     public function blockFactory() : BlockFactory
     {
         return $this->blockFactory;
+    }
+
+    public function fileFastPath() : bool
+    {
+        return $this->fileFastPath;
     }
 
     public function partSize() : int
@@ -46,6 +53,19 @@ final class Options
         }
 
         $this->partSize = $bytes;
+
+        return $this;
+    }
+
+    /**
+     * When enabled (default), list() on a single-file path will first attempt a HEAD on the object.
+     * If the object exists, list() yields just that single FileStatus and never issues listObjectsV2.
+     * This avoids the s3:ListBucket permission requirement and an extra round-trip when reading single files.
+     * Disable if your workloads typically pass folder/prefix paths to list(), to skip the (failing) HEAD.
+     */
+    public function withFileFastPath(bool $enabled = true) : self
+    {
+        $this->fileFastPath = $enabled;
 
         return $this;
     }

--- a/src/bridge/filesystem/async-aws/tests/Flow/Filesystem/Bridge/AsyncAWS/Tests/Double/RecordingS3Client.php
+++ b/src/bridge/filesystem/async-aws/tests/Flow/Filesystem/Bridge/AsyncAWS/Tests/Double/RecordingS3Client.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\Filesystem\Bridge\AsyncAWS\Tests\Double;
+
+use AsyncAws\S3\Result\{
+    CopyObjectOutput,
+    DeleteObjectOutput,
+    HeadObjectOutput,
+    ListObjectsV2Output,
+};
+use AsyncAws\S3\S3Client;
+
+final class RecordingS3Client extends S3Client
+{
+    public int $copyObjectCount = 0;
+
+    public int $deleteObjectCount = 0;
+
+    public int $headObjectCount = 0;
+
+    public int $listObjectsV2Count = 0;
+
+    #[\Override]
+    public function copyObject($input) : CopyObjectOutput
+    {
+        $this->copyObjectCount++;
+
+        return parent::copyObject($input);
+    }
+
+    #[\Override]
+    public function deleteObject($input) : DeleteObjectOutput
+    {
+        $this->deleteObjectCount++;
+
+        return parent::deleteObject($input);
+    }
+
+    #[\Override]
+    public function headObject($input) : HeadObjectOutput
+    {
+        $this->headObjectCount++;
+
+        return parent::headObject($input);
+    }
+
+    #[\Override]
+    public function listObjectsV2($input) : ListObjectsV2Output
+    {
+        $this->listObjectsV2Count++;
+
+        return parent::listObjectsV2($input);
+    }
+
+    public function resetCounters() : void
+    {
+        $this->copyObjectCount = 0;
+        $this->deleteObjectCount = 0;
+        $this->headObjectCount = 0;
+        $this->listObjectsV2Count = 0;
+    }
+}

--- a/src/bridge/filesystem/async-aws/tests/Flow/Filesystem/Bridge/AsyncAWS/Tests/Integration/AsyncAWSS3FilesystemFileFastPathTest.php
+++ b/src/bridge/filesystem/async-aws/tests/Flow/Filesystem/Bridge/AsyncAWS/Tests/Integration/AsyncAWSS3FilesystemFileFastPathTest.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\Filesystem\Bridge\AsyncAWS\Tests\Integration;
+
+use function Flow\Filesystem\Bridge\AsyncAWS\DSL\aws_s3_filesystem;
+use function Flow\Filesystem\DSL\path;
+use Flow\Filesystem\Bridge\AsyncAWS\Options;
+use Flow\Filesystem\Bridge\AsyncAWS\Tests\Double\RecordingS3Client;
+use Flow\Filesystem\Path\Filter\OnlyFiles;
+use Flow\Filesystem\Tests\Double\RejectingFilter;
+
+final class AsyncAWSS3FilesystemFileFastPathTest extends AsyncAWSS3TestCase
+{
+    public function test_list_disabled_fast_path_falls_back_to_listing_for_single_file() : void
+    {
+        $client = $this->recordingClient();
+        $fs = aws_s3_filesystem(
+            $this->bucket(),
+            $client,
+            (new Options())->withFileFastPath(false),
+        );
+
+        $fs->writeTo(path('aws-s3://var/orders/orders.csv'))->append('a,b')->close();
+
+        $client->resetCounters();
+
+        $statuses = \iterator_to_array($fs->list(path('aws-s3://var/orders/orders.csv')));
+
+        self::assertCount(1, $statuses);
+        self::assertSame(0, $client->headObjectCount, 'HEAD must not be issued when fast path is disabled');
+        self::assertSame(1, $client->listObjectsV2Count, 'listObjectsV2 must run when fast path is disabled');
+    }
+
+    public function test_list_filter_is_applied_on_single_file_fast_path() : void
+    {
+        $client = $this->recordingClient();
+        $fs = aws_s3_filesystem($this->bucket(), $client);
+
+        $fs->writeTo(path('aws-s3://var/orders/orders.csv'))->append('a,b')->close();
+
+        $client->resetCounters();
+
+        $statuses = \iterator_to_array(
+            $fs->list(path('aws-s3://var/orders/orders.csv'), new RejectingFilter()),
+        );
+
+        self::assertCount(0, $statuses);
+        self::assertSame(1, $client->headObjectCount);
+        self::assertSame(0, $client->listObjectsV2Count);
+    }
+
+    public function test_list_folder_path_with_trailing_slash_skips_head() : void
+    {
+        $client = $this->recordingClient();
+        $fs = aws_s3_filesystem($this->bucket(), $client);
+
+        $fs->writeTo(path('aws-s3://var/orders/a.csv'))->append('a')->close();
+        $fs->writeTo(path('aws-s3://var/orders/b.csv'))->append('b')->close();
+
+        $client->resetCounters();
+
+        $statuses = \iterator_to_array($fs->list(path('aws-s3://var/orders/')));
+
+        self::assertCount(2, $statuses);
+        self::assertSame(0, $client->headObjectCount, 'HEAD must be skipped for paths ending with /');
+        self::assertSame(1, $client->listObjectsV2Count);
+    }
+
+    public function test_list_non_existing_single_file_path_falls_back_to_listing() : void
+    {
+        $client = $this->recordingClient();
+        $fs = aws_s3_filesystem($this->bucket(), $client);
+
+        $client->resetCounters();
+
+        $statuses = \iterator_to_array($fs->list(path('aws-s3://var/missing/file.csv')));
+
+        self::assertCount(0, $statuses);
+        self::assertSame(1, $client->headObjectCount, 'HEAD is attempted on non-pattern, non-folder path');
+        self::assertSame(1, $client->listObjectsV2Count, 'fallback listing runs after NoSuchKey');
+    }
+
+    public function test_list_pattern_skips_head() : void
+    {
+        $client = $this->recordingClient();
+        $fs = aws_s3_filesystem($this->bucket(), $client);
+
+        $fs->writeTo(path('aws-s3://var/orders/a.csv'))->append('a')->close();
+        $fs->writeTo(path('aws-s3://var/orders/b.csv'))->append('b')->close();
+
+        $client->resetCounters();
+
+        $statuses = \iterator_to_array($fs->list(path('aws-s3://var/orders/*.csv')));
+
+        self::assertCount(2, $statuses);
+        self::assertSame(0, $client->headObjectCount, 'HEAD must not be issued for pattern paths');
+        self::assertSame(1, $client->listObjectsV2Count);
+    }
+
+    public function test_list_root_path_skips_head() : void
+    {
+        $client = $this->recordingClient();
+        $fs = aws_s3_filesystem($this->bucket(), $client);
+
+        $fs->writeTo(path('aws-s3://root.txt'))->append('x')->close();
+
+        $client->resetCounters();
+
+        \iterator_to_array($fs->list(path('aws-s3:///')));
+
+        self::assertSame(0, $client->headObjectCount);
+        self::assertSame(1, $client->listObjectsV2Count);
+    }
+
+    public function test_list_single_file_does_not_yield_prefix_siblings() : void
+    {
+        $client = $this->recordingClient();
+        $fs = aws_s3_filesystem($this->bucket(), $client);
+
+        $fs->writeTo(path('aws-s3://var/orders/file.txt'))->append('a')->close();
+        $fs->writeTo(path('aws-s3://var/orders/file.txt.bak'))->append('b')->close();
+
+        $client->resetCounters();
+
+        $statuses = \iterator_to_array($fs->list(path('aws-s3://var/orders/file.txt')));
+
+        self::assertCount(1, $statuses);
+        self::assertSame('aws-s3://var/orders/file.txt', $statuses[0]->path->uri());
+        self::assertSame(1, $client->headObjectCount);
+        self::assertSame(0, $client->listObjectsV2Count);
+    }
+
+    public function test_list_single_file_yields_via_head_only_when_fast_path_enabled() : void
+    {
+        $client = $this->recordingClient();
+        $fs = aws_s3_filesystem($this->bucket(), $client);
+
+        $fs->writeTo(path('aws-s3://var/orders/orders.csv'))->append('a,b,c')->close();
+
+        $client->resetCounters();
+
+        $statuses = \iterator_to_array($fs->list(path('aws-s3://var/orders/orders.csv'), new OnlyFiles()));
+
+        self::assertCount(1, $statuses);
+        self::assertSame('aws-s3://var/orders/orders.csv', $statuses[0]->path->uri());
+        self::assertTrue($statuses[0]->isFile());
+        self::assertSame(1, $client->headObjectCount, 'exactly one HEAD must be issued');
+        self::assertSame(0, $client->listObjectsV2Count, 'listObjectsV2 must NOT be issued for single-file fast path');
+    }
+
+    private function recordingClient() : RecordingS3Client
+    {
+        $configuration = [
+            'pathStyleEndpoint' => true,
+            'endpoint' => $_ENV['S3_ENDPOINT'],
+            'region' => $_ENV['S3_REGION'],
+            'accessKeyId' => $_ENV['S3_ACCESS_KEY_ID'],
+            'accessKeySecret' => $_ENV['S3_SECRET_ACCESS_KEY'],
+        ];
+
+        /** @phpstan-ignore-next-line */
+        return new RecordingS3Client($configuration);
+    }
+}

--- a/src/bridge/filesystem/azure/src/Flow/Filesystem/Bridge/Azure/AzureBlobFilesystem.php
+++ b/src/bridge/filesystem/azure/src/Flow/Filesystem/Bridge/Azure/AzureBlobFilesystem.php
@@ -47,6 +47,28 @@ final readonly class AzureBlobFilesystem implements Filesystem
     {
         $this->mount->supports($path) || throw new InvalidSchemeException($path->protocol(), $this->mount->protocol);
 
+        if (!$path->isPattern()
+            && $this->options->fileFastPath()
+            && $path->extension() !== false
+            && !\str_ends_with($path->path(), DIRECTORY_SEPARATOR)) {
+            $blobProperties = $this->blobService->getBlobProperties(\ltrim($path->path(), DIRECTORY_SEPARATOR));
+
+            if ($blobProperties !== null) {
+                $fileStatus = new FileStatus(
+                    $path,
+                    true,
+                    $blobProperties->size(),
+                    $blobProperties->lastModifiedAt(),
+                );
+
+                if ($pathFilter->accept($fileStatus)) {
+                    yield $fileStatus;
+                }
+
+                return;
+            }
+        }
+
         if ($path->isPattern()) {
             $prefix = \ltrim($path->staticPart()->path(), DIRECTORY_SEPARATOR);
         } else {

--- a/src/bridge/filesystem/azure/src/Flow/Filesystem/Bridge/Azure/Options.php
+++ b/src/bridge/filesystem/azure/src/Flow/Filesystem/Bridge/Azure/Options.php
@@ -15,6 +15,8 @@ final class Options
 
     private int $blockSize = 1024 * 1024 * 4;
 
+    private bool $fileFastPath = true;
+
     /**
      * @var null|array<OptionInclude>
      */
@@ -40,6 +42,11 @@ final class Options
     public function blockSize() : int
     {
         return $this->blockSize;
+    }
+
+    public function fileFastPath() : bool
+    {
+        return $this->fileFastPath;
     }
 
     public function listBlobOptions() : ListBlobOptions
@@ -76,6 +83,19 @@ final class Options
     public function withBlockSize(int $blockSize) : self
     {
         $this->blockSize = $blockSize;
+
+        return $this;
+    }
+
+    /**
+     * When enabled (default), list() on a single-file path will first attempt getBlobProperties on the blob.
+     * If it exists, list() yields just that single FileStatus and never issues listBlobs.
+     * This avoids the container-list permission requirement and an extra round-trip when reading single files.
+     * Disable if your workloads typically pass folder/prefix paths to list(), to skip the (failing) properties call.
+     */
+    public function withFileFastPath(bool $enabled = true) : self
+    {
+        $this->fileFastPath = $enabled;
 
         return $this;
     }

--- a/src/bridge/filesystem/azure/tests/Flow/Filesystem/Bridge/Azure/Tests/Double/RecordingBlobService.php
+++ b/src/bridge/filesystem/azure/tests/Flow/Filesystem/Bridge/Azure/Tests/Double/RecordingBlobService.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\Filesystem\Bridge\Azure\Tests\Double;
+
+use Flow\Azure\SDK\BlobService\BlockBlob\BlockList;
+use Flow\Azure\SDK\BlobService\CopyBlob\CopyBlobOptions;
+use Flow\Azure\SDK\BlobService\CreateContainer\CreateContainerOptions;
+use Flow\Azure\SDK\BlobService\DeleteBlob\DeleteBlobOptions;
+use Flow\Azure\SDK\BlobService\DeleteContainer\DeleteContainerOptions;
+use Flow\Azure\SDK\BlobService\GetBlob\{BlobContent, GetBlobOptions};
+use Flow\Azure\SDK\BlobService\GetBlobProperties\{BlobProperties, GetBlobPropertiesOptions};
+use Flow\Azure\SDK\BlobService\GetBlockBlobBlockList\GetBlockBlobBlockListOptions;
+use Flow\Azure\SDK\BlobService\GetContainerProperties\{ContainerProperties, GetContainerPropertiesOptions};
+use Flow\Azure\SDK\BlobService\ListBlobs\ListBlobOptions;
+use Flow\Azure\SDK\BlobService\PutBlockBlob\PutBlockBlobOptions;
+use Flow\Azure\SDK\BlobService\PutBlockBlobBlock\PutBlockBlobBlockOptions;
+use Flow\Azure\SDK\BlobService\PutBlockBlobBlockList\{PutBlockBlobBlockListOptions, SimpleXMLSerializer};
+use Flow\Azure\SDK\{BlobServiceInterface, Serializer};
+
+final class RecordingBlobService implements BlobServiceInterface
+{
+    public int $copyBlobCount = 0;
+
+    public int $deleteBlobCount = 0;
+
+    public int $getBlobPropertiesCount = 0;
+
+    public int $listBlobsCount = 0;
+
+    public function __construct(private readonly BlobServiceInterface $delegate)
+    {
+    }
+
+    public function copyBlob(string $fromBlob, string $toBlob, CopyBlobOptions $options = new CopyBlobOptions()) : void
+    {
+        $this->copyBlobCount++;
+        $this->delegate->copyBlob($fromBlob, $toBlob, $options);
+    }
+
+    public function deleteBlob(string $blob, DeleteBlobOptions $options = new DeleteBlobOptions()) : void
+    {
+        $this->deleteBlobCount++;
+        $this->delegate->deleteBlob($blob, $options);
+    }
+
+    public function deleteContainer(DeleteContainerOptions $options = new DeleteContainerOptions()) : void
+    {
+        $this->delegate->deleteContainer($options);
+    }
+
+    public function getBlob(string $blob, GetBlobOptions $options = new GetBlobOptions()) : BlobContent
+    {
+        return $this->delegate->getBlob($blob, $options);
+    }
+
+    public function getBlobProperties(string $blob, GetBlobPropertiesOptions $options = new GetBlobPropertiesOptions()) : ?BlobProperties
+    {
+        $this->getBlobPropertiesCount++;
+
+        return $this->delegate->getBlobProperties($blob, $options);
+    }
+
+    public function getBlockBlobBlockList(string $blob, GetBlockBlobBlockListOptions $options = new GetBlockBlobBlockListOptions()) : BlockList
+    {
+        return $this->delegate->getBlockBlobBlockList($blob, $options);
+    }
+
+    public function getContainerProperties(GetContainerPropertiesOptions $options = new GetContainerPropertiesOptions()) : ?ContainerProperties
+    {
+        return $this->delegate->getContainerProperties($options);
+    }
+
+    public function listBlobs(ListBlobOptions $options = new ListBlobOptions()) : \Generator
+    {
+        $this->listBlobsCount++;
+
+        yield from $this->delegate->listBlobs($options);
+    }
+
+    public function putBlockBlob(string $path, $content = null, ?int $size = null, PutBlockBlobOptions $options = new PutBlockBlobOptions()) : void
+    {
+        $this->delegate->putBlockBlob($path, $content, $size, $options);
+    }
+
+    public function putBlockBlobBlock(string $path, string $blockId, $content, int $size, PutBlockBlobBlockOptions $options = new PutBlockBlobBlockOptions()) : void
+    {
+        $this->delegate->putBlockBlobBlock($path, $blockId, $content, $size, $options);
+    }
+
+    public function putBlockBlobBlockList(string $path, BlockList $blockList, PutBlockBlobBlockListOptions $options = new PutBlockBlobBlockListOptions(), Serializer $serializer = new SimpleXMLSerializer()) : void
+    {
+        $this->delegate->putBlockBlobBlockList($path, $blockList, $options, $serializer);
+    }
+
+    public function putContainer(CreateContainerOptions $options = new CreateContainerOptions()) : void
+    {
+        $this->delegate->putContainer($options);
+    }
+
+    public function resetCounters() : void
+    {
+        $this->copyBlobCount = 0;
+        $this->deleteBlobCount = 0;
+        $this->getBlobPropertiesCount = 0;
+        $this->listBlobsCount = 0;
+    }
+}

--- a/src/bridge/filesystem/azure/tests/Flow/Filesystem/Bridge/Azure/Tests/Integration/AzureBlobFilesystemFileFastPathTest.php
+++ b/src/bridge/filesystem/azure/tests/Flow/Filesystem/Bridge/Azure/Tests/Integration/AzureBlobFilesystemFileFastPathTest.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\Filesystem\Bridge\Azure\Tests\Integration;
+
+use function Flow\Filesystem\Bridge\Azure\DSL\azure_filesystem;
+use function Flow\Filesystem\DSL\path;
+use Flow\Filesystem\Bridge\Azure\Options;
+use Flow\Filesystem\Bridge\Azure\Tests\Double\RecordingBlobService;
+use Flow\Filesystem\Path\Filter\OnlyFiles;
+use Flow\Filesystem\Tests\Double\RejectingFilter;
+
+final class AzureBlobFilesystemFileFastPathTest extends AzureBlobServiceTestCase
+{
+    public function test_list_disabled_fast_path_falls_back_to_listing_for_single_file() : void
+    {
+        $blobService = new RecordingBlobService($this->blobService('flow-php-list-opt-disabled'));
+        $fs = azure_filesystem(
+            $blobService,
+            (new Options())->withFileFastPath(false),
+        );
+
+        $fs->writeTo(path('azure-blob://orders/orders.csv'))->append('a,b')->close();
+
+        $blobService->resetCounters();
+
+        $statuses = \iterator_to_array($fs->list(path('azure-blob://orders/orders.csv')));
+
+        self::assertCount(1, $statuses);
+        self::assertSame(0, $blobService->getBlobPropertiesCount, 'getBlobProperties must not be issued when fast path is disabled');
+        self::assertSame(1, $blobService->listBlobsCount, 'listBlobs must run when fast path is disabled');
+    }
+
+    public function test_list_filter_is_applied_on_single_file_fast_path() : void
+    {
+        $blobService = new RecordingBlobService($this->blobService('flow-php-list-filter'));
+        $fs = azure_filesystem($blobService);
+
+        $fs->writeTo(path('azure-blob://orders/orders.csv'))->append('a,b')->close();
+
+        $blobService->resetCounters();
+
+        $statuses = \iterator_to_array(
+            $fs->list(path('azure-blob://orders/orders.csv'), new RejectingFilter()),
+        );
+
+        self::assertCount(0, $statuses);
+        self::assertSame(1, $blobService->getBlobPropertiesCount);
+        self::assertSame(0, $blobService->listBlobsCount);
+    }
+
+    public function test_list_folder_path_with_trailing_slash_skips_get_blob_properties() : void
+    {
+        $blobService = new RecordingBlobService($this->blobService('flow-php-list-folder'));
+        $fs = azure_filesystem($blobService);
+
+        $fs->writeTo(path('azure-blob://orders/a.csv'))->append('a')->close();
+        $fs->writeTo(path('azure-blob://orders/b.csv'))->append('b')->close();
+
+        $blobService->resetCounters();
+
+        $statuses = \iterator_to_array($fs->list(path('azure-blob://orders/')));
+
+        self::assertCount(2, $statuses);
+        self::assertSame(0, $blobService->getBlobPropertiesCount, 'getBlobProperties must be skipped for paths ending with /');
+        self::assertSame(1, $blobService->listBlobsCount);
+    }
+
+    public function test_list_non_existing_single_file_path_falls_back_to_listing() : void
+    {
+        $blobService = new RecordingBlobService($this->blobService('flow-php-list-missing'));
+        $fs = azure_filesystem($blobService);
+
+        $blobService->resetCounters();
+
+        $statuses = \iterator_to_array($fs->list(path('azure-blob://missing/file.csv')));
+
+        self::assertCount(0, $statuses);
+        self::assertSame(1, $blobService->getBlobPropertiesCount, 'getBlobProperties is attempted on non-pattern, non-folder path');
+        self::assertSame(1, $blobService->listBlobsCount, 'fallback listing runs after null properties');
+    }
+
+    public function test_list_pattern_skips_get_blob_properties() : void
+    {
+        $blobService = new RecordingBlobService($this->blobService('flow-php-list-pattern'));
+        $fs = azure_filesystem($blobService);
+
+        $fs->writeTo(path('azure-blob://orders/a.csv'))->append('a')->close();
+        $fs->writeTo(path('azure-blob://orders/b.csv'))->append('b')->close();
+
+        $blobService->resetCounters();
+
+        $statuses = \iterator_to_array($fs->list(path('azure-blob://orders/*.csv')));
+
+        self::assertCount(2, $statuses);
+        self::assertSame(0, $blobService->getBlobPropertiesCount, 'getBlobProperties must not be issued for pattern paths');
+        self::assertSame(1, $blobService->listBlobsCount);
+    }
+
+    public function test_list_root_path_skips_get_blob_properties() : void
+    {
+        $blobService = new RecordingBlobService($this->blobService('flow-php-list-root'));
+        $fs = azure_filesystem($blobService);
+
+        $fs->writeTo(path('azure-blob://root.txt'))->append('x')->close();
+
+        $blobService->resetCounters();
+
+        \iterator_to_array($fs->list(path('azure-blob:///')));
+
+        self::assertSame(0, $blobService->getBlobPropertiesCount);
+        self::assertSame(1, $blobService->listBlobsCount);
+    }
+
+    public function test_list_single_file_does_not_yield_prefix_siblings() : void
+    {
+        $blobService = new RecordingBlobService($this->blobService('flow-php-list-siblings'));
+        $fs = azure_filesystem($blobService);
+
+        $fs->writeTo(path('azure-blob://orders/file.txt'))->append('a')->close();
+        $fs->writeTo(path('azure-blob://orders/file.txt.bak'))->append('b')->close();
+
+        $blobService->resetCounters();
+
+        $statuses = \iterator_to_array($fs->list(path('azure-blob://orders/file.txt')));
+
+        self::assertCount(1, $statuses);
+        self::assertSame('azure-blob://orders/file.txt', $statuses[0]->path->uri());
+        self::assertSame(1, $blobService->getBlobPropertiesCount);
+        self::assertSame(0, $blobService->listBlobsCount);
+    }
+
+    public function test_list_single_file_yields_via_get_blob_properties_only_when_fast_path_enabled() : void
+    {
+        $blobService = new RecordingBlobService($this->blobService('flow-php-list-opt-enabled'));
+        $fs = azure_filesystem($blobService);
+
+        $fs->writeTo(path('azure-blob://orders/orders.csv'))->append('a,b,c')->close();
+
+        $blobService->resetCounters();
+
+        $statuses = \iterator_to_array(
+            $fs->list(path('azure-blob://orders/orders.csv'), new OnlyFiles()),
+        );
+
+        self::assertCount(1, $statuses);
+        self::assertSame('azure-blob://orders/orders.csv', $statuses[0]->path->uri());
+        self::assertTrue($statuses[0]->isFile());
+        self::assertSame(1, $blobService->getBlobPropertiesCount, 'exactly one getBlobProperties must be issued');
+        self::assertSame(0, $blobService->listBlobsCount, 'listBlobs must NOT be issued for single-file fast path');
+    }
+}

--- a/src/lib/filesystem/tests/Flow/Filesystem/Tests/Double/RejectingFilter.php
+++ b/src/lib/filesystem/tests/Flow/Filesystem/Tests/Double/RejectingFilter.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\Filesystem\Tests\Double;
+
+use Flow\Filesystem\FileStatus;
+use Flow\Filesystem\Path\Filter;
+
+final class RejectingFilter implements Filter
+{
+    public function accept(FileStatus $status) : bool
+    {
+        return false;
+    }
+}


### PR DESCRIPTION
<!-- 
    Below section will be used to automatically generate changelog, please do not modify HTML code structure
    DO NOT REMOVE that HTML STRUCTURE, INSTEAD ADD YOUR CHANGES INSIDE THE LISTS 
    PULL REQUESTS WITHOUT CHANGELOG CAN'T BE MERGED 
-->
<h2>Change Log</h2>
<hr /> 
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Avoid listing the remote storages when direct file path is used</li> 
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>

This behavior was noticed in one of the projects I have been consulting. 
What happens is that even when the extractor has a direct file path `s3://some-bucket/some-folder/file.xml` for example the XMLParserExtrator is using list action on Streams

 https://github.com/flow-php/flow/blob/5ac37fe1a1f253e0f5f51b95772460f4877d9e60/src/adapter/etl-adapter-xml/src/Flow/ETL/Adapter/XML/XMLParserExtractor.php#L95
 
 And then in FilesystemStreams regardless is this is direct file path or folder or pattern we stilld call list. 

https://github.com/flow-php/flow/blob/1558c15ed08233efae8653c7d71b6fa0efe52748/src/core/etl/src/Flow/ETL/Filesystem/FilesystemStreams.php#L121-L127

This PR changes that behavior, now list methods of [AzureBlob](https://github.com/flow-php/flow/blob/e955c4de46f9364b4517c0aa307eca74373afc27/src/bridge/filesystem/azure/src/Flow/Filesystem/Bridge/Azure/AzureBlobFilesystem.php) and [AsyncAWSS3Filesystem](https://github.com/flow-php/flow/blob/e955c4de46f9364b4517c0aa307eca74373afc27/src/bridge/filesystem/async-aws/src/Flow/Filesystem/Bridge/AsyncAWS/AsyncAWSS3Filesystem.php) will first (if that option is enabled) check if path is pointing to a file. 

This way it wont need an actual list bucket / container permission 