### PR TITLE
fix: bug in recursive delete based on glob

### DIFF
--- a/src/lib/filesystem/src/Flow/Filesystem/Local/NativeLocalFilesystem.php
+++ b/src/lib/filesystem/src/Flow/Filesystem/Local/NativeLocalFilesystem.php
@@ -10,7 +10,8 @@ use Flow\Filesystem\{DestinationStream, FileStatus, Filesystem, Mount, Path, Pat
 use Flow\Filesystem\Exception\{InvalidArgumentException, InvalidSchemeException, RuntimeException};
 use Flow\Filesystem\Path\Filter\OnlyFiles;
 use Flow\Filesystem\Stream\{NativeLocalDestinationStream, NativeLocalSourceStream};
-use Webmozart\Glob\Iterator\GlobIterator;
+use Webmozart\Glob\Glob;
+use Webmozart\Glob\Iterator\{GlobFilterIterator, GlobIterator};
 
 /**
  * This implementation is based on the native PHP filesystem functions documented here: https://www.php.net/manual/en/book.filesystem.php
@@ -129,7 +130,7 @@ final readonly class NativeLocalFilesystem implements Filesystem
 
         $deletedCount = 0;
 
-        foreach (new GlobIterator($path->path()) as $filePath) {
+        foreach ($this->matchChildFirst($path->path()) as $filePath) {
             $filePath = type_string()->assert($filePath);
 
             if (\is_dir($filePath)) {
@@ -186,6 +187,32 @@ final readonly class NativeLocalFilesystem implements Filesystem
         }
 
         return NativeLocalDestinationStream::openBlank($path);
+    }
+
+    /**
+     * Lazy iterator over glob matches in CHILD_FIRST order so callers can safely delete each match
+     * without confusing webmozart/glob's internal RecursiveIteratorIterator (which descends with SELF_FIRST).
+     */
+    private function matchChildFirst(string $glob) : \Iterator
+    {
+        $basePath = Glob::getBasePath($glob);
+
+        if (!\is_dir($basePath)) {
+            return new \EmptyIterator();
+        }
+
+        return new GlobFilterIterator(
+            $glob,
+            new \RecursiveIteratorIterator(
+                new \RecursiveDirectoryIterator(
+                    $basePath,
+                    \RecursiveDirectoryIterator::CURRENT_AS_PATHNAME
+                    | \RecursiveDirectoryIterator::SKIP_DOTS
+                ),
+                \RecursiveIteratorIterator::CHILD_FIRST
+            ),
+            GlobFilterIterator::FILTER_VALUE
+        );
     }
 
     private function rmdir(string $dirPath) : void

--- a/src/lib/filesystem/src/Flow/Filesystem/Local/NativeLocalFilesystem.php
+++ b/src/lib/filesystem/src/Flow/Filesystem/Local/NativeLocalFilesystem.php
@@ -195,22 +195,28 @@ final readonly class NativeLocalFilesystem implements Filesystem
      */
     private function matchChildFirst(string $glob) : \Iterator
     {
+        $glob = self::canonicalizePath($glob);
         $basePath = Glob::getBasePath($glob);
 
         if (!\is_dir($basePath)) {
             return new \EmptyIterator();
         }
 
+        $recursive = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator(
+                $basePath,
+                \RecursiveDirectoryIterator::CURRENT_AS_PATHNAME | \RecursiveDirectoryIterator::SKIP_DOTS
+            ),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+
         return new GlobFilterIterator(
             $glob,
-            new \RecursiveIteratorIterator(
-                new \RecursiveDirectoryIterator(
-                    $basePath,
-                    \RecursiveDirectoryIterator::CURRENT_AS_PATHNAME
-                    | \RecursiveDirectoryIterator::SKIP_DOTS
-                ),
-                \RecursiveIteratorIterator::CHILD_FIRST
-            ),
+            (static function () use ($recursive) {
+                foreach ($recursive as $path) {
+                    yield self::canonicalizePath(type_string()->assert($path));
+                }
+            })(),
             GlobFilterIterator::FILTER_VALUE
         );
     }
@@ -248,13 +254,21 @@ final readonly class NativeLocalFilesystem implements Filesystem
         \rmdir($dirPath);
     }
 
+    private static function canonicalizePath(string $path) : string
+    {
+        return type_string()->cast(\preg_replace('#/+#', '/', \str_replace('\\', '/', $path)));
+    }
+
     private static function statFor(Path $path, string $absolutePath) : FileStatus
     {
         $isFile = \is_file($absolutePath);
-        $size = $isFile ? (\filesize($absolutePath) ?: null) : null;
         $mtime = \filemtime($absolutePath);
-        $lastModifiedAt = $mtime !== false ? new \DateTimeImmutable('@' . $mtime) : null;
 
-        return new FileStatus($path, $isFile, $size, $lastModifiedAt);
+        return new FileStatus(
+            $path,
+            $isFile,
+            $isFile ? (\filesize($absolutePath) ?: null) : null,
+            $mtime !== false ? new \DateTimeImmutable('@' . $mtime) : null
+        );
     }
 }

--- a/src/lib/filesystem/tests/Flow/Filesystem/Tests/Integration/NativeLocalFilesystemTest.php
+++ b/src/lib/filesystem/tests/Flow/Filesystem/Tests/Integration/NativeLocalFilesystemTest.php
@@ -451,6 +451,29 @@ TXT
         self::assertNull($fs->status(path(__DIR__ . '/var/nested/orders/orders_01.csv')));
     }
 
+    public function test_removing_recursive_pattern_with_nested_directories() : void
+    {
+        $fs = native_local_filesystem();
+
+        $resource1 = \fopen(__DIR__ . '/Fixtures/orders.csv', 'rb');
+        self::assertIsResource($resource1);
+        $fs->writeTo(path(__DIR__ . '/var/recursive_rm/dir_a/file1.txt'))->fromResource($resource1);
+
+        $resource2 = \fopen(__DIR__ . '/Fixtures/orders.csv', 'rb');
+        self::assertIsResource($resource2);
+        $fs->writeTo(path(__DIR__ . '/var/recursive_rm/dir_a/nested/file2.txt'))->fromResource($resource2);
+
+        $resource3 = \fopen(__DIR__ . '/Fixtures/orders.csv', 'rb');
+        self::assertIsResource($resource3);
+        $fs->writeTo(path(__DIR__ . '/var/recursive_rm/dir_b/file3.txt'))->fromResource($resource3);
+
+        $fs->rm(path(__DIR__ . '/var/recursive_rm/**/*'));
+
+        self::assertNull($fs->status(path(__DIR__ . '/var/recursive_rm/dir_a/file1.txt')));
+        self::assertNull($fs->status(path(__DIR__ . '/var/recursive_rm/dir_a/nested/file2.txt')));
+        self::assertNull($fs->status(path(__DIR__ . '/var/recursive_rm/dir_b/file3.txt')));
+    }
+
     public function test_rm_rejects_mismatched_scheme() : void
     {
         $this->expectException(InvalidSchemeException::class);

--- a/src/lib/filesystem/tests/Flow/Filesystem/Tests/Integration/NativeLocalFilesystemTest.php
+++ b/src/lib/filesystem/tests/Flow/Filesystem/Tests/Integration/NativeLocalFilesystemTest.php
@@ -451,6 +451,19 @@ TXT
         self::assertNull($fs->status(path(__DIR__ . '/var/nested/orders/orders_01.csv')));
     }
 
+    public function test_removing_pattern_with_redundant_slashes() : void
+    {
+        $fs = native_local_filesystem();
+
+        $resource = \fopen(__DIR__ . '/Fixtures/orders.csv', 'rb');
+        self::assertIsResource($resource);
+        $fs->writeTo(path(__DIR__ . '/var/redundant_slash/file.txt'))->fromResource($resource);
+
+        $fs->rm(path(__DIR__ . '/var/redundant_slash//*.txt'));
+
+        self::assertNull($fs->status(path(__DIR__ . '/var/redundant_slash/file.txt')));
+    }
+
     public function test_removing_recursive_pattern_with_nested_directories() : void
     {
         $fs = native_local_filesystem();


### PR DESCRIPTION
<!-- 
    Please replace #xxx with a GitHub issue id from flow-php/flow repository. For example #1234 
    If there is no item in a roadmap related to this PR, please check our contributing guidelines first. 
-->
Resolves: #xxx

<!-- 
    Below section will be used to automatically generate changelog, please do not modify HTML code structure
    DO NOT REMOVE that HTML STRUCTURE, INSTEAD ADD YOUR CHANGES INSIDE THE LISTS 
    PULL REQUESTS WITHOUT CHANGELOG CAN'T BE MERGED 
-->
<h2>Change Log</h2>
<hr /> 
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>bug in recursive delete based on glob</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>