### PR TITLE
Correction of handling of null counts metadata in parquet files for PhpParquetEngine

### DIFF
--- a/src/lib/parquet/src/Flow/Parquet/Writer/ColumnChunkBuilder/DeltaBinaryPackedColumnChunkBuilder.php
+++ b/src/lib/parquet/src/Flow/Parquet/Writer/ColumnChunkBuilder/DeltaBinaryPackedColumnChunkBuilder.php
@@ -73,9 +73,12 @@ final class DeltaBinaryPackedColumnChunkBuilder implements ColumnChunkBuilder
 
         $maxDefinitionLevel = $this->column->maxDefinitionsLevel();
 
+        $nullsInBatch = 0;
+
         foreach ($defLevels as $definitionLevel) {
             if ($definitionLevel < $maxDefinitionLevel) {
                 $this->nullCount++;
+                $nullsInBatch++;
             } else {
                 $this->nonNullValuesCount++;
             }
@@ -83,6 +86,11 @@ final class DeltaBinaryPackedColumnChunkBuilder implements ColumnChunkBuilder
 
         $this->valueStorage->addValues($this->column, $columnValues->values());
         $this->pageStatistics->addBatch($columnValues->values());
+
+        if ($nullsInBatch > 0) {
+            $this->pageStatistics->addNulls($nullsInBatch);
+        }
+
         $this->rowsCount += $columnValues->rowsCount();
     }
 

--- a/src/lib/parquet/src/Flow/Parquet/Writer/ColumnChunkBuilder/PlainFlatColumnChunkBuilder.php
+++ b/src/lib/parquet/src/Flow/Parquet/Writer/ColumnChunkBuilder/PlainFlatColumnChunkBuilder.php
@@ -71,9 +71,12 @@ final class PlainFlatColumnChunkBuilder implements ColumnChunkBuilder
 
         $maxDefinitionLevel = $this->column->maxDefinitionsLevel();
 
+        $nullsInBatch = 0;
+
         foreach ($defLevels as $definitionLevel) {
             if ($definitionLevel < $maxDefinitionLevel) {
                 $this->nullCount++;
+                $nullsInBatch++;
             } else {
                 $this->nonNullValuesCount++;
             }
@@ -81,6 +84,11 @@ final class PlainFlatColumnChunkBuilder implements ColumnChunkBuilder
 
         $this->valueStorage->addValues($this->column, $columnValues->values());
         $this->pageStatistics->addBatch($columnValues->values());
+
+        if ($nullsInBatch > 0) {
+            $this->pageStatistics->addNulls($nullsInBatch);
+        }
+
         $this->rowsCount += $columnValues->rowsCount();
     }
 

--- a/src/lib/parquet/src/Flow/Parquet/Writer/ColumnChunkBuilder/RLEDictionaryChunkBuilder.php
+++ b/src/lib/parquet/src/Flow/Parquet/Writer/ColumnChunkBuilder/RLEDictionaryChunkBuilder.php
@@ -70,14 +70,22 @@ final class RLEDictionaryChunkBuilder implements ColumnChunkBuilder
 
         $maxDefinitionLevel = $this->column->maxDefinitionsLevel();
 
+        $nullsInBatch = 0;
+
         foreach ($defLevels as $definitionLevel) {
             if ($definitionLevel < $maxDefinitionLevel) {
                 $this->nullCount++;
+                $nullsInBatch++;
             }
         }
 
         array_push($this->pageValues, ...$columnValues->values());
         $this->pageStatistics->addBatch($columnValues->values());
+
+        if ($nullsInBatch > 0) {
+            $this->pageStatistics->addNulls($nullsInBatch);
+        }
+
         $this->rowsCount += $columnValues->rowsCount();
     }
 

--- a/src/lib/parquet/src/Flow/Parquet/Writer/StatisticsCounter.php
+++ b/src/lib/parquet/src/Flow/Parquet/Writer/StatisticsCounter.php
@@ -105,6 +105,16 @@ final class StatisticsCounter
         }
     }
 
+    public function addNulls(int $count) : void
+    {
+        if ($count < 0) {
+            throw new InvalidArgumentException('Null count cannot be negative.');
+        }
+
+        $this->nullCount += $count;
+        $this->valuesCount += $count;
+    }
+
     public function max() : mixed
     {
         return $this->max;

--- a/src/lib/parquet/tests/Flow/Parquet/Tests/Integration/IO/WriterTest.php
+++ b/src/lib/parquet/tests/Flow/Parquet/Tests/Integration/IO/WriterTest.php
@@ -141,6 +141,38 @@ class WriterTest extends ParquetIntegrationTestCase
         \unlink($path);
     }
 
+    #[DataProvider('engine_provider')]
+    public function test_writing_column_statistics_with_null_values(ParquetEngine $engine) : void
+    {
+        $schema = Schema::with(
+            FlatColumn::string('all_null'),
+            FlatColumn::string('all_string'),
+            FlatColumn::string('mixed'),
+        );
+
+        $rows = [
+            ['all_null' => null, 'all_string' => 'a', 'mixed' => 'x'],
+            ['all_null' => null, 'all_string' => 'b', 'mixed' => null],
+            ['all_null' => null, 'all_string' => 'c', 'mixed' => 'z'],
+        ];
+
+        $path = __DIR__ . '/var/test-writer-parquet-null-stats-' . generate_random_string() . '.parquet';
+
+        (new Writer(engine: $engine))->write($path, $schema, $rows);
+
+        $chunks = [];
+
+        foreach ((new Reader(engine: $engine))->read($path)->metadata()->columnChunks() as $chunk) {
+            $chunks[$chunk->flatPath()] = $chunk;
+        }
+
+        static::assertSame(3, $chunks['all_null']->statistics()->nullCount());
+        static::assertSame(0, $chunks['all_string']->statistics()->nullCount());
+        static::assertSame(1, $chunks['mixed']->statistics()->nullCount());
+
+        \unlink($path);
+    }
+
     public function test_writing_data_page_v2_statistics() : void
     {
         $options = Options::default()->set(Option::WRITER_VERSION, 2);

--- a/src/lib/parquet/tests/Flow/Parquet/Tests/Unit/Writer/ColumnChunkBuilder/PlainFlatColumnChunkBuilderTest.php
+++ b/src/lib/parquet/tests/Flow/Parquet/Tests/Unit/Writer/ColumnChunkBuilder/PlainFlatColumnChunkBuilderTest.php
@@ -776,4 +776,38 @@ final class PlainFlatColumnChunkBuilderTest extends TestCase
         self::assertCount(1, $containers);
         self::assertSame(5, $containers[0]->columnChunk->valuesCount());
     }
+
+    public function test_statistics_track_null_count_for_all_null_chunk() : void
+    {
+        $column = FlatColumn::string('all_null');
+        $options = new Options();
+        $compression = Compressions::UNCOMPRESSED;
+        $builder = new PlainFlatColumnChunkBuilder($column, $options, $compression);
+
+        $builder->addColumn(new WriteFlatColumnValues($column, [0, 0, 0], [0, 0, 0], []));
+
+        $statistics = $builder->flush(0)[0]->columnChunk->statistics();
+
+        self::assertNotNull($statistics);
+        self::assertSame(3, $statistics->nullCount());
+        self::assertNull($statistics->min($column));
+        self::assertNull($statistics->max($column));
+    }
+
+    public function test_statistics_track_null_count_for_mixed_chunk() : void
+    {
+        $column = FlatColumn::string('mixed');
+        $options = new Options();
+        $compression = Compressions::UNCOMPRESSED;
+        $builder = new PlainFlatColumnChunkBuilder($column, $options, $compression);
+
+        $builder->addColumn(new WriteFlatColumnValues($column, [0, 0, 0], [1, 0, 1], ['x', 'z']));
+
+        $statistics = $builder->flush(0)[0]->columnChunk->statistics();
+
+        self::assertNotNull($statistics);
+        self::assertSame(1, $statistics->nullCount());
+        self::assertSame('x', $statistics->min($column));
+        self::assertSame('z', $statistics->max($column));
+    }
 }

--- a/src/lib/parquet/tests/Flow/Parquet/Tests/Unit/Writer/ColumnChunkBuilder/PlainFlatColumnChunkBuilderTest.php
+++ b/src/lib/parquet/tests/Flow/Parquet/Tests/Unit/Writer/ColumnChunkBuilder/PlainFlatColumnChunkBuilderTest.php
@@ -637,6 +637,40 @@ final class PlainFlatColumnChunkBuilderTest extends TestCase
         self::assertNotNull($statistics);
     }
 
+    public function test_statistics_track_null_count_for_all_null_chunk() : void
+    {
+        $column = FlatColumn::string('all_null');
+        $options = new Options();
+        $compression = Compressions::UNCOMPRESSED;
+        $builder = new PlainFlatColumnChunkBuilder($column, $options, $compression);
+
+        $builder->addColumn(new WriteFlatColumnValues($column, [0, 0, 0], [0, 0, 0], []));
+
+        $statistics = $builder->flush(0)[0]->columnChunk->statistics();
+
+        self::assertNotNull($statistics);
+        self::assertSame(3, $statistics->nullCount());
+        self::assertNull($statistics->min($column));
+        self::assertNull($statistics->max($column));
+    }
+
+    public function test_statistics_track_null_count_for_mixed_chunk() : void
+    {
+        $column = FlatColumn::string('mixed');
+        $options = new Options();
+        $compression = Compressions::UNCOMPRESSED;
+        $builder = new PlainFlatColumnChunkBuilder($column, $options, $compression);
+
+        $builder->addColumn(new WriteFlatColumnValues($column, [0, 0, 0], [1, 0, 1], ['x', 'z']));
+
+        $statistics = $builder->flush(0)[0]->columnChunk->statistics();
+
+        self::assertNotNull($statistics);
+        self::assertSame(1, $statistics->nullCount());
+        self::assertSame('x', $statistics->min($column));
+        self::assertSame('z', $statistics->max($column));
+    }
+
     public function test_uncompressed_size_accumulates_multiple_pages() : void
     {
         $column = new FlatColumn('test_col', PhysicalType::INT32);
@@ -775,39 +809,5 @@ final class PlainFlatColumnChunkBuilderTest extends TestCase
         self::assertIsArray($containers);
         self::assertCount(1, $containers);
         self::assertSame(5, $containers[0]->columnChunk->valuesCount());
-    }
-
-    public function test_statistics_track_null_count_for_all_null_chunk() : void
-    {
-        $column = FlatColumn::string('all_null');
-        $options = new Options();
-        $compression = Compressions::UNCOMPRESSED;
-        $builder = new PlainFlatColumnChunkBuilder($column, $options, $compression);
-
-        $builder->addColumn(new WriteFlatColumnValues($column, [0, 0, 0], [0, 0, 0], []));
-
-        $statistics = $builder->flush(0)[0]->columnChunk->statistics();
-
-        self::assertNotNull($statistics);
-        self::assertSame(3, $statistics->nullCount());
-        self::assertNull($statistics->min($column));
-        self::assertNull($statistics->max($column));
-    }
-
-    public function test_statistics_track_null_count_for_mixed_chunk() : void
-    {
-        $column = FlatColumn::string('mixed');
-        $options = new Options();
-        $compression = Compressions::UNCOMPRESSED;
-        $builder = new PlainFlatColumnChunkBuilder($column, $options, $compression);
-
-        $builder->addColumn(new WriteFlatColumnValues($column, [0, 0, 0], [1, 0, 1], ['x', 'z']));
-
-        $statistics = $builder->flush(0)[0]->columnChunk->statistics();
-
-        self::assertNotNull($statistics);
-        self::assertSame(1, $statistics->nullCount());
-        self::assertSame('x', $statistics->min($column));
-        self::assertSame('z', $statistics->max($column));
     }
 }

--- a/src/lib/parquet/tests/Flow/Parquet/Tests/Unit/Writer/StatisticsCounterTest.php
+++ b/src/lib/parquet/tests/Flow/Parquet/Tests/Unit/Writer/StatisticsCounterTest.php
@@ -130,6 +130,43 @@ final class StatisticsCounterTest extends TestCase
         self::assertNull($statistics->max());
     }
 
+    public function test_add_nulls_increments_null_and_values_count() : void
+    {
+        $column = FlatColumn::string('test_column');
+        $statistics = new StatisticsCounter($column);
+
+        $statistics->add('hello');
+        $statistics->addNulls(3);
+
+        self::assertSame(3, $statistics->nullCount());
+        self::assertSame(4, $statistics->valuesCount());
+        self::assertSame(1, $statistics->notNullCount());
+        self::assertSame('hello', $statistics->min());
+        self::assertSame('hello', $statistics->max());
+    }
+
+    public function test_add_nulls_with_zero_is_noop() : void
+    {
+        $column = FlatColumn::string('test_column');
+        $statistics = new StatisticsCounter($column);
+
+        $statistics->addNulls(0);
+
+        self::assertSame(0, $statistics->nullCount());
+        self::assertSame(0, $statistics->valuesCount());
+    }
+
+    public function test_add_nulls_with_negative_throws() : void
+    {
+        $column = FlatColumn::string('test_column');
+        $statistics = new StatisticsCounter($column);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Null count cannot be negative.');
+
+        $statistics->addNulls(-1);
+    }
+
     public function test_add_object_value() : void
     {
         $column = FlatColumn::string('test_column');

--- a/src/lib/parquet/tests/Flow/Parquet/Tests/Unit/Writer/StatisticsCounterTest.php
+++ b/src/lib/parquet/tests/Flow/Parquet/Tests/Unit/Writer/StatisticsCounterTest.php
@@ -145,17 +145,6 @@ final class StatisticsCounterTest extends TestCase
         self::assertSame('hello', $statistics->max());
     }
 
-    public function test_add_nulls_with_zero_is_noop() : void
-    {
-        $column = FlatColumn::string('test_column');
-        $statistics = new StatisticsCounter($column);
-
-        $statistics->addNulls(0);
-
-        self::assertSame(0, $statistics->nullCount());
-        self::assertSame(0, $statistics->valuesCount());
-    }
-
     public function test_add_nulls_with_negative_throws() : void
     {
         $column = FlatColumn::string('test_column');
@@ -165,6 +154,17 @@ final class StatisticsCounterTest extends TestCase
         $this->expectExceptionMessage('Null count cannot be negative.');
 
         $statistics->addNulls(-1);
+    }
+
+    public function test_add_nulls_with_zero_is_noop() : void
+    {
+        $column = FlatColumn::string('test_column');
+        $statistics = new StatisticsCounter($column);
+
+        $statistics->addNulls(0);
+
+        self::assertSame(0, $statistics->nullCount());
+        self::assertSame(0, $statistics->valuesCount());
     }
 
     public function test_add_object_value() : void


### PR DESCRIPTION
<!-- 
    Please replace #xxx with a GitHub issue id from flow-php/flow repository. For example #1234 
    If there is no item in a roadmap related to this PR, please check our contributing guidelines first. 
-->
Resolves: #2349 

<!-- 
    Below section will be used to automatically generate changelog, please do not modify HTML code structure
    DO NOT REMOVE that HTML STRUCTURE, INSTEAD ADD YOUR CHANGES INSIDE THE LISTS 
    PULL REQUESTS WITHOUT CHANGELOG CAN'T BE MERGED 
-->
<h2>Change Log</h2>
<hr /> 
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
     <li>Correction of handling of null counts metadata in parquet files for PhpParquetEngine</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>