### PR TITLE
fix: default values in ForeingKey and UniqueConstraint postgersql

### DIFF
--- a/src/lib/postgresql/src/Flow/PostgreSql/Schema/Constraint/ForeignKey.php
+++ b/src/lib/postgresql/src/Flow/PostgreSql/Schema/Constraint/ForeignKey.php
@@ -7,7 +7,7 @@ namespace Flow\PostgreSql\Schema\Constraint;
 use Flow\PostgreSql\QueryBuilder\Schema\ReferentialAction;
 
 /**
- * @phpstan-type ForeignKeyShape = array{name: ?string, columns: non-empty-list<string>, reference_schema: string, reference_table: string, reference_columns: non-empty-list<string>, on_update: string, on_delete: string, deferrable: bool, initially_deferred: bool}
+ * @phpstan-type ForeignKeyShape = array{name: ?string, columns: non-empty-list<string>, reference_schema: string, reference_table: string, reference_columns: non-empty-list<string>, on_update?: string, on_delete?: string, deferrable?: bool, initially_deferred?: bool}
  */
 final readonly class ForeignKey
 {
@@ -44,8 +44,8 @@ final readonly class ForeignKey
             onDelete: array_key_exists('on_delete', $data)
                 ? ReferentialAction::from($data['on_delete'])
                 : ReferentialAction::NO_ACTION,
-            deferrable: $data['deferrable'],
-            initiallyDeferred: $data['initially_deferred'],
+            deferrable: $data['deferrable'] ?? false,
+            initiallyDeferred: $data['initially_deferred'] ?? false,
         );
     }
 

--- a/src/lib/postgresql/src/Flow/PostgreSql/Schema/Constraint/UniqueConstraint.php
+++ b/src/lib/postgresql/src/Flow/PostgreSql/Schema/Constraint/UniqueConstraint.php
@@ -7,7 +7,7 @@ namespace Flow\PostgreSql\Schema\Constraint;
 use function sort;
 
 /**
- * @phpstan-type UniqueConstraintShape = array{columns: non-empty-list<string>, name: ?string, nulls_not_distinct: bool}
+ * @phpstan-type UniqueConstraintShape = array{columns: non-empty-list<string>, name?: ?string, nulls_not_distinct?: bool}
  */
 final readonly class UniqueConstraint
 {
@@ -28,7 +28,7 @@ final readonly class UniqueConstraint
         return new self(
             columns: $data['columns'],
             name: $data['name'] ?? null,
-            nullsNotDistinct: $data['nulls_not_distinct'],
+            nullsNotDistinct: $data['nulls_not_distinct'] ?? false,
         );
     }
 

--- a/src/lib/postgresql/tests/Flow/PostgreSql/Tests/Unit/Schema/Constraint/ForeignKeyTest.php
+++ b/src/lib/postgresql/tests/Flow/PostgreSql/Tests/Unit/Schema/Constraint/ForeignKeyTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Flow\PostgreSql\Tests\Unit\Schema\Constraint;
 
 use Flow\PostgreSql\QueryBuilder\Schema\ReferentialAction;
+use Flow\PostgreSql\Schema\Constraint\ForeignKey;
 use PHPUnit\Framework\TestCase;
 
 use function Flow\PostgreSql\DSL\schema_foreign_key;
@@ -126,6 +127,63 @@ final class ForeignKeyTest extends TestCase
         $b = schema_foreign_key(['user_id'], 'users', ['id'], referenceSchema: 'other');
 
         static::assertFalse($a->isEqualStructure($b));
+    }
+
+    public function test_from_array_defaults_optional_keys_when_absent(): void
+    {
+        $fk = ForeignKey::fromArray([
+            'name' => 'fk_orders_user',
+            'columns' => ['user_id'],
+            'reference_schema' => 'public',
+            'reference_table' => 'users',
+            'reference_columns' => ['id'],
+        ]);
+
+        static::assertSame('fk_orders_user', $fk->name);
+        static::assertSame(['user_id'], $fk->columns);
+        static::assertSame('public', $fk->referenceSchema);
+        static::assertSame('users', $fk->referenceTable);
+        static::assertSame(['id'], $fk->referenceColumns);
+        static::assertSame(ReferentialAction::NO_ACTION, $fk->onUpdate);
+        static::assertSame(ReferentialAction::NO_ACTION, $fk->onDelete);
+        static::assertFalse($fk->deferrable);
+        static::assertFalse($fk->initiallyDeferred);
+    }
+
+    public function test_from_array_with_all_keys(): void
+    {
+        $fk = ForeignKey::fromArray([
+            'name' => 'fk_orders_user',
+            'columns' => ['user_id'],
+            'reference_schema' => 'public',
+            'reference_table' => 'users',
+            'reference_columns' => ['id'],
+            'on_update' => ReferentialAction::CASCADE->value,
+            'on_delete' => ReferentialAction::RESTRICT->value,
+            'deferrable' => true,
+            'initially_deferred' => true,
+        ]);
+
+        static::assertSame(ReferentialAction::CASCADE, $fk->onUpdate);
+        static::assertSame(ReferentialAction::RESTRICT, $fk->onDelete);
+        static::assertTrue($fk->deferrable);
+        static::assertTrue($fk->initiallyDeferred);
+    }
+
+    public function test_normalize_and_from_array_round_trip(): void
+    {
+        $fk = schema_foreign_key(
+            ['user_id'],
+            'users',
+            ['id'],
+            name: 'fk_orders_user',
+            onDelete: ReferentialAction::CASCADE,
+            onUpdate: ReferentialAction::SET_NULL,
+            deferrable: true,
+            initiallyDeferred: true,
+        );
+
+        static::assertTrue($fk->isEqual(ForeignKey::fromArray($fk->normalize())));
     }
 
     public function test_is_equal_structure_returns_true_when_only_name_differs(): void

--- a/src/lib/postgresql/tests/Flow/PostgreSql/Tests/Unit/Schema/Constraint/UniqueConstraintTest.php
+++ b/src/lib/postgresql/tests/Flow/PostgreSql/Tests/Unit/Schema/Constraint/UniqueConstraintTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Flow\PostgreSql\Tests\Unit\Schema\Constraint;
 
+use Flow\PostgreSql\Schema\Constraint\UniqueConstraint;
 use PHPUnit\Framework\TestCase;
 
 use function Flow\PostgreSql\DSL\schema_unique;
@@ -16,6 +17,48 @@ final class UniqueConstraintTest extends TestCase
         $b = schema_unique(['email'], 'uq_email', nullsNotDistinct: true);
 
         static::assertTrue($a->isEqual($b));
+    }
+
+    public function test_from_array_defaults_nulls_not_distinct_when_absent(): void
+    {
+        $unique = UniqueConstraint::fromArray([
+            'columns' => ['email'],
+            'name' => 'uq_email',
+        ]);
+
+        static::assertSame(['email'], $unique->columns);
+        static::assertSame('uq_email', $unique->name);
+        static::assertFalse($unique->nullsNotDistinct);
+    }
+
+    public function test_from_array_defaults_name_when_absent(): void
+    {
+        $unique = UniqueConstraint::fromArray([
+            'columns' => ['email'],
+        ]);
+
+        static::assertNull($unique->name);
+        static::assertFalse($unique->nullsNotDistinct);
+    }
+
+    public function test_from_array_with_all_keys(): void
+    {
+        $unique = UniqueConstraint::fromArray([
+            'columns' => ['email', 'tenant_id'],
+            'name' => 'uq_email_tenant',
+            'nulls_not_distinct' => true,
+        ]);
+
+        static::assertSame(['email', 'tenant_id'], $unique->columns);
+        static::assertSame('uq_email_tenant', $unique->name);
+        static::assertTrue($unique->nullsNotDistinct);
+    }
+
+    public function test_normalize_and_from_array_round_trip(): void
+    {
+        $unique = schema_unique(['email', 'tenant_id'], 'uq_email_tenant', nullsNotDistinct: true);
+
+        static::assertTrue($unique->isEqual(UniqueConstraint::fromArray($unique->normalize())));
     }
 
     public function test_is_equal_returns_false_when_columns_differ(): void


### PR DESCRIPTION
<!-- 
    Please replace #xxx with a GitHub issue id from flow-php/flow repository. For example #1234 
    If there is no item in a roadmap related to this PR, please check our contributing guidelines first. 
-->
Resolves: #xxx

<!-- 
    Below section will be used to automatically generate changelog, please do not modify HTML code structure
    DO NOT REMOVE that HTML STRUCTURE, INSTEAD ADD YOUR CHANGES INSIDE THE LISTS 
    PULL REQUESTS WITHOUT CHANGELOG CAN'T BE MERGED 
-->
<h2>Change Log</h2>
<hr /> 
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>default values in ForeingKey and UniqueConstraint postgersql</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>