### PR TITLE
Add PHPUnit bridge compatibility with PHPUnit 11/12/13

### DIFF
--- a/.github/workflows/job-phpunit-telemetry-tests.yml
+++ b/.github/workflows/job-phpunit-telemetry-tests.yml
@@ -1,0 +1,67 @@
+name: PHPUnit Telemetry Bridge Tests
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    services:
+      postgres:
+        image: postgres:18-alpine
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432/tcp
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+    strategy:
+      fail-fast: false
+      matrix:
+        phpunit-version:
+          - "11"
+          - "12"
+          - "13"
+        php-version:
+          - "8.3"
+          - "8.4"
+          - "8.5"
+        exclude:
+          # PHPUnit 13 requires PHP >= 8.4.1.
+          - phpunit-version: "13"
+            php-version: "8.3"
+
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: "Setup PHP Environment"
+        uses: "./.github/actions/setup-php-env"
+        with:
+          php-version: "${{ matrix.php-version }}"
+          dependencies: "locked"
+          extensions: ':psr, bcmath, dom, hash, json, mbstring, xml, xmlwriter, xmlreader, zlib, curl, pgsql, grpc, protobuf'
+          ini-values: 'memory_limit=-1'
+          apt-packages: "build-essential autoconf automake libtool protobuf-compiler libprotobuf-c-dev"
+          pie-extensions: "flow-php/pg-query-ext:1.x-dev"
+
+      - name: "Install PHPUnit ${{ matrix.phpunit-version }}"
+        if: ${{ matrix.phpunit-version != '11' }}
+        run: |
+          composer require --working-dir=tools/phpunit --no-interaction --no-progress -W \
+            "phpunit/phpunit:^${{ matrix.phpunit-version }}"
+
+      - name: "Show PHPUnit version"
+        run: tools/phpunit/vendor/bin/phpunit --version
+
+      - name: "Test"
+        run: just test --testsuite bridge-phpunit-postgresql-unit,bridge-phpunit-postgresql-integration,bridge-phpunit-telemetry-unit
+        env:
+          PGSQL_DATABASE_URL: pgsql://postgres:postgres@127.0.0.1:${{ job.services.postgres.ports['5432'] }}/postgres?serverVersion=11&charset=utf8

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -42,6 +42,9 @@ jobs:
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
+  phpunit-telemetry-tests:
+    uses: ./.github/workflows/job-phpunit-telemetry-tests.yml
+
   extension-tests:
     uses: ./.github/workflows/job-extension-tests.yml
     secrets:

--- a/src/bridge/phpunit/postgresql/composer.json
+++ b/src/bridge/phpunit/postgresql/composer.json
@@ -15,7 +15,7 @@
     "require": {
         "php": "~8.3.0 || ~8.4.0 || ~8.5.0",
         "flow-php/postgresql": "self.version",
-        "phpunit/phpunit": "^11"
+        "phpunit/phpunit": "^11 || ^12 || ^13"
     },
     "autoload": {
         "psr-4": {

--- a/src/bridge/phpunit/telemetry/composer.json
+++ b/src/bridge/phpunit/telemetry/composer.json
@@ -17,7 +17,7 @@
         "php": "~8.3.0 || ~8.4.0 || ~8.5.0",
         "flow-php/telemetry": "self.version",
         "flow-php/telemetry-otlp-bridge": "self.version",
-        "phpunit/phpunit": "^11"
+        "phpunit/phpunit": "^11 || ^12 || ^13"
     },
     "require-dev": {
         "google/protobuf": "^4.0 || ^5.0",

--- a/src/bridge/phpunit/telemetry/tests/Flow/Bridge/PHPUnit/Telemetry/Tests/Mother/TestEventMother.php
+++ b/src/bridge/phpunit/telemetry/tests/Flow/Bridge/PHPUnit/Telemetry/Tests/Mother/TestEventMother.php
@@ -46,7 +46,7 @@ final class TestEventMother
                 HRTime::fromSecondsAndNanoseconds(0, 0),
                 MemoryUsage::fromBytes(0),
                 MemoryUsage::fromBytes(0),
-                new GarbageCollectorStatus(0, 0, 0, 0, null, null, null, null, null, null, null, null),
+                new GarbageCollectorStatus(0, 0, 0, 0, 0.0, 0.0, 0.0, 0.0, false, false, false, 0),
             ),
             Duration::fromSecondsAndNanoseconds(0, 0),
             MemoryUsage::fromBytes(0),


### PR DESCRIPTION
<h2>Change Log</h2>
<hr /> 
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <li>Add PHPUnit bridge compatibility with PHPUnit 11/12/13</li>
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>

<h2>Description</h2>
<hr /> 
The PHPUnit extension for OpenTelemetry is very interesting but it's actually only compatible with PHPUnit 11.

So this PR allows the bridge to be installed with versions 12 and 13.

I've updated the CI workflow to run tests for those dedicated versions.