### PR TITLE
fix: postgresql saving migrations table in custom schema

### DIFF
--- a/docker/otel-collector-config.yaml
+++ b/docker/otel-collector-config.yaml
@@ -1,5 +1,3 @@
-file_format: '1.0'
-
 receivers:
   otlp:
     protocols:

--- a/docker/otel-collector-test-config.yaml
+++ b/docker/otel-collector-test-config.yaml
@@ -1,5 +1,3 @@
-file_format: '1.0'
-
 receivers:
   otlp:
     protocols:

--- a/src/lib/postgresql/src/Flow/PostgreSql/Migrations/Store/PostgreSqlMigrationStore.php
+++ b/src/lib/postgresql/src/Flow/PostgreSql/Migrations/Store/PostgreSqlMigrationStore.php
@@ -74,6 +74,8 @@ final readonly class PostgreSqlMigrationStore implements MigrationStore
 
     public function initialize(): void
     {
+        $this->client->execute(create()->schema($this->configuration->tableSchema)->ifNotExists());
+
         $this->client->execute(
             create()
                 ->table($this->configuration->tableName, $this->configuration->tableSchema)

--- a/src/lib/postgresql/tests/Flow/PostgreSql/Migrations/Tests/Integration/CustomSchemaMigrationTest.php
+++ b/src/lib/postgresql/tests/Flow/PostgreSql/Migrations/Tests/Integration/CustomSchemaMigrationTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\PostgreSql\Migrations\Tests\Integration;
+
+use Flow\PostgreSql\Migrations\Configuration;
+use Flow\PostgreSql\Migrations\Direction;
+use Flow\PostgreSql\Migrations\Executor\DefaultMigrationExecutor;
+use Flow\PostgreSql\Migrations\Migrator;
+use Flow\PostgreSql\Migrations\Repository\AvailableMigration;
+use Flow\PostgreSql\Migrations\Store\PostgreSqlMigrationStore;
+use Flow\PostgreSql\Migrations\Tests\Double\FakeCatalogProvider;
+use Flow\PostgreSql\Migrations\Tests\Double\FakeMigrationRepository;
+use Flow\PostgreSql\Migrations\Tests\Double\SpyMigration;
+use Flow\PostgreSql\Migrations\Version;
+use Flow\PostgreSql\Schema\Catalog;
+use PHPUnit\Framework\TestCase;
+
+final class CustomSchemaMigrationTest extends TestCase
+{
+    private const CUSTOM_SCHEMA = 'flow_custom_schema_test';
+
+    private const TABLE_NAME = 'flow_migrations_test';
+
+    protected PostgreSqlMigrationsContext $context;
+
+    protected function setUp(): void
+    {
+        $this->context = new PostgreSqlMigrationsContext();
+        $this->context->dropSchemaIfExists(self::CUSTOM_SCHEMA);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->context->dropSchemaIfExists(self::CUSTOM_SCHEMA);
+        $this->context->close();
+    }
+
+    public function test_migrate_creates_tracking_table_in_custom_schema_and_records_migration(): void
+    {
+        $configuration = new Configuration(
+            client: $this->context->client,
+            targetCatalogProvider: new FakeCatalogProvider(new Catalog([])),
+            migrationsDirectory: __DIR__,
+            migrationsNamespace: __NAMESPACE__,
+            tableName: self::TABLE_NAME,
+            tableSchema: self::CUSTOM_SCHEMA,
+        );
+        $store = new PostgreSqlMigrationStore($this->context->client, $configuration);
+
+        static::assertFalse($store->isInitialized());
+
+        $migration = new SpyMigration();
+        $repository = new FakeMigrationRepository(
+            new AvailableMigration(Version::fromString('20260601120000'), 'noop', $migration, null),
+        );
+        $migrator = new Migrator(
+            $repository,
+            $store,
+            new DefaultMigrationExecutor(),
+            $this->context->client,
+            $configuration,
+        );
+
+        $results = $migrator->migrate();
+
+        static::assertCount(1, $results);
+        static::assertTrue($results[0]->isSuccessful());
+        static::assertSame(Direction::UP, $results[0]->direction);
+        static::assertTrue($migration->migrateCalled);
+        static::assertTrue($store->isInitialized());
+        static::assertCount(1, $store->executedMigrations());
+    }
+}

--- a/src/lib/postgresql/tests/Flow/PostgreSql/Migrations/Tests/Integration/PostgreSqlMigrationsContext.php
+++ b/src/lib/postgresql/tests/Flow/PostgreSql/Migrations/Tests/Integration/PostgreSqlMigrationsContext.php
@@ -32,6 +32,11 @@ final class PostgreSqlMigrationsContext
         $this->client->close();
     }
 
+    public function dropSchemaIfExists(string $schema): void
+    {
+        $this->client->execute(drop()->schema($schema)->ifExists()->cascade()->toSql());
+    }
+
     public function dropTableIfExists(string $table): void
     {
         $this->client->execute(drop()->table($table)->ifExists()->cascade()->toSql());


### PR DESCRIPTION

<h2>Change Log</h2>
<hr /> 
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>saving postgresql migrations table in schema other than public</li>
    <li>reverted file_format introduced in otel collector config</li> 
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>