### PR TITLE
chore(flow-php/pg-query-ext): bump libpg_query to PostgreSQL 18 grammar

### DIFF
--- a/documentation/contributing/c.md
+++ b/documentation/contributing/c.md
@@ -10,7 +10,7 @@ actual PostgreSQL parser.
 
 The `pg-query-ext` extension exposes PostgreSQL's SQL parser to PHP, providing functions for
 parsing, normalizing, fingerprinting, and splitting SQL queries. It statically links against
-`libpg_query` which embeds the PostgreSQL 17 grammar.
+`libpg_query` which embeds the PostgreSQL 18 grammar.
 
 For usage documentation, see [pg-query Extension](/documentation/components/extensions/pg-query-ext.md).
 

--- a/src/extension/pg-query-ext/Makefile
+++ b/src/extension/pg-query-ext/Makefile
@@ -1,5 +1,5 @@
 # Flow PHP pg_query Extension Makefile
-LIBPG_QUERY_VERSION := 17-latest
+LIBPG_QUERY_VERSION := 18-latest
 LIBPG_QUERY_DIR := ./vendor/libpg_query
 LIBPG_QUERY_LIB := $(LIBPG_QUERY_DIR)/libpg_query.a
 EXTENSION_DIR := ./ext

--- a/src/extension/pg-query-ext/ext/config.m4
+++ b/src/extension/pg-query-ext/ext/config.m4
@@ -6,9 +6,9 @@ PHP_ARG_WITH([pg-query],
     [Include pg_query support. DIR is the libpg_query install prefix (optional - will download if not found)])])
 
 if test "$PHP_PG_QUERY" != "no"; then
-  dnl libpg_query 17-latest is required for postgres_deparse.h support
-  LIBPG_QUERY_VERSION="17-latest"
-  AC_MSG_NOTICE([Using libpg_query $LIBPG_QUERY_VERSION (PostgreSQL 17 grammar)])
+  dnl libpg_query 18-latest is required for postgres_deparse.h support
+  LIBPG_QUERY_VERSION="18-latest"
+  AC_MSG_NOTICE([Using libpg_query $LIBPG_QUERY_VERSION (PostgreSQL 18 grammar)])
 
   PG_QUERY_DIR=""
 

--- a/src/extension/pg-query-ext/ext/pg_query.c
+++ b/src/extension/pg-query-ext/ext/pg_query.c
@@ -87,7 +87,7 @@ PHP_MINFO_FUNCTION(pg_query)
     php_info_print_table_start();
     php_info_print_table_header(2, "pg_query support", "enabled");
     php_info_print_table_row(2, "Version", PHP_PG_QUERY_VERSION);
-    php_info_print_table_row(2, "libpg_query version", "17-6.2.1");
+    php_info_print_table_row(2, "libpg_query version", "18.0.0");
     php_info_print_table_end();
 }
 


### PR DESCRIPTION
<h2>Change Log</h2>
<hr />
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul>
  <h4>Fixed</h4>
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li><code>flow-php/pg-query-ext</code> - bumped libpg_query to the PostgreSQL 18 grammar</li>
  </ul>
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>
  <h4>Security</h4>
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>
</div>
