### PR TITLE
fix(flow-php/postgresql): quote schema-qualified table per identifier part in BulkInsert

### DIFF
--- a/src/lib/postgresql/src/Flow/PostgreSql/QueryBuilder/Insert/BulkInsert.php
+++ b/src/lib/postgresql/src/Flow/PostgreSql/QueryBuilder/Insert/BulkInsert.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Flow\PostgreSql\QueryBuilder\Insert;
 
 use Flow\PostgreSql\QueryBuilder\Clause\ConflictTarget;
+use Flow\PostgreSql\QueryBuilder\QualifiedIdentifier;
 use Flow\PostgreSql\QueryBuilder\Sql;
 use InvalidArgumentException;
 
@@ -96,7 +97,7 @@ final readonly class BulkInsert implements Sql
             $rows[] = '(' . implode(', ', $placeholders) . ')';
         }
 
-        $sql = sprintf('INSERT INTO "%s" (%s) VALUES %s', $this->table, $quotedColumns, implode(', ', $rows));
+        $sql = sprintf('INSERT INTO %s (%s) VALUES %s', $this->quotedTable(), $quotedColumns, implode(', ', $rows));
 
         if ($this->doNothing) {
             $sql .= ' ON CONFLICT';
@@ -123,6 +124,14 @@ final readonly class BulkInsert implements Sql
         }
 
         return $sql;
+    }
+
+    private function quotedTable(): string
+    {
+        return implode('.', array_map(
+            static fn(string $part): string => '"' . $part . '"',
+            QualifiedIdentifier::parse($this->table)->parts(),
+        ));
     }
 
     private function formatConflictTarget(ConflictTarget $target): string

--- a/src/lib/postgresql/tests/Flow/PostgreSql/Tests/Unit/QueryBuilder/Insert/BulkInsertTest.php
+++ b/src/lib/postgresql/tests/Flow/PostgreSql/Tests/Unit/QueryBuilder/Insert/BulkInsertTest.php
@@ -48,6 +48,41 @@ final class BulkInsertTest extends TestCase
         static::assertStringContainsString('DO UPDATE', $query2->toSql());
     }
 
+    public function test_insert_into_schema_qualified_table(): void
+    {
+        $query = BulkInsert::into('enriched.production', ['a', 'b'], 1);
+
+        static::assertSame('INSERT INTO "enriched"."production" ("a", "b") VALUES ($1, $2)', $query->toSql());
+    }
+
+    public function test_insert_into_three_part_qualified_table(): void
+    {
+        $query = BulkInsert::into('db.enriched.production', ['a'], 1);
+
+        static::assertSame('INSERT INTO "db"."enriched"."production" ("a") VALUES ($1)', $query->toSql());
+    }
+
+    public function test_insert_into_already_quoted_qualified_table(): void
+    {
+        $query = BulkInsert::into('enriched."my.table"', ['a'], 1);
+
+        static::assertSame('INSERT INTO "enriched"."my.table" ("a") VALUES ($1)', $query->toSql());
+    }
+
+    public function test_schema_qualified_table_with_on_conflict_do_update(): void
+    {
+        $query = BulkInsert::into(
+            'enriched.production',
+            ['email', 'name'],
+            1,
+        )->onConflictDoUpdate(ConflictTarget::columns(['email']));
+
+        static::assertSame(
+            'INSERT INTO "enriched"."production" ("email", "name") VALUES ($1, $2) ON CONFLICT ("email") DO UPDATE SET "name" = EXCLUDED."name"',
+            $query->toSql(),
+        );
+    }
+
     public function test_insert_with_many_columns(): void
     {
         $query = BulkInsert::into('products', ['id', 'name', 'price', 'category', 'stock'], 2);


### PR DESCRIPTION
… 

<!-- 
    Please replace #xxx with a GitHub issue id from flow-php/flow repository. For example #1234 
    If there is no item in a roadmap related to this PR, please check our contributing guidelines first. 
-->
Resolves: #xxx

<!-- 
    Below section will be used to automatically generate changelog, please do not modify HTML code structure
    DO NOT REMOVE that HTML STRUCTURE, INSTEAD ADD YOUR CHANGES INSIDE THE LISTS 
    PULL REQUESTS WITHOUT CHANGELOG CAN'T BE MERGED 
-->
<h2>Change Log</h2>
<hr />
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul>
  <h4>Fixed</h4>
  <ul id="fixed">
    <li><code>flow-php/postgresql</code> - BulkInsert now quotes schema-qualified table names per identifier part.</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->                                                                                                                                                                                                                            
  </ul>
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>
  <h4>Security</h4>
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>
</div>
