### PR TITLE
fix(flow-php/postgresql): raise parser nesting ceiling for large queries

### DIFF
--- a/.nix/pkgs/flow-php/package.nix
+++ b/.nix/pkgs/flow-php/package.nix
@@ -1,5 +1,6 @@
 {
     php,
+    fetchurl,
     php-snappy,
     php-lz4,
     php-brotli,
@@ -38,7 +39,15 @@ let
         ++ (if with-pg-query-ext then [(php-pg-query-ext.override { inherit php; })] else [])
         ++ (if with-arrow-ext then [(php-arrow-ext.override { inherit php; })] else [])
         ++ (if with-grpc then [grpc] else [])
-        ++ (if with-protobuf then [protobuf] else [])
+        ++ (if with-protobuf then [
+            (protobuf.overrideAttrs (old: {
+                version = "5.35.0";
+                src = fetchurl {
+                    url = "https://pecl.php.net/get/protobuf-5.35.0.tgz";
+                    sha256 = "1wk5q2fd7wlb2qs41ikdbdhpf4248i86fsphg7gnq97zi88aar7m";
+                };
+            }))
+        ] else [])
     );
 in
 flowPHP.buildEnv {

--- a/src/bridge/phpunit/telemetry/tests/Flow/Bridge/PHPUnit/Telemetry/Tests/Mother/TestEventMother.php
+++ b/src/bridge/phpunit/telemetry/tests/Flow/Bridge/PHPUnit/Telemetry/Tests/Mother/TestEventMother.php
@@ -16,6 +16,10 @@ use PHPUnit\Event\Test\Finished;
 use PHPUnit\Event\Test\PreparationStarted;
 use PHPUnit\Event\TestData\TestDataCollection;
 use PHPUnit\Metadata\MetadataCollection;
+use ReflectionClass;
+use ReflectionNamedType;
+
+use function count;
 
 final class TestEventMother
 {
@@ -42,17 +46,45 @@ final class TestEventMother
     private static function createInfo(): Info
     {
         return new Info(
-            new Snapshot(
-                HRTime::fromSecondsAndNanoseconds(0, 0),
-                MemoryUsage::fromBytes(0),
-                MemoryUsage::fromBytes(0),
-                new GarbageCollectorStatus(0, 0, 0, 0, 0.0, 0.0, 0.0, 0.0, false, false, false, 0),
-            ),
+            self::createSnapshot(),
             Duration::fromSecondsAndNanoseconds(0, 0),
             MemoryUsage::fromBytes(0),
             Duration::fromSecondsAndNanoseconds(0, 0),
             MemoryUsage::fromBytes(0),
         );
+    }
+
+    /**
+     * PHPUnit 13 extended Snapshot::__construct() with userCpuTime/systemCpuTime/totalCpuTime
+     * (CpuTime). The trailing arguments are built reflectively from the constructor's own
+     * parameter types so the mother stays compatible with PHPUnit 11/12 (4 arguments) and 13
+     * (7 arguments) without referencing the 13-only CpuTime class.
+     */
+    private static function createSnapshot(): Snapshot
+    {
+        $arguments = [
+            HRTime::fromSecondsAndNanoseconds(0, 0),
+            MemoryUsage::fromBytes(0),
+            MemoryUsage::fromBytes(0),
+            new GarbageCollectorStatus(0, 0, 0, 0, 0.0, 0.0, 0.0, 0.0, false, false, false, 0),
+        ];
+
+        $constructor = (new ReflectionClass(Snapshot::class))->getConstructor();
+
+        if ($constructor !== null) {
+            $parameters = $constructor->getParameters();
+
+            for ($position = count($arguments); $position < count($parameters); $position++) {
+                $type = $parameters[$position]->getType();
+
+                if ($type instanceof ReflectionNamedType) {
+                    $cpuTime = $type->getName();
+                    $arguments[] = $cpuTime::fromSecondsAndNanoseconds(0, 0);
+                }
+            }
+        }
+
+        return new Snapshot(...$arguments);
     }
 
     /**

--- a/src/bridge/phpunit/telemetry/tests/Flow/Bridge/PHPUnit/Telemetry/Tests/Mother/TestEventMother.php
+++ b/src/bridge/phpunit/telemetry/tests/Flow/Bridge/PHPUnit/Telemetry/Tests/Mother/TestEventMother.php
@@ -43,22 +43,41 @@ final class TestEventMother
         return new PreparationStarted(self::createInfo(), self::createTestMethod($className, $methodName));
     }
 
+    /**
+     * PHPUnit 13 extended Info::__construct() from 5 to 11 arguments, adding trailing CpuTime
+     * values.
+     */
     private static function createInfo(): Info
     {
-        return new Info(
+        $arguments = [
             self::createSnapshot(),
             Duration::fromSecondsAndNanoseconds(0, 0),
             MemoryUsage::fromBytes(0),
             Duration::fromSecondsAndNanoseconds(0, 0),
             MemoryUsage::fromBytes(0),
-        );
+        ];
+
+        $constructor = (new ReflectionClass(Info::class))->getConstructor();
+
+        if ($constructor !== null) {
+            $parameters = $constructor->getParameters();
+
+            for ($position = count($arguments); $position < count($parameters); $position++) {
+                $type = $parameters[$position]->getType();
+
+                if ($type instanceof ReflectionNamedType) {
+                    $cpuTime = $type->getName();
+                    $arguments[] = $cpuTime::fromSecondsAndNanoseconds(0, 0);
+                }
+            }
+        }
+
+        return new Info(...$arguments);
     }
 
     /**
-     * PHPUnit 13 extended Snapshot::__construct() with userCpuTime/systemCpuTime/totalCpuTime
-     * (CpuTime). The trailing arguments are built reflectively from the constructor's own
-     * parameter types so the mother stays compatible with PHPUnit 11/12 (4 arguments) and 13
-     * (7 arguments) without referencing the 13-only CpuTime class.
+     * PHPUnit 13 extended Snapshot::__construct() from 4 to 7 arguments, adding trailing CpuTime
+     * values. See createInfo() for the reflective rationale.
      */
     private static function createSnapshot(): Snapshot
     {

--- a/src/lib/postgresql/src/Flow/PostgreSql/Parser.php
+++ b/src/lib/postgresql/src/Flow/PostgreSql/Parser.php
@@ -36,13 +36,13 @@ final class Parser
     public function parse(string $sql): ParsedQuery
     {
         try {
-            $json = pg_query_parse($sql);
+            $protobuf = pg_query_parse_protobuf($sql);
         } catch (RuntimeException $e) {
             throw new ParserException($e->getMessage());
         }
 
         $result = new ParseResult();
-        $result->mergeFromJsonString($json);
+        $result->mergeFromString($protobuf);
 
         return new ParsedQuery($result);
     }


### PR DESCRIPTION
<h2>Change Log</h2>
<hr />
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul>
  <h4>Fixed</h4>
  <ul id="fixed">
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li><code>flow-php/postgresql</code> - Parser::parse() ingests binary protobuf instead of JSON</li>
    <li><code>flow-php/postgresql</code> - dev ext-protobuf bumped to 5.35.0 (depth limit 64 to 100)</li>
<li><code>flow-php/phpunit-telemetry-bridge</code> - TestEventMother builds Snapshot reflectively for PHPUnit 11/12/13 compatibility</li>
  </ul>
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->                                                                                                                                                                                                                        
  </ul>
  <h4>Security</h4>
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>
</div>
