### PR TITLE
fix(flow-php/postgresql): count ParamRef nodes inside List expressions during AST traversal

### DIFF
--- a/src/lib/postgresql/src/Flow/PostgreSql/AST/Traverser.php
+++ b/src/lib/postgresql/src/Flow/PostgreSql/AST/Traverser.php
@@ -570,6 +570,12 @@ final class Traverser
             $this->traverseRepeatedField($boolExpr->getArgs());
         }
 
+        $list = $node->getList();
+
+        if ($list !== null) {
+            $this->traverseRepeatedField($list->getItems());
+        }
+
         $caseExpr = $node->getCaseExpr();
 
         if ($caseExpr !== null) {

--- a/src/lib/postgresql/tests/Flow/PostgreSql/Tests/Unit/AST/Transformers/KeysetPaginationModifierTest.php
+++ b/src/lib/postgresql/tests/Flow/PostgreSql/Tests/Unit/AST/Transformers/KeysetPaginationModifierTest.php
@@ -157,6 +157,18 @@ final class KeysetPaginationModifierTest extends TestCase
             'SELECT * FROM users WHERE status = $1 ORDER BY id LIMIT 10',
         ];
 
+        yield 'base query with BETWEEN params - keyset offset past list bounds' => [
+            'SELECT * FROM t WHERE t.d BETWEEN $1 AND $2',
+            new KeysetPaginationConfig(10, [sql_keyset_column('t.id', SortOrder::ASC)], [100]),
+            'SELECT * FROM t WHERE t.d BETWEEN $1 AND $2 AND t.id > $3 ORDER BY t.id ASC LIMIT 10',
+        ];
+
+        yield 'base query with IN list params - keyset offset past list items' => [
+            'SELECT * FROM t WHERE t.s IN ($1, $2, $3)',
+            new KeysetPaginationConfig(10, [sql_keyset_column('t.id', SortOrder::ASC)], [100]),
+            'SELECT * FROM t WHERE t.s IN ($1, $2, $3) AND t.id > $4 ORDER BY t.id ASC LIMIT 10',
+        ];
+
         yield 'with out-of-order parameters - max detected correctly' => [
             'SELECT * FROM users WHERE id > $10 OR status = $1 ORDER BY id',
             new KeysetPaginationConfig(10, [sql_keyset_column('id', SortOrder::ASC)], [42]),

--- a/src/lib/postgresql/tests/Flow/PostgreSql/Tests/Unit/AST/TraverserTest.php
+++ b/src/lib/postgresql/tests/Flow/PostgreSql/Tests/Unit/AST/TraverserTest.php
@@ -10,6 +10,7 @@ use Flow\PostgreSql\AST\NodeVisitor;
 use Flow\PostgreSql\AST\Traverser;
 use Flow\PostgreSql\AST\Visitors\ColumnRefCollector;
 use Flow\PostgreSql\AST\Visitors\FuncCallCollector;
+use Flow\PostgreSql\AST\Visitors\ParamRefCollector;
 use Flow\PostgreSql\AST\Visitors\RangeVarCollector;
 use Flow\PostgreSql\Protobuf\AST\A_Const;
 use Flow\PostgreSql\Protobuf\AST\ColumnRef;
@@ -394,6 +395,30 @@ final class TraverserTest extends TestCase
         static::assertCount(3, $columnCollector->getColumnRefs());
         static::assertCount(1, $funcCollector->getFuncCalls());
         static::assertCount(1, $rangeVarCollector->getRangeVars());
+    }
+
+    public function test_param_ref_collector_inside_between(): void
+    {
+        $collector = new ParamRefCollector();
+        $traverser = new Traverser($collector);
+
+        $result = $this->parseQuery('SELECT * FROM t WHERE t.d BETWEEN $1 AND $2');
+        $traverser->traverse($result);
+
+        static::assertCount(2, $collector->getParamRefs());
+        static::assertSame(2, $collector->getMaxParamNumber());
+    }
+
+    public function test_param_ref_collector_inside_in_list(): void
+    {
+        $collector = new ParamRefCollector();
+        $traverser = new Traverser($collector);
+
+        $result = $this->parseQuery('SELECT * FROM t WHERE t.s IN ($1, $2, $3)');
+        $traverser->traverse($result);
+
+        static::assertCount(3, $collector->getParamRefs());
+        static::assertSame(3, $collector->getMaxParamNumber());
     }
 
     public function test_range_var_collector(): void

--- a/src/lib/postgresql/tests/Flow/PostgreSql/Tests/Unit/AST/Visitors/ParamRefCollectorTest.php
+++ b/src/lib/postgresql/tests/Flow/PostgreSql/Tests/Unit/AST/Visitors/ParamRefCollectorTest.php
@@ -32,6 +32,28 @@ final class ParamRefCollectorTest extends TestCase
         static::assertSame(3, $collector->getMaxParamNumber());
     }
 
+    public function test_collects_params_inside_between(): void
+    {
+        $parsed = sql_parse('SELECT * FROM t WHERE t.d BETWEEN $1 AND $2');
+
+        $collector = new ParamRefCollector();
+        $parsed->traverse($collector);
+
+        static::assertCount(2, $collector->getParamRefs());
+        static::assertSame(2, $collector->getMaxParamNumber());
+    }
+
+    public function test_collects_params_inside_in_list(): void
+    {
+        $parsed = sql_parse('SELECT * FROM t WHERE t.s IN ($1, $2, $3)');
+
+        $collector = new ParamRefCollector();
+        $parsed->traverse($collector);
+
+        static::assertCount(3, $collector->getParamRefs());
+        static::assertSame(3, $collector->getMaxParamNumber());
+    }
+
     public function test_collects_no_params_from_query_without_placeholders(): void
     {
         $parsed = sql_parse('SELECT * FROM users WHERE active = true');


### PR DESCRIPTION
<h2>Change Log</h2>
<hr />
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul>
  <h4>Fixed</h4>
  <ul id="fixed">
    <li><code>flow-php/postgresql</code> - detect ParamRef nodes inside List expressions so BETWEEN/IN/VALUES placeholders are counted during keyset pagination offset.</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->                                                                                                                                                                                                                            
  </ul>
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>
  <h4>Security</h4>
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>
</div>
