### PR TITLE
feat(flow-php/symfony-telemetry-bundle): add telemetry logging channels

### DIFF
--- a/documentation/components/bridges/symfony-telemetry-bundle.md
+++ b/documentation/components/bridges/symfony-telemetry-bundle.md
@@ -14,11 +14,14 @@ backends.
 
 ## Installation
 
-For detailed installation instructions, see the [installation page](/documentation/installation/packages/symfony-telemetry-bundle.md).
+For detailed installation instructions, see
+the [installation page](/documentation/installation/packages/symfony-telemetry-bundle.md).
 
 ## Overview
 
-This bundle is built on top of [flow-php/telemetry](/documentation/components/libs/telemetry.md) — see that page for the underlying `Telemetry`, tracer/meter/logger API, and processor/exporter primitives. For exporting to OTLP-compatible backends, it also uses the [Telemetry OTLP Bridge](/documentation/components/bridges/telemetry-otlp-bridge.md).
+This bundle is built on top of [flow-php/telemetry](/documentation/components/libs/telemetry.md) — see that page for the
+underlying `Telemetry`, tracer/meter/logger API, and processor/exporter primitives. For exporting to OTLP-compatible
+backends, it also uses the [Telemetry OTLP Bridge](/documentation/components/bridges/telemetry-otlp-bridge.md).
 
 This bundle integrates Flow PHP's Telemetry library with Symfony applications. It provides:
 
@@ -158,7 +161,7 @@ flow_telemetry:
 
     fanout:
       type: composite
-      handlers: [default, to_file, to_syslog]
+      handlers: [ default, to_file, to_syslog ]
 
     silent:
       type: noop
@@ -177,63 +180,64 @@ Service IDs registered by the bundle (predictable for `decorates:`):
 
 #### error_log (default)
 
-Writes formatted Throwables via PHP's `error_log()` — stderr in CLI by default, or the `error_log` ini setting otherwise.
+Writes formatted Throwables via PHP's `error_log()` — stderr in CLI by default, or the `error_log` ini setting
+otherwise.
 Matches the OTEL spec recommendation to log to standard error output.
 
-| Option            | Type    | Default           | Description                                                       |
-|-------------------|---------|-------------------|-------------------------------------------------------------------|
-| `message_type`    | enum    | `operating_system` | `operating_system` (0), `email` (1), `file` (3), `sapi` (4)       |
-| `expand_newlines` | boolean | `false`           | Emit one `error_log()` call per line of the formatted message     |
-| `message_prefix`  | string  | `[flow-telemetry]` | Prefix prepended to every message                                 |
+| Option            | Type    | Default            | Description                                                   |
+|-------------------|---------|--------------------|---------------------------------------------------------------|
+| `message_type`    | enum    | `operating_system` | `operating_system` (0), `email` (1), `file` (3), `sapi` (4)   |
+| `expand_newlines` | boolean | `false`            | Emit one `error_log()` call per line of the formatted message |
+| `message_prefix`  | string  | `[flow-telemetry]` | Prefix prepended to every message                             |
 
 #### stream
 
 Appends formatted Throwables (one per line) to a file path or `php://` stream wrapper. The handle is opened lazily on
 the first call and reused.
 
-| Option               | Type    | Default            | Description                                                  |
-|----------------------|---------|--------------------|--------------------------------------------------------------|
-| `destination`        | string  | -                  | File path or `php://stdout`/`php://stderr`/etc. (required)   |
-| `file_permissions`   | integer | `0644`             | Permissions for newly created files (ignored for `php://`)   |
-| `create_directories` | boolean | `true`             | Create parent directories of the destination if missing      |
-| `message_prefix`     | string  | `[flow-telemetry]` | Prefix prepended to every line                               |
+| Option               | Type    | Default            | Description                                                |
+|----------------------|---------|--------------------|------------------------------------------------------------|
+| `destination`        | string  | -                  | File path or `php://stdout`/`php://stderr`/etc. (required) |
+| `file_permissions`   | integer | `0644`             | Permissions for newly created files (ignored for `php://`) |
+| `create_directories` | boolean | `true`             | Create parent directories of the destination if missing    |
+| `message_prefix`     | string  | `[flow-telemetry]` | Prefix prepended to every line                             |
 
 #### syslog
 
 Writes via `openlog/syslog/closelog`.
 
-| Option     | Type    | Default          | Description                                            |
-|------------|---------|------------------|--------------------------------------------------------|
-| `ident`    | string  | `flow-telemetry` | Syslog identity tag                                    |
-| `facility` | enum    | `user`           | RFC 5424 facility (see table below)                    |
-| `log_opts` | integer | `LOG_PID`        | Bitmask of `LOG_*` flags passed to `openlog()`         |
-| `severity` | enum    | `error`          | RFC 5424 severity (see table below)                    |
+| Option     | Type    | Default          | Description                                    |
+|------------|---------|------------------|------------------------------------------------|
+| `ident`    | string  | `flow-telemetry` | Syslog identity tag                            |
+| `facility` | enum    | `user`           | RFC 5424 facility (see table below)            |
+| `log_opts` | integer | `LOG_PID`        | Bitmask of `LOG_*` flags passed to `openlog()` |
+| `severity` | enum    | `error`          | RFC 5424 severity (see table below)            |
 
 #### udp_syslog
 
 Sends RFC 5424 syslog frames over UDP.
 
-| Option     | Type    | Default          | Description                                  |
-|------------|---------|------------------|----------------------------------------------|
-| `host`     | string  | -                | Remote syslog host (required)                |
-| `port`     | integer | `514`            | Remote syslog port                           |
-| `ident`    | string  | `flow-telemetry` | Syslog identity tag                          |
-| `facility` | enum    | `user`           | RFC 5424 facility                            |
-| `severity` | enum    | `error`          | RFC 5424 severity                            |
+| Option     | Type    | Default          | Description                   |
+|------------|---------|------------------|-------------------------------|
+| `host`     | string  | -                | Remote syslog host (required) |
+| `port`     | integer | `514`            | Remote syslog port            |
+| `ident`    | string  | `flow-telemetry` | Syslog identity tag           |
+| `facility` | enum    | `user`           | RFC 5424 facility             |
+| `severity` | enum    | `error`          | RFC 5424 severity             |
 
 #### composite
 
 Fans an error out to multiple named handlers. Each child invocation is wrapped so a misbehaving handler cannot prevent
 siblings from running.
 
-| Option     | Type            | Default | Description                                                |
-|------------|-----------------|---------|------------------------------------------------------------|
-| `handlers` | list of strings | -       | Names of other entries in `error_handlers:` (required)     |
+| Option     | Type            | Default | Description                                            |
+|------------|-----------------|---------|--------------------------------------------------------|
+| `handlers` | list of strings | -       | Names of other entries in `error_handlers:` (required) |
 
 ```yaml
 fanout:
   type: composite
-  handlers: [default, to_file]
+  handlers: [ default, to_file ]
 ```
 
 #### noop
@@ -248,9 +252,9 @@ silent: { type: noop }
 
 Aliases an existing service that implements `Flow\Telemetry\ErrorHandler\ErrorHandler`.
 
-| Option       | Type   | Default | Description                                              |
-|--------------|--------|---------|----------------------------------------------------------|
-| `service_id` | string | -       | Service id of the user-provided handler (required)       |
+| Option       | Type   | Default | Description                                        |
+|--------------|--------|---------|----------------------------------------------------|
+| `service_id` | string | -       | Service id of the user-provided handler (required) |
 
 ```yaml
 custom:
@@ -260,18 +264,18 @@ custom:
 
 #### Facility values
 
-| Value     | Constant      |
-|-----------|---------------|
-| `kernel`  | `LOG_KERN`    |
-| `user`    | `LOG_USER`    |
-| `mail`    | `LOG_MAIL`    |
-| `daemon`  | `LOG_DAEMON`  |
-| `auth`    | `LOG_AUTH`    |
-| `syslog`  | `LOG_SYSLOG`  |
-| `lpr`     | `LOG_LPR`     |
-| `news`    | `LOG_NEWS`    |
-| `uucp`    | `LOG_UUCP`    |
-| `cron`    | `LOG_CRON`    |
+| Value              | Constant                   |
+|--------------------|----------------------------|
+| `kernel`           | `LOG_KERN`                 |
+| `user`             | `LOG_USER`                 |
+| `mail`             | `LOG_MAIL`                 |
+| `daemon`           | `LOG_DAEMON`               |
+| `auth`             | `LOG_AUTH`                 |
+| `syslog`           | `LOG_SYSLOG`               |
+| `lpr`              | `LOG_LPR`                  |
+| `news`             | `LOG_NEWS`                 |
+| `uucp`             | `LOG_UUCP`                 |
+| `cron`             | `LOG_CRON`                 |
 | `local0`..`local7` | `LOG_LOCAL0`..`LOG_LOCAL7` |
 
 #### Severity values
@@ -296,21 +300,21 @@ sub-blocks: `otlp`, `service`, `console`, `memory`, `void`. Per-signal processor
 ```yaml
 flow_telemetry:
   exporters:
-    otlp:                              # exporter name
-      otlp:                            # sub-block selects implementation
+    otlp: # exporter name
+      otlp: # sub-block selects implementation
         transport:
           type: curl
           endpoint: 'http://otel-collector:4318'
           encoding: protobuf
 ```
 
-| Sub-block | Options                                | Description                              |
-|-----------|----------------------------------------|------------------------------------------|
-| `otlp`    | `transport: { ... }`                   | Sends batches over OTLP curl/grpc/service |
-| `service` | `id: <service_id>`                     | Aliases an existing user-provided service |
-| `console` | none (use `~` / `null` / `{}`)          | Pretty-prints to console                  |
-| `memory`  | none                                   | Stores batches in memory (testing)        |
-| `void`    | none                                   | Discards everything (no-op)               |
+| Sub-block | Options                        | Description                               |
+|-----------|--------------------------------|-------------------------------------------|
+| `otlp`    | `transport: { ... }`           | Sends batches over OTLP curl/grpc/service |
+| `service` | `id: <service_id>`             | Aliases an existing user-provided service |
+| `console` | none (use `~` / `null` / `{}`) | Pretty-prints to console                  |
+| `memory`  | none                           | Stores batches in memory (testing)        |
+| `void`    | none                           | Discards everything (no-op)               |
 
 Service IDs registered by the bundle (predictable for `decorates:`):
 
@@ -424,10 +428,10 @@ processor:
 
 Batches items before export.
 
-| Option       | Type    | Default | Description                                  |
-|--------------|---------|---------|----------------------------------------------|
-| `batch_size` | integer | `512`   | Number of items per batch                    |
-| `exporter`   | string  | -       | Name of a top-level exporter (required)      |
+| Option       | Type    | Default | Description                             |
+|--------------|---------|---------|-----------------------------------------|
+| `batch_size` | integer | `512`   | Number of items per batch               |
+| `exporter`   | string  | -       | Name of a top-level exporter (required) |
 
 ```yaml
 processor:
@@ -545,9 +549,9 @@ budget for graceful drain at shutdown:
 
 | Setting               | Default | Applies to | Bounds                                                      |
 |-----------------------|--------:|------------|-------------------------------------------------------------|
-| `timeout_ms`          |   250   | curl, grpc | Per-request deadline (curl: total request; grpc: per-call)  |
-| `connect_timeout_ms`  |   250   | curl only  | TCP/TLS connect; gRPC has no separate bound                 |
-| `shutdown_timeout_ms` |  5000   | curl, grpc | Wall-clock budget for draining pending requests at shutdown |
+| `timeout_ms`          |     250 | curl, grpc | Per-request deadline (curl: total request; grpc: per-call)  |
+| `connect_timeout_ms`  |     250 | curl only  | TCP/TLS connect; gRPC has no separate bound                 |
+| `shutdown_timeout_ms` |    5000 | curl, grpc | Wall-clock budget for draining pending requests at shutdown |
 
 The defaults assume the recommended deployment: an OpenTelemetry Collector running close to the application (loopback,
 UDS, or sidecar). `shutdown_timeout_ms` is independent of `timeout_ms` — keep the per-request value tight to surface
@@ -589,24 +593,24 @@ For the underlying behavior — when a forwarded batch is treated as absorbed vs
 
 #### curl (default)
 
-| Option                | Type    | Default | Description                                                                |
-|-----------------------|---------|---------|----------------------------------------------------------------------------|
-| `endpoint`            | string  | -       | OTLP base URL (required)                                                   |
-| `timeout_ms`          | integer | `250`   | Total per-request deadline in **milliseconds**                             |
-| `connect_timeout_ms`  | integer | `250`   | TCP/TLS connect deadline in **milliseconds**                               |
+| Option                | Type    | Default | Description                                                                     |
+|-----------------------|---------|---------|---------------------------------------------------------------------------------|
+| `endpoint`            | string  | -       | OTLP base URL (required)                                                        |
+| `timeout_ms`          | integer | `250`   | Total per-request deadline in **milliseconds**                                  |
+| `connect_timeout_ms`  | integer | `250`   | TCP/TLS connect deadline in **milliseconds**                                    |
 | `shutdown_timeout_ms` | integer | `5000`  | Wall-clock budget in **milliseconds** for draining pending requests at shutdown |
-| `compression`         | boolean | `false` | Enable compression                                                         |
-| `follow_redirects`    | boolean | `true`  | Follow HTTP redirects                                                      |
-| `max_redirects`       | integer | `3`     | Maximum redirects to follow                                                |
-| `proxy`               | string  | `null`  | Proxy URL                                                                  |
-| `ssl_verify_peer`     | boolean | `true`  | Verify SSL peer                                                            |
-| `ssl_verify_host`     | boolean | `true`  | Verify SSL host                                                            |
-| `ssl_cert_path`       | string  | `null`  | SSL certificate path                                                       |
-| `ssl_key_path`        | string  | `null`  | SSL key path                                                               |
-| `ca_info_path`        | string  | `null`  | CA info path                                                               |
-| `headers`             | object  | `{}`    | Additional HTTP headers                                                    |
-| `encoding`            | enum    | `json`  | OTLP/HTTP wire encoding: `json` or `protobuf`                              |
-| `failover`            | object  | `null`  | Optional [failover transport](#failover-transport)                         |
+| `compression`         | boolean | `false` | Enable compression                                                              |
+| `follow_redirects`    | boolean | `true`  | Follow HTTP redirects                                                           |
+| `max_redirects`       | integer | `3`     | Maximum redirects to follow                                                     |
+| `proxy`               | string  | `null`  | Proxy URL                                                                       |
+| `ssl_verify_peer`     | boolean | `true`  | Verify SSL peer                                                                 |
+| `ssl_verify_host`     | boolean | `true`  | Verify SSL host                                                                 |
+| `ssl_cert_path`       | string  | `null`  | SSL certificate path                                                            |
+| `ssl_key_path`        | string  | `null`  | SSL key path                                                                    |
+| `ca_info_path`        | string  | `null`  | CA info path                                                                    |
+| `headers`             | object  | `{}`    | Additional HTTP headers                                                         |
+| `encoding`            | enum    | `json`  | OTLP/HTTP wire encoding: `json` or `protobuf`                                   |
+| `failover`            | object  | `null`  | Optional [failover transport](#failover-transport)                              |
 
 See [Timeouts](#timeouts) for guidance on the millisecond defaults.
 
@@ -631,14 +635,14 @@ gRPC transport. `encoding` is rejected by validation (OTLP/gRPC mandates Protobu
 `connect_timeout_ms` is rejected because gRPC has no separate connect bound — `timeout_ms` is the per-call deadline
 covering DNS, connect, send and receive together.
 
-| Option                | Type    | Default | Description                                                                |
-|-----------------------|---------|---------|----------------------------------------------------------------------------|
-| `endpoint`            | string  | -       | gRPC endpoint (required)                                                   |
-| `timeout_ms`          | integer | `250`   | Per-call deadline in **milliseconds**                                      |
+| Option                | Type    | Default | Description                                                                  |
+|-----------------------|---------|---------|------------------------------------------------------------------------------|
+| `endpoint`            | string  | -       | gRPC endpoint (required)                                                     |
+| `timeout_ms`          | integer | `250`   | Per-call deadline in **milliseconds**                                        |
 | `shutdown_timeout_ms` | integer | `5000`  | Wall-clock budget in **milliseconds** for draining pending calls at shutdown |
-| `insecure`            | boolean | `true`  | Allow insecure connections                                                 |
-| `headers`             | object  | `{}`    | gRPC metadata                                                              |
-| `failover`            | object  | `null`  | Optional [failover transport](#failover-transport)                         |
+| `insecure`            | boolean | `true`  | Allow insecure connections                                                   |
+| `headers`             | object  | `{}`    | gRPC metadata                                                                |
+| `failover`            | object  | `null`  | Optional [failover transport](#failover-transport)                           |
 
 ```yaml
 exporters:
@@ -658,11 +662,11 @@ per batch to the configured destination — either an absolute file path or a `p
 `LOCK_EX` around each `fwrite`. Only JSON encoding is supported per the spec; `encoding` and HTTP-specific options
 (`timeout`, `ssl_*`, `headers`, etc.) are rejected at config time.
 
-| Option                | Type    | Default  | Description                                                                  |
-|-----------------------|---------|----------|------------------------------------------------------------------------------|
-| `endpoint`            | string  | -        | File path or `php://` stream wrapper URI (required)                          |
-| `file_permissions`    | integer | `0644`   | File mode applied when creating new files; ignored for `php://` destinations |
-| `create_directories`  | boolean | `true`   | Create the destination's parent directories if missing; ignored for `php://` destinations |
+| Option               | Type    | Default | Description                                                                               |
+|----------------------|---------|---------|-------------------------------------------------------------------------------------------|
+| `endpoint`           | string  | -       | File path or `php://` stream wrapper URI (required)                                       |
+| `file_permissions`   | integer | `0644`  | File mode applied when creating new files; ignored for `php://` destinations              |
+| `create_directories` | boolean | `true`  | Create the destination's parent directories if missing; ignored for `php://` destinations |
 
 ```yaml
 exporters:
@@ -726,9 +730,9 @@ flow_telemetry:
   tracer_provider:
     processor: { type: batching, exporter: otlp_traces,  batch_size: 1024 }
   meter_provider:
-    processor: { type: batching, exporter: otlp_metrics, batch_size: 256  }
+    processor: { type: batching, exporter: otlp_metrics, batch_size: 256 }
   logger_provider:
-    processor: { type: batching, exporter: otlp_logs,    batch_size: 100  }
+    processor: { type: batching, exporter: otlp_logs,    batch_size: 100 }
 ```
 
 ### Migrating from older config
@@ -933,9 +937,15 @@ flow_telemetry:
 
 ### Main Logger
 
-The bundle depends on [PSR-3 Telemetry Bridge](/documentation/components/bridges/psr3-telemetry-bridge.md) and registers a PSR-3 wrapper service for every named Telemetry logger at `flow.telemetry.<name>.logger.psr3`. This makes Flow Telemetry loggers usable as Symfony's `logger` service, removing the need for Monolog when telemetry is the only logging destination.
+The bundle depends on [PSR-3 Telemetry Bridge](/documentation/components/bridges/psr3-telemetry-bridge.md) and registers
+a PSR-3 wrapper service for every named Telemetry logger at `flow.telemetry.<name>.logger.psr3`. This makes Flow
+Telemetry loggers usable as Symfony's `logger` service, removing the need for Monolog when telemetry is the only logging
+destination.
 
-In addition, the bundle always registers a `default` logger, meter, and tracer — `flow.telemetry.default.logger`, `flow.telemetry.default.logger.psr3`, `flow.telemetry.default.meter`, `flow.telemetry.default.tracer` — regardless of what is configured under `loggers`/`meters`/`tracers`. Defining your own `default` entry under those keys is allowed and will override the auto-default.
+In addition, the bundle always registers a `default` logger, meter, and tracer — `flow.telemetry.default.logger`,
+`flow.telemetry.default.logger.psr3`, `flow.telemetry.default.meter`, `flow.telemetry.default.tracer` — regardless of
+what is configured under `loggers`/`meters`/`tracers`. Defining your own `default` entry under those keys is allowed and
+will override the auto-default.
 
 **Options:**
 
@@ -945,9 +955,14 @@ In addition, the bundle always registers a `default` logger, meter, and tracer �
 
 **Behavior:**
 
-- When `framework_logger` is set, the bundle aliases the Symfony `logger` service to `flow.telemetry.<framework_logger>.logger.psr3`. If no logger with that name exists, container compilation fails with a clear error.
-- When `framework_logger` is `null` and Symfony's `logger` service is the default `Symfony\Component\HttpKernel\Log\Logger`, the bundle automatically aliases `logger` to `flow.telemetry.default.logger.psr3`.
-- When `framework_logger` is `null` and `logger` is provided by another bundle (Monolog, custom alias, etc.), the bundle leaves `logger` alone.
+- When `framework_logger` is set, the bundle aliases the Symfony `logger` service to
+  `flow.telemetry.<framework_logger>.logger.psr3`. If no logger with that name exists, container compilation fails with
+  a clear error.
+- When `framework_logger` is `null` and Symfony's `logger` service is the default
+  `Symfony\Component\HttpKernel\Log\Logger`, the bundle automatically aliases `logger` to
+  `flow.telemetry.default.logger.psr3`.
+- When `framework_logger` is `null` and `logger` is provided by another bundle (Monolog, custom alias, etc.), the bundle
+  leaves `logger` alone.
 
 ```yaml
 flow_telemetry:
@@ -957,6 +972,128 @@ flow_telemetry:
 
   framework_logger: app   # Symfony "logger" service -> flow.telemetry.app.logger.psr3
 ```
+
+### Logging Channels
+
+Channels let you route different parts of your application to different telemetry loggers — the Flow Telemetry
+equivalent of Monolog channels — without installing Monolog. Each channel is a [named logger](#named-instruments);
+messages emitted through it are tagged with a `log.channel` scope attribute, so you can filter and group them per
+channel in your backend.
+
+A service opts into a channel by carrying the `flow.telemetry.channel` tag. The recommended way is the
+`#[WithTelemetryChannel]` attribute:
+
+```php
+<?php
+
+namespace App\Messaging;
+
+use Flow\Bridge\Symfony\TelemetryBundle\Attribute\WithTelemetryChannel;
+use Psr\Log\LoggerInterface;
+
+#[WithTelemetryChannel('events')]
+final class OrderSubscriber
+{
+    public function __construct(
+        private readonly LoggerInterface $logger, // resolves to the "events" channel logger
+    ) {
+    }
+}
+```
+
+The autowired `LoggerInterface` now resolves to `flow.telemetry.events.logger.psr3` instead of the default logger. A
+tagged service may instead typehint the native `Flow\Telemetry\Logger\Logger` — it resolves to that channel's native
+logger (`flow.telemetry.events.logger`), the instance the PSR-3 wrapper delegates to. Both the PSR-3 interface and the
+native class are bound, so either typehint works.
+
+The channel can also be requested with a raw tag in `services.yaml`:
+
+```yaml
+services:
+  App\Messaging\OrderSubscriber:
+    tags:
+      - { name: 'flow.telemetry.channel', channel: 'events' }
+```
+
+**Behavior:**
+
+- Each distinct channel is synthesized on demand as `flow.telemetry.<channel>.logger` (+ its PSR-3 wrapper
+  `flow.telemetry.<channel>.logger.psr3`), carrying a `log.channel: <channel>` scope attribute — unless a logger of that
+  name already exists, which is then reused untouched (so the `log.channel` attribute is only added to loggers the
+  bundle creates).
+- To route a service to the bundle's main logger, use the `default` channel (`#[WithTelemetryChannel('default')]`).
+  A `default` logger always exists, so it is reused as-is rather than re-created. Every channel name — including `app`,
+  which carries no special meaning here — behaves the same way.
+- For every channel in use, two named-argument autowiring aliases are registered — `LoggerInterface $<channel>Logger`
+  (the PSR-3 wrapper) and `Logger $<channel>Logger` (the native Flow `Logger`) — so any service can request a channel
+  logger by argument name (e.g. `LoggerInterface $eventsLogger`, `Logger $httpClientLogger`) without the tag.
+- On a tagged service, an explicit `@logger` reference is rewritten to the channel logger as well — in both constructor
+  arguments and method calls (e.g. `setLogger()`), preserving the reference's invalid-behavior flag.
+- A channel already declared under `loggers` is **not** overwritten, so you can customise its `version`, `schema_url`,
+  or `attributes`. Because declaring it opts out of synthesis, set `log.channel` yourself if you want it:
+
+```yaml
+flow_telemetry:
+  loggers:
+    events:
+      version: '1.0.0'
+      attributes:
+        log.channel: events      # not auto-added for a declared logger — set it explicitly
+        team: checkout
+```
+
+#### Capturing Framework Channels
+
+Symfony's own services already declare channels by tagging themselves `monolog.logger` (the router, the request logger,
+the event dispatcher, the HTTP client, cache pools, the messenger, …) — that tag comes from FrameworkBundle and is
+present whether or not MonologBundle is installed. Enable `capture_framework_channels` and the bundle **consumes that
+tag**, routing these framework channels to Flow telemetry loggers exactly the way MonologBundle would — making it a
+drop-in replacement for Monolog's channel routing, without Monolog.
+
+It is **disabled by default**, because MonologBundle claims the same `monolog.logger` tag: if both are installed and
+both process it, they fight over the same services. Enable it only when Flow telemetry owns channel routing (i.e. you
+are not running MonologBundle):
+
+```yaml
+flow_telemetry:
+  capture_framework_channels: true   # default: false
+```
+
+Each framework channel becomes `flow.telemetry.<channel>.logger` (e.g. `flow.telemetry.router.logger`,
+`flow.telemetry.http_client.logger`), carries the `log.channel` scope attribute, and gets the
+`LoggerInterface $<channel>Logger` / `Logger $<channel>Logger` autowiring aliases — the same treatment as an explicitly
+tagged service. A channel you declare under `loggers` still wins, so you can customise any framework channel's scope.
+
+Services that opt in explicitly via `#[WithTelemetryChannel]` / the `flow.telemetry.channel` tag are always routed
+regardless of this flag.
+
+> [!NOTE]
+> `capture_framework_channels` rewrites the `logger` reference on framework services to their channel logger. A
+> service-specific channel takes precedence over the global [`framework_logger`](#main-logger) redirect.
+
+#### Coexisting with MonologBundle
+
+You can run this bundle **alongside MonologBundle** — as long as `capture_framework_channels` stays `false` (the
+default). The two are independent because they read different DI tags: framework capture reads Symfony's
+`monolog.logger`, while the `#[WithTelemetryChannel]` attribute uses this bundle's own `flow.telemetry.channel` tag,
+which Monolog never looks at. With the flag off, this bundle never touches `monolog.logger`, so:
+
+- MonologBundle keeps full ownership of every framework channel (router, request, Doctrine, …) and the default `app`
+  logger — uncontested.
+- `#[WithTelemetryChannel('events')]` still scopes an individual class: it binds only that service's `LoggerInterface`
+  (and native `Logger`) to the Flow telemetry channel logger. Because the binding fills the argument directly, it wins
+  over Monolog's global `LoggerInterface` autowiring alias for that one class; every other class keeps resolving to
+  Monolog.
+
+What you **cannot** do is enable `capture_framework_channels` *and* keep MonologBundle: both passes then rewrite the same
+`monolog.logger`-tagged services, and the outcome depends on compiler-pass ordering. Ownership of the framework channels
+is all-or-nothing:
+
+- **Flow telemetry owns the framework channels** — `capture_framework_channels: true`, MonologBundle not installed.
+- **Monolog owns the framework channels, Flow scopes specific classes** — `capture_framework_channels: false`,
+  MonologBundle installed.
+
+The `#[WithTelemetryChannel]` attribute works in both setups.
 
 ## Pattern Matching
 

--- a/src/bridge/symfony/telemetry-bundle/src/Flow/Bridge/Symfony/TelemetryBundle/Attribute/WithTelemetryChannel.php
+++ b/src/bridge/symfony/telemetry-bundle/src/Flow/Bridge/Symfony/TelemetryBundle/Attribute/WithTelemetryChannel.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\Bridge\Symfony\TelemetryBundle\Attribute;
+
+use Attribute;
+
+/**
+ * Routes a service's logger to a named Flow telemetry channel.
+ *
+ * Applying this attribute autoconfigures the service with the
+ * "flow.telemetry.channel" tag, so its autowired PSR-3 LoggerInterface
+ * resolves to the channel's logger (scope) instead of the default one:
+ *
+ * ```php
+ * #[WithTelemetryChannel('events')]
+ * final class OrderSubscriber
+ * {
+ *     public function __construct(private LoggerInterface $logger) {}
+ * }
+ * ```
+ */
+#[Attribute(Attribute::TARGET_CLASS)]
+final class WithTelemetryChannel
+{
+    public function __construct(
+        public string $channel,
+    ) {}
+}

--- a/src/bridge/symfony/telemetry-bundle/src/Flow/Bridge/Symfony/TelemetryBundle/DependencyInjection/Compiler/ChannelLoggerPass.php
+++ b/src/bridge/symfony/telemetry-bundle/src/Flow/Bridge/Symfony/TelemetryBundle/DependencyInjection/Compiler/ChannelLoggerPass.php
@@ -1,0 +1,227 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\Bridge\Symfony\TelemetryBundle\DependencyInjection\Compiler;
+
+use Flow\Bridge\Symfony\TelemetryBundle\Exception\RuntimeException;
+use Flow\Bridge\Symfony\TelemetryBundle\FlowTelemetryBundle;
+use Flow\Telemetry\Logger\Logger;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Argument\BoundArgument;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+use function is_array;
+use function is_string;
+use function lcfirst;
+use function sprintf;
+use function str_replace;
+use function ucwords;
+
+/**
+ * Routes services to a named telemetry logger based on their logging channel.
+ *
+ * Two populations are handled:
+ *
+ *  - Services explicitly opting in via the "flow.telemetry.channel" tag
+ *    (typically through the #[WithTelemetryChannel] attribute). A missing or
+ *    empty channel here is a configuration error and throws.
+ *  - When "flow.telemetry.capture_framework_channels" is enabled, services
+ *    Symfony tags "monolog.logger" (router, request, http_client, cache,
+ *    messenger, …). This makes the bundle a drop-in for MonologBundle's channel
+ *    routing without Monolog. We do not own that tag, so a tag without a usable
+ *    channel is skipped rather than treated as an error.
+ *
+ * For each routed service the channel's PSR-3 logger is bound to its autowired
+ * LoggerInterface argument and the native Flow Logger to its autowired Logger
+ * argument; every explicit "logger" reference (in constructor arguments and method
+ * calls) is rewritten to the PSR-3 logger, preserving the reference's
+ * invalid-behavior flag. Per channel, both a "LoggerInterface $<channel>Logger" and
+ * a "Logger $<channel>Logger" autowiring alias are registered so any service can
+ * request a channel logger by named argument. Each channel is synthesized on demand
+ * carrying a "log.channel" scope attribute; a logger already declared under that
+ * name (e.g. the always-present "default") is reused as-is.
+ */
+final class ChannelLoggerPass implements CompilerPassInterface
+{
+    public const string TAG = 'flow.telemetry.channel';
+
+    private const string CAPTURE_PARAMETER = 'flow.telemetry.capture_framework_channels';
+
+    private const string FRAMEWORK_TAG = 'monolog.logger';
+
+    public function process(ContainerBuilder $container): void
+    {
+        /** @var array<string, array{0: string, 1: string}> $channels */
+        $channels = [];
+
+        if ($this->capturesFrameworkChannels($container)) {
+            foreach ($container->findTaggedServiceIds(self::FRAMEWORK_TAG) as $serviceId => $tags) {
+                // @mago-expect analysis:mixed-assignment
+                foreach ($tags as $tag) {
+                    $channel = $this->resolveChannel($tag, $container);
+
+                    if ($channel === null) {
+                        continue;
+                    }
+
+                    $channels[$channel] = $this->route($serviceId, $channel, $container);
+                }
+            }
+        }
+
+        foreach ($container->findTaggedServiceIds(self::TAG) as $serviceId => $tags) {
+            // @mago-expect analysis:mixed-assignment
+            foreach ($tags as $tag) {
+                $channel = $this->requireChannel($serviceId, $tag, $container);
+
+                $channels[$channel] = $this->route($serviceId, $channel, $container);
+            }
+        }
+
+        foreach ($channels as $channel => [$nativeId, $psr3Id]) {
+            $argument = $this->camelize($channel) . 'Logger';
+            $container->registerAliasForArgument($psr3Id, LoggerInterface::class, $argument);
+            $container->registerAliasForArgument($nativeId, Logger::class, $argument);
+        }
+    }
+
+    private function bindLogger(Definition $definition, string $nativeId, string $psr3Id): void
+    {
+        $this->rewriteLoggerReferences($definition, $psr3Id);
+
+        $bindings = $definition->getBindings();
+        $bindings[LoggerInterface::class] = new BoundArgument(
+            new Reference($psr3Id),
+            false,
+            BoundArgument::SERVICE_BINDING,
+        );
+        $bindings[Logger::class] = new BoundArgument(new Reference($nativeId), false, BoundArgument::SERVICE_BINDING);
+        $definition->setBindings($bindings);
+    }
+
+    private function camelize(string $channel): string
+    {
+        return lcfirst(str_replace(' ', '', ucwords(str_replace(['_', '.', '-'], ' ', $channel))));
+    }
+
+    private function capturesFrameworkChannels(ContainerBuilder $container): bool
+    {
+        if (!$container->hasParameter(self::CAPTURE_PARAMETER)) {
+            return false;
+        }
+
+        return $container->getParameter(self::CAPTURE_PARAMETER) === true;
+    }
+
+    /**
+     * @return array{0: string, 1: string} the native logger id and its PSR-3 wrapper id
+     */
+    private function channelLoggerIds(string $channel, ContainerBuilder $container): array
+    {
+        $psr3Id = FlowTelemetryBundle::defineLogger(
+            $channel,
+            ['attributes' => ['log.channel' => $channel]],
+            $container,
+        );
+
+        return ['flow.telemetry.' . $channel . '.logger', $psr3Id];
+    }
+
+    private function requireChannel(string $serviceId, mixed $tag, ContainerBuilder $container): string
+    {
+        // @mago-expect analysis:mixed-assignment
+        $channel = is_array($tag) ? $tag['channel'] ?? null : null;
+
+        if (!is_string($channel) || $channel === '') {
+            throw new RuntimeException(sprintf(
+                'Service "%s" is tagged "%s" but is missing the required non-empty "channel" attribute.',
+                $serviceId,
+                self::TAG,
+            ));
+        }
+
+        // @mago-expect analysis:mixed-assignment
+        $resolved = $container->getParameterBag()->resolveValue($channel);
+
+        if (!is_string($resolved) || $resolved === '') {
+            throw new RuntimeException(sprintf(
+                'Channel "%s" on service "%s" did not resolve to a non-empty string.',
+                $channel,
+                $serviceId,
+            ));
+        }
+
+        return $resolved;
+    }
+
+    private function resolveChannel(mixed $tag, ContainerBuilder $container): ?string
+    {
+        // @mago-expect analysis:mixed-assignment
+        $channel = is_array($tag) ? $tag['channel'] ?? null : null;
+
+        if (!is_string($channel) || $channel === '') {
+            return null;
+        }
+
+        // @mago-expect analysis:mixed-assignment
+        $resolved = $container->getParameterBag()->resolveValue($channel);
+
+        if (!is_string($resolved) || $resolved === '') {
+            return null;
+        }
+
+        return $resolved;
+    }
+
+    private function rewriteLoggerReferences(Definition $definition, string $psr3Id): void
+    {
+        $definition->setArguments($this->swapLoggerReferences($definition->getArguments(), $psr3Id));
+
+        $methodCalls = $definition->getMethodCalls();
+
+        // @mago-expect analysis:mixed-assignment
+        foreach ($methodCalls as $index => $call) {
+            if (!is_array($call) || !is_array($call[1] ?? null)) {
+                continue;
+            }
+
+            /** @var array{0: string, 1: array<array-key, mixed>} $call */
+            $call[1] = $this->swapLoggerReferences($call[1], $psr3Id);
+            $methodCalls[$index] = $call;
+        }
+
+        $definition->setMethodCalls($methodCalls);
+    }
+
+    /**
+     * @return array{0: string, 1: string} the native logger id and its PSR-3 wrapper id
+     */
+    private function route(string $serviceId, string $channel, ContainerBuilder $container): array
+    {
+        [$nativeId, $psr3Id] = $this->channelLoggerIds($channel, $container);
+        $this->bindLogger($container->getDefinition($serviceId), $nativeId, $psr3Id);
+
+        return [$nativeId, $psr3Id];
+    }
+
+    /**
+     * @param array<mixed> $arguments
+     *
+     * @return array<mixed>
+     */
+    private function swapLoggerReferences(array $arguments, string $psr3Id): array
+    {
+        // @mago-expect analysis:mixed-assignment
+        foreach ($arguments as $key => $argument) {
+            if ($argument instanceof Reference && (string) $argument === 'logger') {
+                $arguments[$key] = new Reference($psr3Id, $argument->getInvalidBehavior());
+            }
+        }
+
+        return $arguments;
+    }
+}

--- a/src/bridge/symfony/telemetry-bundle/src/Flow/Bridge/Symfony/TelemetryBundle/FlowTelemetryBundle.php
+++ b/src/bridge/symfony/telemetry-bundle/src/Flow/Bridge/Symfony/TelemetryBundle/FlowTelemetryBundle.php
@@ -6,7 +6,9 @@ namespace Flow\Bridge\Symfony\TelemetryBundle;
 
 use Flow\Bridge\Psr3\Telemetry\LogRecordConverter;
 use Flow\Bridge\Psr3\Telemetry\TelemetryLogger;
+use Flow\Bridge\Symfony\TelemetryBundle\Attribute\WithTelemetryChannel;
 use Flow\Bridge\Symfony\TelemetryBundle\DependencyInjection\Compiler\CacheTelemetryPass;
+use Flow\Bridge\Symfony\TelemetryBundle\DependencyInjection\Compiler\ChannelLoggerPass;
 use Flow\Bridge\Symfony\TelemetryBundle\DependencyInjection\Compiler\DBALTelemetryPass;
 use Flow\Bridge\Symfony\TelemetryBundle\DependencyInjection\Compiler\FrameworkLoggerPass;
 use Flow\Bridge\Symfony\TelemetryBundle\DependencyInjection\Compiler\HttpClientTelemetryPass;
@@ -82,6 +84,7 @@ use Psr\Clock\ClockInterface;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Configurator\DefinitionConfigurator;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -123,6 +126,14 @@ final class FlowTelemetryBundle extends AbstractBundle
 
         $container->addCompilerPass(new OTLPAvailabilityPass());
         $container->addCompilerPass(new FrameworkLoggerPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, -64);
+
+        $container->registerAttributeForAutoconfiguration(
+            WithTelemetryChannel::class,
+            static function (ChildDefinition $definition, WithTelemetryChannel $attribute): void {
+                $definition->addTag(ChannelLoggerPass::TAG, ['channel' => $attribute->channel]);
+            },
+        );
+        $container->addCompilerPass(new ChannelLoggerPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION);
 
         if (interface_exists(self::HTTP_CLIENT_INTERFACE)) {
             $container->addCompilerPass(new HttpClientTelemetryPass());
@@ -263,6 +274,12 @@ final class FlowTelemetryBundle extends AbstractBundle
                 'Name of the logger (matching a key under "loggers", or "default") whose PSR-3 wrapper will be aliased to Symfony\'s "logger" service. Leave null to auto-replace only when Symfony\'s default HttpKernel Logger is currently bound.',
             )
             ->defaultNull()
+            ->end()
+            ->booleanNode('capture_framework_channels')
+            ->info(
+                'Reroute services Symfony tags "monolog.logger" to per-channel Flow telemetry loggers. Disabled by default to avoid colliding with MonologBundle, which claims the same tag.',
+            )
+            ->defaultFalse()
             ->end()
             ->arrayNode('context_storage')
             ->info('Context storage configuration')
@@ -557,12 +574,13 @@ final class FlowTelemetryBundle extends AbstractBundle
     }
 
     /**
-     * @param array{resource: array{detectors?: array{enabled?: bool, static?: array{cache?: array{enabled?: bool, path?: null|string}, os?: array{enabled?: bool}, host?: array{enabled?: bool}, service?: array{enabled?: bool}, deployment?: array{enabled?: bool}, environment?: array{enabled?: bool}}, dynamic?: array{process?: array{enabled?: bool}}}, custom?: array<string, mixed>}, clock_service_id?: null|string, framework_logger?: null|string, context_storage?: array{type?: string, service_id?: null|string}, propagator?: array{type?: string, service_id?: null|string}, exporters?: array<string, array<string, mixed>>, error_handlers?: array<string, array<string, mixed>>, tracer_provider?: array<string, mixed>, meter_provider?: array<string, mixed>, logger_provider?: array<string, mixed>, instrumentation?: array{http_kernel?: array{enabled?: bool, exclude_paths?: array<array{path: string, method?: null|string}>, context_propagation?: bool}, console?: array{enabled?: bool, exclude_commands?: array<string>}, messenger?: array{enabled?: bool, context_propagation?: bool}, twig?: array{enabled?: bool, trace_templates?: bool, trace_blocks?: bool, trace_macros?: bool, exclude_templates?: array<string>}, http_client?: array{enabled?: bool, exclude_clients?: array<string>}, psr18_client?: array{enabled?: bool, exclude_clients?: array<string>}, dbal?: array{enabled?: bool, log_sql?: bool, max_sql_length?: int, exclude_connections?: array<string>}, cache?: array{enabled?: bool, exclude_pools?: array<string>}}, tracers?: array<string, array{version?: string, schema_url?: null|string, attributes?: array<string, mixed>}>, meters?: array<string, array{version?: string, schema_url?: null|string, attributes?: array<string, mixed>}>, loggers?: array<string, array{version?: string, schema_url?: null|string, attributes?: array<string, mixed>}>} $config
+     * @param array{resource: array{detectors?: array{enabled?: bool, static?: array{cache?: array{enabled?: bool, path?: null|string}, os?: array{enabled?: bool}, host?: array{enabled?: bool}, service?: array{enabled?: bool}, deployment?: array{enabled?: bool}, environment?: array{enabled?: bool}}, dynamic?: array{process?: array{enabled?: bool}}}, custom?: array<string, mixed>}, clock_service_id?: null|string, framework_logger?: null|string, capture_framework_channels?: bool, context_storage?: array{type?: string, service_id?: null|string}, propagator?: array{type?: string, service_id?: null|string}, exporters?: array<string, array<string, mixed>>, error_handlers?: array<string, array<string, mixed>>, tracer_provider?: array<string, mixed>, meter_provider?: array<string, mixed>, logger_provider?: array<string, mixed>, instrumentation?: array{http_kernel?: array{enabled?: bool, exclude_paths?: array<array{path: string, method?: null|string}>, context_propagation?: bool}, console?: array{enabled?: bool, exclude_commands?: array<string>}, messenger?: array{enabled?: bool, context_propagation?: bool}, twig?: array{enabled?: bool, trace_templates?: bool, trace_blocks?: bool, trace_macros?: bool, exclude_templates?: array<string>}, http_client?: array{enabled?: bool, exclude_clients?: array<string>}, psr18_client?: array{enabled?: bool, exclude_clients?: array<string>}, dbal?: array{enabled?: bool, log_sql?: bool, max_sql_length?: int, exclude_connections?: array<string>}, cache?: array{enabled?: bool, exclude_pools?: array<string>}}, tracers?: array<string, array{version?: string, schema_url?: null|string, attributes?: array<string, mixed>}>, meters?: array<string, array{version?: string, schema_url?: null|string, attributes?: array<string, mixed>}>, loggers?: array<string, array{version?: string, schema_url?: null|string, attributes?: array<string, mixed>}>} $config
      */
     #[Override]
     public function loadExtension(array $config, ContainerConfigurator $container, ContainerBuilder $builder): void
     {
         $builder->setParameter('flow.telemetry.framework_logger', $config['framework_logger'] ?? null);
+        $builder->setParameter('flow.telemetry.capture_framework_channels', $config['capture_framework_channels'] ?? false);
 
         $tracers = ($config['tracers'] ?? []) + ['default' => []];
         $meters = ($config['meters'] ?? []) + ['default' => []];
@@ -1996,11 +2014,19 @@ final class FlowTelemetryBundle extends AbstractBundle
     }
 
     /**
-     * @param array<string, array{version?: string, schema_url?: null|string, attributes?: array<string, mixed>}> $config
+     * Register the named logger and its PSR-3 wrapper, returning the PSR-3 service id.
+     *
+     * Idempotent: a logger already defined under this name (e.g. declared via
+     * configuration) is left untouched, so a channel synthesized by
+     * {@see ChannelLoggerPass} never overrides a user-declared scope.
+     *
+     * @param array{version?: string, schema_url?: null|string, attributes?: array<string, mixed>} $loggerConfig
      */
-    private function registerLoggers(array $config, ContainerBuilder $builder): void
+    public static function defineLogger(string $name, array $loggerConfig, ContainerBuilder $builder): string
     {
-        foreach ($config as $name => $loggerConfig) {
+        $loggerServiceId = 'flow.telemetry.' . $name . '.logger';
+
+        if (!$builder->hasDefinition($loggerServiceId)) {
             $definition = new Definition(Logger::class);
             $definition->setFactory([new Reference('flow.telemetry'), 'logger']);
             $definition->setArgument(0, $name);
@@ -2019,7 +2045,6 @@ final class FlowTelemetryBundle extends AbstractBundle
             }
 
             $definition->setPublic(true);
-            $loggerServiceId = 'flow.telemetry.' . $name . '.logger';
             $builder->setDefinition($loggerServiceId, $definition);
 
             $psr3Definition = new Definition(TelemetryLogger::class);
@@ -2027,6 +2052,18 @@ final class FlowTelemetryBundle extends AbstractBundle
             $psr3Definition->setArgument(1, new Reference('flow.telemetry.psr3.log_record_converter'));
             $psr3Definition->setPublic(true);
             $builder->setDefinition($loggerServiceId . '.psr3', $psr3Definition);
+        }
+
+        return $loggerServiceId . '.psr3';
+    }
+
+    /**
+     * @param array<string, array{version?: string, schema_url?: null|string, attributes?: array<string, mixed>}> $config
+     */
+    private function registerLoggers(array $config, ContainerBuilder $builder): void
+    {
+        foreach ($config as $name => $loggerConfig) {
+            self::defineLogger($name, $loggerConfig, $builder);
         }
     }
 

--- a/src/bridge/symfony/telemetry-bundle/tests/Flow/Bridge/Symfony/TelemetryBundle/Tests/Fixtures/Channel/AppChannelConsumer.php
+++ b/src/bridge/symfony/telemetry-bundle/tests/Flow/Bridge/Symfony/TelemetryBundle/Tests/Fixtures/Channel/AppChannelConsumer.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\Bridge\Symfony\TelemetryBundle\Tests\Fixtures\Channel;
+
+use Flow\Bridge\Symfony\TelemetryBundle\Attribute\WithTelemetryChannel;
+use Psr\Log\LoggerInterface;
+
+#[WithTelemetryChannel('app')]
+final class AppChannelConsumer
+{
+    public function __construct(
+        public readonly LoggerInterface $logger,
+    ) {}
+}

--- a/src/bridge/symfony/telemetry-bundle/tests/Flow/Bridge/Symfony/TelemetryBundle/Tests/Fixtures/Channel/EventsChannelConsumer.php
+++ b/src/bridge/symfony/telemetry-bundle/tests/Flow/Bridge/Symfony/TelemetryBundle/Tests/Fixtures/Channel/EventsChannelConsumer.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\Bridge\Symfony\TelemetryBundle\Tests\Fixtures\Channel;
+
+use Flow\Bridge\Symfony\TelemetryBundle\Attribute\WithTelemetryChannel;
+use Psr\Log\LoggerInterface;
+
+#[WithTelemetryChannel('events')]
+final class EventsChannelConsumer
+{
+    public function __construct(
+        public readonly LoggerInterface $logger,
+    ) {}
+}

--- a/src/bridge/symfony/telemetry-bundle/tests/Flow/Bridge/Symfony/TelemetryBundle/Tests/Fixtures/Channel/FrameworkChannelConsumer.php
+++ b/src/bridge/symfony/telemetry-bundle/tests/Flow/Bridge/Symfony/TelemetryBundle/Tests/Fixtures/Channel/FrameworkChannelConsumer.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\Bridge\Symfony\TelemetryBundle\Tests\Fixtures\Channel;
+
+use Psr\Log\LoggerInterface;
+
+final class FrameworkChannelConsumer
+{
+    public function __construct(
+        public readonly LoggerInterface $logger,
+    ) {}
+}

--- a/src/bridge/symfony/telemetry-bundle/tests/Flow/Bridge/Symfony/TelemetryBundle/Tests/Fixtures/Channel/NamedArgumentConsumer.php
+++ b/src/bridge/symfony/telemetry-bundle/tests/Flow/Bridge/Symfony/TelemetryBundle/Tests/Fixtures/Channel/NamedArgumentConsumer.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\Bridge\Symfony\TelemetryBundle\Tests\Fixtures\Channel;
+
+use Psr\Log\LoggerInterface;
+
+final class NamedArgumentConsumer
+{
+    public function __construct(
+        public readonly LoggerInterface $eventsLogger,
+    ) {}
+}

--- a/src/bridge/symfony/telemetry-bundle/tests/Flow/Bridge/Symfony/TelemetryBundle/Tests/Fixtures/Channel/NativeChannelConsumer.php
+++ b/src/bridge/symfony/telemetry-bundle/tests/Flow/Bridge/Symfony/TelemetryBundle/Tests/Fixtures/Channel/NativeChannelConsumer.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\Bridge\Symfony\TelemetryBundle\Tests\Fixtures\Channel;
+
+use Flow\Bridge\Symfony\TelemetryBundle\Attribute\WithTelemetryChannel;
+use Flow\Telemetry\Logger\Logger;
+
+#[WithTelemetryChannel('events')]
+final class NativeChannelConsumer
+{
+    public function __construct(
+        public readonly Logger $logger,
+    ) {}
+}

--- a/src/bridge/symfony/telemetry-bundle/tests/Flow/Bridge/Symfony/TelemetryBundle/Tests/Integration/ChannelLoggerPassTest.php
+++ b/src/bridge/symfony/telemetry-bundle/tests/Flow/Bridge/Symfony/TelemetryBundle/Tests/Integration/ChannelLoggerPassTest.php
@@ -1,0 +1,208 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\Bridge\Symfony\TelemetryBundle\Tests\Integration;
+
+use Flow\Bridge\Symfony\TelemetryBundle\Attribute\WithTelemetryChannel;
+use Flow\Bridge\Symfony\TelemetryBundle\DependencyInjection\Compiler\ChannelLoggerPass;
+use Flow\Bridge\Symfony\TelemetryBundle\FlowTelemetryBundle;
+use Flow\Bridge\Symfony\TelemetryBundle\Tests\Fixtures\Channel\AppChannelConsumer;
+use Flow\Bridge\Symfony\TelemetryBundle\Tests\Fixtures\Channel\EventsChannelConsumer;
+use Flow\Bridge\Symfony\TelemetryBundle\Tests\Fixtures\Channel\FrameworkChannelConsumer;
+use Flow\Bridge\Symfony\TelemetryBundle\Tests\Fixtures\Channel\NamedArgumentConsumer;
+use Flow\Bridge\Symfony\TelemetryBundle\Tests\Fixtures\Channel\NativeChannelConsumer;
+use Flow\Bridge\Symfony\TelemetryBundle\Tests\Fixtures\TestKernel;
+use Flow\Telemetry\Logger\Logger;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\HttpKernel\Log\Logger as SymfonyDefaultLogger;
+
+#[CoversClass(FlowTelemetryBundle::class)]
+#[CoversClass(ChannelLoggerPass::class)]
+#[CoversClass(WithTelemetryChannel::class)]
+final class ChannelLoggerPassTest extends KernelTestCase
+{
+    public function test_app_channel_attribute_binds_its_own_channel_logger(): void
+    {
+        $this->bootKernel([
+            'config' => static function (TestKernel $kernel): void {
+                $kernel->addTestExtensionConfig('flow_telemetry', ['resource' => []]);
+                $kernel->addTestContainerConfigurator(static function (ContainerBuilder $container): void {
+                    $container->setDefinition(
+                        'test.app_consumer',
+                        self::autoconfiguredConsumer(AppChannelConsumer::class),
+                    );
+                });
+            },
+        ]);
+
+        $consumer = $this->getContainer()->get('test.app_consumer');
+
+        static::assertInstanceOf(AppChannelConsumer::class, $consumer);
+        static::assertSame($this->getContainer()->get('flow.telemetry.app.logger.psr3'), $consumer->logger);
+    }
+
+    public function test_channel_attribute_binds_the_channel_logger_to_an_autowired_consumer(): void
+    {
+        $this->bootKernel([
+            'config' => static function (TestKernel $kernel): void {
+                $kernel->addTestExtensionConfig('flow_telemetry', ['resource' => []]);
+                $kernel->addTestContainerConfigurator(static function (ContainerBuilder $container): void {
+                    $container->setDefinition(
+                        'test.events_consumer',
+                        self::autoconfiguredConsumer(EventsChannelConsumer::class),
+                    );
+                });
+            },
+        ]);
+
+        $consumer = $this->getContainer()->get('test.events_consumer');
+
+        static::assertInstanceOf(EventsChannelConsumer::class, $consumer);
+        static::assertSame($this->getContainer()->get('flow.telemetry.events.logger.psr3'), $consumer->logger);
+    }
+
+    public function test_channel_attribute_binds_the_native_logger_to_a_concrete_typehint(): void
+    {
+        $this->bootKernel([
+            'config' => static function (TestKernel $kernel): void {
+                $kernel->addTestExtensionConfig('flow_telemetry', ['resource' => []]);
+                $kernel->addTestContainerConfigurator(static function (ContainerBuilder $container): void {
+                    $container->setDefinition(
+                        'test.native_consumer',
+                        self::autoconfiguredConsumer(NativeChannelConsumer::class),
+                    );
+                });
+            },
+        ]);
+
+        $consumer = $this->getContainer()->get('test.native_consumer');
+
+        static::assertInstanceOf(NativeChannelConsumer::class, $consumer);
+        static::assertSame($this->getContainer()->get('flow.telemetry.events.logger'), $consumer->logger);
+    }
+
+    public function test_channel_logger_carries_the_log_channel_scope_attribute(): void
+    {
+        $this->bootKernel([
+            'config' => static function (TestKernel $kernel): void {
+                $kernel->addTestExtensionConfig('flow_telemetry', ['resource' => []]);
+                $kernel->addTestContainerConfigurator(static function (ContainerBuilder $container): void {
+                    $container->setDefinition(
+                        'test.events_consumer',
+                        self::autoconfiguredConsumer(EventsChannelConsumer::class),
+                    );
+                });
+            },
+        ]);
+
+        $logger = $this->getContainer()->get('flow.telemetry.events.logger');
+
+        static::assertInstanceOf(Logger::class, $logger);
+        static::assertSame('events', $logger->instrumentationScope()->attributes->get('log.channel'));
+    }
+
+    public function test_named_argument_alias_resolves_to_the_channel_logger(): void
+    {
+        $this->bootKernel([
+            'config' => static function (TestKernel $kernel): void {
+                $kernel->addTestExtensionConfig('flow_telemetry', ['resource' => []]);
+                $kernel->addTestContainerConfigurator(static function (ContainerBuilder $container): void {
+                    $container->setDefinition(
+                        'test.events_consumer',
+                        self::autoconfiguredConsumer(EventsChannelConsumer::class),
+                    );
+                    $container->setDefinition(
+                        'test.named_arg_consumer',
+                        self::autoconfiguredConsumer(NamedArgumentConsumer::class),
+                    );
+                });
+            },
+        ]);
+
+        $consumer = $this->getContainer()->get('test.named_arg_consumer');
+
+        static::assertInstanceOf(NamedArgumentConsumer::class, $consumer);
+        static::assertSame($this->getContainer()->get('flow.telemetry.events.logger.psr3'), $consumer->eventsLogger);
+    }
+
+    public function test_captures_a_framework_tagged_service_into_a_channel_logger(): void
+    {
+        $this->bootKernel([
+            'config' => static function (TestKernel $kernel): void {
+                $kernel->addTestExtensionConfig('flow_telemetry', [
+                    'resource' => [],
+                    'capture_framework_channels' => true,
+                ]);
+                $kernel->addTestContainerConfigurator(static function (ContainerBuilder $container): void {
+                    $container->setDefinition('logger', self::publicDefinition(SymfonyDefaultLogger::class));
+                    $container->setDefinition('test.framework_consumer', self::frameworkConsumer('events'));
+                });
+            },
+        ]);
+
+        $consumer = $this->getContainer()->get('test.framework_consumer');
+
+        static::assertInstanceOf(FrameworkChannelConsumer::class, $consumer);
+        static::assertSame($this->getContainer()->get('flow.telemetry.events.logger.psr3'), $consumer->logger);
+    }
+
+    public function test_does_not_capture_framework_channels_when_disabled(): void
+    {
+        $this->bootKernel([
+            'config' => static function (TestKernel $kernel): void {
+                $kernel->addTestExtensionConfig('flow_telemetry', [
+                    'resource' => [],
+                    'capture_framework_channels' => false,
+                ]);
+                $kernel->addTestContainerConfigurator(static function (ContainerBuilder $container): void {
+                    $container->setDefinition('logger', self::publicDefinition(SymfonyDefaultLogger::class));
+                    $container->setDefinition('test.framework_consumer', self::frameworkConsumer('events'));
+                });
+            },
+        ]);
+
+        $consumer = $this->getContainer()->get('test.framework_consumer');
+
+        static::assertInstanceOf(FrameworkChannelConsumer::class, $consumer);
+        static::assertSame($this->getContainer()->get('flow.telemetry.default.logger.psr3'), $consumer->logger);
+        static::assertFalse($this->getContainer()->has('flow.telemetry.events.logger.psr3'));
+    }
+
+    private static function frameworkConsumer(string $channel): Definition
+    {
+        $definition = new Definition(FrameworkChannelConsumer::class);
+        $definition->setArgument(0, new Reference('logger'));
+        $definition->addTag('monolog.logger', ['channel' => $channel]);
+        $definition->setPublic(true);
+
+        return $definition;
+    }
+
+    /**
+     * @param class-string $class
+     */
+    private static function publicDefinition(string $class): Definition
+    {
+        $definition = new Definition($class);
+        $definition->setPublic(true);
+
+        return $definition;
+    }
+
+    /**
+     * @param class-string $class
+     */
+    private static function autoconfiguredConsumer(string $class): Definition
+    {
+        $definition = new Definition($class);
+        $definition->setAutowired(true);
+        $definition->setAutoconfigured(true);
+        $definition->setPublic(true);
+
+        return $definition;
+    }
+}

--- a/src/bridge/symfony/telemetry-bundle/tests/Flow/Bridge/Symfony/TelemetryBundle/Tests/Unit/Attribute/WithTelemetryChannelTest.php
+++ b/src/bridge/symfony/telemetry-bundle/tests/Flow/Bridge/Symfony/TelemetryBundle/Tests/Unit/Attribute/WithTelemetryChannelTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\Bridge\Symfony\TelemetryBundle\Tests\Unit\Attribute;
+
+use Attribute;
+use Flow\Bridge\Symfony\TelemetryBundle\Attribute\WithTelemetryChannel;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+#[CoversClass(WithTelemetryChannel::class)]
+final class WithTelemetryChannelTest extends TestCase
+{
+    public function test_exposes_the_channel(): void
+    {
+        static::assertSame('events', (new WithTelemetryChannel('events'))->channel);
+    }
+
+    public function test_is_a_class_targeted_attribute(): void
+    {
+        $attributes = (new ReflectionClass(WithTelemetryChannel::class))->getAttributes(Attribute::class);
+
+        static::assertCount(1, $attributes);
+        static::assertSame(Attribute::TARGET_CLASS, $attributes[0]->newInstance()->flags);
+    }
+}

--- a/src/bridge/symfony/telemetry-bundle/tests/Flow/Bridge/Symfony/TelemetryBundle/Tests/Unit/DependencyInjection/Compiler/ChannelLoggerPassTest.php
+++ b/src/bridge/symfony/telemetry-bundle/tests/Flow/Bridge/Symfony/TelemetryBundle/Tests/Unit/DependencyInjection/Compiler/ChannelLoggerPassTest.php
@@ -1,0 +1,332 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\Bridge\Symfony\TelemetryBundle\Tests\Unit\DependencyInjection\Compiler;
+
+use Flow\Bridge\Symfony\TelemetryBundle\DependencyInjection\Compiler\ChannelLoggerPass;
+use Flow\Bridge\Symfony\TelemetryBundle\Exception\RuntimeException;
+use Flow\Telemetry\Attributes;
+use Flow\Telemetry\Logger\Logger;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Argument\BoundArgument;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+#[CoversClass(ChannelLoggerPass::class)]
+final class ChannelLoggerPassTest extends TestCase
+{
+    public function test_app_channel_is_synthesized_like_any_other_channel(): void
+    {
+        $container = $this->containerWithTaggedConsumer('app');
+
+        (new ChannelLoggerPass())->process($container);
+
+        static::assertTrue($container->hasDefinition('flow.telemetry.app.logger'));
+        static::assertSame(
+            'flow.telemetry.app.logger.psr3',
+            (string) $this->loggerBinding($container->getDefinition('consumer')),
+        );
+    }
+
+    public function test_default_channel_reuses_the_always_present_default_logger(): void
+    {
+        $container = $this->containerWithTaggedConsumer('default');
+        $existing = new Definition(Logger::class);
+        $container->setDefinition('flow.telemetry.default.logger', $existing);
+        $container->setDefinition('flow.telemetry.default.logger.psr3', new Definition(Logger::class));
+
+        (new ChannelLoggerPass())->process($container);
+
+        static::assertSame($existing, $container->getDefinition('flow.telemetry.default.logger'));
+        static::assertSame(
+            'flow.telemetry.default.logger.psr3',
+            (string) $this->loggerBinding($container->getDefinition('consumer')),
+        );
+    }
+
+    public function test_binds_channel_logger_to_tagged_service(): void
+    {
+        $container = $this->containerWithTaggedConsumer('events');
+
+        (new ChannelLoggerPass())->process($container);
+
+        static::assertSame(
+            'flow.telemetry.events.logger.psr3',
+            (string) $this->loggerBinding($container->getDefinition('consumer')),
+        );
+    }
+
+    public function test_binds_native_logger_to_tagged_service(): void
+    {
+        $container = $this->containerWithTaggedConsumer('events');
+
+        (new ChannelLoggerPass())->process($container);
+
+        static::assertSame(
+            'flow.telemetry.events.logger',
+            (string) $this->loggerBinding($container->getDefinition('consumer'), Logger::class),
+        );
+    }
+
+    public function test_app_channel_binds_its_own_native_logger(): void
+    {
+        $container = $this->containerWithTaggedConsumer('app');
+
+        (new ChannelLoggerPass())->process($container);
+
+        static::assertSame(
+            'flow.telemetry.app.logger',
+            (string) $this->loggerBinding($container->getDefinition('consumer'), Logger::class),
+        );
+    }
+
+    public function test_registers_native_logger_named_argument_alias(): void
+    {
+        $container = $this->containerWithTaggedConsumer('events');
+
+        (new ChannelLoggerPass())->process($container);
+
+        $aliasId = Logger::class . ' $eventsLogger';
+        static::assertTrue($container->hasAlias($aliasId));
+        static::assertSame('flow.telemetry.events.logger', (string) $container->getAlias($aliasId));
+    }
+
+    public function test_does_not_override_a_declared_logger(): void
+    {
+        $container = $this->containerWithTaggedConsumer('events');
+        $declared = new Definition(Logger::class);
+        $container->setDefinition('flow.telemetry.events.logger', $declared);
+        $container->setDefinition('flow.telemetry.events.logger.psr3', new Definition(Logger::class));
+
+        (new ChannelLoggerPass())->process($container);
+
+        static::assertSame($declared, $container->getDefinition('flow.telemetry.events.logger'));
+    }
+
+    public function test_empty_channel_attribute_throws(): void
+    {
+        $container = $this->containerWithTaggedConsumer('');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('missing the required non-empty "channel" attribute');
+
+        (new ChannelLoggerPass())->process($container);
+    }
+
+    public function test_channel_parameter_resolving_to_empty_throws(): void
+    {
+        $container = $this->containerWithTaggedConsumer('%flow.test.channel%');
+        $container->setParameter('flow.test.channel', '');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('did not resolve to a non-empty string');
+
+        (new ChannelLoggerPass())->process($container);
+    }
+
+    public function test_missing_channel_attribute_throws(): void
+    {
+        $container = new ContainerBuilder();
+        $consumer = new Definition();
+        $consumer->addTag(ChannelLoggerPass::TAG);
+        $container->setDefinition('consumer', $consumer);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Service "consumer" is tagged');
+
+        (new ChannelLoggerPass())->process($container);
+    }
+
+    public function test_registers_camel_cased_named_argument_alias(): void
+    {
+        $container = $this->containerWithTaggedConsumer('http_client');
+
+        (new ChannelLoggerPass())->process($container);
+
+        $aliasId = LoggerInterface::class . ' $httpClientLogger';
+        static::assertTrue($container->hasAlias($aliasId));
+        static::assertSame('flow.telemetry.http_client.logger.psr3', (string) $container->getAlias($aliasId));
+    }
+
+    public function test_rewrites_explicit_logger_reference_in_arguments(): void
+    {
+        $container = $this->containerWithTaggedConsumer('events');
+        $container->getDefinition('consumer')->setArgument(0, new Reference('logger'));
+
+        (new ChannelLoggerPass())->process($container);
+
+        static::assertSame(
+            'flow.telemetry.events.logger.psr3',
+            (string) $container->getDefinition('consumer')->getArgument(0),
+        );
+    }
+
+    public function test_synthesizes_channel_logger_with_log_channel_scope_attribute(): void
+    {
+        $container = $this->containerWithTaggedConsumer('events');
+
+        (new ChannelLoggerPass())->process($container);
+
+        // @mago-expect analysis:mixed-assignment
+        $attributes = $container->getDefinition('flow.telemetry.events.logger')->getArgument(3);
+        static::assertInstanceOf(Definition::class, $attributes);
+        static::assertSame(Attributes::class, $attributes->getClass());
+        static::assertSame(['log.channel' => 'events'], $attributes->getArgument(0));
+    }
+
+    public function test_captures_framework_monolog_logger_channel(): void
+    {
+        $container = $this->containerWithFrameworkConsumer('request');
+
+        (new ChannelLoggerPass())->process($container);
+
+        static::assertSame(
+            'flow.telemetry.request.logger.psr3',
+            (string) $this->loggerBinding($container->getDefinition('framework.consumer')),
+        );
+    }
+
+    public function test_does_not_capture_framework_channels_when_disabled(): void
+    {
+        $container = $this->containerWithFrameworkConsumer('request');
+        $container->setParameter('flow.telemetry.capture_framework_channels', false);
+        $container->getDefinition('framework.consumer')->setArgument(0, new Reference('logger'));
+
+        (new ChannelLoggerPass())->process($container);
+
+        static::assertSame('logger', (string) $container->getDefinition('framework.consumer')->getArgument(0));
+        static::assertArrayNotHasKey(
+            LoggerInterface::class,
+            $container->getDefinition('framework.consumer')->getBindings(),
+        );
+    }
+
+    public function test_explicit_channel_takes_precedence_over_framework_channel(): void
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('flow.telemetry.capture_framework_channels', true);
+        $consumer = new Definition();
+        $consumer->addTag('monolog.logger', ['channel' => 'request']);
+        $consumer->addTag(ChannelLoggerPass::TAG, ['channel' => 'events']);
+        $container->setDefinition('consumer', $consumer);
+
+        (new ChannelLoggerPass())->process($container);
+
+        static::assertSame(
+            'flow.telemetry.events.logger.psr3',
+            (string) $this->loggerBinding($container->getDefinition('consumer')),
+        );
+    }
+
+    public function test_preserves_invalid_reference_behavior_when_rewriting(): void
+    {
+        $container = $this->containerWithFrameworkConsumer('router');
+        $container->getDefinition('framework.consumer')->setArgument(
+            0,
+            new Reference('logger', ContainerInterface::IGNORE_ON_INVALID_REFERENCE),
+        );
+
+        (new ChannelLoggerPass())->process($container);
+
+        // @mago-expect analysis:mixed-assignment
+        $reference = $container->getDefinition('framework.consumer')->getArgument(0);
+        static::assertInstanceOf(Reference::class, $reference);
+        static::assertSame('flow.telemetry.router.logger.psr3', (string) $reference);
+        static::assertSame(ContainerInterface::IGNORE_ON_INVALID_REFERENCE, $reference->getInvalidBehavior());
+    }
+
+    public function test_registers_named_argument_alias_for_framework_channel(): void
+    {
+        $container = $this->containerWithFrameworkConsumer('http_client');
+
+        (new ChannelLoggerPass())->process($container);
+
+        $aliasId = LoggerInterface::class . ' $httpClientLogger';
+        static::assertTrue($container->hasAlias($aliasId));
+        static::assertSame('flow.telemetry.http_client.logger.psr3', (string) $container->getAlias($aliasId));
+    }
+
+    public function test_rewrites_logger_reference_in_method_call(): void
+    {
+        $container = $this->containerWithFrameworkConsumer('cache');
+        $container->getDefinition('framework.consumer')->addMethodCall('setLogger', [new Reference('logger')]);
+
+        (new ChannelLoggerPass())->process($container);
+
+        // @mago-expect analysis:mixed-assignment
+        $call = $container->getDefinition('framework.consumer')->getMethodCalls()[0] ?? null;
+        static::assertIsArray($call);
+        // @mago-expect analysis:mixed-assignment
+        $arguments = $call[1] ?? null;
+        static::assertIsArray($arguments);
+        // @mago-expect analysis:mixed-assignment
+        $argument = $arguments[0] ?? null;
+        static::assertInstanceOf(Reference::class, $argument);
+        static::assertSame('flow.telemetry.cache.logger.psr3', (string) $argument);
+    }
+
+    public function test_skips_framework_tag_whose_channel_resolves_to_empty(): void
+    {
+        $container = $this->containerWithFrameworkConsumer('%flow.test.channel%');
+        $container->setParameter('flow.test.channel', '');
+        $container->getDefinition('framework.consumer')->setArgument(0, new Reference('logger'));
+
+        (new ChannelLoggerPass())->process($container);
+
+        static::assertSame('logger', (string) $container->getDefinition('framework.consumer')->getArgument(0));
+    }
+
+    public function test_skips_framework_tag_without_a_channel(): void
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('flow.telemetry.capture_framework_channels', true);
+        $consumer = new Definition();
+        $consumer->addTag('monolog.logger');
+        $consumer->setArgument(0, new Reference('logger'));
+        $container->setDefinition('framework.consumer', $consumer);
+
+        (new ChannelLoggerPass())->process($container);
+
+        static::assertSame('logger', (string) $container->getDefinition('framework.consumer')->getArgument(0));
+    }
+
+    private function containerWithFrameworkConsumer(string $channel): ContainerBuilder
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('flow.telemetry.capture_framework_channels', true);
+        $consumer = new Definition();
+        $consumer->addTag('monolog.logger', ['channel' => $channel]);
+        $container->setDefinition('framework.consumer', $consumer);
+
+        return $container;
+    }
+
+    private function containerWithTaggedConsumer(string $channel): ContainerBuilder
+    {
+        $container = new ContainerBuilder();
+        $consumer = new Definition();
+        $consumer->addTag(ChannelLoggerPass::TAG, ['channel' => $channel]);
+        $container->setDefinition('consumer', $consumer);
+
+        return $container;
+    }
+
+    /**
+     * @param class-string $type
+     */
+    private function loggerBinding(Definition $definition, string $type = LoggerInterface::class): Reference
+    {
+        $binding = $definition->getBindings()[$type];
+        self::assertInstanceOf(BoundArgument::class, $binding);
+        // @mago-expect analysis:mixed-assignment
+        $value = $binding->getValues()[0];
+        self::assertInstanceOf(Reference::class, $value);
+
+        return $value;
+    }
+}


### PR DESCRIPTION
<h2>Change Log</h2>
<hr />
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <li><code>flow-php/symfony-telemetry-bundle</code> - <code>#[WithTelemetryChannel]</code> attribute to scope a service's logger to a named channel</li>
    <li><code>flow-php/symfony-telemetry-bundle</code> - optional <code>capture_framework_channels</code> to reroute Symfony's <code>monolog.logger</code> channels (off by default)</li>
    <li><code>flow-php/symfony-telemetry-bundle</code> - per-channel binding of PSR-3 <code>LoggerInterface</code> and native <code>Logger</code> with <code>$&lt;channel&gt;Logger</code> aliases</li>
  </ul>
  <h4>Fixed</h4>
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>
  <h4>Security</h4>
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>
</div>
