### PR TITLE
feat(flow-php/etl-adapter-postgresql): explicit index column position…

### DIFF
--- a/documentation/components/adapters/postgresql.md
+++ b/documentation/components/adapters/postgresql.md
@@ -500,13 +500,57 @@ $schema = schema(
 | `PostgreSqlMetadata::precision($p)` / `::scale($s)` | Emit `numeric($p, $s)`                   |
 | `PostgreSqlMetadata::default($v)` | Set a column `DEFAULT`                                      |
 | `PostgreSqlMetadata::primaryKey($name)` | Include the column in the table primary key          |
-| `PostgreSqlMetadata::indexUnique($name)` | Include the column in a named `UNIQUE` constraint   |
-| `PostgreSqlMetadata::index($name)` | Include the column in a named index                       |
+| `PostgreSqlMetadata::indexUnique($name, $position)` | Include the column in a named `UNIQUE` constraint, optionally at an explicit position |
+| `PostgreSqlMetadata::index($name, $position)` | Include the column in a named index, optionally at an explicit position |
 | `PostgreSqlMetadata::identity($generation)` | Make the column an identity column               |
 | `PostgreSqlMetadata::generated($expr)` | Make the column a generated column                    |
 
 Columns sharing the same primary key, unique constraint, or index name are grouped together, so composite keys are
 expressed by attaching the same name to several definitions.
+
+#### Ordering Columns Within an Index
+
+For composite indexes and unique constraints, column order matters. By default columns are ordered the way they appear
+in the schema. Pass an explicit `$position` (ascending, lower first) to `index()` / `indexUnique()` to control the
+order independently of schema field order — useful, for example, for a keyset-pagination index where the leading
+column must serve `ORDER BY`:
+
+```php
+use Flow\ETL\Adapter\PostgreSql\PostgreSqlMetadata;
+
+use function Flow\ETL\Adapter\PostgreSql\to_pgsql_schema_table;
+use function Flow\ETL\DSL\{datetime_schema, int_schema, schema};
+
+// `id` is field 0, `created_at` is field 1, but the index must lead with `created_at`.
+$table = to_pgsql_schema_table(
+    schema(
+        int_schema('id', metadata: PostgreSqlMetadata::index('orders_created_at_id_idx', position: 2)),
+        datetime_schema('created_at', metadata: PostgreSqlMetadata::index('orders_created_at_id_idx', position: 1)),
+    ),
+    'orders',
+);
+
+// => CREATE INDEX orders_created_at_id_idx ON public.orders (created_at, id)
+```
+
+Columns without an explicit position default to the end (`PHP_INT_MAX`), and schema order breaks ties — so leaving
+positions off keeps the schema-order behavior.
+
+#### A Column in Multiple Indexes
+
+Because each index is tracked under its own metadata key, a single column can belong to several indexes at once. Chain
+`merge()` to attach more than one:
+
+```php
+$schema = schema(
+    int_schema('id', metadata: PostgreSqlMetadata::primaryKey('pk_orders')
+        ->merge(PostgreSqlMetadata::index('orders_created_at_id_idx', position: 2))),
+    datetime_schema('created_at', metadata: PostgreSqlMetadata::index('orders_created_at_id_idx', position: 1)),
+);
+```
+
+> Index and unique-constraint names must not contain a colon (`:`) — it is reserved internally as the name/position
+> separator and passing one throws an `InvalidArgumentException`.
 
 ### Reading a Flow Schema back from a Table
 

--- a/src/adapter/etl-adapter-postgresql/src/Flow/ETL/Adapter/PostgreSql/PostgreSqlMetadata.php
+++ b/src/adapter/etl-adapter-postgresql/src/Flow/ETL/Adapter/PostgreSql/PostgreSqlMetadata.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Adapter\PostgreSql;
 
+use Flow\ETL\Exception\InvalidArgumentException;
 use Flow\ETL\Schema\Metadata;
 use Flow\PostgreSql\Schema\IdentityGeneration;
+
+use function str_contains;
 
 /**
  * Per-column metadata keys understood by {@see SchemaConverter} when converting a Flow Schema to a
@@ -39,14 +42,25 @@ enum PostgreSqlMetadata: string
         return Metadata::with(self::IDENTITY->value, $generation->value);
     }
 
-    public static function index(string $name): Metadata
+    public static function index(string $name, int $position = PHP_INT_MAX): Metadata
     {
-        return Metadata::with(self::INDEX->value, $name);
+        if (str_contains($name, ':')) {
+            throw InvalidArgumentException::because('PostgreSQL index name "%s" must not contain a colon ":"', $name);
+        }
+
+        return Metadata::with(self::INDEX->value . ':' . $name, $position);
     }
 
-    public static function indexUnique(string $name): Metadata
+    public static function indexUnique(string $name, int $position = PHP_INT_MAX): Metadata
     {
-        return Metadata::with(self::INDEX_UNIQUE->value, $name);
+        if (str_contains($name, ':')) {
+            throw InvalidArgumentException::because(
+                'PostgreSQL unique index name "%s" must not contain a colon ":"',
+                $name,
+            );
+        }
+
+        return Metadata::with(self::INDEX_UNIQUE->value . ':' . $name, $position);
     }
 
     public static function length(int $length): Metadata

--- a/src/adapter/etl-adapter-postgresql/src/Flow/ETL/Adapter/PostgreSql/SchemaConverter.php
+++ b/src/adapter/etl-adapter-postgresql/src/Flow/ETL/Adapter/PostgreSql/SchemaConverter.php
@@ -19,6 +19,8 @@ use Flow\PostgreSql\Schema\TableOptions;
 use Flow\Types\Type;
 
 use function array_keys;
+use function array_map;
+use function array_search;
 use function count;
 use function Flow\ETL\DSL\definition_from_type;
 use function Flow\PostgreSql\DSL\column_type_from_string;
@@ -26,6 +28,11 @@ use function Flow\Types\DSL\type_integer;
 use function Flow\Types\DSL\type_string;
 use function implode;
 use function in_array;
+use function is_int;
+use function str_starts_with;
+use function strlen;
+use function substr;
+use function usort;
 
 /**
  * Converts between a Flow {@see Schema} and a PostgreSQL {@see Table}.
@@ -122,14 +129,22 @@ final readonly class SchemaConverter
         }
 
         foreach ($table->uniqueConstraints as $unique) {
-            if (in_array($column->name, $unique->columns, true)) {
-                $metadata = $metadata->merge(PostgreSqlMetadata::indexUnique($unique->name ?? ''));
+            $position = array_search($column->name, $unique->columns, true);
+
+            if ($position !== false) {
+                $metadata = $metadata->merge(PostgreSqlMetadata::indexUnique($unique->name ?? '', $position));
             }
         }
 
         foreach ($table->indexes as $index) {
-            if (!$index->unique && !$index->primary && in_array($column->name, $index->columns, true)) {
-                $metadata = $metadata->merge(PostgreSqlMetadata::index($index->name));
+            if ($index->unique || $index->primary) {
+                continue;
+            }
+
+            $position = array_search($column->name, $index->columns, true);
+
+            if ($position !== false) {
+                $metadata = $metadata->merge(PostgreSqlMetadata::index($index->name, $position));
             }
         }
 
@@ -215,13 +230,57 @@ final readonly class SchemaConverter
     }
 
     /**
+     *
+     * @return array<string, non-empty-list<string>>
+     */
+    private function groupColumnsByIndexPrefix(Schema $schema, string $prefix): array
+    {
+        $prefix .= ':';
+        /** @var array<string, list<array{column: string, position: int, ordinal: int}>> $grouped */
+        $grouped = [];
+        $ordinal = 0;
+
+        foreach ($schema->definitions() as $definition) {
+            foreach ($definition->metadata()->normalize() as $key => $value) {
+                if (str_starts_with($key, $prefix)) {
+                    $grouped[substr($key, strlen($prefix))][] = [
+                        'column' => $definition->entry()->name(),
+                        'position' => is_int($value) ? $value : PHP_INT_MAX,
+                        'ordinal' => $ordinal,
+                    ];
+                }
+            }
+
+            $ordinal++;
+        }
+
+        $ordered = [];
+
+        foreach ($grouped as $name => $columns) {
+            if ($columns === []) {
+                continue;
+            }
+
+            usort(
+                $columns,
+                static fn(array $a, array $b): int => (
+                    [$a['position'], $a['ordinal']] <=> [$b['position'], $b['ordinal']]
+                ),
+            );
+            $ordered[$name] = array_map(static fn(array $c): string => $c['column'], $columns);
+        }
+
+        return $ordered;
+    }
+
+    /**
      * @return list<Index>
      */
     private function indexes(Schema $schema): array
     {
         $indexes = [];
 
-        foreach ($this->groupColumnsByMetadata($schema, PostgreSqlMetadata::INDEX->value) as $name => $columns) {
+        foreach ($this->groupColumnsByIndexPrefix($schema, PostgreSqlMetadata::INDEX->value) as $name => $columns) {
             $indexes[] = new Index(name: $name, columns: $columns);
         }
 
@@ -254,7 +313,10 @@ final readonly class SchemaConverter
     {
         $constraints = [];
 
-        foreach ($this->groupColumnsByMetadata($schema, PostgreSqlMetadata::INDEX_UNIQUE->value) as $name => $columns) {
+        foreach ($this->groupColumnsByIndexPrefix(
+            $schema,
+            PostgreSqlMetadata::INDEX_UNIQUE->value,
+        ) as $name => $columns) {
             $constraints[] = new UniqueConstraint(columns: $columns, name: $name === '' ? null : $name);
         }
 

--- a/src/adapter/etl-adapter-postgresql/tests/Flow/ETL/Adapter/PostgreSql/Tests/Integration/SchemaConverterIntegrationTest.php
+++ b/src/adapter/etl-adapter-postgresql/tests/Flow/ETL/Adapter/PostgreSql/Tests/Integration/SchemaConverterIntegrationTest.php
@@ -14,6 +14,7 @@ use Flow\Types\Type\Native\StringType;
 use function Flow\ETL\Adapter\PostgreSql\pgsql_table_to_flow_schema;
 use function Flow\ETL\Adapter\PostgreSql\to_pgsql_schema_table;
 use function Flow\ETL\DSL\bool_schema;
+use function Flow\ETL\DSL\datetime_schema;
 use function Flow\ETL\DSL\int_schema;
 use function Flow\ETL\DSL\json_schema;
 use function Flow\ETL\DSL\schema;
@@ -71,6 +72,45 @@ final class SchemaConverterIntegrationTest extends IntegrationTestCase
         static::assertInstanceOf(BooleanType::class, $flowSchema->get('active')->type());
         static::assertInstanceOf(JsonType::class, $flowSchema->get('payload')->type());
         static::assertFalse($flowSchema->get('id')->isNullable());
+    }
+
+    public function test_creates_index_with_explicit_column_order(): void
+    {
+        $indexName = 'idx_' . $this->tableName . '_keyset';
+
+        $table = to_pgsql_schema_table(
+            schema(
+                int_schema(
+                    'id',
+                    metadata: PostgreSqlMetadata::primaryKey('pk_' . $this->tableName)->merge(PostgreSqlMetadata::index(
+                        $indexName,
+                        2,
+                    )),
+                ),
+                datetime_schema('created_at', metadata: PostgreSqlMetadata::index($indexName, 1)),
+            ),
+            $this->tableName,
+        );
+
+        foreach ($table->toSql() as $sql) {
+            $this->client->execute($sql);
+        }
+
+        $introspected = client_catalog_provider($this->client, ['public'])
+            ->get()
+            ->get('public')
+            ->table($this->tableName);
+
+        $keyset = null;
+
+        foreach ($introspected->indexes as $index) {
+            if ($index->name === $indexName) {
+                $keyset = $index;
+            }
+        }
+
+        static::assertNotNull($keyset);
+        static::assertSame(['created_at', 'id'], $keyset->columns);
     }
 
     public function test_creates_unlogged_table_from_options(): void

--- a/src/adapter/etl-adapter-postgresql/tests/Flow/ETL/Adapter/PostgreSql/Tests/Unit/PostgreSqlMetadataTest.php
+++ b/src/adapter/etl-adapter-postgresql/tests/Flow/ETL/Adapter/PostgreSql/Tests/Unit/PostgreSqlMetadataTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Flow\ETL\Adapter\PostgreSql\Tests\Unit;
 
 use Flow\ETL\Adapter\PostgreSql\PostgreSqlMetadata;
+use Flow\ETL\Exception\InvalidArgumentException;
 use Flow\PostgreSql\Schema\IdentityGeneration;
 use PHPUnit\Framework\TestCase;
 
@@ -45,16 +46,52 @@ final class PostgreSqlMetadataTest extends TestCase
     {
         $metadata = PostgreSqlMetadata::index('idx_name');
 
-        static::assertTrue($metadata->has(PostgreSqlMetadata::INDEX->value));
-        static::assertSame('idx_name', $metadata->get(PostgreSqlMetadata::INDEX->value));
+        static::assertTrue($metadata->has(PostgreSqlMetadata::INDEX->value . ':idx_name'));
+        static::assertSame(PHP_INT_MAX, $metadata->get(PostgreSqlMetadata::INDEX->value . ':idx_name'));
+    }
+
+    public function test_index_factory_rejects_colon_in_name(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        PostgreSqlMetadata::index('bad:name');
+    }
+
+    public function test_index_factory_with_position(): void
+    {
+        $metadata = PostgreSqlMetadata::index('idx_name', 2);
+
+        static::assertSame(2, $metadata->get(PostgreSqlMetadata::INDEX->value . ':idx_name'));
     }
 
     public function test_index_unique_factory(): void
     {
         $metadata = PostgreSqlMetadata::indexUnique('uq_email');
 
-        static::assertTrue($metadata->has(PostgreSqlMetadata::INDEX_UNIQUE->value));
-        static::assertSame('uq_email', $metadata->get(PostgreSqlMetadata::INDEX_UNIQUE->value));
+        static::assertTrue($metadata->has(PostgreSqlMetadata::INDEX_UNIQUE->value . ':uq_email'));
+        static::assertSame(PHP_INT_MAX, $metadata->get(PostgreSqlMetadata::INDEX_UNIQUE->value . ':uq_email'));
+    }
+
+    public function test_index_unique_factory_rejects_colon_in_name(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        PostgreSqlMetadata::indexUnique('bad:name');
+    }
+
+    public function test_index_unique_factory_with_position(): void
+    {
+        $metadata = PostgreSqlMetadata::indexUnique('uq_email', 1);
+
+        static::assertSame(1, $metadata->get(PostgreSqlMetadata::INDEX_UNIQUE->value . ':uq_email'));
+    }
+
+    public function test_merge_keeps_both_index_keys(): void
+    {
+        $metadata = PostgreSqlMetadata::index('idx_a', 1)->merge(PostgreSqlMetadata::index('idx_b', 2));
+
+        static::assertSame(1, $metadata->get(PostgreSqlMetadata::INDEX->value . ':idx_a'));
+        static::assertSame(2, $metadata->get(PostgreSqlMetadata::INDEX->value . ':idx_b'));
     }
 
     public function test_length_factory(): void

--- a/src/adapter/etl-adapter-postgresql/tests/Flow/ETL/Adapter/PostgreSql/Tests/Unit/SchemaConverterTest.php
+++ b/src/adapter/etl-adapter-postgresql/tests/Flow/ETL/Adapter/PostgreSql/Tests/Unit/SchemaConverterTest.php
@@ -12,6 +12,7 @@ use Flow\PostgreSql\Schema\Column;
 use Flow\PostgreSql\Schema\Constraint\PrimaryKey;
 use Flow\PostgreSql\Schema\Constraint\UniqueConstraint;
 use Flow\PostgreSql\Schema\IdentityGeneration;
+use Flow\PostgreSql\Schema\Index;
 use Flow\PostgreSql\Schema\PartitionStrategy;
 use Flow\PostgreSql\Schema\Table;
 use Flow\PostgreSql\Schema\TriggerEvent;
@@ -155,6 +156,95 @@ final class SchemaConverterTest extends TestCase
         static::assertSame('idx_email', $table->indexes[0]->name);
         static::assertSame(['email'], $table->indexes[0]->columns);
         static::assertFalse($table->indexes[0]->unique);
+    }
+
+    public function test_index_explicit_position_overrides_schema_order(): void
+    {
+        $table = (new SchemaConverter())->toPostgreSqlTable(
+            schema(
+                int_schema('id', metadata: PostgreSqlMetadata::index('idx', 2)),
+                datetime_schema('created_at', metadata: PostgreSqlMetadata::index('idx', 1)),
+            ),
+            'orders',
+        );
+
+        static::assertCount(1, $table->indexes);
+        static::assertSame('idx', $table->indexes[0]->name);
+        static::assertSame(['created_at', 'id'], $table->indexes[0]->columns);
+    }
+
+    public function test_composite_index_without_positions_preserves_schema_order(): void
+    {
+        $table = (new SchemaConverter())->toPostgreSqlTable(
+            schema(
+                int_schema('id', metadata: PostgreSqlMetadata::index('idx')),
+                datetime_schema('created_at', metadata: PostgreSqlMetadata::index('idx')),
+            ),
+            'orders',
+        );
+
+        static::assertSame(['id', 'created_at'], $table->indexes[0]->columns);
+    }
+
+    public function test_composite_unique_with_positions_is_ordered(): void
+    {
+        $table = (new SchemaConverter())->toPostgreSqlTable(
+            schema(
+                int_schema('warehouse', metadata: PostgreSqlMetadata::indexUnique('uq_stock', 2)),
+                int_schema('product_id', metadata: PostgreSqlMetadata::indexUnique('uq_stock', 1)),
+            ),
+            'stock',
+        );
+
+        static::assertCount(1, $table->uniqueConstraints);
+        static::assertSame(['product_id', 'warehouse'], $table->uniqueConstraints[0]->columns);
+        static::assertSame('uq_stock', $table->uniqueConstraints[0]->name);
+    }
+
+    public function test_column_can_belong_to_multiple_indexes(): void
+    {
+        $table = (new SchemaConverter())->toPostgreSqlTable(
+            schema(
+                int_schema(
+                    'id',
+                    metadata: PostgreSqlMetadata::index('idx_a', 1)->merge(PostgreSqlMetadata::index('idx_b', 2)),
+                ),
+                datetime_schema('created_at', metadata: PostgreSqlMetadata::index('idx_b', 1)),
+            ),
+            'orders',
+        );
+
+        $byName = [];
+
+        foreach ($table->indexes as $index) {
+            $byName[$index->name] = $index->columns;
+        }
+
+        static::assertArrayHasKey('idx_a', $byName);
+        static::assertArrayHasKey('idx_b', $byName);
+        static::assertSame(['id'], $byName['idx_a']);
+        static::assertSame(['created_at', 'id'], $byName['idx_b']);
+    }
+
+    public function test_reverse_preserves_index_column_order(): void
+    {
+        $table = new Table(
+            schema: 'public',
+            name: 'orders',
+            columns: [
+                Column::create('id', ColumnType::bigint(), nullable: false),
+                Column::create('created_at', ColumnType::timestamptz()),
+            ],
+            indexes: [
+                new Index(name: 'idx', columns: ['created_at', 'id']),
+            ],
+        );
+
+        $converter = new SchemaConverter();
+        $roundTripped = $converter->toPostgreSqlTable($converter->toFlowSchema($table), 'orders');
+
+        static::assertCount(1, $roundTripped->indexes);
+        static::assertSame(['created_at', 'id'], $roundTripped->indexes[0]->columns);
     }
 
     public function test_nullability_from_definition(): void


### PR DESCRIPTION
<h2>Change Log</h2>
<hr />
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <li><code>etl-adapter-postgresql</code> - explicit column position in index/unique metadata</li>
    <li><code>etl-adapter-postgresql</code> - a column can belong to multiple indexes</li>
  </ul>
  <h4>Fixed</h4>
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li><code>etl-adapter-postgresql</code> - composite index/unique columns ordered by position, schema order as tiebreak</li>
    <li><code>etl-adapter-postgresql</code> - reverse Table to Flow conversion preserves index column order</li>
  </ul>
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>
  <h4>Security</h4>
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>
</div>
