### PR TITLE
feat(flow-php/symfony-postgresql-messenger-bridge): store messenger time columns as timestamp instead of timestamptz

### DIFF
--- a/documentation/upgrading.md
+++ b/documentation/upgrading.md
@@ -121,6 +121,22 @@ to_pgsql_table($client, 'users')->withTypesMap(new EntryTypesMap(
 ));
 ```
 
+### 6) `flow-php/symfony-postgresql-messenger` - `messenger_messages` time columns use `timestamp` instead of `timestamptz`
+
+| Column type for `created_at`, `available_at`, `delivered_at` | Before        | After       |
+|--------------------------------------------------------------|---------------|-------------|
+| `MessengerCatalogProvider` (DDL)                             | `timestamptz` | `timestamp` |
+| `Connection` bindings                                        | `TIMESTAMPTZ` | `TIMESTAMP` |
+
+Existing tables, realign the column type (UTC instants preserved):
+
+```sql
+ALTER TABLE messenger_messages
+    ALTER COLUMN created_at   TYPE timestamp USING created_at   AT TIME ZONE 'UTC',
+    ALTER COLUMN available_at TYPE timestamp USING available_at AT TIME ZONE 'UTC',
+    ALTER COLUMN delivered_at TYPE timestamp USING delivered_at AT TIME ZONE 'UTC';
+```
+
 ---
 
 ## Upgrading from 0.37.x to 0.38.x

--- a/src/bridge/symfony/postgresql-messenger/src/Flow/Bridge/Symfony/PostgreSQLMessenger/Connection.php
+++ b/src/bridge/symfony/postgresql-messenger/src/Flow/Bridge/Symfony/PostgreSQLMessenger/Connection.php
@@ -106,8 +106,8 @@ final readonly class Connection
                     ->forUpdateSkipLocked(),
                 [
                     $this->queueName,
-                    typed($now, ValueType::TIMESTAMPTZ),
-                    typed($redeliverCutoff, ValueType::TIMESTAMPTZ),
+                    typed($now, ValueType::TIMESTAMP),
+                    typed($redeliverCutoff, ValueType::TIMESTAMP),
                 ],
             );
 
@@ -129,7 +129,7 @@ final readonly class Connection
                     ->set('delivered_at', param(1))
                     ->where(eq(col('id'), param(2))),
                 [
-                    typed($now, ValueType::TIMESTAMPTZ),
+                    typed($now, ValueType::TIMESTAMP),
                     (int) $rowId,
                 ],
             );
@@ -152,7 +152,7 @@ final readonly class Connection
                 )),
             [
                 $this->queueName,
-                typed($now, ValueType::TIMESTAMPTZ),
+                typed($now, ValueType::TIMESTAMP),
             ],
         );
     }
@@ -173,7 +173,7 @@ final readonly class Connection
                 ->set('delivered_at', param(1))
                 ->where(eq(col('id'), param(2))),
             [
-                typed(new DateTimeImmutable('now'), ValueType::TIMESTAMPTZ),
+                typed(new DateTimeImmutable('now'), ValueType::TIMESTAMP),
                 (int) $id,
             ],
         );
@@ -202,8 +202,8 @@ final readonly class Connection
                 $body,
                 json_encode($headers, JSON_THROW_ON_ERROR),
                 $this->queueName,
-                typed($now, ValueType::TIMESTAMPTZ),
-                typed($availableAt, ValueType::TIMESTAMPTZ),
+                typed($now, ValueType::TIMESTAMP),
+                typed($availableAt, ValueType::TIMESTAMP),
             ],
         );
 

--- a/src/bridge/symfony/postgresql-messenger/src/Flow/Bridge/Symfony/PostgreSQLMessenger/MessengerCatalogProvider.php
+++ b/src/bridge/symfony/postgresql-messenger/src/Flow/Bridge/Symfony/PostgreSQLMessenger/MessengerCatalogProvider.php
@@ -12,7 +12,7 @@ use Flow\PostgreSql\Schema\IdentityGeneration;
 use function Flow\PostgreSql\DSL\schema;
 use function Flow\PostgreSql\DSL\schema_column;
 use function Flow\PostgreSql\DSL\schema_column_text;
-use function Flow\PostgreSql\DSL\schema_column_timestamp_tz;
+use function Flow\PostgreSql\DSL\schema_column_timestamp;
 use function Flow\PostgreSql\DSL\schema_column_varchar;
 use function Flow\PostgreSql\DSL\schema_index;
 use function Flow\PostgreSql\DSL\schema_primary_key;
@@ -42,9 +42,9 @@ final readonly class MessengerCatalogProvider implements CatalogProvider
                         schema_column_text('body', nullable: false),
                         schema_column_text('headers', nullable: false),
                         schema_column_varchar('queue_name', 190, nullable: false, default: 'default'),
-                        schema_column_timestamp_tz('created_at', nullable: false),
-                        schema_column_timestamp_tz('available_at', nullable: false),
-                        schema_column_timestamp_tz('delivered_at', nullable: true),
+                        schema_column_timestamp('created_at', nullable: false),
+                        schema_column_timestamp('available_at', nullable: false),
+                        schema_column_timestamp('delivered_at', nullable: true),
                     ],
                     primaryKey: schema_primary_key(['id']),
                     indexes: [

--- a/src/bridge/symfony/postgresql-messenger/tests/Flow/Bridge/Symfony/PostgreSQLMessenger/Tests/Unit/MessengerCatalogProviderTest.php
+++ b/src/bridge/symfony/postgresql-messenger/tests/Flow/Bridge/Symfony/PostgreSQLMessenger/Tests/Unit/MessengerCatalogProviderTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Flow\Bridge\Symfony\PostgreSQLMessenger\Tests\Unit;
 
 use Flow\Bridge\Symfony\PostgreSQLMessenger\MessengerCatalogProvider;
+use Flow\PostgreSql\QueryBuilder\Schema\ColumnType;
 use Flow\PostgreSql\Schema\IdentityGeneration;
 use PHPUnit\Framework\TestCase;
 
@@ -91,6 +92,17 @@ final class MessengerCatalogProviderTest extends TestCase
         $table = $provider->get()->get('public')->tables[0];
 
         static::assertSame('messenger_messages', $table->name);
+    }
+
+    public function test_timestamp_columns_use_timestamp_without_time_zone(): void
+    {
+        $provider = new MessengerCatalogProvider();
+        $table = $provider->get()->get('public')->tables[0];
+
+        static::assertTrue($table->column('created_at')->type->isEqual(ColumnType::timestamp()));
+        static::assertTrue($table->column('available_at')->type->isEqual(ColumnType::timestamp()));
+        static::assertTrue($table->column('delivered_at')->type->isEqual(ColumnType::timestamp()));
+        static::assertFalse($table->column('created_at')->type->isEqual(ColumnType::timestamptz()));
     }
 
     public function test_table_has_expected_columns(): void


### PR DESCRIPTION
<h2>Change Log</h2>
<hr />
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul>
  <h4>Fixed</h4>
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li><code>flow-php/symfony-postgresql-messenger-bridge</code> - store <code>messenger_messages</code> time columns as <code>timestamp</code> instead of <code>timestamptz</code></li>
  </ul>
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>
  <h4>Security</h4>
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>
</div>
