### PR TITLE
feat(flow-php/telemetry): expose log severity to the attribute filter

### DIFF
--- a/.github/actions/codecov-report/action.yml
+++ b/.github/actions/codecov-report/action.yml
@@ -50,7 +50,7 @@ runs:
         flags: tests
 
     - name: Upload code coverage (pull request)
-      if: ${{ github.event_name == 'pull_request' && !cancelled() && inputs.dependencies == 'locked' }}
+      if: ${{ github.event_name == 'pull_request' && !cancelled() && inputs.dependencies == 'locked' && inputs.php-version == '8.3' }}
       uses: codecov/codecov-action@v6
       with:
         token: ${{ inputs.token }}

--- a/.github/workflows/job-extension-tests.yml
+++ b/.github/workflows/job-extension-tests.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           php-version: "${{ matrix.php-version }}"
           dependencies: "${{ matrix.dependencies }}"
-          coverage: "pcov"
+          coverage: ${{ matrix.php-version == '8.3' && 'pcov' || 'none' }}
           extensions: ':psr, bcmath, dom, hash, json, mbstring, xml, xmlwriter, xmlreader, zlib, brotli, lz4, zstd, snappy-https://github.com/kjdev/php-ext-snappy@0.2.1'
           php-env: '{"SNAPPY_CONFIGURE_PREFIX_OPTS": "CXXFLAGS=-std=c++11"}'
           cache-key-suffix: "-extensions"

--- a/.github/workflows/job-tests.yml
+++ b/.github/workflows/job-tests.yml
@@ -93,7 +93,7 @@ jobs:
         with:
           php-version: "${{ matrix.php-version }}"
           dependencies: "${{ matrix.dependencies }}"
-          coverage: 'pcov'
+          coverage: ${{ matrix.php-version == '8.3' && 'pcov' || 'none' }}
           extensions: ':psr, bcmath, dom, hash, json, mbstring, xml, xmlwriter, xmlreader, zlib, curl, pgsql, grpc, protobuf'
           ini-values: 'memory_limit=-1, post_max_size=32M, upload_max_filesize=32M'
           apt-packages: "build-essential autoconf automake libtool protobuf-compiler libprotobuf-c-dev"
@@ -125,7 +125,7 @@ jobs:
 
       - name: "Test"
         timeout-minutes: 10
-        run: "just test --coverage-clover=./var/phpunit/coverage/clover/coverage.xml --log-junit ./var/phpunit/logs/junit.xml"
+        run: "just test --log-junit ./var/phpunit/logs/junit.xml ${{ matrix.php-version == '8.3' && '--coverage-clover=./var/phpunit/coverage/clover/coverage.xml' || '' }}"
         env:
           PGSQL_DATABASE_URL: pgsql://postgres:postgres@127.0.0.1:${{ job.services.postgres.ports['5432'] }}/postgres?serverVersion=11&charset=utf8
           MYSQL_DATABASE_URL: mysql://mysql:mysql@127.0.0.1:${{ job.services.mysql.ports['3306'] }}/mysql

--- a/documentation/components/bridges/symfony-telemetry-bundle.md
+++ b/documentation/components/bridges/symfony-telemetry-bundle.md
@@ -627,6 +627,47 @@ flow_telemetry:
         exporter: otlp
 ```
 
+**Filtering logs by severity (logs only).** Severity is not an attribute, but on `logger_provider` the
+`attribute_filtering` middleware exposes the record's severity to the matcher as two reserved **signal** keys, so
+per-channel (or per-attribute) severity thresholds are expressible alongside any other attribute:
+
+- `log.severity` — the OpenTelemetry severity **number** (`trace`=1, `debug`=5, `info`=9, `warn`=13, `error`=17,
+  `fatal`=21), for ordered comparisons (`greater_than_equal`, …).
+- `log.severity_name` — the level **name** (`TRACE`…`FATAL`), for `equal`/`regexp`.
+
+These keys exist only for the filter decision — they are never exported (severity already travels in the native OTLP
+`severityNumber`/`severityText` fields) and they shadow any user attribute of the same name. Because they live on the
+`signal` source, an `all` node that combines severity with another attribute needs that attribute on `signal` too — the
+channel's `log.channel` attribute is on `signal` under the default `channel_attribute_target: both`.
+
+Keep `error`+ from the `payments` channel but `debug`+ from the `importer` channel (`exclude: false` keeps only
+matching records — exactly the case a single global [`severity_filtering`](#pipeline-logger_provider-only) threshold
+cannot express):
+
+```yaml
+flow_telemetry:
+  logger_provider:
+    processor:
+      type: pipeline
+      middleware:
+        - type: attribute_filtering
+          exclude: false
+          matcher:
+            any:
+              - all:
+                  - { path: log.channel, mode: equal, value: payments }
+                  - { path: log.severity, mode: greater_than_equal, value: 17 }   # error+
+              - all:
+                  - { path: log.channel, mode: equal, value: importer }
+                  - { path: log.severity, mode: greater_than_equal, value: 5 }    # debug+
+      sink:
+        type: batching
+        exporter: otlp
+```
+
+For a single global threshold prefer the simpler `severity_filtering` middleware; reach for `log.severity` only when
+the threshold varies by channel or another attribute.
+
 The matcher is compiled to a cached PHP matcher in `cache_dir` (the project cache directory by default) so per-signal
 evaluation stays cheap; it falls back to interpreted matching when the directory is not writable. Because the compiled
 file is `require`d, `cache_dir` must be **trusted** (not writable by untrusted users) — the project cache directory is

--- a/documentation/components/libs/telemetry.md
+++ b/documentation/components/libs/telemetry.md
@@ -540,11 +540,11 @@ and metrics this is a processor wrapping an inner processor; for logs it is a mi
 An `AttributeFilter` evaluates a single root **matcher**. The leaf matcher, `attribute_rule()`, targets
 an attribute *path* and applies a `MatchMode`:
 
-| Family      | Modes                                                                              |
-|-------------|------------------------------------------------------------------------------------|
-| Equality    | `EQUAL`, `NOT_EQUAL` (strict comparison against the expected value)                 |
-| Ordering    | `GREATER_THAN`, `GREATER_THAN_EQUAL`, `LESS_THAN`, `LESS_THAN_EQUAL`                |
-| Pattern     | `REGEXP`, `STARTS_WITH`, `ENDS_WITH`, `CONTAINS` (operate on the value's string form) |
+| Family   | Modes                                                                                 |
+|----------|---------------------------------------------------------------------------------------|
+| Equality | `EQUAL`, `NOT_EQUAL` (strict comparison against the expected value)                   |
+| Ordering | `GREATER_THAN`, `GREATER_THAN_EQUAL`, `LESS_THAN`, `LESS_THAN_EQUAL`                  |
+| Pattern  | `REGEXP`, `STARTS_WITH`, `ENDS_WITH`, `CONTAINS` (operate on the value's string form) |
 
 A path is one segment (a top-level attribute key) or several segments descending into nested array
 values (e.g. `['user', 'id']`). The pattern modes accept a per-rule `caseSensitive` flag (default `true`).
@@ -672,19 +672,20 @@ attributes set at the call site win over them. Implement `LogMiddleware` to add 
 A `Sampler` decides, at span **start**, whether a span is recorded and exported. This is the OpenTelemetry-idiomatic
 way to drop spans — a dropped span never records, so it never reaches a processor or exporter.
 
-| Sampler | DSL | Behavior |
-|---|---|---|
-| `AlwaysOnSampler` | `always_on_sampler()` | Record + sample every span (the default) |
-| `AlwaysOffSampler` | `always_off_sampler()` | Drop every span |
-| `TraceIdRatioBasedSampler` | `trace_id_ratio_based_sampler($ratio)` | Sample a deterministic fraction of traces |
-| `ParentBasedSampler` | `parent_based_sampler($root)` | Honor the parent's decision; use the root sampler for parentless spans |
+| Sampler                    | DSL                                              | Behavior                                                                                                        |
+|----------------------------|--------------------------------------------------|-----------------------------------------------------------------------------------------------------------------|
+| `AlwaysOnSampler`          | `always_on_sampler()`                            | Record + sample every span (the default)                                                                        |
+| `AlwaysOffSampler`         | `always_off_sampler()`                           | Drop every span                                                                                                 |
+| `TraceIdRatioBasedSampler` | `trace_id_ratio_based_sampler($ratio)`           | Sample a deterministic fraction of traces                                                                       |
+| `ParentBasedSampler`       | `parent_based_sampler($root)`                    | Honor the parent's decision; use the root sampler for parentless spans                                          |
 | `AttributeMatchingSampler` | `attribute_matching_sampler($filter, $delegate)` | Drop spans whose **start-time** attributes match an `AttributeFilter`, deferring the rest to a delegate sampler |
 
 `AttributeMatchingSampler` reuses the same matcher stack as the [filtering processors](#filtering-by-attributes) — the
 `AttributeFilter` (matcher tree, compiled drop-closure, `sources`, `exclude` polarity). A match drops the span (the
 default) or keeps only matching spans (`exclude: false`); everything else is decided by the `$delegate` sampler, so it
 composes with ratio/parent-based sampling. It only sees attributes available at span start — end-state attributes
-(status codes, durations) are not visible, so end-attribute filtering remains a [span processor](#filtering-by-attributes)
+(status codes, durations) are not visible, so end-attribute filtering remains
+a [span processor](#filtering-by-attributes)
 concern.
 
 ```php

--- a/src/bridge/symfony/telemetry-bundle/tests/Flow/Bridge/Symfony/TelemetryBundle/Tests/Integration/AttributeFilteringProcessorTest.php
+++ b/src/bridge/symfony/telemetry-bundle/tests/Flow/Bridge/Symfony/TelemetryBundle/Tests/Integration/AttributeFilteringProcessorTest.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 namespace Flow\Bridge\Symfony\TelemetryBundle\Tests\Integration;
 
 use Flow\Bridge\Symfony\TelemetryBundle\Tests\Fixtures\TestKernel;
+use Flow\Bridge\Symfony\TelemetryBundle\Tests\Mother\LogEntryMother;
 use Flow\Telemetry\Attributes;
 use Flow\Telemetry\Filter\AttributeFilter;
 use Flow\Telemetry\Filter\AttributeSource;
 use Flow\Telemetry\Logger\Middleware\AttributeFilteringLogMiddleware;
 use Flow\Telemetry\Logger\Processor\BatchingLogProcessor;
 use Flow\Telemetry\Logger\Processor\PipelineLogProcessor;
+use Flow\Telemetry\Logger\Severity;
 use Flow\Telemetry\Meter\Processor\AttributeFilteringMetricProcessor;
 use Flow\Telemetry\Tracer\Processor\AttributeFilteringSpanProcessor;
 
@@ -316,6 +318,66 @@ final class AttributeFilteringProcessorTest extends KernelTestCase
             'severity' => 1,
             'path' => '/api',
         ])));
+    }
+
+    public function test_per_channel_severity_thresholds_drive_the_wired_middleware(): void
+    {
+        $this->bootKernel([
+            'config' => static function (TestKernel $kernel): void {
+                $kernel->addTestExtensionConfig('flow_telemetry', [
+                    'resource' => [],
+                    'exporters' => self::OTLP,
+                    'logger_provider' => [
+                        'processor' => [
+                            'type' => 'pipeline',
+                            'middleware' => [
+                                [
+                                    'type' => 'attribute_filtering',
+                                    // Keep ERROR+ from payments, but DEBUG+ from importer.
+                                    'exclude' => false,
+                                    'matcher' => [
+                                        'any' => [
+                                            [
+                                                'all' => [
+                                                    ['path' => 'log.channel', 'mode' => 'equal', 'value' => 'payments'],
+                                                    [
+                                                        'path' => AttributeFilteringLogMiddleware::SEVERITY_KEY,
+                                                        'mode' => 'greater_than_equal',
+                                                        'value' => Severity::ERROR->value,
+                                                    ],
+                                                ],
+                                            ],
+                                            [
+                                                'all' => [
+                                                    ['path' => 'log.channel', 'mode' => 'equal', 'value' => 'importer'],
+                                                    [
+                                                        'path' => AttributeFilteringLogMiddleware::SEVERITY_KEY,
+                                                        'mode' => 'greater_than_equal',
+                                                        'value' => Severity::DEBUG->value,
+                                                    ],
+                                                ],
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                            'sink' => ['type' => 'void'],
+                        ],
+                    ],
+                ]);
+            },
+        ]);
+
+        $middleware = $this->getContainer()->get('flow.telemetry.logger_provider.processor.middleware.0');
+        static::assertInstanceOf(AttributeFilteringLogMiddleware::class, $middleware);
+
+        $paymentsError = LogEntryMother::onChannel(Severity::ERROR, 'payments');
+        $importerDebug = LogEntryMother::onChannel(Severity::DEBUG, 'importer');
+
+        static::assertSame($paymentsError, $middleware->process($paymentsError));
+        static::assertSame($importerDebug, $middleware->process($importerDebug));
+        static::assertNull($middleware->process(LogEntryMother::onChannel(Severity::INFO, 'payments')));
+        static::assertNull($middleware->process(LogEntryMother::onChannel(Severity::TRACE, 'importer')));
     }
 
     public function test_matcher_compiles_into_the_kernel_cache_dir(): void

--- a/src/bridge/symfony/telemetry-bundle/tests/Flow/Bridge/Symfony/TelemetryBundle/Tests/Mother/LogEntryMother.php
+++ b/src/bridge/symfony/telemetry-bundle/tests/Flow/Bridge/Symfony/TelemetryBundle/Tests/Mother/LogEntryMother.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\Bridge\Symfony\TelemetryBundle\Tests\Mother;
+
+use DateTimeImmutable;
+use Flow\Telemetry\Logger\LogEntry;
+use Flow\Telemetry\Logger\LogRecord;
+use Flow\Telemetry\Logger\Severity;
+
+use function Flow\Telemetry\DSL\instrumentation_scope;
+use function Flow\Telemetry\DSL\resource;
+
+final class LogEntryMother
+{
+    public static function onChannel(Severity $severity, string $channel): LogEntry
+    {
+        return new LogEntry(new LogRecord($severity, 'message', [
+            'log.channel' => $channel,
+        ]), resource(), instrumentation_scope($channel), new DateTimeImmutable());
+    }
+}

--- a/src/lib/telemetry/src/Flow/Telemetry/Logger/Middleware/AttributeFilteringLogMiddleware.php
+++ b/src/lib/telemetry/src/Flow/Telemetry/Logger/Middleware/AttributeFilteringLogMiddleware.php
@@ -20,6 +20,10 @@ use Flow\Telemetry\Logger\LogMiddleware;
  */
 final readonly class AttributeFilteringLogMiddleware implements LogMiddleware
 {
+    public const string SEVERITY_KEY = 'log.severity';
+
+    public const string SEVERITY_NAME_KEY = 'log.severity_name';
+
     /**
      * @var Closure(Attributes ...): bool
      */
@@ -52,7 +56,11 @@ final readonly class AttributeFilteringLogMiddleware implements LogMiddleware
     {
         return AttributeSource::select(
             $this->sources,
-            $entry->record->attributes,
+            $entry
+                ->record
+                ->attributes
+                ->with(self::SEVERITY_KEY, $entry->record->severity->value)
+                ->with(self::SEVERITY_NAME_KEY, $entry->record->severity->name()),
             $entry->resource->attributes,
             $entry->scope->attributes,
         );

--- a/src/lib/telemetry/tests/Flow/Telemetry/Tests/Unit/Logger/Middleware/AttributeFilteringLogMiddlewareTest.php
+++ b/src/lib/telemetry/tests/Flow/Telemetry/Tests/Unit/Logger/Middleware/AttributeFilteringLogMiddlewareTest.php
@@ -6,11 +6,14 @@ namespace Flow\Telemetry\Tests\Unit\Logger\Middleware;
 
 use Flow\Telemetry\Filter\AttributeSource;
 use Flow\Telemetry\Filter\MatchMode;
+use Flow\Telemetry\Logger\Middleware\AttributeFilteringLogMiddleware;
 use Flow\Telemetry\Logger\Severity;
 use Flow\Telemetry\Tests\Mother\LogEntryMother;
 use Flow\Telemetry\Tests\Mother\TempDir;
 use PHPUnit\Framework\TestCase;
 
+use function Flow\Telemetry\DSL\all;
+use function Flow\Telemetry\DSL\any;
 use function Flow\Telemetry\DSL\attribute_filter;
 use function Flow\Telemetry\DSL\attribute_filtering_log_middleware;
 use function Flow\Telemetry\DSL\attribute_rule;
@@ -106,6 +109,164 @@ final class AttributeFilteringLogMiddlewareTest extends TestCase
 
             static::assertNull($middleware->process(LogEntryMother::create('dropped', Severity::INFO, [
                 'env' => 'dev',
+            ])));
+        } finally {
+            $tmp->remove();
+        }
+    }
+
+    public function test_keeps_entry_at_or_above_severity_threshold(): void
+    {
+        $tmp = TempDir::create();
+
+        try {
+            $middleware = attribute_filtering_log_middleware(attribute_filter(
+                attribute_rule(
+                    AttributeFilteringLogMiddleware::SEVERITY_KEY,
+                    MatchMode::GREATER_THAN_EQUAL,
+                    Severity::ERROR->value,
+                ),
+                exclude: false,
+                cacheDir: $tmp->path(),
+            ));
+
+            $entry = LogEntryMother::create('boom', Severity::ERROR);
+
+            static::assertSame($entry, $middleware->process($entry));
+        } finally {
+            $tmp->remove();
+        }
+    }
+
+    public function test_drops_entry_below_severity_threshold(): void
+    {
+        $tmp = TempDir::create();
+
+        try {
+            $middleware = attribute_filtering_log_middleware(attribute_filter(
+                attribute_rule(
+                    AttributeFilteringLogMiddleware::SEVERITY_KEY,
+                    MatchMode::GREATER_THAN_EQUAL,
+                    Severity::ERROR->value,
+                ),
+                exclude: false,
+                cacheDir: $tmp->path(),
+            ));
+
+            static::assertNull($middleware->process(LogEntryMother::create('chatter', Severity::INFO)));
+        } finally {
+            $tmp->remove();
+        }
+    }
+
+    public function test_per_channel_severity_thresholds(): void
+    {
+        $tmp = TempDir::create();
+
+        try {
+            // Keep ERROR+ from the payments channel, but DEBUG+ from the importer channel.
+            $middleware = attribute_filtering_log_middleware(attribute_filter(
+                any(
+                    all(
+                        attribute_rule('log.channel', MatchMode::EQUAL, 'payments'),
+                        attribute_rule(
+                            AttributeFilteringLogMiddleware::SEVERITY_KEY,
+                            MatchMode::GREATER_THAN_EQUAL,
+                            Severity::ERROR->value,
+                        ),
+                    ),
+                    all(
+                        attribute_rule('log.channel', MatchMode::EQUAL, 'importer'),
+                        attribute_rule(
+                            AttributeFilteringLogMiddleware::SEVERITY_KEY,
+                            MatchMode::GREATER_THAN_EQUAL,
+                            Severity::DEBUG->value,
+                        ),
+                    ),
+                ),
+                exclude: false,
+                cacheDir: $tmp->path(),
+            ));
+
+            $paymentsError = LogEntryMother::create('payment failed', Severity::ERROR, ['log.channel' => 'payments']);
+            $importerDebug = LogEntryMother::create('row parsed', Severity::DEBUG, ['log.channel' => 'importer']);
+
+            static::assertSame($paymentsError, $middleware->process($paymentsError));
+            static::assertSame($importerDebug, $middleware->process($importerDebug));
+            static::assertNull($middleware->process(LogEntryMother::create('payment ok', Severity::INFO, [
+                'log.channel' => 'payments',
+            ])));
+            static::assertNull($middleware->process(LogEntryMother::create('importer trace', Severity::TRACE, [
+                'log.channel' => 'importer',
+            ])));
+            static::assertNull($middleware->process(LogEntryMother::create('other error', Severity::ERROR, [
+                'log.channel' => 'web',
+            ])));
+        } finally {
+            $tmp->remove();
+        }
+    }
+
+    public function test_matches_on_severity_name(): void
+    {
+        $tmp = TempDir::create();
+
+        try {
+            $middleware = attribute_filtering_log_middleware(attribute_filter(
+                attribute_rule(AttributeFilteringLogMiddleware::SEVERITY_NAME_KEY, MatchMode::EQUAL, 'ERROR'),
+                cacheDir: $tmp->path(),
+            ));
+
+            static::assertNull($middleware->process(LogEntryMother::create('boom', Severity::ERROR)));
+
+            $kept = LogEntryMother::create('chatter', Severity::INFO);
+            static::assertSame($kept, $middleware->process($kept));
+        } finally {
+            $tmp->remove();
+        }
+    }
+
+    public function test_does_not_leak_synthetic_severity_keys_onto_kept_entry(): void
+    {
+        $tmp = TempDir::create();
+
+        try {
+            $middleware = attribute_filtering_log_middleware(attribute_filter(
+                attribute_rule('env', MatchMode::EQUAL, 'prod'),
+                cacheDir: $tmp->path(),
+            ));
+
+            $entry = LogEntryMother::create('kept', Severity::ERROR, ['env' => 'dev']);
+            $processed = $middleware->process($entry);
+
+            static::assertSame($entry, $processed);
+            static::assertFalse($processed->record->attributes->has(AttributeFilteringLogMiddleware::SEVERITY_KEY));
+            static::assertFalse($processed->record->attributes->has(AttributeFilteringLogMiddleware::SEVERITY_NAME_KEY));
+        } finally {
+            $tmp->remove();
+        }
+    }
+
+    public function test_synthetic_severity_shadows_user_attribute_of_same_name(): void
+    {
+        $tmp = TempDir::create();
+
+        try {
+            // A user attribute named log.severity must not fool a severity threshold:
+            // the record's real severity (INFO) is below ERROR, so the entry is dropped
+            // despite the user claiming ERROR's number.
+            $middleware = attribute_filtering_log_middleware(attribute_filter(
+                attribute_rule(
+                    AttributeFilteringLogMiddleware::SEVERITY_KEY,
+                    MatchMode::GREATER_THAN_EQUAL,
+                    Severity::ERROR->value,
+                ),
+                exclude: false,
+                cacheDir: $tmp->path(),
+            ));
+
+            static::assertNull($middleware->process(LogEntryMother::create('spoofed', Severity::INFO, [
+                AttributeFilteringLogMiddleware::SEVERITY_KEY => Severity::ERROR->value,
             ])));
         } finally {
             $tmp->remove();


### PR DESCRIPTION

<h2>Change Log</h2>
<hr />
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <li><code>flow-php/telemetry</code> - log severity exposed to the attribute filter as <code>log.severity</code> and <code>log.severity_name</code></li>
    <li><code>flow-php/symfony-telemetry-bundle</code> - per-channel severity thresholds via <code>attribute_filtering</code> log middleware</li>
  </ul>
  <h4>Fixed</h4>
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>
  <h4>Security</h4>
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>
</div>