### PR TITLE
fix: collect coverage only from php8.3 tests

### DIFF
--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -1,10 +1,10 @@
 codecov:
   notify:
-    after_n_builds: 3
+    after_n_builds: 1
 
 comment:
   layout: "condensed_header, diff, components"
-  after_n_builds: 3
+  after_n_builds: 1
 
 flag_management:
   default_rules:
@@ -15,6 +15,8 @@ flag_management:
     - name: extension-tests
       carryforward: true
     - name: arrow-extension
+      carryforward: true
+    - name: telemetry-tests
       carryforward: true
 
 component_management:

--- a/.github/workflows/job-arrow-extension.yml
+++ b/.github/workflows/job-arrow-extension.yml
@@ -103,7 +103,7 @@ jobs:
           dependencies: locked
 
       - name: Run Parquet Integration Tests with Arrow
-        run: just test --testsuite=lib-parquet-integration
+        run: just test --testsuite=lib-parquet-integration ${{ (matrix.php == '8.3' && matrix.os == 'ubuntu-latest') && '--coverage-clover=./var/phpunit/coverage/clover/coverage.xml' || '' }}
 
       - name: Upload to Codecov
         if: ${{ !cancelled() && matrix.php == '8.3' && matrix.os == 'ubuntu-latest' }}

--- a/.github/workflows/job-extension-tests.yml
+++ b/.github/workflows/job-extension-tests.yml
@@ -40,16 +40,16 @@ jobs:
           cache-key-suffix: "-extensions"
 
       - name: "Test Brotli"
-        run: "just test --group brotli-extension"
+        run: "just test --group brotli-extension ${{ matrix.php-version == '8.3' && '--coverage-clover=./var/phpunit/coverage/clover/brotli.xml' || '' }}"
 
       - name: "Test LZ4"
-        run: "just test --group lz4-extension"
+        run: "just test --group lz4-extension ${{ matrix.php-version == '8.3' && '--coverage-clover=./var/phpunit/coverage/clover/lz4.xml' || '' }}"
 
       - name: "Test ZSTD"
-        run: "just test --group zstd-extension"
+        run: "just test --group zstd-extension ${{ matrix.php-version == '8.3' && '--coverage-clover=./var/phpunit/coverage/clover/zstd.xml' || '' }}"
 
       - name: "Test Snappy"
-        run: "just test --group snappy-extension"
+        run: "just test --group snappy-extension ${{ matrix.php-version == '8.3' && '--coverage-clover=./var/phpunit/coverage/clover/snappy.xml' || '' }}"
 
       - name: Upload to Codecov
         if: ${{ !cancelled() && matrix.php-version == '8.3' }}

--- a/.github/workflows/job-phpunit-telemetry-tests.yml
+++ b/.github/workflows/job-phpunit-telemetry-tests.yml
@@ -2,6 +2,9 @@ name: PHPUnit Telemetry Bridge Tests
 
 on:
   workflow_call:
+    secrets:
+      CODECOV_TOKEN:
+        required: false
 
 permissions:
   contents: read
@@ -47,6 +50,7 @@ jobs:
         with:
           php-version: "${{ matrix.php-version }}"
           dependencies: "locked"
+          coverage: ${{ matrix.php-version == '8.3' && 'pcov' || 'none' }}
           extensions: ':psr, bcmath, dom, hash, json, mbstring, xml, xmlwriter, xmlreader, zlib, curl, pgsql, grpc, protobuf'
           ini-values: 'memory_limit=-1'
           apt-packages: "build-essential autoconf automake libtool protobuf-compiler libprotobuf-c-dev"
@@ -62,6 +66,14 @@ jobs:
         run: tools/phpunit/vendor/bin/phpunit --version
 
       - name: "Test"
-        run: just test --testsuite bridge-phpunit-postgresql-unit,bridge-phpunit-postgresql-integration,bridge-phpunit-telemetry-unit
+        run: just test --testsuite bridge-phpunit-postgresql-unit,bridge-phpunit-postgresql-integration,bridge-phpunit-telemetry-unit ${{ matrix.php-version == '8.3' && '--coverage-clover=./var/phpunit/coverage/clover/coverage.xml' || '' }}
         env:
-          PGSQL_DATABASE_URL: pgsql://postgres:postgres@127.0.0.1:${{ job.services.postgres.ports['5432'] }}/postgres?serverVersion=11&charset=utf8
+          PGSQL_DATABASE_URL: pgsql://postgres:postgres@127.0.0.1:${{ job.services.postgres.ports['5432'] }}/postgres?serverVersion=18&charset=utf8
+
+      - name: Upload to Codecov
+        if: ${{ !cancelled() && matrix.php-version == '8.3' && matrix.phpunit-version == '11' }}
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          directory: ./var/phpunit/coverage/clover
+          flags: telemetry-tests

--- a/.github/workflows/job-tests.yml
+++ b/.github/workflows/job-tests.yml
@@ -129,7 +129,7 @@ jobs:
         timeout-minutes: 15
         run: "just test --exclude-group grpc --log-junit ./var/phpunit/logs/junit.xml ${{ matrix.php-version == '8.3' && '--coverage-clover=./var/phpunit/coverage/clover/coverage.xml' || '' }}"
         env:
-          PGSQL_DATABASE_URL: pgsql://postgres:postgres@127.0.0.1:${{ job.services.postgres.ports['5432'] }}/postgres?serverVersion=11&charset=utf8
+          PGSQL_DATABASE_URL: pgsql://postgres:postgres@127.0.0.1:${{ job.services.postgres.ports['5432'] }}/postgres?serverVersion=18&charset=utf8
           MYSQL_DATABASE_URL: mysql://mysql:mysql@127.0.0.1:${{ job.services.mysql.ports['3306'] }}/mysql
           SQLITE_DATABASE_URL: "sqlite:///:memory:"
           AZURITE_HOST: "localhost"
@@ -152,9 +152,9 @@ jobs:
       - name: "Test (grpc)"
         timeout-minutes: 10
         continue-on-error: ${{ matrix.php-version == '8.5' }}
-        run: "just test --group grpc --log-junit ./var/phpunit/logs/grpc-junit.xml"
+        run: "just test --group grpc --log-junit ./var/phpunit/logs/grpc-junit.xml ${{ matrix.php-version == '8.3' && '--coverage-clover=./var/phpunit/coverage/clover/grpc-coverage.xml' || '' }}"
         env:
-          PGSQL_DATABASE_URL: pgsql://postgres:postgres@127.0.0.1:${{ job.services.postgres.ports['5432'] }}/postgres?serverVersion=11&charset=utf8
+          PGSQL_DATABASE_URL: pgsql://postgres:postgres@127.0.0.1:${{ job.services.postgres.ports['5432'] }}/postgres?serverVersion=18&charset=utf8
           MYSQL_DATABASE_URL: mysql://mysql:mysql@127.0.0.1:${{ job.services.mysql.ports['3306'] }}/mysql
           SQLITE_DATABASE_URL: "sqlite:///:memory:"
           AZURITE_HOST: "localhost"

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -44,6 +44,8 @@ jobs:
 
   phpunit-telemetry-tests:
     uses: ./.github/workflows/job-phpunit-telemetry-tests.yml
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   extension-tests:
     uses: ./.github/workflows/job-extension-tests.yml

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -20,7 +20,7 @@
         <env name="S3_BUCKET" value="flowphpbucket01"/>
         <env name="REDIS_HOST" value="localhost"/>
         <env name="REDIS_PORT" value="6379"/>
-        <env name="PGSQL_DATABASE_URL" value="pgsql://postgres:postgres@127.0.0.1:5432/postgres?serverVersion=11%26charset=utf8"/>
+        <env name="PGSQL_DATABASE_URL" value="pgsql://postgres:postgres@127.0.0.1:5432/postgres?serverVersion=18%26charset=utf8"/>
         <env name="MYSQL_DATABASE_URL" value="mysql://mysql:mysql@127.0.0.1:3306/mysql"/>
         <env name="SQLITE_DATABASE_PATH" value="./var/db/sqlite/test.db"/>
         <env name="ELASTICSEARCH_URL" value="localhost:9200"/>


### PR DESCRIPTION
<!-- 
    Please replace #xxx with a GitHub issue id from flow-php/flow repository. For example #1234 
    If there is no item in a roadmap related to this PR, please check our contributing guidelines first. 
-->
Resolves: #xxx

<!-- 
    Below section will be used to automatically generate changelog, please do not modify HTML code structure
    DO NOT REMOVE that HTML STRUCTURE, INSTEAD ADD YOUR CHANGES INSIDE THE LISTS 
    PULL REQUESTS WITHOUT CHANGELOG CAN'T BE MERGED 
-->
<h2>Change Log</h2>
<hr /> 
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>collect coverage only from php8.3 tests</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>