### PR TITLE
feature: add Web Profiler integration for telemetry and postgresql bundles

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -70,6 +70,7 @@
         "symfony/messenger": "^6.4 || ^7.4 || ^8.0",
         "symfony/process": "^7.4 || ^8.0",
         "symfony/routing": "^6.4 || ^7.4 || ^8.0",
+        "symfony/web-profiler-bundle": "^6.4 || ^7.4 || ^8.0",
         "twig/twig": "^3.0"
     },
     "replace": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1a9bd3c351016efdf2dd8257f0b7081c",
+    "content-hash": "f6394f00de07ef61b8cf18f11c743114",
     "packages": [
         {
             "name": "async-aws/core",
@@ -6578,6 +6578,301 @@
                 }
             ],
             "time": "2026-05-24T11:20:33+00:00"
+        },
+        {
+            "name": "symfony/twig-bridge",
+            "version": "v7.4.12",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/twig-bridge.git",
+                "reference": "81663873d946531129c76c65e80b681ce99c0e89"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/twig-bridge/zipball/81663873d946531129c76c65e80b681ce99c0e89",
+                "reference": "81663873d946531129c76c65e80b681ce99c0e89",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/translation-contracts": "^2.5|^3",
+                "twig/twig": "^3.21"
+            },
+            "conflict": {
+                "phpdocumentor/reflection-docblock": "<5.2|>=7",
+                "phpdocumentor/type-resolver": "<1.5.1",
+                "symfony/console": "<6.4",
+                "symfony/form": "<6.4.32|>7,<7.3.10|>7.4,<7.4.4|>8.0,<8.0.4",
+                "symfony/http-foundation": "<6.4",
+                "symfony/http-kernel": "<6.4",
+                "symfony/mime": "<6.4.37|>7,<7.4.9|>8.0,<8.0.9",
+                "symfony/serializer": "<6.4",
+                "symfony/translation": "<6.4",
+                "symfony/workflow": "<6.4"
+            },
+            "require-dev": {
+                "egulias/email-validator": "^2.1.10|^3|^4",
+                "league/html-to-markdown": "^5.0",
+                "phpdocumentor/reflection-docblock": "^5.2|^6.0",
+                "symfony/asset": "^6.4|^7.0|^8.0",
+                "symfony/asset-mapper": "^6.4|^7.0|^8.0",
+                "symfony/console": "^6.4|^7.0|^8.0",
+                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
+                "symfony/emoji": "^7.1|^8.0",
+                "symfony/expression-language": "^6.4|^7.0|^8.0",
+                "symfony/finder": "^6.4|^7.0|^8.0",
+                "symfony/form": "^6.4.32|~7.3.10|^7.4.4|^8.0.4",
+                "symfony/html-sanitizer": "^6.4|^7.0|^8.0",
+                "symfony/http-foundation": "^7.3|^8.0",
+                "symfony/http-kernel": "^6.4|^7.0|^8.0",
+                "symfony/intl": "^6.4|^7.0|^8.0",
+                "symfony/mime": "^6.4.37|^7.4.9|^8.0.9",
+                "symfony/polyfill-intl-icu": "~1.0",
+                "symfony/property-info": "^6.4|^7.0|^8.0",
+                "symfony/routing": "^6.4|^7.0|^8.0",
+                "symfony/security-acl": "^2.8|^3.0",
+                "symfony/security-core": "^6.4|^7.0|^8.0",
+                "symfony/security-csrf": "^6.4|^7.0|^8.0",
+                "symfony/security-http": "^6.4|^7.0|^8.0",
+                "symfony/serializer": "^6.4.3|^7.0.3|^8.0",
+                "symfony/stopwatch": "^6.4|^7.0|^8.0",
+                "symfony/translation": "^6.4|^7.0|^8.0",
+                "symfony/validator": "^6.4|^7.0|^8.0",
+                "symfony/web-link": "^6.4|^7.0|^8.0",
+                "symfony/workflow": "^6.4|^7.0|^8.0",
+                "symfony/yaml": "^6.4|^7.0|^8.0",
+                "twig/cssinliner-extra": "^3",
+                "twig/inky-extra": "^3",
+                "twig/markdown-extra": "^3"
+            },
+            "type": "symfony-bridge",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Bridge\\Twig\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides integration for Twig with various Symfony components",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/twig-bridge/tree/v7.4.12"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-29T17:13:54+00:00"
+        },
+        {
+            "name": "symfony/twig-bundle",
+            "version": "v7.4.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/twig-bundle.git",
+                "reference": "ba1e06d7ff1ebb1d1799b6608d925f4eaba88d95"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/twig-bundle/zipball/ba1e06d7ff1ebb1d1799b6608d925f4eaba88d95",
+                "reference": "ba1e06d7ff1ebb1d1799b6608d925f4eaba88d95",
+                "shasum": ""
+            },
+            "require": {
+                "composer-runtime-api": ">=2.1",
+                "php": ">=8.2",
+                "symfony/config": "^7.4|^8.0",
+                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/http-foundation": "^6.4|^7.0|^8.0",
+                "symfony/http-kernel": "^6.4.13|^7.1.6|^8.0",
+                "symfony/twig-bridge": "^7.3|^8.0",
+                "twig/twig": "^3.12"
+            },
+            "conflict": {
+                "symfony/framework-bundle": "<6.4",
+                "symfony/translation": "<6.4"
+            },
+            "require-dev": {
+                "symfony/asset": "^6.4|^7.0|^8.0",
+                "symfony/expression-language": "^6.4|^7.0|^8.0",
+                "symfony/finder": "^6.4|^7.0|^8.0",
+                "symfony/form": "^6.4|^7.0|^8.0",
+                "symfony/framework-bundle": "^6.4.13|^7.1.6|^8.0",
+                "symfony/routing": "^6.4|^7.0|^8.0",
+                "symfony/runtime": "^6.4.13|^7.1.6",
+                "symfony/stopwatch": "^6.4|^7.0|^8.0",
+                "symfony/translation": "^6.4|^7.0|^8.0",
+                "symfony/web-link": "^6.4|^7.0|^8.0",
+                "symfony/yaml": "^6.4|^7.0|^8.0"
+            },
+            "type": "symfony-bundle",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Bundle\\TwigBundle\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides a tight integration of Twig into the Symfony full-stack framework",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/twig-bundle/tree/v7.4.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-24T13:12:05+00:00"
+        },
+        {
+            "name": "symfony/web-profiler-bundle",
+            "version": "v7.4.13",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/web-profiler-bundle.git",
+                "reference": "153076bb3f0690fff0e95e55cc06358b22f236a5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/web-profiler-bundle/zipball/153076bb3f0690fff0e95e55cc06358b22f236a5",
+                "reference": "153076bb3f0690fff0e95e55cc06358b22f236a5",
+                "shasum": ""
+            },
+            "require": {
+                "composer-runtime-api": ">=2.1",
+                "php": ">=8.2",
+                "symfony/config": "^7.3|^8.0",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/framework-bundle": "^6.4.13|^7.1.6|^8.0",
+                "symfony/http-kernel": "^6.4.13|^7.1.6|^8.0",
+                "symfony/routing": "^6.4|^7.0|^8.0",
+                "symfony/twig-bundle": "^6.4|^7.0|^8.0",
+                "twig/twig": "^3.15"
+            },
+            "conflict": {
+                "symfony/form": "<6.4",
+                "symfony/mailer": "<6.4",
+                "symfony/messenger": "<6.4",
+                "symfony/serializer": "<7.2",
+                "symfony/workflow": "<7.3"
+            },
+            "require-dev": {
+                "symfony/browser-kit": "^6.4|^7.0|^8.0",
+                "symfony/console": "^6.4|^7.0|^8.0",
+                "symfony/css-selector": "^6.4|^7.0|^8.0",
+                "symfony/runtime": "^6.4.13|^7.1.6|^8.0",
+                "symfony/stopwatch": "^6.4|^7.0|^8.0"
+            },
+            "type": "symfony-bundle",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Bundle\\WebProfilerBundle\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides a development tool that gives detailed information about the execution of any request",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "dev"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/web-profiler-bundle/tree/v7.4.13"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-23T16:05:06+00:00"
         },
         {
             "name": "twig/twig",

--- a/documentation/components/bridges/symfony-postgresql-bundle.md
+++ b/documentation/components/bridges/symfony-postgresql-bundle.md
@@ -122,6 +122,35 @@ flow_postgresql:
         max_parameter_length: 100            # Max length of each parameter value (chars)
 ```
 
+### Web Profiler
+
+Adds a **Flow PostgreSQL** panel to the Symfony Web Profiler listing the SQL executed during the
+current request — like the Doctrine bundle's Queries panel, but for the Flow PostgreSQL client and
+independent of telemetry. Each connection's client is decorated with a recording wrapper that
+captures statement, bound parameters, duration, returned/affected rows, the calling code location,
+and failures.
+
+```yaml
+flow_postgresql:
+  profiler:
+    # enabled: null (default) auto-enables iff WebProfilerBundle is registered; true forces it on
+    # (throws if WebProfilerBundle is absent); false forces it off entirely.
+    enabled: ~
+    include_parameters: true # show bound query parameters in the panel
+```
+
+Recording is dev-only and adds nothing in production: when the profiler is disabled — or
+WebProfilerBundle is absent in `enabled: ~` mode — no connection is decorated. A single connection
+can opt out while the profiler is on:
+
+```yaml
+flow_postgresql:
+  connections:
+    default:
+      dsn: '%env(DATABASE_URL)%'
+      profiler: false   # do not record this connection's queries (default: true)
+```
+
 ### Migrations
 
 Migrations are configured at the top level, not per connection. Use `--connection` to target a specific connection

--- a/documentation/components/bridges/symfony-postgresql-bundle.md
+++ b/documentation/components/bridges/symfony-postgresql-bundle.md
@@ -133,7 +133,7 @@ and failures.
 ```yaml
 flow_postgresql:
   profiler:
-    # enabled: null (default) auto-enables iff WebProfilerBundle is registered; true forces it on
+    # enabled: null (default) auto-enables when WebProfilerBundle is registered; true forces it on
     # (throws if WebProfilerBundle is absent); false forces it off entirely.
     enabled: ~
     include_parameters: true # show bound query parameters in the panel
@@ -148,7 +148,7 @@ flow_postgresql:
   connections:
     default:
       dsn: '%env(DATABASE_URL)%'
-      profiler: false   # do not record this connection's queries (default: true)
+      profiler: false # do not record queries in selected connection (default: true)
 ```
 
 ### Migrations

--- a/documentation/components/bridges/symfony-telemetry-bundle.md
+++ b/documentation/components/bridges/symfony-telemetry-bundle.md
@@ -1110,7 +1110,7 @@ count; the panel breaks it down per signal type.
 ```yaml
 flow_telemetry:
   profiler:
-    # enabled: null (default) auto-enables iff WebProfilerBundle is registered; true forces it on
+    # enabled: null (default) auto-enables when WebProfilerBundle is registered; true forces it on
     # (throws if WebProfilerBundle is absent); false forces it off.
     enabled: ~
     capture_logs: false # also capture logs and render them in the panel's Logs section (off by default)

--- a/documentation/components/bridges/symfony-telemetry-bundle.md
+++ b/documentation/components/bridges/symfony-telemetry-bundle.md
@@ -342,14 +342,14 @@ flow_telemetry:
 
 **Sampler types:**
 
-| Type                 | Description                                                              |
-|----------------------|--------------------------------------------------------------------------|
-| `always_on`          | Sample all traces (default)                                              |
-| `always_off`         | Sample no traces                                                         |
-| `trace_id_ratio`     | Sample based on trace ID ratio                                           |
-| `parent_based`       | Respect parent span's sampling decision                                  |
+| Type                 | Description                                                                                       |
+|----------------------|---------------------------------------------------------------------------------------------------|
+| `always_on`          | Sample all traces (default)                                                                       |
+| `always_off`         | Sample no traces                                                                                  |
+| `trace_id_ratio`     | Sample based on trace ID ratio                                                                    |
+| `parent_based`       | Respect parent span's sampling decision                                                           |
 | `attribute_matching` | Drop spans matching an attribute matcher (start-time attrs); defer the rest to a delegate sampler |
-| `service`            | Custom sampler service                                                   |
+| `service`            | Custom sampler service                                                                            |
 
 **`attribute_matching`** is the OTel-idiomatic way to drop spans by attribute — the decision is made at span start, so a
 matched span never records or reaches a processor. It only sees attributes available at span start (not end-state values
@@ -490,18 +490,18 @@ Runs each log record through an ordered list of **middleware** (enrich / filter)
 single **sink**. This is the log-only way to combine more than one processing step (the OpenTelemetry
 `LogRecordProcessor` model: each step may modify the record or drop it, with changes visible to the next).
 
-| Option       | Type   | Default      | Description                                                                 |
-|--------------|--------|--------------|-----------------------------------------------------------------------------|
-| `middleware` | list   | `[]`         | Ordered middleware; the first to drop a record short-circuits the rest      |
+| Option       | Type   | Default      | Description                                                                                                        |
+|--------------|--------|--------------|--------------------------------------------------------------------------------------------------------------------|
+| `middleware` | list   | `[]`         | Ordered middleware; the first to drop a record short-circuits the rest                                             |
 | `sink`       | object | – (required) | Terminal processor (`memory`, `batching`, `passthrough`, `void`, `service`, or `composite`) that exports survivors |
 
 Each `middleware` entry has a `type` and its own options:
 
-| `type`               | Options                                                                 | Effect                                          |
-|----------------------|-------------------------------------------------------------------------|-------------------------------------------------|
-| `enriching`          | `attributes` (map)                                                      | Merges default attributes (call-site values win)|
-| `severity_filtering` | `minimum_severity` (`trace`…`fatal`, default `info`)                    | Drops records below the level                   |
-| `attribute_filtering`| `matcher`, `exclude`, `sources`, `cache_dir` (see [attribute_filtering](#attribute_filtering)) | Drops/keeps records by attribute matcher        |
+| `type`                | Options                                                                                        | Effect                                           |
+|-----------------------|------------------------------------------------------------------------------------------------|--------------------------------------------------|
+| `enriching`           | `attributes` (map)                                                                             | Merges default attributes (call-site values win) |
+| `severity_filtering`  | `minimum_severity` (`trace`…`fatal`, default `info`)                                           | Drops records below the level                    |
+| `attribute_filtering` | `matcher`, `exclude`, `sources`, `cache_dir` (see [attribute_filtering](#attribute_filtering)) | Drops/keeps records by attribute matcher         |
 
 ```yaml
 processor:
@@ -525,31 +525,32 @@ traffic before it is exported. On `tracer_provider` and `meter_provider` it is a
 [`pipeline`](#pipeline-logger_provider-only) (no `inner_processor` — the pipeline's `sink` receives the survivors). The
 `matcher`/`exclude`/`sources`/`cache_dir` options below apply in both forms.
 
-| Option            | Type           | Default                                      | Description                                                        |
-|-------------------|----------------|----------------------------------------------|--------------------------------------------------------------------|
-| `matcher`         | object         | – (required)                                 | The matcher tree (see below)                                       |
-| `exclude`         | boolean        | `true`                                       | `true`: drop matching signals; `false`: keep ONLY matching signals |
-| `sources`         | list of enum   | `[signal]`                                   | Which attribute sets to inspect: any of `signal`, `resource`, `scope`. The matcher is evaluated against each listed source and OR-combined — a signal matches if it matches in **any** source |
-| `cache_dir`       | string         | `%kernel.cache_dir%/flow_telemetry_filters`  | Directory for the compiled matcher cache                          |
-| `cache_dir_permissions` | int      | `0o700`                                      | Octal mode applied when the cache directory is **created** (owner-only by default, since it holds `require`d PHP; subject to umask). Write it as a YAML octal literal, e.g. `0o750`. Only applies on creation — an existing directory is left untouched |
-| `inner_processor` | object         | – (required for span/metric)                 | **tracer/meter only** — the wrapped processor that receives surviving signals (leaf types only: `memory`, `batching`, `passthrough`, `void`, `service`). For logs, omit it: the [`pipeline`](#pipeline-logger_provider-only) `sink` receives survivors |
+| Option                  | Type         | Default                                     | Description                                                                                                                                                                                                                                             |
+|-------------------------|--------------|---------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `matcher`               | object       | – (required)                                | The matcher tree (see below)                                                                                                                                                                                                                            |
+| `exclude`               | boolean      | `true`                                      | `true`: drop matching signals; `false`: keep ONLY matching signals                                                                                                                                                                                      |
+| `sources`               | list of enum | `[signal]`                                  | Which attribute sets to inspect: any of `signal`, `resource`, `scope`. The matcher is evaluated against each listed source and OR-combined — a signal matches if it matches in **any** source                                                           |
+| `cache_dir`             | string       | `%kernel.cache_dir%/flow_telemetry_filters` | Directory for the compiled matcher cache                                                                                                                                                                                                                |
+| `cache_dir_permissions` | int          | `0o700`                                     | Octal mode applied when the cache directory is **created** (owner-only by default, since it holds `require`d PHP; subject to umask). Write it as a YAML octal literal, e.g. `0o750`. Only applies on creation — an existing directory is left untouched |
+| `inner_processor`       | object       | – (required for span/metric)                | **tracer/meter only** — the wrapped processor that receives surviving signals (leaf types only: `memory`, `batching`, `passthrough`, `void`, `service`). For logs, omit it: the [`pipeline`](#pipeline-logger_provider-only) `sink` receives survivors  |
 
 The `matcher` is a tree. Each node is **exactly one** of:
 
 - `all: [ … ]` — a list of child matchers; matches when **every** child matches (AND).
 - `any: [ … ]` — a list of child matchers; matches when **at least one** child matches (OR).
 - `not: { … }` — a single child matcher; matches when the child does **not**.
-- a **leaf rule** carrying a `path` (the four kinds are mutually exclusive — mixing them in one node is a configuration error).
+- a **leaf rule** carrying a `path` (the four kinds are mutually exclusive — mixing them in one node is a configuration
+  error).
 
 Composites and leaves nest to any depth, so arbitrary combinations of ANDs, ORs and NOTs are expressible. A leaf rule
 accepts:
 
-| Option           | Type         | Default  | Description                                                                |
-|------------------|--------------|----------|----------------------------------------------------------------------------|
-| `path`           | string\|list | required | Attribute key, or a list of segments descending into nested array values   |
-| `mode`           | enum         | required | Comparison mode (see below)                                                |
-| `value`          | scalar       | required | Expected value (must be a string for the pattern modes)                    |
-| `case_sensitive` | boolean      | `true`   | Substring modes only                                                       |
+| Option           | Type         | Default  | Description                                                              |
+|------------------|--------------|----------|--------------------------------------------------------------------------|
+| `path`           | string\|list | required | Attribute key, or a list of segments descending into nested array values |
+| `mode`           | enum         | required | Comparison mode (see below)                                              |
+| `value`          | scalar       | required | Expected value (must be a string for the pattern modes)                  |
+| `case_sensitive` | boolean      | `true`   | Substring modes only                                                     |
 
 **Modes:** `equal`, `not_equal`, `greater_than`, `greater_than_equal`, `less_than`, `less_than_equal`, `regexp`,
 `starts_with`, `ends_with`, `contains`.
@@ -581,7 +582,7 @@ flow_telemetry:
     processor:
       type: attribute_filtering
       exclude: false
-      sources: [scope]
+      sources: [ scope ]
       matcher:
         all:
           - { path: name, mode: equal, value: app.payments }
@@ -599,7 +600,7 @@ flow_telemetry:
   tracer_provider:
     processor:
       type: attribute_filtering
-      sources: [signal, resource]
+      sources: [ signal, resource ]
       matcher: { path: http.route, mode: equal, value: /health }
       inner_processor:
         type: batching
@@ -617,7 +618,7 @@ flow_telemetry:
       matcher:
         any:
           - all:
-              - { path: [timing, duration_ms], mode: less_than, value: 5 }
+              - { path: [ timing, duration_ms ], mode: less_than, value: 5 }
               - { path: internal, mode: equal, value: true }
           - all:
               - { path: tenant, mode: equal, value: a }
@@ -1099,18 +1100,40 @@ flow_telemetry:
         - '/^cache\.validator.*/'
 ```
 
+### Web Profiler
+
+Adds a **Flow Telemetry** panel to the Symfony Web Profiler showing the signals captured during the
+current request — spans as a timeline waterfall, metrics, and (when `capture_logs` is enabled) logs —
+so telemetry is visible locally without an external OTLP backend. The toolbar shows the total signal
+count; the panel breaks it down per signal type.
+
+```yaml
+flow_telemetry:
+  profiler:
+    # enabled: null (default) auto-enables iff WebProfilerBundle is registered; true forces it on
+    # (throws if WebProfilerBundle is absent); false forces it off.
+    enabled: ~
+    capture_logs: false # also capture logs and render them in the panel's Logs section (off by default)
+```
+
+When enabled, the bundle mirrors every exported traces/metrics batch into a shared in-memory store by
+decorating the exporters the `tracer_provider` / `meter_provider` (and, with `capture_logs: true`, the
+`logger_provider`) reference. OTLP export is unaffected — the real exporter still receives every batch.
+
+The store is exposed under the stable, public service id **`flow.telemetry.profiler.store`**.
+
 ### Named Instruments
 
 Configure named tracers, meters, and loggers with custom attributes.
 
 **Options:**
 
-| Option              | Type   | Default     | Description                                                          |
-|---------------------|--------|-------------|---------------------------------------------------------------------|
-| `version`           | string | `'unknown'` | Instrumentation scope version                                       |
-| `schema_url`        | string | `null`      | Schema URL for semantic conventions                                 |
-| `attributes.scope`  | object | `{}`        | Attributes attached to the instrumentation scope                    |
-| `attributes.signal` | object | `{}`        | Default attributes merged into every emitted signal                 |
+| Option              | Type   | Default     | Description                                         |
+|---------------------|--------|-------------|-----------------------------------------------------|
+| `version`           | string | `'unknown'` | Instrumentation scope version                       |
+| `schema_url`        | string | `null`      | Schema URL for semantic conventions                 |
+| `attributes.scope`  | object | `{}`        | Attributes attached to the instrumentation scope    |
+| `attributes.signal` | object | `{}`        | Default attributes merged into every emitted signal |
 
 `attributes` has two sub-keys:
 
@@ -1230,7 +1253,8 @@ services:
 
 - Each distinct channel is synthesized on demand as `flow.telemetry.<channel>.logger` (+ its PSR-3 wrapper
   `flow.telemetry.<channel>.logger.psr3`), carrying a `log.channel: <channel>` attribute placed per
-  [`channel_attribute_target`](#channel-attribute-placement) — unless a logger of that name already exists, which is then
+  [`channel_attribute_target`](#channel-attribute-placement) — unless a logger of that name already exists, which is
+  then
   reused untouched (so the `log.channel` attribute is only added to loggers the bundle creates).
 - To route a service to the bundle's main logger, use the `default` channel (`#[WithTelemetryChannel('default')]`).
   A `default` logger always exists, so it is reused as-is rather than re-created. Every channel name — including `app`,
@@ -1319,7 +1343,8 @@ which Monolog never looks at. With the flag off, this bundle never touches `mono
   over Monolog's global `LoggerInterface` autowiring alias for that one class; every other class keeps resolving to
   Monolog.
 
-What you **cannot** do is enable `capture_framework_channels` *and* keep MonologBundle: both passes then rewrite the same
+What you **cannot** do is enable `capture_framework_channels` *and* keep MonologBundle: both passes then rewrite the
+same
 `monolog.logger`-tagged services, and the outcome depends on compiler-pass ordering. Ownership of the framework channels
 is all-or-nothing:
 

--- a/src/bridge/symfony/postgresql-bundle/composer.json
+++ b/src/bridge/symfony/postgresql-bundle/composer.json
@@ -27,13 +27,16 @@
         "flow-php/symfony-postgresql-session-bridge": "self.version",
         "symfony/cache": "^6.4 || ^7.4 || ^8.0",
         "symfony/framework-bundle": "^6.4 || ^7.4 || ^8.0",
-        "symfony/messenger": "^6.4 || ^7.4 || ^8.0"
+        "symfony/messenger": "^6.4 || ^7.4 || ^8.0",
+        "symfony/var-dumper": "^6.4 || ^7.4 || ^8.0",
+        "symfony/web-profiler-bundle": "^6.4 || ^7.4 || ^8.0"
     },
     "suggest": {
         "flow-php/phpunit-postgresql-bridge": "For PHPUnit PostgreSQL transaction rollback support in tests",
         "flow-php/symfony-postgresql-cache-bridge": "For Symfony Cache PostgreSQL adapter support",
         "flow-php/symfony-postgresql-messenger-bridge": "For Symfony Messenger PostgreSQL transport support",
-        "flow-php/symfony-postgresql-session-bridge": "For Symfony Session PostgreSQL handler support"
+        "flow-php/symfony-postgresql-session-bridge": "For Symfony Session PostgreSQL handler support",
+        "symfony/web-profiler-bundle": "For the dev-only Flow PostgreSQL Web Profiler queries panel"
     },
     "config": {
         "optimize-autoloader": true,

--- a/src/bridge/symfony/postgresql-bundle/src/Flow/Bridge/Symfony/PostgreSqlBundle/FlowPostgreSqlBundle.php
+++ b/src/bridge/symfony/postgresql-bundle/src/Flow/Bridge/Symfony/PostgreSqlBundle/FlowPostgreSqlBundle.php
@@ -13,6 +13,7 @@ use Flow\Bridge\Symfony\PostgreSqlBundle\DependencyInjection\Compiler\CatalogPro
 use Flow\Bridge\Symfony\PostgreSqlBundle\DependencyInjection\Compiler\CommandLocatorPass;
 use Flow\Bridge\Symfony\PostgreSqlBundle\Generator\TwigMigrationGenerator;
 use Flow\Bridge\Symfony\PostgreSqlBundle\Messenger\FlowPostgreSqlTransportFactory;
+use Flow\Bridge\Symfony\PostgreSqlBundle\Profiler\ProfilerController;
 use Flow\Bridge\Symfony\PostgreSqlBundle\Repository\FilesystemMigrationRepository;
 use Flow\Bridge\Symfony\PostgreSQLCache\CacheCatalogProvider;
 use Flow\Bridge\Symfony\PostgreSQLCache\FlowPostgreSqlCacheAdapter;
@@ -24,6 +25,7 @@ use Flow\Filesystem\Path;
 use Flow\PostgreSql\Client\Client;
 use Flow\PostgreSql\Client\ConnectionParameters;
 use Flow\PostgreSql\Client\Context;
+use Flow\PostgreSql\Client\Debug\RecordingClient;
 use Flow\PostgreSql\Client\DsnParser;
 use Flow\PostgreSql\Client\Infrastructure\PgSql\PgSqlClient;
 use Flow\PostgreSql\Client\Telemetry\PostgreSqlTelemetryConfig;
@@ -69,6 +71,7 @@ use function class_exists;
 use function Flow\Types\DSL\type_string;
 use function implode;
 use function in_array;
+use function is_bool;
 use function is_string;
 use function sprintf;
 use function str_starts_with;
@@ -78,7 +81,21 @@ final class FlowPostgreSqlBundle extends AbstractBundle
 {
     public const string SERVICE_CONTAINER = 'service_container';
 
+    private const string WEB_PROFILER_BUNDLE = 'Symfony\\Bundle\\WebProfilerBundle\\WebProfilerBundle';
+
     protected string $extensionAlias = 'flow_postgresql';
+
+    /**
+     * The bundle class lives directly in its package root rather than the "modern" `<root>/src/`
+     * layout that {@see AbstractBundle::getPath()} assumes (it returns `dirname(file, 2)`), so the
+     * default overshoots by one directory and Twig never registers the `@FlowPostgreSql` view
+     * namespace. Pin the path to this directory so `Resources/views` resolves.
+     */
+    #[Override]
+    public function getPath(): string
+    {
+        return __DIR__;
+    }
 
     #[Override]
     public function build(ContainerBuilder $container): void
@@ -190,6 +207,10 @@ final class FlowPostgreSqlBundle extends AbstractBundle
             ->min(0)
             ->end()
             ->end()
+            ->end()
+            ->booleanNode('profiler')
+            ->info('Record this connection\'s queries in the Flow PostgreSQL Web Profiler panel when the profiler is enabled (default true). Set false to skip decorating this connection.')
+            ->defaultTrue()
             ->end()
             ->end()
             ->end()
@@ -437,11 +458,30 @@ final class FlowPostgreSqlBundle extends AbstractBundle
             ->end()
             ->end()
             ->end()
+            ->arrayNode('profiler')
+            ->info('Symfony Web Profiler SQL queries panel (dev only; requires symfony/web-profiler-bundle)')
+            ->canBeUnset()
+            ->addDefaultsIfNotSet()
+            ->children()
+            ->variableNode('enabled')
+            ->info('null (default) = auto-enable iff WebProfilerBundle is registered; true/false to force')
+            ->defaultNull()
+            ->validate()
+            ->ifTrue(static fn (mixed $v): bool => $v !== null && !is_bool($v))
+            ->thenInvalid('flow_postgresql.profiler.enabled must be true, false, or null')
+            ->end()
+            ->end()
+            ->booleanNode('include_parameters')
+            ->info('Show bound query parameters in the panel')
+            ->defaultTrue()
+            ->end()
+            ->end()
+            ->end()
             ->end();
     }
 
     /**
-     * @param array{connections: array<string, array{dsn: string, dbname: ?string, host: ?string, port: ?int, user: ?string, password: ?string, dbname_suffix: string, test_transaction_rollback: bool, context?: array<string, mixed>, telemetry?: array{service_id: string, clock_service_id: ?string, trace_queries: bool, trace_transactions: bool, collect_metrics: bool, log_queries: bool, max_query_length: int, include_parameters: bool, max_parameters: int, max_parameter_length: int}}>, messenger: array{enabled: bool, table_name: string, schema: string}, cache: array{pools?: array<string, array{connection: ?string, table_name: string, schema: string, id_col: string, data_col: string, lifetime_col: string, time_col: string, namespace: string, default_lifetime: int, marshaller_service_id: ?string, share_connection: bool}>}, session: array{enabled: bool, connection: ?string, table_name: string, schema: string, id_col: string, data_col: string, lifetime_col: string, time_col: string, lock_mode: string, ttl: ?int, share_connection: bool}, migrations: array{enabled: bool, directory: string, namespace: string, table_name: string, table_schema: string, migration_file_name: string, rollback_file_name: string, all_or_nothing: bool, generate_rollback: bool, drop_if_exists: bool, context?: array<string, mixed>, exclude?: list<array{schema: ?string, table: ?string, exact: ?string, starts_with: ?string, ends_with: ?string, pattern: ?string, policy_id: ?string, type: ?string, for_schema: ?string}>}, catalog_providers: list<array{catalog_provider_id: ?string, catalog: ?array<string, mixed>}>} $config
+     * @param array{connections: array<string, array{dsn: string, dbname: ?string, host: ?string, port: ?int, user: ?string, password: ?string, dbname_suffix: string, test_transaction_rollback: bool, context?: array<string, mixed>, telemetry?: array{service_id: string, clock_service_id: ?string, trace_queries: bool, trace_transactions: bool, collect_metrics: bool, log_queries: bool, max_query_length: int, include_parameters: bool, max_parameters: int, max_parameter_length: int}, profiler?: bool}>, messenger: array{enabled: bool, table_name: string, schema: string}, cache: array{pools?: array<string, array{connection: ?string, table_name: string, schema: string, id_col: string, data_col: string, lifetime_col: string, time_col: string, namespace: string, default_lifetime: int, marshaller_service_id: ?string, share_connection: bool}>}, session: array{enabled: bool, connection: ?string, table_name: string, schema: string, id_col: string, data_col: string, lifetime_col: string, time_col: string, lock_mode: string, ttl: ?int, share_connection: bool}, migrations: array{enabled: bool, directory: string, namespace: string, table_name: string, table_schema: string, migration_file_name: string, rollback_file_name: string, all_or_nothing: bool, generate_rollback: bool, drop_if_exists: bool, context?: array<string, mixed>, exclude?: list<array{schema: ?string, table: ?string, exact: ?string, starts_with: ?string, ends_with: ?string, pattern: ?string, policy_id: ?string, type: ?string, for_schema: ?string}>}, catalog_providers: list<array{catalog_provider_id: ?string, catalog: ?array<string, mixed>}>, profiler?: array{enabled?: bool|null, include_parameters?: bool}} $config
      */
     #[Override]
     public function loadExtension(array $config, ContainerConfigurator $configurator, ContainerBuilder $container): void
@@ -479,6 +519,87 @@ final class FlowPostgreSqlBundle extends AbstractBundle
         $this->registerMessenger($config['messenger'], $connectionNames, $container);
         $this->registerCache($config['cache'] ?? [], $connectionNames, $container);
         $this->registerSession($config['session'] ?? [], $connectionNames, $container);
+        $this->registerProfiler($config, $configurator, $container, $connectionNames);
+    }
+
+    /**
+     * @param array<array-key, mixed> $config
+     * @param list<string> $connectionNames
+     */
+    private function registerProfiler(
+        array $config,
+        ContainerConfigurator $configurator,
+        ContainerBuilder $container,
+        array $connectionNames,
+    ): void {
+        $profilerConfig = is_array($config['profiler'] ?? null) ? $config['profiler'] : [];
+        // @mago-expect analysis:mixed-assignment
+        $enabled = $profilerConfig['enabled'] ?? null;
+        $includeParameters = (bool) ($profilerConfig['include_parameters'] ?? true);
+
+        if ($enabled === false) {
+            return;
+        }
+
+        $hasWebProfiler = $this->isWebProfilerBundleRegistered($container);
+
+        if ($enabled === true && !$hasWebProfiler) {
+            throw new LogicException(
+                'flow_postgresql.profiler.enabled is true but symfony/web-profiler-bundle is not registered in the kernel. Install it (composer require --dev symfony/web-profiler-bundle) and enable it for this environment, or set profiler.enabled to null/false.',
+            );
+        }
+
+        if ($enabled === null && !$hasWebProfiler) {
+            return;
+        }
+
+        $container->setParameter('flow.postgresql.profiler.include_parameters', $includeParameters);
+        $configurator->import(__DIR__ . '/Resources/config/profiler.php');
+
+        $connections = is_array($config['connections'] ?? null) ? $config['connections'] : [];
+        $clientRefs = [];
+
+        foreach ($connectionNames as $name) {
+            $connectionConfig = is_array($connections[$name] ?? null) ? $connections[$name] : [];
+
+            if (($connectionConfig['profiler'] ?? true) === false) {
+                continue;
+            }
+
+            $recordingDefinition = new Definition(RecordingClient::class, [
+                new Reference("flow.postgresql.{$name}.client.profiler.inner"),
+                new Reference('flow.postgresql.profiler.query_log'),
+                $name,
+            ]);
+            $recordingDefinition->setDecoratedService("flow.postgresql.{$name}.client", null, 10);
+            $recordingDefinition->setPublic(true);
+            $container->setDefinition("flow.postgresql.{$name}.client.profiler", $recordingDefinition);
+
+            $clientRefs[$name] = new Reference("flow.postgresql.{$name}.client");
+        }
+
+        $locator = new Definition(ServiceLocator::class, [$clientRefs]);
+        $locator->addTag('container.service_locator');
+        $container->setDefinition('flow.postgresql.profiler.client_locator', $locator);
+
+        $controller = new Definition(ProfilerController::class, [
+            new Reference('twig'),
+            new Reference('flow.postgresql.profiler.client_locator'),
+            new Reference('profiler'),
+        ]);
+        $controller->setPublic(true);
+        $container->setDefinition(ProfilerController::class, $controller);
+    }
+
+    private function isWebProfilerBundleRegistered(ContainerBuilder $container): bool
+    {
+        if (!$container->hasParameter('kernel.bundles')) {
+            return false;
+        }
+
+        $bundles = $container->getParameter('kernel.bundles');
+
+        return is_array($bundles) && in_array(self::WEB_PROFILER_BUNDLE, $bundles, true);
     }
 
     /**
@@ -579,7 +700,7 @@ final class FlowPostgreSqlBundle extends AbstractBundle
     }
 
     /**
-     * @param array{dsn: string, dbname: ?string, host: ?string, port: ?int, user: ?string, password: ?string, dbname_suffix: string, test_transaction_rollback: bool, context?: array<string, mixed>, telemetry?: array{service_id: string, clock_service_id: ?string, trace_queries: bool, trace_transactions: bool, collect_metrics: bool, log_queries: bool, max_query_length: int, include_parameters: bool, max_parameters: int, max_parameter_length: int}} $connectionConfig
+     * @param array{dsn: string, dbname: ?string, host: ?string, port: ?int, user: ?string, password: ?string, dbname_suffix: string, test_transaction_rollback: bool, context?: array<string, mixed>, telemetry?: array{service_id: string, clock_service_id: ?string, trace_queries: bool, trace_transactions: bool, collect_metrics: bool, log_queries: bool, max_query_length: int, include_parameters: bool, max_parameters: int, max_parameter_length: int}, profiler?: bool} $connectionConfig
      */
     private function registerConnection(
         string $name,

--- a/src/bridge/symfony/postgresql-bundle/src/Flow/Bridge/Symfony/PostgreSqlBundle/Profiler/FlowPostgreSqlDataCollector.php
+++ b/src/bridge/symfony/postgresql-bundle/src/Flow/Bridge/Symfony/PostgreSqlBundle/Profiler/FlowPostgreSqlDataCollector.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\Bridge\Symfony\PostgreSqlBundle\Profiler;
+
+use Flow\PostgreSql\Client\Debug\QueryLog;
+use Flow\PostgreSql\Client\Debug\RecordedQuery;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\DataCollector\DataCollector;
+use Symfony\Component\HttpKernel\DataCollector\LateDataCollectorInterface;
+use Throwable;
+
+use function array_keys;
+use function count;
+use function in_array;
+use function is_float;
+use function ltrim;
+use function preg_split;
+use function strtoupper;
+
+/**
+ * @phpstan-type QueryRow array{statement: string, parameters: array<int, mixed>, returnedRows: null|int, durationMs: float, failed: bool, error: null|string, connection: string, caller: null|string, explainable: bool, runCount: int, isDuplicate: bool}
+ */
+final class FlowPostgreSqlDataCollector extends DataCollector implements LateDataCollectorInterface
+{
+    private const array EXPLAINABLE_KEYWORDS = ['SELECT', 'WITH', 'INSERT', 'UPDATE', 'DELETE', 'VALUES', 'TABLE'];
+
+    public function __construct(
+        private readonly QueryLog $queryLog,
+        private readonly bool $includeParameters,
+    ) {}
+
+    public function collect(Request $request, Response $response, ?Throwable $exception = null): void {}
+
+    public function lateCollect(): void
+    {
+        $queries = $this->queryLog->queries();
+
+        $runCounts = [];
+
+        foreach ($queries as $query) {
+            $runCounts[$query->sql] = ($runCounts[$query->sql] ?? 0) + 1;
+        }
+
+        $byConnection = [];
+        $failedCount = 0;
+        $totalDurationMs = 0.0;
+
+        foreach ($queries as $query) {
+            $totalDurationMs += $query->durationMs;
+
+            if ($query->failed) {
+                $failedCount++;
+            }
+
+            $byConnection[$query->connection][] = [
+                'statement' => $query->sql,
+                'parameters' => $this->includeParameters ? $query->parameters : [],
+                'returnedRows' => $query->rowCount,
+                'durationMs' => $query->durationMs,
+                'failed' => $query->failed,
+                'error' => $query->error,
+                'connection' => $query->connection,
+                'caller' => $query->caller,
+                'explainable' => $this->isExplainable($query),
+                'runCount' => $runCounts[$query->sql],
+                'isDuplicate' => $runCounts[$query->sql] > 1,
+            ];
+        }
+
+        $this->data = [
+            'queries' => $byConnection,
+            'queryCount' => count($queries),
+            'failedCount' => $failedCount,
+            'totalDurationMs' => $totalDurationMs,
+            'duplicateCount' => count($queries) - count($runCounts),
+        ];
+    }
+
+    public function reset(): void
+    {
+        $this->data = [];
+        $this->queryLog->reset();
+    }
+
+    public function getName(): string
+    {
+        return 'flow_postgresql';
+    }
+
+    /**
+     * @return array<string, list<QueryRow>>
+     */
+    public function getQueries(): array
+    {
+        // @mago-expect analysis:mixed-return-statement
+        return $this->data['queries'] ?? [];
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getConnections(): array
+    {
+        return array_keys($this->getQueries());
+    }
+
+    public function getQueryCount(): int
+    {
+        return (int) ($this->data['queryCount'] ?? 0);
+    }
+
+    public function getFailedCount(): int
+    {
+        return (int) ($this->data['failedCount'] ?? 0);
+    }
+
+    public function getDuplicateCount(): int
+    {
+        return (int) ($this->data['duplicateCount'] ?? 0);
+    }
+
+    public function getTotalDurationMs(): float
+    {
+        // @mago-expect analysis:mixed-assignment
+        $value = $this->data['totalDurationMs'] ?? 0.0;
+
+        return is_float($value) ? $value : 0.0;
+    }
+
+    private function isExplainable(RecordedQuery $query): bool
+    {
+        if ($query->failed) {
+            return false;
+        }
+
+        $words = preg_split('/\s+/', ltrim($query->sql), 2);
+
+        if ($words === false || $words === []) {
+            return false;
+        }
+
+        return in_array(strtoupper($words[0]), self::EXPLAINABLE_KEYWORDS, true);
+    }
+}

--- a/src/bridge/symfony/postgresql-bundle/src/Flow/Bridge/Symfony/PostgreSqlBundle/Profiler/ProfilerController.php
+++ b/src/bridge/symfony/postgresql-bundle/src/Flow/Bridge/Symfony/PostgreSqlBundle/Profiler/ProfilerController.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\Bridge\Symfony\PostgreSqlBundle\Profiler;
+
+use Flow\PostgreSql\AST\Transformers\ExplainConfig;
+use Flow\PostgreSql\Client\Client;
+use Psr\Container\ContainerInterface;
+use SensitiveParameter;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Profiler\Profiler;
+use Throwable;
+use Twig\Environment;
+
+use function array_key_exists;
+use function array_values;
+
+/**
+ * Renders the "Explain query" fragment for the Flow PostgreSQL profiler panel. Reached via the
+ * standard `_profiler` route with `page=explain` and a controller sub-request (no custom route),
+ * mirroring how the Doctrine bundle exposes EXPLAIN. Dev-only: this service is registered solely
+ * when the profiler panel is enabled.
+ *
+ * @internal
+ */
+final readonly class ProfilerController
+{
+    public function __construct(
+        private Environment $twig,
+        private ContainerInterface $clients,
+        private Profiler $profiler,
+    ) {}
+
+    public function explainAction(#[SensitiveParameter] string $token, string $connection, int $query): Response
+    {
+        $this->profiler->disable();
+
+        $profile = $this->profiler->loadProfile($token);
+
+        if ($profile === null || !$profile->hasCollector('flow_postgresql')) {
+            return new Response('This query does not exist.');
+        }
+
+        $collector = $profile->getCollector('flow_postgresql');
+
+        if (!$collector instanceof FlowPostgreSqlDataCollector) {
+            return new Response('This query does not exist.');
+        }
+
+        $queries = $collector->getQueries();
+
+        if (!array_key_exists($connection, $queries) || !array_key_exists($query, $queries[$connection])) {
+            return new Response('This query does not exist.');
+        }
+
+        $row = $queries[$connection][$query];
+
+        if (!$row['explainable']) {
+            return new Response('This query cannot be explained.');
+        }
+
+        if (!$this->clients->has($connection)) {
+            return new Response('This query cannot be explained.');
+        }
+
+        // @mago-expect analysis:mixed-assignment
+        $client = $this->clients->get($connection);
+
+        if (!$client instanceof Client) {
+            return new Response('This query cannot be explained.');
+        }
+
+        try {
+            $plan = $client->explain($row['statement'], array_values($row['parameters']), ExplainConfig::forEstimate());
+        } catch (Throwable $e) {
+            return new Response('An error occurred while explaining the query: ' . $e->getMessage());
+        }
+
+        return new Response($this->twig->render('@FlowPostgreSql/Collector/explain.html.twig', [
+            'plan' => $plan,
+        ]));
+    }
+}

--- a/src/bridge/symfony/postgresql-bundle/src/Flow/Bridge/Symfony/PostgreSqlBundle/Resources/config/profiler.php
+++ b/src/bridge/symfony/postgresql-bundle/src/Flow/Bridge/Symfony/PostgreSqlBundle/Resources/config/profiler.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+use Flow\Bridge\Symfony\PostgreSqlBundle\Profiler\FlowPostgreSqlDataCollector;
+use Flow\PostgreSql\Client\Debug\QueryLog;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+use function Symfony\Component\DependencyInjection\Loader\Configurator\param;
+use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
+
+return static function (ContainerConfigurator $container): void {
+    $services = $container->services();
+
+    $services->set('flow.postgresql.profiler.query_log', QueryLog::class)->public();
+
+    $services->set('flow.postgresql.profiler.collector', FlowPostgreSqlDataCollector::class)->args([
+        service('flow.postgresql.profiler.query_log'),
+        param('flow.postgresql.profiler.include_parameters'),
+    ])->tag('data_collector', [
+        'id' => 'flow_postgresql',
+        'template' => '@FlowPostgreSql/Collector/postgresql.html.twig',
+        'priority' => 240,
+    ]);
+};

--- a/src/bridge/symfony/postgresql-bundle/src/Flow/Bridge/Symfony/PostgreSqlBundle/Resources/views/Collector/explain.html.twig
+++ b/src/bridge/symfony/postgresql-bundle/src/Flow/Bridge/Symfony/PostgreSqlBundle/Resources/views/Collector/explain.html.twig
@@ -1,0 +1,22 @@
+{% macro node(n, depth) %}
+    <li style="padding: 2px 0 2px {{ depth * 18 }}px;">
+        {% if depth > 0 %}<span style="color: var(--color-muted);">→ </span>{% endif %}
+        <strong>{{ n.nodeType.value }}</strong>
+        {% if n.relationName %}
+            on <code>{{ n.relationName }}</code>{% if n.alias and n.alias != n.relationName %} <span class="text-muted">({{ n.alias }})</span>{% endif %}
+        {% endif %}
+        <span class="text-muted text-small">cost={{ n.cost.totalCost|number_format(2) }} · rows≈{{ n.estimatedRows }}</span>
+        {% if n.hasChildren %}
+            <ul style="list-style:none; margin:0; padding:0;">
+                {% for child in n.children %}{{ _self.node(child, depth + 1) }}{% endfor %}
+            </ul>
+        {% endif %}
+    </li>
+{% endmacro %}
+
+<div class="flow-pg-explain">
+    <ul style="list-style:none; margin:0; padding:0; font-size:13px;">
+        {{ _self.node(plan.rootNode, 0) }}
+    </ul>
+    <p class="text-small text-muted">Plain <code>EXPLAIN</code> — estimated plan; the query was not executed.</p>
+</div>

--- a/src/bridge/symfony/postgresql-bundle/src/Flow/Bridge/Symfony/PostgreSqlBundle/Resources/views/Collector/postgresql.html.twig
+++ b/src/bridge/symfony/postgresql-bundle/src/Flow/Bridge/Symfony/PostgreSqlBundle/Resources/views/Collector/postgresql.html.twig
@@ -1,0 +1,182 @@
+{% extends '@WebProfiler/Profiler/layout.html.twig' %}
+
+{% macro parameter_table(parameters) %}
+    <table class="text-small">
+        <tbody>
+            {% for key, value in parameters %}
+                <tr>
+                    <th>{{ key }}</th>
+                    <td>{{ value is iterable ? value|json_encode : (value is same as(true) ? 'true' : (value is same as(false) ? 'false' : value)) }}</td>
+                </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+{% endmacro %}
+
+{% block toolbar %}
+    {% set icon %}
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20"><path fill="currentColor" d="M12 3C7.58 3 4 4.79 4 7s3.58 4 8 4 8-1.79 8-4-3.58-4-8-4zM4 9v3c0 2.21 3.58 4 8 4s8-1.79 8-4V9c0 2.21-3.58 4-8 4S4 11.21 4 9zm0 5v3c0 2.21 3.58 4 8 4s8-1.79 8-4v-3c0 2.21-3.58 4-8 4s-8-1.79-8-4z"/></svg>
+        <span class="sf-toolbar-value">{{ collector.queryCount }}</span>
+        <span class="sf-toolbar-label">queries</span>
+    {% endset %}
+
+    {% set text %}
+        <div class="sf-toolbar-info-piece">
+            <b>Queries</b>
+            <span class="sf-toolbar-status">{{ collector.queryCount }}</span>
+        </div>
+        <div class="sf-toolbar-info-piece">
+            <b>Query time</b>
+            <span>{{ collector.totalDurationMs|number_format(2) }} ms</span>
+        </div>
+        {% if collector.duplicateCount > 0 %}
+            <div class="sf-toolbar-info-piece">
+                <b>Duplicates</b>
+                <span class="sf-toolbar-status sf-toolbar-status-yellow">{{ collector.duplicateCount }}</span>
+            </div>
+        {% endif %}
+        {% if collector.failedCount > 0 %}
+            <div class="sf-toolbar-info-piece">
+                <b>Failed</b>
+                <span class="sf-toolbar-status sf-toolbar-status-red">{{ collector.failedCount }}</span>
+            </div>
+        {% endif %}
+    {% endset %}
+
+    {{ include('@WebProfiler/Profiler/toolbar_item.html.twig', { link: profiler_url, status: collector.failedCount > 0 ? 'red' : (collector.queryCount > 0 ? '' : 'disabled') }) }}
+{% endblock %}
+
+{% block menu %}
+    <span class="label {{ collector.queryCount == 0 ? 'disabled' }} {{ collector.failedCount > 0 ? 'label-status-error' }}">
+        <span class="icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24"><path fill="currentColor" d="M12 3C7.58 3 4 4.79 4 7s3.58 4 8 4 8-1.79 8-4-3.58-4-8-4zM4 9v3c0 2.21 3.58 4 8 4s8-1.79 8-4V9c0 2.21-3.58 4-8 4S4 11.21 4 9zm0 5v3c0 2.21 3.58 4 8 4s8-1.79 8-4v-3c0 2.21-3.58 4-8 4s-8-1.79-8-4z"/></svg>
+        </span>
+        <strong>Flow PostgreSQL</strong>
+        <span class="count">
+            <span>{{ collector.queryCount }}</span>
+        </span>
+    </span>
+{% endblock %}
+
+{% block panel %}
+    {% if 'explain' == page %}
+        {{ render(controller('Flow\\Bridge\\Symfony\\PostgreSqlBundle\\Profiler\\ProfilerController::explainAction', {
+            token: token,
+            connection: request.query.get('connection'),
+            query: request.query.get('query'),
+        })) }}
+    {% else %}
+        {{ block('queries') }}
+    {% endif %}
+{% endblock %}
+
+{% block queries %}
+    <h2>Flow PostgreSQL Queries</h2>
+
+    <div class="metrics">
+        <div class="metric">
+            <span class="value">{{ collector.queryCount }}</span>
+            <span class="label">Queries</span>
+        </div>
+        <div class="metric">
+            <span class="value">{{ collector.totalDurationMs|number_format(2) }} <span class="unit">ms</span></span>
+            <span class="label">Total query time</span>
+        </div>
+        <div class="metric{{ collector.duplicateCount > 0 ? ' yellow' }}">
+            <span class="value">{{ collector.duplicateCount }}</span>
+            <span class="label">Duplicates</span>
+        </div>
+        <div class="metric{{ collector.failedCount > 0 ? ' red' }}">
+            <span class="value">{{ collector.failedCount }}</span>
+            <span class="label">Failed</span>
+        </div>
+    </div>
+
+    {% if collector.queryCount == 0 %}
+        <div class="empty"><p>No PostgreSQL queries were executed for this request.</p></div>
+    {% else %}
+        {% for connection, queries in collector.queries %}
+            <h3>Connection: {{ connection }} <small class="text-muted">({{ queries|length }} queries)</small></h3>
+            <table>
+                <thead>
+                    <tr>
+                        <th>#</th>
+                        <th class="text-right">Rows</th>
+                        <th class="text-right">Duration</th>
+                        <th>Query</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for query in queries %}
+                        {% set row = loop.index0 %}
+                        <tr{% if query.failed %} class="status-error"{% endif %}>
+                            <td>{{ loop.index }}</td>
+                            <td class="text-right">{{ query.returnedRows ?? '—' }}</td>
+                            <td class="text-right">{{ query.durationMs|number_format(2) }} ms</td>
+                            <td>
+                                <code class="sql">{{ query.statement }}</code>
+                                {% if query.isDuplicate %}
+                                    <span class="label label-status-warning text-small" title="This statement ran {{ query.runCount }} times">×{{ query.runCount }}</span>
+                                {% endif %}
+                                <div class="text-small text-muted">
+                                    {% if query.caller %}<span title="{{ query.caller }}">{{ query.caller|split('/')|last }}</span>{% endif %}
+                                    {% if query.parameters is not empty %}
+                                        · <a class="btn btn-link text-small sf-toggle" data-toggle-selector="#query-params-{{ connection }}-{{ row }}" data-toggle-alt-content="Hide parameters">View parameters</a>
+                                    {% endif %}
+                                    {% if query.explainable %}
+                                        · <a class="link-inverse" href="{{ path('_profiler', { panel: 'flow_postgresql', token: token, page: 'explain', connection: connection, query: row }) }}" onclick="return flowPgExplain(this);" data-target-id="flow-pg-explain-{{ connection }}-{{ row }}">Explain query</a>
+                                    {% endif %}
+                                </div>
+                                {% if query.parameters is not empty %}
+                                    <div id="query-params-{{ connection }}-{{ row }}" class="hidden">
+                                        {{ _self.parameter_table(query.parameters) }}
+                                    </div>
+                                {% endif %}
+                                {% if query.explainable %}
+                                    <div id="flow-pg-explain-{{ connection }}-{{ row }}" class="hidden"></div>
+                                {% endif %}
+                                {% if query.failed and query.error %}
+                                    <div class="text-small status-error">{{ query.error }}</div>
+                                {% endif %}
+                            </td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        {% endfor %}
+
+        <script{{ csp_script_nonce|default('') ? ' nonce="' ~ csp_script_nonce ~ '"' : '' }}>//<![CDATA[
+            function flowPgExplain(link) {
+                "use strict";
+                var target = document.getElementById(link.getAttribute('data-target-id'));
+                if (target.style.display === 'block') {
+                    target.style.display = 'none';
+                    link.innerHTML = 'Explain query';
+                    return false;
+                }
+                if (target.getAttribute('data-loaded') !== link.href) {
+                    var xhr = new XMLHttpRequest();
+                    xhr.open('GET', link.href, true);
+                    xhr.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
+                    xhr.onreadystatechange = function () {
+                        if (xhr.readyState === 4) {
+                            if (xhr.status === 200) {
+                                // The profiler renders the fragment inside full page chrome; extract just our panel.
+                                var parsed = new DOMParser().parseFromString(xhr.responseText, 'text/html');
+                                var fragment = parsed.querySelector('.flow-pg-explain');
+                                target.innerHTML = fragment ? fragment.outerHTML : xhr.responseText;
+                            } else {
+                                target.innerHTML = 'An error occurred while loading the query explanation.';
+                            }
+                            target.setAttribute('data-loaded', link.href);
+                        }
+                    };
+                    xhr.send('');
+                }
+                target.style.display = 'block';
+                link.innerHTML = 'Hide query explanation';
+                return false;
+            }
+        //]]></script>
+    {% endif %}
+{% endblock %}

--- a/src/bridge/symfony/postgresql-bundle/tests/Flow/Bridge/Symfony/PostgreSqlBundle/Tests/Fixtures/Controller/QueryController.php
+++ b/src/bridge/symfony/postgresql-bundle/tests/Flow/Bridge/Symfony/PostgreSqlBundle/Tests/Fixtures/Controller/QueryController.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\Bridge\Symfony\PostgreSqlBundle\Tests\Fixtures\Controller;
+
+use Flow\PostgreSql\Client\Client;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+
+use function count;
+
+final class QueryController
+{
+    public function __construct(
+        private readonly Client $client,
+    ) {}
+
+    public function run(): Response
+    {
+        $rows = $this->client->fetchAll('SELECT n FROM (VALUES (1), (2), (3)) AS t(n) WHERE n >= $1', [2]);
+
+        return new JsonResponse(['count' => count($rows)]);
+    }
+}

--- a/src/bridge/symfony/postgresql-bundle/tests/Flow/Bridge/Symfony/PostgreSqlBundle/Tests/Fixtures/config/profiler_panel_routes.php
+++ b/src/bridge/symfony/postgresql-bundle/tests/Flow/Bridge/Symfony/PostgreSqlBundle/Tests/Fixtures/config/profiler_panel_routes.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
+
+return static function (RoutingConfigurator $routes): void {
+    $routes->import('@WebProfilerBundle/Resources/config/routing/profiler.xml')->prefix('/_profiler');
+};

--- a/src/bridge/symfony/postgresql-bundle/tests/Flow/Bridge/Symfony/PostgreSqlBundle/Tests/Integration/Profiler/FlowPostgreSqlProfilerTest.php
+++ b/src/bridge/symfony/postgresql-bundle/tests/Flow/Bridge/Symfony/PostgreSqlBundle/Tests/Integration/Profiler/FlowPostgreSqlProfilerTest.php
@@ -1,0 +1,331 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\Bridge\Symfony\PostgreSqlBundle\Tests\Integration\Profiler;
+
+use Flow\Bridge\Symfony\PostgreSqlBundle\FlowPostgreSqlBundle;
+use Flow\Bridge\Symfony\PostgreSqlBundle\Profiler\FlowPostgreSqlDataCollector;
+use Flow\Bridge\Symfony\PostgreSqlBundle\Tests\Fixtures\Controller\QueryController;
+use Flow\Bridge\Symfony\PostgreSqlBundle\Tests\Fixtures\TestKernel;
+use Flow\Bridge\Symfony\PostgreSqlBundle\Tests\Integration\KernelTestCase;
+use Flow\PostgreSql\Client\Client;
+use Flow\PostgreSql\Client\Debug\RecordingClient;
+use LogicException;
+use Override;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Bundle\TwigBundle\TwigBundle;
+use Symfony\Bundle\WebProfilerBundle\WebProfilerBundle;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\Compiler\PassConfig;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\Router;
+use Throwable;
+
+use function array_merge;
+use function getenv;
+
+#[CoversClass(FlowPostgreSqlBundle::class)]
+#[CoversClass(FlowPostgreSqlDataCollector::class)]
+final class FlowPostgreSqlProfilerTest extends KernelTestCase
+{
+    #[Override]
+    protected function tearDown(): void
+    {
+        restore_exception_handler();
+        parent::tearDown();
+    }
+
+    public function test_collector_registered_and_client_decorated_when_enabled(): void
+    {
+        $container = $this->bootWithWebProfiler(['enabled' => true])->getContainer();
+
+        static::assertTrue($container->has('flow.postgresql.profiler.collector'));
+        static::assertInstanceOf(
+            FlowPostgreSqlDataCollector::class,
+            $container->get('flow.postgresql.profiler.collector'),
+        );
+        static::assertInstanceOf(RecordingClient::class, $container->get('flow.postgresql.default.client'));
+    }
+
+    public function test_executed_queries_are_collected(): void
+    {
+        $container = $this->bootWithWebProfiler(['enabled' => true])->getContainer();
+
+        /** @var Client $client */
+        $client = $container->get('flow.postgresql.default.client');
+        $client->fetchAll('SELECT n FROM (VALUES (1), (2), (3)) AS t(n) WHERE n >= $1', [2]);
+
+        /** @var FlowPostgreSqlDataCollector $collector */
+        $collector = $container->get('flow.postgresql.profiler.collector');
+        $collector->lateCollect();
+
+        static::assertSame(1, $collector->getQueryCount());
+        $query = $collector->getQueries()['default'][0];
+        static::assertStringContainsString('VALUES (1), (2), (3)', $query['statement']);
+        static::assertSame([2], $query['parameters']);
+        static::assertSame(2, $query['returnedRows']);
+        static::assertFalse($query['failed']);
+        static::assertSame('default', $query['connection']);
+        static::assertNotNull($query['caller']);
+    }
+
+    public function test_failed_query_is_recorded_as_failed(): void
+    {
+        $container = $this->bootWithWebProfiler(['enabled' => true])->getContainer();
+
+        /** @var Client $client */
+        $client = $container->get('flow.postgresql.default.client');
+
+        try {
+            $client->execute('SELECT * FROM table_that_does_not_exist');
+        } catch (Throwable) {
+            // expected
+        }
+
+        /** @var FlowPostgreSqlDataCollector $collector */
+        $collector = $container->get('flow.postgresql.profiler.collector');
+        $collector->lateCollect();
+
+        static::assertSame(1, $collector->getFailedCount());
+        static::assertTrue($collector->getQueries()['default'][0]['failed']);
+    }
+
+    public function test_collector_not_registered_when_disabled(): void
+    {
+        $container = $this->bootWithWebProfiler(['enabled' => false])->getContainer();
+
+        static::assertFalse($container->has('flow.postgresql.profiler.collector'));
+        static::assertNotInstanceOf(RecordingClient::class, $container->get('flow.postgresql.default.client'));
+    }
+
+    public function test_connection_can_opt_out_while_profiler_enabled(): void
+    {
+        $kernel = $this->bootKernel([
+            'config' => function (TestKernel $kernel): void {
+                $kernel->addTestBundle(FrameworkBundle::class);
+                $kernel->addTestBundle(TwigBundle::class);
+                $kernel->addTestBundle(WebProfilerBundle::class);
+                $kernel->addTestExtensionConfig('framework', array_merge($this->frameworkConfig(), [
+                    'profiler' => ['enabled' => true, 'collect' => true],
+                ]));
+                $kernel->addTestExtensionConfig('twig', ['debug' => true, 'strict_variables' => false]);
+                $kernel->addTestExtensionConfig('web_profiler', ['toolbar' => false, 'intercept_redirects' => false]);
+                $kernel->addTestExtensionConfig('flow_postgresql', [
+                    'connections' => [
+                        'default' => [
+                            'dsn' => getenv('PGSQL_DATABASE_URL')
+                                ?: 'postgresql://postgres:postgres@127.0.0.1:5452/postgres',
+                            'profiler' => false,
+                        ],
+                    ],
+                    'profiler' => ['enabled' => true],
+                ]);
+            },
+        ]);
+        $container = $kernel->getContainer();
+
+        // Panel still registered (profiler enabled) but the opted-out connection is not decorated.
+        static::assertTrue($container->has('flow.postgresql.profiler.collector'));
+        static::assertNotInstanceOf(RecordingClient::class, $container->get('flow.postgresql.default.client'));
+    }
+
+    public function test_auto_disabled_when_web_profiler_bundle_absent(): void
+    {
+        $container = $this->bootWithoutWebProfiler([])->getContainer();
+
+        static::assertFalse($container->has('flow.postgresql.profiler.collector'));
+    }
+
+    public function test_forcing_enabled_without_web_profiler_bundle_throws(): void
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('symfony/web-profiler-bundle is not registered');
+
+        $this->bootWithoutWebProfiler(['enabled' => true]);
+    }
+
+    public function test_panel_renders_executed_queries_in_the_profiler(): void
+    {
+        $kernel = $this->bootForPanelRendering();
+        $container = $kernel->getContainer();
+
+        /** @var Router $router */
+        $router = $container->get('router');
+        $router->getRouteCollection()->add('query', new Route('/query', [
+            '_controller' => QueryController::class . '::run',
+        ]));
+
+        $request = Request::create('/query', 'GET');
+        $response = $kernel->handle($request);
+        $token = $response->headers->get('X-Debug-Token');
+        $kernel->terminate($request, $response);
+
+        static::assertNotNull($token);
+
+        $panel = $kernel->handle(Request::create('/_profiler/' . $token . '?panel=flow_postgresql'));
+        $html = (string) $panel->getContent();
+
+        static::assertSame(200, $panel->getStatusCode());
+        static::assertStringContainsString('Flow PostgreSQL', $html);
+        static::assertStringContainsString('VALUES (1), (2), (3)', $html);
+        static::assertStringContainsString('Explain query', $html);
+    }
+
+    public function test_explain_endpoint_renders_the_plan(): void
+    {
+        [$kernel, $token] = $this->runQueryRequest();
+
+        $explain = $kernel->handle(Request::create(
+            '/_profiler/' . $token . '?panel=flow_postgresql&page=explain&connection=default&query=0',
+        ));
+
+        static::assertSame(200, $explain->getStatusCode());
+        static::assertStringContainsString('cost=', (string) $explain->getContent());
+    }
+
+    public function test_explain_endpoint_rejects_unknown_query(): void
+    {
+        [$kernel, $token] = $this->runQueryRequest();
+
+        $explain = $kernel->handle(Request::create(
+            '/_profiler/' . $token . '?panel=flow_postgresql&page=explain&connection=default&query=99',
+        ));
+
+        static::assertStringContainsString('does not exist', (string) $explain->getContent());
+    }
+
+    /**
+     * @return array{0: TestKernel, 1: string}
+     */
+    private function runQueryRequest(): array
+    {
+        $kernel = $this->bootForPanelRendering();
+        $container = $kernel->getContainer();
+
+        /** @var Router $router */
+        $router = $container->get('router');
+        $router->getRouteCollection()->add('query', new Route('/query', [
+            '_controller' => QueryController::class . '::run',
+        ]));
+
+        $request = Request::create('/query', 'GET');
+        $response = $kernel->handle($request);
+        $token = (string) $response->headers->get('X-Debug-Token');
+        $kernel->terminate($request, $response);
+
+        return [$kernel, $token];
+    }
+
+    /**
+     * @param array{enabled?: bool|null, include_parameters?: bool} $profilerConfig
+     */
+    private function bootWithWebProfiler(array $profilerConfig): TestKernel
+    {
+        return $this->bootKernel([
+            'config' => function (TestKernel $kernel) use ($profilerConfig): void {
+                $kernel->addTestBundle(FrameworkBundle::class);
+                $kernel->addTestBundle(TwigBundle::class);
+                $kernel->addTestBundle(WebProfilerBundle::class);
+                $kernel->addTestExtensionConfig('framework', array_merge($this->frameworkConfig(), [
+                    'profiler' => ['enabled' => true, 'collect' => true],
+                ]));
+                $kernel->addTestExtensionConfig('twig', ['debug' => true, 'strict_variables' => false]);
+                $kernel->addTestExtensionConfig('web_profiler', ['toolbar' => false, 'intercept_redirects' => false]);
+                $kernel->addTestExtensionConfig('flow_postgresql', $this->flowConfig($profilerConfig));
+            },
+        ]);
+    }
+
+    /**
+     * @param array{enabled?: bool|null, include_parameters?: bool} $profilerConfig
+     */
+    private function bootWithoutWebProfiler(array $profilerConfig): TestKernel
+    {
+        return $this->bootKernel([
+            'config' => function (TestKernel $kernel) use ($profilerConfig): void {
+                $kernel->addTestBundle(FrameworkBundle::class);
+                $kernel->addTestExtensionConfig('framework', $this->frameworkConfig());
+                $kernel->addTestExtensionConfig('flow_postgresql', $this->flowConfig($profilerConfig));
+            },
+        ]);
+    }
+
+    private function bootForPanelRendering(): TestKernel
+    {
+        return $this->bootKernel([
+            'config' => function (TestKernel $kernel): void {
+                $kernel->addTestBundle(FrameworkBundle::class);
+                $kernel->addTestBundle(TwigBundle::class);
+                $kernel->addTestBundle(WebProfilerBundle::class);
+                $kernel->addTestExtensionConfig('framework', [
+                    'router' => [
+                        'utf8' => true,
+                        'resource' => __DIR__ . '/../../Fixtures/config/profiler_panel_routes.php',
+                    ],
+                    'http_method_override' => false,
+                    'handle_all_throwables' => true,
+                    'profiler' => ['enabled' => true, 'collect' => true],
+                ]);
+                $kernel->addTestExtensionConfig('twig', ['debug' => true, 'strict_variables' => false]);
+                $kernel->addTestExtensionConfig('web_profiler', ['toolbar' => false, 'intercept_redirects' => false]);
+                $kernel->addTestExtensionConfig('flow_postgresql', $this->flowConfig(['enabled' => true]));
+                $kernel->addTestContainerConfigurator(static function (ContainerBuilder $container): void {
+                    $controller = new Definition(QueryController::class, [new Reference(
+                        'flow.postgresql.default.client',
+                    )]);
+                    $controller->setPublic(true);
+                    $controller->addTag('controller.service_arguments');
+                    $container->setDefinition(QueryController::class, $controller);
+
+                    $container->addCompilerPass(
+                        new class implements CompilerPassInterface {
+                            public function process(ContainerBuilder $container): void
+                            {
+                                if ($container->hasDefinition('profiler')) {
+                                    $container->getDefinition('profiler')->setPublic(true);
+                                }
+                            }
+                        },
+                        PassConfig::TYPE_BEFORE_OPTIMIZATION,
+                        -256,
+                    );
+                });
+            },
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function frameworkConfig(): array
+    {
+        return [
+            'http_method_override' => false,
+            'handle_all_throwables' => true,
+            'router' => ['utf8' => true, 'resource' => __DIR__ . '/../../Fixtures/config/profiler_panel_routes.php'],
+        ];
+    }
+
+    /**
+     * @param array{enabled?: bool|null, include_parameters?: bool} $profilerConfig
+     *
+     * @return array<string, mixed>
+     */
+    private function flowConfig(array $profilerConfig): array
+    {
+        return [
+            'connections' => [
+                'default' => [
+                    'dsn' => getenv('PGSQL_DATABASE_URL') ?: 'postgresql://postgres:postgres@127.0.0.1:5452/postgres',
+                ],
+            ],
+            'profiler' => $profilerConfig,
+        ];
+    }
+}

--- a/src/bridge/symfony/postgresql-bundle/tests/Flow/Bridge/Symfony/PostgreSqlBundle/Tests/Unit/Profiler/FlowPostgreSqlDataCollectorTest.php
+++ b/src/bridge/symfony/postgresql-bundle/tests/Flow/Bridge/Symfony/PostgreSqlBundle/Tests/Unit/Profiler/FlowPostgreSqlDataCollectorTest.php
@@ -1,0 +1,169 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\Bridge\Symfony\PostgreSqlBundle\Tests\Unit\Profiler;
+
+use Flow\Bridge\Symfony\PostgreSqlBundle\Profiler\FlowPostgreSqlDataCollector;
+use Flow\PostgreSql\Client\Debug\QueryLog;
+use Flow\PostgreSql\Client\Debug\RecordedQuery;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\TestWith;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(FlowPostgreSqlDataCollector::class)]
+final class FlowPostgreSqlDataCollectorTest extends TestCase
+{
+    public function test_get_name_is_flow_postgresql(): void
+    {
+        static::assertSame('flow_postgresql', $this->collector(new QueryLog())->getName());
+    }
+
+    public function test_late_collect_maps_recorded_queries(): void
+    {
+        $log = new QueryLog();
+        $log->add(
+            new RecordedQuery(
+                'SELECT * FROM users WHERE id = $1',
+                [42],
+                1.5,
+                1,
+                false,
+                null,
+                'default',
+                '/app/Repo.php:10',
+            ),
+        );
+        $collector = $this->collector($log);
+
+        $collector->lateCollect();
+
+        static::assertSame(1, $collector->getQueryCount());
+        $query = $collector->getQueries()['default'][0];
+        static::assertSame('SELECT * FROM users WHERE id = $1', $query['statement']);
+        static::assertSame([42], $query['parameters']);
+        static::assertSame(1, $query['returnedRows']);
+        static::assertSame(1.5, $query['durationMs']);
+        static::assertFalse($query['failed']);
+        static::assertNull($query['error']);
+        static::assertSame('default', $query['connection']);
+        static::assertSame('/app/Repo.php:10', $query['caller']);
+        static::assertTrue($query['explainable']);
+        static::assertFalse($query['isDuplicate']);
+    }
+
+    public function test_late_collect_counts_and_totals(): void
+    {
+        $log = new QueryLog();
+        $log->add(new RecordedQuery('SELECT 1', [], 2.0, 1, false, null));
+        $log->add(new RecordedQuery('SELECT 2', [], 3.0, 1, false, null));
+        $log->add(new RecordedQuery('BAD SQL', [], 0.5, null, true, 'syntax error'));
+        $collector = $this->collector($log);
+
+        $collector->lateCollect();
+
+        static::assertSame(3, $collector->getQueryCount());
+        static::assertSame(1, $collector->getFailedCount());
+        static::assertSame(5.5, $collector->getTotalDurationMs());
+    }
+
+    public function test_groups_queries_by_connection(): void
+    {
+        $log = new QueryLog();
+        $log->add(new RecordedQuery('SELECT 1', [], 1.0, 1, false, null, 'default'));
+        $log->add(new RecordedQuery('SELECT 2', [], 1.0, 1, false, null, 'analytics'));
+        $log->add(new RecordedQuery('SELECT 3', [], 1.0, 1, false, null, 'analytics'));
+        $collector = $this->collector($log);
+
+        $collector->lateCollect();
+
+        static::assertSame(['default', 'analytics'], $collector->getConnections());
+        static::assertCount(1, $collector->getQueries()['default']);
+        static::assertCount(2, $collector->getQueries()['analytics']);
+    }
+
+    public function test_detects_duplicate_statements(): void
+    {
+        $log = new QueryLog();
+        $log->add(new RecordedQuery('SELECT * FROM users WHERE id = $1', [1], 1.0, 1, false, null));
+        $log->add(new RecordedQuery('SELECT * FROM users WHERE id = $1', [2], 1.0, 1, false, null));
+        $log->add(new RecordedQuery('SELECT * FROM posts', [], 1.0, 5, false, null));
+        $collector = $this->collector($log);
+
+        $collector->lateCollect();
+
+        static::assertSame(1, $collector->getDuplicateCount());
+        $rows = $collector->getQueries()['default'];
+        static::assertSame(2, $rows[0]['runCount']);
+        static::assertTrue($rows[0]['isDuplicate']);
+        static::assertSame(1, $rows[2]['runCount']);
+        static::assertFalse($rows[2]['isDuplicate']);
+    }
+
+    /**
+     * @param non-empty-string $statement
+     */
+    #[TestWith(['SELECT 1', true])]
+    #[TestWith(['  with cte as (select 1) select * from cte', true])]
+    #[TestWith(['INSERT INTO t (a) VALUES (1)', true])]
+    #[TestWith(['UPDATE t SET a = 1', true])]
+    #[TestWith(['DELETE FROM t', true])]
+    #[TestWith(['SET search_path TO public', false])]
+    #[TestWith(['SHOW server_version', false])]
+    #[TestWith(['BEGIN', false])]
+    #[TestWith(['CREATE TABLE t (a int)', false])]
+    public function test_explainable_flag(string $statement, bool $expected): void
+    {
+        $log = new QueryLog();
+        $log->add(new RecordedQuery($statement, [], 1.0, 1, false, null));
+        $collector = $this->collector($log);
+
+        $collector->lateCollect();
+
+        static::assertSame($expected, $collector->getQueries()['default'][0]['explainable']);
+    }
+
+    public function test_failed_query_is_not_explainable(): void
+    {
+        $log = new QueryLog();
+        $log->add(new RecordedQuery('SELECT 1', [], 0.5, null, true, 'boom'));
+        $collector = $this->collector($log);
+
+        $collector->lateCollect();
+
+        $query = $collector->getQueries()['default'][0];
+        static::assertTrue($query['failed']);
+        static::assertSame('boom', $query['error']);
+        static::assertFalse($query['explainable']);
+    }
+
+    public function test_include_parameters_false_omits_parameters(): void
+    {
+        $log = new QueryLog();
+        $log->add(new RecordedQuery('SELECT * FROM users WHERE id = $1', [42], 1.0, 1, false, null));
+        $collector = $this->collector($log, includeParameters: false);
+
+        $collector->lateCollect();
+
+        static::assertSame([], $collector->getQueries()['default'][0]['parameters']);
+    }
+
+    public function test_reset_clears_data_and_query_log(): void
+    {
+        $log = new QueryLog();
+        $log->add(new RecordedQuery('SELECT 1', [], 1.0, 1, false, null));
+        $collector = $this->collector($log);
+        $collector->lateCollect();
+
+        $collector->reset();
+
+        static::assertSame([], $collector->getQueries());
+        static::assertSame(0, $collector->getQueryCount());
+        static::assertSame([], $log->queries());
+    }
+
+    private function collector(QueryLog $log, bool $includeParameters = true): FlowPostgreSqlDataCollector
+    {
+        return new FlowPostgreSqlDataCollector($log, $includeParameters);
+    }
+}

--- a/src/bridge/symfony/postgresql-bundle/tests/Flow/Bridge/Symfony/PostgreSqlBundle/Tests/Unit/Profiler/ProfilerControllerTest.php
+++ b/src/bridge/symfony/postgresql-bundle/tests/Flow/Bridge/Symfony/PostgreSqlBundle/Tests/Unit/Profiler/ProfilerControllerTest.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\Bridge\Symfony\PostgreSqlBundle\Tests\Unit\Profiler;
+
+use Flow\Bridge\Symfony\PostgreSqlBundle\Profiler\FlowPostgreSqlDataCollector;
+use Flow\Bridge\Symfony\PostgreSqlBundle\Profiler\ProfilerController;
+use Flow\PostgreSql\Client\Debug\QueryLog;
+use Flow\PostgreSql\Client\Debug\RecordedQuery;
+use Flow\PostgreSql\Client\Exception\PostgreSqlError;
+use Flow\PostgreSql\Client\Exception\QueryException;
+use Flow\PostgreSql\Tests\Mother\FakeClient;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ServiceLocator;
+use Symfony\Component\HttpKernel\Profiler\Profile;
+use Symfony\Component\HttpKernel\Profiler\Profiler;
+use Twig\Environment;
+
+#[CoversClass(ProfilerController::class)]
+final class ProfilerControllerTest extends TestCase
+{
+    public function test_renders_the_plan_for_an_explainable_query(): void
+    {
+        $controller = $this->controller(
+            $this->profilerWith($this->collectorWith('SELECT * FROM users WHERE id = $1', [7])),
+            new ServiceLocator(['default' => static fn(): FakeClient => new FakeClient()]),
+            renders: '<div class="flow-pg-explain">plan</div>',
+        );
+
+        $response = $controller->explainAction('tok', 'default', 0);
+
+        static::assertSame(200, $response->getStatusCode());
+        static::assertStringContainsString('flow-pg-explain', (string) $response->getContent());
+    }
+
+    public function test_returns_message_when_profile_missing(): void
+    {
+        $profiler = $this->createMock(Profiler::class);
+        $profiler->method('loadProfile')->willReturn(null);
+
+        $response = $this->controller($profiler, new ServiceLocator([]))->explainAction('tok', 'default', 0);
+
+        static::assertStringContainsString('does not exist', (string) $response->getContent());
+    }
+
+    public function test_returns_message_when_collector_absent(): void
+    {
+        $profiler = $this->createMock(Profiler::class);
+        $profiler->method('loadProfile')->willReturn(new Profile('tok'));
+
+        $response = $this->controller($profiler, new ServiceLocator([]))->explainAction('tok', 'default', 0);
+
+        static::assertStringContainsString('does not exist', (string) $response->getContent());
+    }
+
+    public function test_returns_message_when_query_index_unknown(): void
+    {
+        $controller = $this->controller($this->profilerWith($this->collectorWith('SELECT 1', [])), new ServiceLocator([
+            'default' => static fn(): FakeClient => new FakeClient(),
+        ]));
+
+        static::assertStringContainsString(
+            'does not exist',
+            (string) $controller->explainAction('tok', 'default', 99)->getContent(),
+        );
+    }
+
+    public function test_returns_message_when_query_is_not_explainable(): void
+    {
+        $controller = $this->controller(
+            $this->profilerWith($this->collectorWith('SET search_path TO public', [])),
+            new ServiceLocator(['default' => static fn(): FakeClient => new FakeClient()]),
+        );
+
+        static::assertStringContainsString(
+            'cannot be explained',
+            (string) $controller->explainAction('tok', 'default', 0)->getContent(),
+        );
+    }
+
+    public function test_returns_message_when_connection_has_no_client(): void
+    {
+        $controller = $this->controller(
+            $this->profilerWith($this->collectorWith('SELECT 1', [])),
+            new ServiceLocator([]),
+        );
+
+        static::assertStringContainsString(
+            'cannot be explained',
+            (string) $controller->explainAction('tok', 'default', 0)->getContent(),
+        );
+    }
+
+    public function test_returns_message_when_explain_fails(): void
+    {
+        $failing = new FakeClient();
+        $failing->failNextQuery(QueryException::executionFailed('SELECT 1', PostgreSqlError::unknown('boom')));
+
+        $controller = $this->controller($this->profilerWith($this->collectorWith('SELECT 1', [])), new ServiceLocator([
+            'default' => static fn(): FakeClient => $failing,
+        ]));
+
+        static::assertStringContainsString(
+            'error occurred',
+            (string) $controller->explainAction('tok', 'default', 0)->getContent(),
+        );
+    }
+
+    /**
+     * @param list<mixed> $parameters
+     */
+    private function collectorWith(string $statement, array $parameters): FlowPostgreSqlDataCollector
+    {
+        $log = new QueryLog();
+        $log->add(new RecordedQuery($statement, $parameters, 1.0, 1, false, null));
+        $collector = new FlowPostgreSqlDataCollector($log, includeParameters: true);
+        $collector->lateCollect();
+
+        return $collector;
+    }
+
+    private function profilerWith(FlowPostgreSqlDataCollector $collector): Profiler
+    {
+        $profile = new Profile('tok');
+        $profile->addCollector($collector);
+
+        $profiler = $this->createMock(Profiler::class);
+        $profiler->method('loadProfile')->willReturn($profile);
+
+        return $profiler;
+    }
+
+    private function controller(Profiler $profiler, ServiceLocator $clients, string $renders = ''): ProfilerController
+    {
+        $twig = $this->createMock(Environment::class);
+        $twig->method('render')->willReturn($renders);
+
+        return new ProfilerController($twig, $clients, $profiler);
+    }
+}

--- a/src/bridge/symfony/telemetry-bundle/composer.json
+++ b/src/bridge/symfony/telemetry-bundle/composer.json
@@ -35,6 +35,8 @@
         "symfony/framework-bundle": "^6.4 || ^7.4 || ^8.0",
         "symfony/messenger": "^6.4 || ^7.4 || ^8.0",
         "symfony/routing": "^6.4 || ^7.4 || ^8.0",
+        "symfony/var-dumper": "^6.4 || ^7.4 || ^8.0",
+        "symfony/web-profiler-bundle": "^6.4 || ^7.4 || ^8.0",
         "twig/twig": "^3.0"
     },
     "suggest": {
@@ -42,6 +44,7 @@
         "flow-php/psr18-telemetry-bridge": "Required for PSR-18 HTTP client tracing",
         "flow-php/telemetry-otlp-bridge": "Required for OTLP exporter support",
         "symfony/messenger": "Required for Messenger tracing middleware",
+        "symfony/web-profiler-bundle": "Required for the dev-only Flow Telemetry Web Profiler panel",
         "twig/twig": "Required for Twig template tracing"
     },
     "autoload": {

--- a/src/bridge/symfony/telemetry-bundle/src/Flow/Bridge/Symfony/TelemetryBundle/DependencyInjection/Compiler/ProfilerSignalCapturePass.php
+++ b/src/bridge/symfony/telemetry-bundle/src/Flow/Bridge/Symfony/TelemetryBundle/DependencyInjection/Compiler/ProfilerSignalCapturePass.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\Bridge\Symfony\TelemetryBundle\DependencyInjection\Compiler;
+
+use Flow\Bridge\Symfony\TelemetryBundle\Exception\RuntimeException;
+use Flow\Telemetry\Provider\Composite\CompositeExporter;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+use function is_array;
+use function is_string;
+use function sprintf;
+
+final class ProfilerSignalCapturePass implements CompilerPassInterface
+{
+    private const string CAPTURED_EXPORTERS_PARAMETER = 'flow.telemetry.profiler.captured_exporters';
+
+    private const string STORE_SERVICE_ID = 'flow.telemetry.profiler.store';
+
+    public function process(ContainerBuilder $container): void
+    {
+        if (!$container->hasParameter(self::CAPTURED_EXPORTERS_PARAMETER)) {
+            return;
+        }
+
+        $capturedIds = $container->getParameter(self::CAPTURED_EXPORTERS_PARAMETER);
+
+        if (!is_array($capturedIds)) {
+            return;
+        }
+
+        // @mago-expect analysis:mixed-assignment
+        foreach ($capturedIds as $exporterId) {
+            if (!is_string($exporterId) || $exporterId === '') {
+                continue;
+            }
+
+            if ($container->hasAlias($exporterId)) {
+                throw new RuntimeException(sprintf(
+                    'Profiler capture cannot transparently decorate exporter "%s" because it is a service alias '
+                    . '(type: service). Decorate the aliased target id instead, or disable profiler capture for it.',
+                    $exporterId,
+                ));
+            }
+
+            if (!$container->hasDefinition($exporterId)) {
+                throw new RuntimeException(sprintf(
+                    'Profiler capture references exporter service "%s" which is not defined.',
+                    $exporterId,
+                ));
+            }
+
+            $innerId = $exporterId . '.profiler_tee.inner';
+
+            $decorator = new Definition(CompositeExporter::class);
+            $decorator->setDecoratedService($exporterId, $innerId);
+            $decorator->setArguments([
+                [
+                    new Reference($innerId),
+                    new Reference(self::STORE_SERVICE_ID),
+                ],
+            ]);
+
+            $container->setDefinition($exporterId . '.profiler_tee', $decorator);
+        }
+    }
+}

--- a/src/bridge/symfony/telemetry-bundle/src/Flow/Bridge/Symfony/TelemetryBundle/FlowTelemetryBundle.php
+++ b/src/bridge/symfony/telemetry-bundle/src/Flow/Bridge/Symfony/TelemetryBundle/FlowTelemetryBundle.php
@@ -13,6 +13,7 @@ use Flow\Bridge\Symfony\TelemetryBundle\DependencyInjection\Compiler\DBALTelemet
 use Flow\Bridge\Symfony\TelemetryBundle\DependencyInjection\Compiler\FrameworkLoggerPass;
 use Flow\Bridge\Symfony\TelemetryBundle\DependencyInjection\Compiler\HttpClientTelemetryPass;
 use Flow\Bridge\Symfony\TelemetryBundle\DependencyInjection\Compiler\OTLPAvailabilityPass;
+use Flow\Bridge\Symfony\TelemetryBundle\DependencyInjection\Compiler\ProfilerSignalCapturePass;
 use Flow\Bridge\Symfony\TelemetryBundle\DependencyInjection\Compiler\Psr18ClientTelemetryPass;
 use Flow\Bridge\Symfony\TelemetryBundle\Exception\RuntimeException;
 use Flow\Bridge\Symfony\TelemetryBundle\Resource\Detector\SymfonyDeploymentDetector;
@@ -114,6 +115,7 @@ use function implode;
 use function in_array;
 use function interface_exists;
 use function is_array;
+use function is_bool;
 use function is_int;
 use function is_string;
 use function sprintf;
@@ -135,12 +137,21 @@ final class FlowTelemetryBundle extends AbstractBundle
 
     private const string PSR18_TRACEABLE_CLIENT = 'Flow\\Bridge\\Psr18\\Telemetry\\PSR18TraceableClient';
 
+    private const string WEB_PROFILER_BUNDLE = 'Symfony\\Bundle\\WebProfilerBundle\\WebProfilerBundle';
+
+    #[Override]
+    public function getPath(): string
+    {
+        return __DIR__;
+    }
+
     #[Override]
     public function build(ContainerBuilder $container): void
     {
         parent::build($container);
 
         $container->addCompilerPass(new OTLPAvailabilityPass());
+        $container->addCompilerPass(new ProfilerSignalCapturePass());
         $container->addCompilerPass(new FrameworkLoggerPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, -64);
 
         $container->registerAttributeForAutoconfiguration(
@@ -564,6 +575,27 @@ final class FlowTelemetryBundle extends AbstractBundle
             ->end()
             ->end()
             ->end()
+            ->arrayNode('profiler')
+            ->info('Symfony Web Profiler integration (dev only; requires symfony/web-profiler-bundle)')
+            ->canBeUnset()
+            ->addDefaultsIfNotSet()
+            ->children()
+            ->variableNode('enabled')
+            ->info(
+                'null (default) = auto-enable iff WebProfilerBundle is present; true/false to force on/off',
+            )
+            ->defaultNull()
+            ->validate()
+            ->ifTrue(static fn (mixed $v): bool => $v !== null && !is_bool($v))
+            ->thenInvalid('flow_telemetry.profiler.enabled must be true, false, or null')
+            ->end()
+            ->end()
+            ->booleanNode('capture_logs')
+            ->info('Also tee logs into the profiler store (Symfony already has a Logs panel; off by default)')
+            ->defaultFalse()
+            ->end()
+            ->end()
+            ->end()
             ->arrayNode('tracers')
             ->info('Named tracer configurations')
             ->useAttributeAsKey('name')
@@ -673,7 +705,7 @@ final class FlowTelemetryBundle extends AbstractBundle
     }
 
     /**
-     * @param array{resource: array{detectors?: array{enabled?: bool, static?: array{cache?: array{enabled?: bool, path?: null|string}, os?: array{enabled?: bool}, host?: array{enabled?: bool}, service?: array{enabled?: bool}, deployment?: array{enabled?: bool}, environment?: array{enabled?: bool}}, dynamic?: array{process?: array{enabled?: bool}}}, custom?: array<string, mixed>}, clock_service_id?: null|string, framework_logger?: null|string, capture_framework_channels?: bool, channel_attribute_target?: 'scope'|'signal'|'both', context_storage?: array{type?: string, service_id?: null|string}, propagator?: array{type?: string, service_id?: null|string}, exporters?: array<string, array<string, mixed>>, error_handlers?: array<string, array<string, mixed>>, tracer_provider?: array<string, mixed>, meter_provider?: array<string, mixed>, logger_provider?: array<string, mixed>, instrumentation?: array{http_kernel?: array{enabled?: bool, exclude_paths?: array<array{path: string, method?: null|string}>, context_propagation?: bool}, console?: array{enabled?: bool, exclude_commands?: array<string>}, messenger?: array{enabled?: bool, context_propagation?: bool}, twig?: array{enabled?: bool, trace_templates?: bool, trace_blocks?: bool, trace_macros?: bool, exclude_templates?: array<string>}, http_client?: array{enabled?: bool, exclude_clients?: array<string>}, psr18_client?: array{enabled?: bool, exclude_clients?: array<string>}, dbal?: array{enabled?: bool, log_sql?: bool, max_sql_length?: int, exclude_connections?: array<string>}, cache?: array{enabled?: bool, exclude_pools?: array<string>}}, tracers?: array<string, array{version?: string, schema_url?: null|string, attributes?: array{scope?: array<string, mixed>, signal?: array<string, mixed>}}>, meters?: array<string, array{version?: string, schema_url?: null|string, attributes?: array{scope?: array<string, mixed>, signal?: array<string, mixed>}}>, loggers?: array<string, array{version?: string, schema_url?: null|string, attributes?: array{scope?: array<string, mixed>, signal?: array<string, mixed>}}>} $config
+     * @param array{resource: array{detectors?: array{enabled?: bool, static?: array{cache?: array{enabled?: bool, path?: null|string}, os?: array{enabled?: bool}, host?: array{enabled?: bool}, service?: array{enabled?: bool}, deployment?: array{enabled?: bool}, environment?: array{enabled?: bool}}, dynamic?: array{process?: array{enabled?: bool}}}, custom?: array<string, mixed>}, clock_service_id?: null|string, framework_logger?: null|string, capture_framework_channels?: bool, channel_attribute_target?: 'scope'|'signal'|'both', context_storage?: array{type?: string, service_id?: null|string}, propagator?: array{type?: string, service_id?: null|string}, exporters?: array<string, array<string, mixed>>, error_handlers?: array<string, array<string, mixed>>, tracer_provider?: array<string, mixed>, meter_provider?: array<string, mixed>, logger_provider?: array<string, mixed>, instrumentation?: array{http_kernel?: array{enabled?: bool, exclude_paths?: array<array{path: string, method?: null|string}>, context_propagation?: bool}, console?: array{enabled?: bool, exclude_commands?: array<string>}, messenger?: array{enabled?: bool, context_propagation?: bool}, twig?: array{enabled?: bool, trace_templates?: bool, trace_blocks?: bool, trace_macros?: bool, exclude_templates?: array<string>}, http_client?: array{enabled?: bool, exclude_clients?: array<string>}, psr18_client?: array{enabled?: bool, exclude_clients?: array<string>}, dbal?: array{enabled?: bool, log_sql?: bool, max_sql_length?: int, exclude_connections?: array<string>}, cache?: array{enabled?: bool, exclude_pools?: array<string>}}, profiler?: array{enabled?: bool|null, capture_logs?: bool}, tracers?: array<string, array{version?: string, schema_url?: null|string, attributes?: array{scope?: array<string, mixed>, signal?: array<string, mixed>}}>, meters?: array<string, array{version?: string, schema_url?: null|string, attributes?: array{scope?: array<string, mixed>, signal?: array<string, mixed>}}>, loggers?: array<string, array{version?: string, schema_url?: null|string, attributes?: array{scope?: array<string, mixed>, signal?: array<string, mixed>}}>} $config
      */
     #[Override]
     public function loadExtension(array $config, ContainerConfigurator $container, ContainerBuilder $builder): void
@@ -698,6 +730,7 @@ final class FlowTelemetryBundle extends AbstractBundle
         $this->registerTelemetry($config, $builder);
         $instrumentation = is_array($config['instrumentation'] ?? null) ? $config['instrumentation'] : [];
         $this->registerInstrumentation($instrumentation, $container, $builder);
+        $this->registerProfiler($config, $container, $builder);
         $this->registerTracers($tracers, $builder);
         $this->registerMeters($meters, $builder);
         $this->registerLoggers($loggers, $builder);
@@ -2554,6 +2587,131 @@ final class FlowTelemetryBundle extends AbstractBundle
         }
 
         $this->registerParameterOnlyInstrumentation($config, $builder);
+    }
+
+    /**
+     * @param array<array-key, mixed> $config
+     */
+    private function registerProfiler(array $config, ContainerConfigurator $container, ContainerBuilder $builder): void
+    {
+        $profilerConfig = is_array($config['profiler'] ?? null) ? $config['profiler'] : [];
+        // @mago-expect analysis:mixed-assignment
+        $enabled = $profilerConfig['enabled'] ?? null;
+        $captureLogs = (bool) ($profilerConfig['capture_logs'] ?? false);
+
+        $hasWebProfiler = $this->isWebProfilerBundleRegistered($builder);
+
+        if ($enabled === false) {
+            return;
+        }
+
+        if ($enabled === true && !$hasWebProfiler) {
+            throw new RuntimeException(
+                'Profiler integration requires symfony/web-profiler-bundle to be registered in the kernel. Install it (composer require --dev symfony/web-profiler-bundle) and enable it for this environment.',
+            );
+        }
+
+        if ($enabled === null && !$hasWebProfiler) {
+            return;
+        }
+
+        $tracerProviderConfig = is_array($config['tracer_provider'] ?? null) ? $config['tracer_provider'] : [];
+        $meterProviderConfig = is_array($config['meter_provider'] ?? null) ? $config['meter_provider'] : [];
+
+        $capturedIds = [];
+
+        foreach ($this->collectExporterServiceIds($tracerProviderConfig) as $id) {
+            $capturedIds[$id] = $id;
+        }
+
+        foreach ($this->collectExporterServiceIds($meterProviderConfig) as $id) {
+            $capturedIds[$id] = $id;
+        }
+
+        if ($captureLogs) {
+            $loggerProviderConfig = is_array($config['logger_provider'] ?? null) ? $config['logger_provider'] : [];
+
+            foreach ($this->collectExporterServiceIds($loggerProviderConfig) as $id) {
+                $capturedIds[$id] = $id;
+            }
+        }
+
+        $builder->setParameter('flow.telemetry.profiler.captured_exporters', array_values($capturedIds));
+        $builder->setParameter('flow.telemetry.profiler.capture_logs', $captureLogs);
+
+        $container->import(__DIR__ . '/Resources/config/profiler.php');
+    }
+
+    /**
+     * @param array<array-key, mixed> $providerConfig
+     *
+     * @return list<string>
+     */
+    private function collectExporterServiceIds(array $providerConfig): array
+    {
+        $processorConfig = is_array($providerConfig['processor'] ?? null) ? $providerConfig['processor'] : [];
+
+        $ids = [];
+
+        foreach ($this->collectExporterNames($processorConfig) as $name) {
+            $ids[] = 'flow.telemetry.exporter.' . $name;
+        }
+
+        return $ids;
+    }
+
+    /**
+     * @param array<array-key, mixed> $processorConfig
+     *
+     * @return list<string>
+     */
+    private function collectExporterNames(array $processorConfig): array
+    {
+        $names = [];
+
+        // @mago-expect analysis:mixed-assignment
+        $exporter = $processorConfig['exporter'] ?? null;
+
+        if (is_string($exporter) && $exporter !== '') {
+            $names[] = $exporter;
+        }
+
+        // @mago-expect analysis:mixed-assignment
+        $children = $processorConfig['processors'] ?? null;
+
+        // @mago-expect analysis:mixed-assignment
+        foreach (is_array($children) ? $children : [] as $child) {
+            if (is_array($child)) {
+                $names = [...$names, ...$this->collectExporterNames($child)];
+            }
+        }
+
+        foreach (['inner_processor', 'sink'] as $key) {
+            // @mago-expect analysis:mixed-assignment
+            $nested = $processorConfig[$key] ?? null;
+
+            if (is_array($nested)) {
+                $names = [...$names, ...$this->collectExporterNames($nested)];
+            }
+        }
+
+        return $names;
+    }
+
+    /**
+     * Auto-detect the profiler only when WebProfilerBundle is actually wired into the kernel, not
+     * merely installed in vendor. Detection is by registered class (the "kernel.bundles" value),
+     * which is stable across Symfony 6.4/7.4/8.0 regardless of the bundle's registration key.
+     */
+    private function isWebProfilerBundleRegistered(ContainerBuilder $builder): bool
+    {
+        if (!$builder->hasParameter('kernel.bundles')) {
+            return false;
+        }
+
+        $bundles = $builder->getParameter('kernel.bundles');
+
+        return is_array($bundles) && in_array(self::WEB_PROFILER_BUNDLE, $bundles, true);
     }
 
     /**

--- a/src/bridge/symfony/telemetry-bundle/src/Flow/Bridge/Symfony/TelemetryBundle/Profiler/FlowTelemetryDataCollector.php
+++ b/src/bridge/symfony/telemetry-bundle/src/Flow/Bridge/Symfony/TelemetryBundle/Profiler/FlowTelemetryDataCollector.php
@@ -1,0 +1,258 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\Bridge\Symfony\TelemetryBundle\Profiler;
+
+use Flow\Telemetry\Logger\LogEntry;
+use Flow\Telemetry\Logger\Severity;
+use Flow\Telemetry\Meter\Metric;
+use Flow\Telemetry\Provider\Memory\MemoryExporter;
+use Flow\Telemetry\Telemetry;
+use Flow\Telemetry\Tracer\Span;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\DataCollector\DataCollector;
+use Symfony\Component\HttpKernel\DataCollector\LateDataCollectorInterface;
+use Throwable;
+
+use function array_key_exists;
+use function array_map;
+use function array_sum;
+use function count;
+use function is_float;
+use function max;
+use function usort;
+
+/**
+ * @phpstan-type SpanRow array{name: string, kind: string, durationMs: null|float, startMs: float, offsetMs: float, startTime: string, scope: string, spanId: string, parentSpanId: null|string, depth: int, statusCode: int, statusDescription: null|string, attributes: array<string, mixed>, eventCount: int}
+ * @phpstan-type MetricRow array{name: string, type: string, value: float|int, unit: null|string, scope: string, attributes: array<string, mixed>}
+ * @phpstan-type LogRow array{severity: string, severityCode: int, message: string, scope: string, time: string, attributes: \Symfony\Component\VarDumper\Cloner\Data, hasAttributes: bool}
+ */
+final class FlowTelemetryDataCollector extends DataCollector implements LateDataCollectorInterface
+{
+    public function __construct(
+        private readonly Telemetry $telemetry,
+        private readonly MemoryExporter $exporter,
+    ) {}
+
+    public function collect(Request $request, Response $response, ?Throwable $exception = null): void {}
+
+    public function lateCollect(): void
+    {
+        // The bundle flushes telemetry on kernel.terminate (priority -20000), long after the
+        // profiler saves the profile.
+        $this->telemetry->flush();
+
+        $spans = $this->normalizeSpans($this->exporter->spans());
+
+        $timelineDurationMs = 0.0;
+
+        foreach ($spans as $span) {
+            $timelineDurationMs = max($timelineDurationMs, $span['offsetMs'] + ($span['durationMs'] ?? 0.0));
+        }
+
+        $this->data = [
+            'spans' => $spans,
+            'metrics' => $this->normalizeMetrics($this->exporter->metrics()),
+            'logs' => $this->normalizeLogs($this->exporter->logs()),
+            'totalDurationMs' => array_sum(array_map(static fn(array $s): float => $s['durationMs'] ?? 0.0, $spans)),
+            'timelineDurationMs' => $timelineDurationMs,
+        ];
+    }
+
+    public function reset(): void
+    {
+        $this->data = [];
+        $this->exporter->reset();
+    }
+
+    public function getName(): string
+    {
+        return 'flow_telemetry';
+    }
+
+    /**
+     * @return list<SpanRow>
+     */
+    public function getSpans(): array
+    {
+        // @mago-expect analysis:mixed-return-statement
+        return $this->data['spans'] ?? [];
+    }
+
+    /**
+     * @return list<MetricRow>
+     */
+    public function getMetrics(): array
+    {
+        // @mago-expect analysis:mixed-return-statement
+        return $this->data['metrics'] ?? [];
+    }
+
+    /**
+     * @return list<LogRow>
+     */
+    public function getLogs(): array
+    {
+        // @mago-expect analysis:mixed-return-statement
+        return $this->data['logs'] ?? [];
+    }
+
+    public function getSpanCount(): int
+    {
+        return count($this->getSpans());
+    }
+
+    public function getMetricCount(): int
+    {
+        return count($this->getMetrics());
+    }
+
+    public function getLogCount(): int
+    {
+        return count($this->getLogs());
+    }
+
+    public function getSignalCount(): int
+    {
+        return $this->getSpanCount() + $this->getMetricCount() + $this->getLogCount();
+    }
+
+    public function getTotalDurationMs(): float
+    {
+        // @mago-expect analysis:mixed-assignment
+        $value = $this->data['totalDurationMs'] ?? 0.0;
+
+        return is_float($value) ? $value : 0.0;
+    }
+
+    public function getTimelineDurationMs(): float
+    {
+        // @mago-expect analysis:mixed-assignment
+        $value = $this->data['timelineDurationMs'] ?? 0.0;
+
+        return is_float($value) ? $value : 0.0;
+    }
+
+    /**
+     * @param array<Span> $spans
+     *
+     * @return list<SpanRow>
+     */
+    private function normalizeSpans(array $spans): array
+    {
+        $parents = [];
+
+        foreach ($spans as $span) {
+            $context = $span->context()->normalize();
+            $parents[$context['spanId']['hex']] = $context['parentSpanId']['hex'] ?? null;
+        }
+
+        $rows = [];
+
+        foreach ($spans as $span) {
+            $context = $span->context()->normalize();
+            $status = $span->status()?->normalize();
+            $spanId = $context['spanId']['hex'];
+            $start = $span->startTime();
+
+            $rows[] = [
+                'name' => $span->name(),
+                'kind' => $span->kind()->value,
+                'durationMs' => $span->duration(),
+                'startMs' => ($start->getTimestamp() * 1000.0) + ((int) $start->format('u') / 1000.0),
+                'offsetMs' => 0.0,
+                'startTime' => $start->format('H:i:s.v'),
+                'scope' => $span->scope()->name,
+                'spanId' => $spanId,
+                'parentSpanId' => $parents[$spanId],
+                'depth' => $this->depthOf($spanId, $parents),
+                'statusCode' => $status['code'] ?? 0,
+                'statusDescription' => $status['description'] ?? null,
+                'attributes' => $span->attributesObject()->normalize(),
+                'eventCount' => count($span->events()),
+            ];
+        }
+
+        usort($rows, static fn(array $a, array $b): int => $a['startMs'] <=> $b['startMs']);
+
+        // Offsets are relative to the earliest span, which anchors the waterfall.
+        if ($rows !== []) {
+            $base = $rows[0]['startMs'];
+
+            foreach ($rows as $index => $row) {
+                $rows[$index]['offsetMs'] = $row['startMs'] - $base;
+            }
+        }
+
+        return $rows;
+    }
+
+    /**
+     * @param array<string, null|string> $parents
+     */
+    private function depthOf(string $spanId, array $parents): int
+    {
+        $depth = 0;
+        $current = $parents[$spanId] ?? null;
+
+        while ($current !== null && array_key_exists($current, $parents)) {
+            $depth++;
+            $current = $parents[$current];
+        }
+
+        return $depth;
+    }
+
+    /**
+     * @param array<Metric> $metrics
+     *
+     * @return list<MetricRow>
+     */
+    private function normalizeMetrics(array $metrics): array
+    {
+        $rows = [];
+
+        foreach ($metrics as $metric) {
+            $rows[] = [
+                'name' => $metric->name,
+                'type' => $metric->type->value,
+                'value' => $metric->value,
+                'unit' => $metric->unit,
+                'scope' => $metric->scope->name,
+                'attributes' => $metric->attributes->normalize(),
+            ];
+        }
+
+        return $rows;
+    }
+
+    /**
+     * @param array<LogEntry> $logs
+     *
+     * @return list<LogRow>
+     */
+    private function normalizeLogs(array $logs): array
+    {
+        $rows = [];
+
+        foreach ($logs as $log) {
+            $normalized = $log->normalize();
+            $severity = $normalized['record']['severity'];
+            $attributes = $normalized['record']['attributes'];
+
+            $rows[] = [
+                'severity' => Severity::tryFrom($severity)?->name() ?? 'unknown',
+                'severityCode' => $severity,
+                'message' => $normalized['record']['body'],
+                'scope' => $normalized['scope']['name'],
+                'time' => $normalized['timestamp'],
+                'attributes' => $this->cloneVar($attributes),
+                'hasAttributes' => $attributes !== [],
+            ];
+        }
+
+        return $rows;
+    }
+}

--- a/src/bridge/symfony/telemetry-bundle/src/Flow/Bridge/Symfony/TelemetryBundle/Resources/config/profiler.php
+++ b/src/bridge/symfony/telemetry-bundle/src/Flow/Bridge/Symfony/TelemetryBundle/Resources/config/profiler.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+use Flow\Bridge\Symfony\TelemetryBundle\Profiler\FlowTelemetryDataCollector;
+use Flow\Telemetry\Provider\Memory\MemoryExporter;
+use Flow\Telemetry\Telemetry;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
+
+return static function (ContainerConfigurator $container): void {
+    $services = $container->services();
+
+    $services->set('flow.telemetry.profiler.store', MemoryExporter::class)->public();
+
+    $services->set('flow.telemetry.profiler.collector', FlowTelemetryDataCollector::class)->args([
+        service(Telemetry::class),
+        service('flow.telemetry.profiler.store'),
+    ])->tag('data_collector', [
+        'id' => 'flow_telemetry',
+        'template' => '@FlowTelemetry/Collector/telemetry.html.twig',
+        'priority' => 250,
+    ]);
+};

--- a/src/bridge/symfony/telemetry-bundle/src/Flow/Bridge/Symfony/TelemetryBundle/Resources/views/Collector/telemetry.html.twig
+++ b/src/bridge/symfony/telemetry-bundle/src/Flow/Bridge/Symfony/TelemetryBundle/Resources/views/Collector/telemetry.html.twig
@@ -1,0 +1,243 @@
+{% extends '@WebProfiler/Profiler/layout.html.twig' %}
+
+{% macro attribute_table(attributes) %}
+    <table class="text-small">
+        <tbody>
+            {% for key, value in attributes %}
+                <tr>
+                    <th>{{ key }}</th>
+                    <td>{{ value is iterable ? value|json_encode : (value is same as(true) ? 'true' : (value is same as(false) ? 'false' : value)) }}</td>
+                </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+{% endmacro %}
+
+{% block toolbar %}
+    {% set icon %}
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20"><path fill="currentColor" d="M4 4h4v4H4V4zm6 3h10v2H10V7zM4 10h4v4H4v-4zm6 3h10v2H10v-2zM4 16h4v4H4v-4zm6 3h10v2H10v-2z"/></svg>
+        <span class="sf-toolbar-value">{{ collector.signalCount }}</span>
+        <span class="sf-toolbar-label">signals</span>
+    {% endset %}
+
+    {% set text %}
+        <div class="sf-toolbar-info-piece">
+            <b>Spans</b>
+            <span class="sf-toolbar-status">{{ collector.spanCount }}</span>
+        </div>
+        <div class="sf-toolbar-info-piece">
+            <b>Span time</b>
+            <span>{{ collector.totalDurationMs|number_format(2) }} ms</span>
+        </div>
+        <div class="sf-toolbar-info-piece">
+            <b>Metrics</b>
+            <span class="sf-toolbar-status">{{ collector.metricCount }}</span>
+        </div>
+        {% if collector.logCount > 0 %}
+            <div class="sf-toolbar-info-piece">
+                <b>Logs</b>
+                <span class="sf-toolbar-status">{{ collector.logCount }}</span>
+            </div>
+        {% endif %}
+    {% endset %}
+
+    {{ include('@WebProfiler/Profiler/toolbar_item.html.twig', { link: profiler_url, status: collector.signalCount > 0 ? '' : 'disabled' }) }}
+{% endblock %}
+
+{% block menu %}
+    <span class="label {{ collector.signalCount == 0 ? 'disabled' }}">
+        <span class="icon">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24"><path fill="currentColor" d="M4 4h4v4H4V4zm6 3h10v2H10V7zM4 10h4v4H4v-4zm6 3h10v2H10v-2zM4 16h4v4H4v-4zm6 3h10v2H10v-2z"/></svg>
+        </span>
+        <strong>Flow Telemetry</strong>
+        <span class="count">
+            <span>{{ collector.signalCount }}</span>
+        </span>
+    </span>
+{% endblock %}
+
+{% block panel %}
+    <h2>Flow Telemetry</h2>
+
+    <div class="metrics">
+        <div class="metric">
+            <span class="value">{{ collector.spanCount }}</span>
+            <span class="label">Spans</span>
+        </div>
+        <div class="metric">
+            <span class="value">{{ collector.totalDurationMs|number_format(2) }} <span class="unit">ms</span></span>
+            <span class="label">Total span time</span>
+        </div>
+        <div class="metric">
+            <span class="value">{{ collector.metricCount }}</span>
+            <span class="label">Metrics</span>
+        </div>
+        {% if collector.logCount > 0 %}
+            <div class="metric">
+                <span class="value">{{ collector.logCount }}</span>
+                <span class="label">Logs</span>
+            </div>
+        {% endif %}
+    </div>
+
+    <h3>Timeline</h3>
+
+    {% if collector.spans is empty %}
+        <div class="empty"><p>No spans were captured for this request.</p></div>
+    {% else %}
+        {% set total = collector.timelineDurationMs > 0 ? collector.timelineDurationMs : 1 %}
+        <style>
+            .flow-tl { width: 100%; border-collapse: collapse; font-size: 12px; }
+            .flow-tl td { padding: 5px 8px; border-bottom: 1px solid rgba(128, 128, 128, 0.2); vertical-align: middle; }
+            .flow-tl-name { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 340px; }
+            .flow-tl-track { position: relative; display: block; width: 100%; height: 14px; background: rgba(128, 128, 128, 0.18); border-radius: 7px; overflow: hidden; }
+            .flow-tl-bar { position: absolute; top: 0; bottom: 0; min-width: 2px; box-sizing: border-box; background: #3b82f6; }
+            .flow-tl-bar.kind-client { background: #8b5cf6; }
+            .flow-tl-bar.kind-server { background: #10b981; }
+            .flow-tl-bar.kind-internal { background: #3b82f6; }
+            .flow-tl-bar.kind-producer, .flow-tl-bar.kind-consumer { background: #f59e0b; }
+            .flow-tl-bar.is-error { background: #ef4444; }
+            .flow-tl-dur { text-align: right; white-space: nowrap; color: var(--color-muted, #999); font-variant-numeric: tabular-nums; }
+        </style>
+        <table class="flow-tl">
+            <tbody>
+                {% for span in collector.spans %}
+                    {% set left = span.offsetMs / total * 100 %}
+                    {% set width = max((span.durationMs ?? 0) / total * 100, 0.4) %}
+                    <tr>
+                        <td class="flow-tl-name" style="padding-left: {{ 8 + span.depth * 12 }}px" title="{{ span.name }} — {{ span.scope }}">
+                            {% if span.depth > 0 %}<span style="color: var(--color-muted);">└ </span>{% endif %}{{ span.name }}
+                        </td>
+                        <td style="width: 60%;">
+                            <div class="flow-tl-track">
+                                <div class="flow-tl-bar kind-{{ span.kind }}{{ span.statusCode == 2 ? ' is-error' }}" style="left: {{ left }}%; width: {{ width }}%;" title="+{{ span.offsetMs|number_format(2) }} ms"></div>
+                            </div>
+                        </td>
+                        <td class="flow-tl-dur">{{ span.durationMs is null ? '—' : span.durationMs|number_format(2) ~ ' ms' }}</td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+        <p class="text-small text-muted">Total window: {{ collector.timelineDurationMs|number_format(2) }} ms · bars are positioned relative to the first captured span.</p>
+    {% endif %}
+
+    <h3>Spans</h3>
+
+    {% if collector.spans is empty %}
+        <div class="empty"><p>No spans were captured for this request.</p></div>
+    {% else %}
+        <table>
+            <thead>
+                <tr>
+                    <th>Name</th>
+                    <th>Kind</th>
+                    <th>Scope</th>
+                    <th class="text-right">Duration</th>
+                    <th>Status</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for span in collector.spans %}
+                    <tr>
+                        <td>
+                            <span style="display:inline-block; width: {{ span.depth * 16 }}px;"></span>
+                            {% if span.depth > 0 %}<span style="color: var(--color-muted);">└ </span>{% endif %}
+                            <span title="{{ span.spanId }}">{{ span.name }}</span>
+                            {% if span.attributes is not empty %}
+                                <a class="btn btn-link text-small sf-toggle" data-toggle-selector="#span-attr-{{ loop.index }}" data-toggle-alt-content="Hide attributes">Attributes ({{ span.attributes|length }})</a>
+                                <div id="span-attr-{{ loop.index }}" class="hidden">
+                                    {{ _self.attribute_table(span.attributes) }}
+                                </div>
+                            {% endif %}
+                        </td>
+                        <td>{{ span.kind }}</td>
+                        <td>{{ span.scope }}</td>
+                        <td class="text-right">{{ span.durationMs is null ? '—' : span.durationMs|number_format(2) ~ ' ms' }}</td>
+                        <td>
+                            {% if span.statusCode == 2 %}
+                                <span class="label status-error">error</span>
+                                {% if span.statusDescription %}<span class="text-small text-muted">{{ span.statusDescription }}</span>{% endif %}
+                            {% elseif span.statusCode == 1 %}
+                                <span class="label status-success">ok</span>
+                            {% else %}
+                                <span class="label">unset</span>
+                            {% endif %}
+                        </td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    {% endif %}
+
+    <h3>Metrics</h3>
+
+    {% if collector.metrics is empty %}
+        <div class="empty"><p>No metrics were recorded for this request.</p></div>
+    {% else %}
+        <table>
+            <thead>
+                <tr>
+                    <th>Name</th>
+                    <th>Type</th>
+                    <th class="text-right">Value</th>
+                    <th>Unit</th>
+                    <th>Scope</th>
+                    <th>Attributes</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for metric in collector.metrics %}
+                    <tr>
+                        <td>{{ metric.name }}</td>
+                        <td>{{ metric.type }}</td>
+                        <td class="text-right">{{ metric.value }}</td>
+                        <td>{{ metric.unit ?? '—' }}</td>
+                        <td>{{ metric.scope }}</td>
+                        <td>
+                            {% if metric.attributes is empty %}
+                                —
+                            {% else %}
+                                <a class="btn btn-link text-small sf-toggle" data-toggle-selector="#metric-attr-{{ loop.index }}" data-toggle-alt-content="Hide attributes">Attributes ({{ metric.attributes|length }})</a>
+                                <div id="metric-attr-{{ loop.index }}" class="hidden">
+                                    {{ _self.attribute_table(metric.attributes) }}
+                                </div>
+                            {% endif %}
+                        </td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    {% endif %}
+
+    {% if collector.logs is not empty %}
+        <h3>Logs</h3>
+        <table>
+            <thead>
+                <tr>
+                    <th>Severity</th>
+                    <th>Scope</th>
+                    <th>Message</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for log in collector.logs %}
+                    <tr>
+                        <td><span class="label {{ log.severityCode >= 17 ? 'status-error' : (log.severityCode >= 13 ? 'status-warning') }}">{{ log.severity|lower }}</span></td>
+                        <td>{{ log.scope }}</td>
+                        <td>
+                            <code>{{ log.message }}</code>
+                            {% if log.hasAttributes %}
+                                <div>
+                                    <a class="btn btn-link text-small sf-toggle" data-toggle-selector="#log-attr-{{ loop.index }}" data-toggle-alt-content="Hide attributes">Show attributes</a>
+                                </div>
+                                <div id="log-attr-{{ loop.index }}" class="context sf-toggle-content sf-toggle-hidden hidden">
+                                    {{ profiler_dump(log.attributes, maxDepth: 1) }}
+                                </div>
+                            {% endif %}
+                        </td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    {% endif %}
+{% endblock %}

--- a/src/bridge/symfony/telemetry-bundle/tests/Flow/Bridge/Symfony/TelemetryBundle/Tests/Fixtures/config/profiler_panel_routes.php
+++ b/src/bridge/symfony/telemetry-bundle/tests/Flow/Bridge/Symfony/TelemetryBundle/Tests/Fixtures/config/profiler_panel_routes.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
+
+return static function (RoutingConfigurator $routes): void {
+    $routes->import('@WebProfilerBundle/Resources/config/routing/profiler.xml')->prefix('/_profiler');
+};

--- a/src/bridge/symfony/telemetry-bundle/tests/Flow/Bridge/Symfony/TelemetryBundle/Tests/Integration/Profiler/FlowTelemetryProfilerTest.php
+++ b/src/bridge/symfony/telemetry-bundle/tests/Flow/Bridge/Symfony/TelemetryBundle/Tests/Integration/Profiler/FlowTelemetryProfilerTest.php
@@ -1,0 +1,269 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\Bridge\Symfony\TelemetryBundle\Tests\Integration\Profiler;
+
+use Flow\Bridge\Symfony\TelemetryBundle\Exception\RuntimeException;
+use Flow\Bridge\Symfony\TelemetryBundle\FlowTelemetryBundle;
+use Flow\Bridge\Symfony\TelemetryBundle\Profiler\FlowTelemetryDataCollector;
+use Flow\Bridge\Symfony\TelemetryBundle\Tests\Fixtures\Controller\TestController;
+use Flow\Bridge\Symfony\TelemetryBundle\Tests\Fixtures\TestKernel;
+use Flow\Bridge\Symfony\TelemetryBundle\Tests\Integration\KernelTestCase;
+use Flow\Telemetry\Provider\Composite\CompositeExporter;
+use Flow\Telemetry\Provider\Memory\MemoryExporter;
+use Flow\Telemetry\Signal\Signals;
+use Flow\Telemetry\Telemetry;
+use Flow\Telemetry\Tests\Mother\SpanMother;
+use Override;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Bundle\TwigBundle\TwigBundle;
+use Symfony\Bundle\WebProfilerBundle\WebProfilerBundle;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\Compiler\PassConfig;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Profiler\Profiler;
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\Router;
+
+use function array_merge;
+
+#[CoversClass(FlowTelemetryBundle::class)]
+#[CoversClass(FlowTelemetryDataCollector::class)]
+final class FlowTelemetryProfilerTest extends KernelTestCase
+{
+    #[Override]
+    protected function tearDown(): void
+    {
+        restore_exception_handler();
+        parent::tearDown();
+    }
+
+    public function test_collector_is_registered_with_the_profiler_when_enabled(): void
+    {
+        $container = $this->bootWithWebProfiler(['enabled' => true])->getContainer();
+
+        /** @var Profiler $profiler */
+        $profiler = $container->get('profiler');
+
+        static::assertTrue($profiler->has('flow_telemetry'));
+        static::assertInstanceOf(FlowTelemetryDataCollector::class, $profiler->get('flow_telemetry'));
+        static::assertInstanceOf(MemoryExporter::class, $container->get('flow.telemetry.profiler.store'));
+    }
+
+    public function test_captured_exporter_is_decorated_and_tees_into_the_store(): void
+    {
+        $container = $this->bootWithWebProfiler(['enabled' => true])->getContainer();
+
+        $exporter = $container->get('flow.telemetry.exporter.memory');
+        static::assertInstanceOf(CompositeExporter::class, $exporter);
+
+        /** @var MemoryExporter $store */
+        $store = $container->get('flow.telemetry.profiler.store');
+        $exporter->export(Signals::traces([SpanMother::withName('decorated-span')]));
+
+        static::assertCount(1, $store->spans());
+    }
+
+    public function test_collector_is_not_registered_when_disabled(): void
+    {
+        $container = $this->bootWithWebProfiler(['enabled' => false])->getContainer();
+
+        static::assertFalse($container->has('flow.telemetry.profiler.collector'));
+        static::assertFalse($container->has('flow.telemetry.profiler.store'));
+        static::assertInstanceOf(MemoryExporter::class, $container->get('flow.telemetry.exporter.memory'));
+    }
+
+    public function test_auto_enables_when_web_profiler_bundle_is_registered(): void
+    {
+        $container = $this->bootWithWebProfiler([])->getContainer();
+
+        static::assertTrue($container->has('flow.telemetry.profiler.collector'));
+    }
+
+    public function test_auto_disabled_when_web_profiler_bundle_is_absent(): void
+    {
+        $container = $this->bootWithoutWebProfiler([])->getContainer();
+
+        static::assertFalse($container->has('flow.telemetry.profiler.collector'));
+    }
+
+    public function test_forcing_enabled_without_web_profiler_bundle_throws(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Profiler integration requires symfony/web-profiler-bundle');
+
+        $this->bootWithoutWebProfiler(['enabled' => true]);
+    }
+
+    public function test_panel_renders_captured_spans_in_the_profiler(): void
+    {
+        $kernel = $this->bootForPanelRendering();
+        $container = $kernel->getContainer();
+
+        /** @var Router $router */
+        $router = $container->get('router');
+        $router->getRouteCollection()->add('test_index', new Route('/test', [
+            '_controller' => TestController::class . '::index',
+        ]));
+
+        // Emit a span that ends before the request handles, so it is flushed into the store at
+        // profiler-save time (the http_kernel root span ends later and is intentionally not captured).
+        /** @var Telemetry $telemetry */
+        $telemetry = $container->get(Telemetry::class);
+        $telemetry->tracer('app')->trace('controller_work', static fn(): ?string => null);
+
+        $request = Request::create('/test', 'GET');
+        $response = $kernel->handle($request);
+        $token = $response->headers->get('X-Debug-Token');
+        $kernel->terminate($request, $response);
+
+        static::assertNotNull($token, 'The request must produce a profiler token');
+
+        $panel = $kernel->handle(Request::create('/_profiler/' . $token . '?panel=flow_telemetry'));
+        $html = (string) $panel->getContent();
+
+        static::assertSame(200, $panel->getStatusCode());
+        static::assertStringContainsString('Flow Telemetry', $html);
+        static::assertStringContainsString('controller_work', $html);
+        static::assertStringContainsString('Timeline', $html);
+    }
+
+    public function test_spans_are_captured_after_a_request(): void
+    {
+        $kernel = $this->bootWithWebProfiler(['enabled' => true]);
+        $container = $kernel->getContainer();
+
+        /** @var Router $router */
+        $router = $container->get('router');
+        $router->getRouteCollection()->add('test_index', new Route('/test', [
+            '_controller' => TestController::class . '::index',
+        ]));
+
+        $request = Request::create('/test', 'GET');
+        $response = $kernel->handle($request);
+        $kernel->terminate($request, $response);
+
+        /** @var FlowTelemetryDataCollector $collector */
+        $collector = $container->get('flow.telemetry.profiler.collector');
+        $collector->lateCollect();
+
+        static::assertGreaterThanOrEqual(1, $collector->getSpanCount());
+    }
+
+    /**
+     * @param array{enabled?: bool|null, capture_logs?: bool} $profilerConfig
+     */
+    private function bootWithWebProfiler(array $profilerConfig): TestKernel
+    {
+        return $this->bootKernel([
+            'config' => function (TestKernel $kernel) use ($profilerConfig): void {
+                $kernel->addTestBundle(FrameworkBundle::class);
+                $kernel->addTestBundle(TwigBundle::class);
+                $kernel->addTestBundle(WebProfilerBundle::class);
+                $kernel->addTestExtensionConfig('framework', array_merge($this->frameworkConfig(), [
+                    'profiler' => ['enabled' => true, 'collect' => true],
+                ]));
+                $kernel->addTestExtensionConfig('twig', ['debug' => true, 'strict_variables' => true]);
+                $kernel->addTestExtensionConfig('web_profiler', ['toolbar' => false, 'intercept_redirects' => false]);
+                $kernel->addTestExtensionConfig('flow_telemetry', $this->flowConfig($profilerConfig));
+                $this->publishProfilerService($kernel);
+            },
+        ]);
+    }
+
+    private function bootForPanelRendering(): TestKernel
+    {
+        return $this->bootKernel([
+            'config' => function (TestKernel $kernel): void {
+                $kernel->addTestBundle(FrameworkBundle::class);
+                $kernel->addTestBundle(TwigBundle::class);
+                $kernel->addTestBundle(WebProfilerBundle::class);
+                $kernel->addTestExtensionConfig('framework', [
+                    'router' => [
+                        'utf8' => true,
+                        'resource' => __DIR__ . '/../../Fixtures/config/profiler_panel_routes.php',
+                    ],
+                    'http_method_override' => false,
+                    'handle_all_throwables' => true,
+                    'profiler' => ['enabled' => true, 'collect' => true],
+                ]);
+                $kernel->addTestExtensionConfig('twig', ['debug' => true, 'strict_variables' => false]);
+                $kernel->addTestExtensionConfig('web_profiler', ['toolbar' => false, 'intercept_redirects' => false]);
+                $kernel->addTestExtensionConfig('flow_telemetry', $this->flowConfig(['enabled' => true]));
+                $this->publishProfilerService($kernel);
+            },
+        ]);
+    }
+
+    /**
+     * @param array{enabled?: bool|null, capture_logs?: bool} $profilerConfig
+     */
+    private function bootWithoutWebProfiler(array $profilerConfig): TestKernel
+    {
+        return $this->bootKernel([
+            'config' => function (TestKernel $kernel) use ($profilerConfig): void {
+                $kernel->addTestBundle(FrameworkBundle::class);
+                $kernel->addTestExtensionConfig('framework', $this->frameworkConfig());
+                $kernel->addTestExtensionConfig('flow_telemetry', $this->flowConfig($profilerConfig));
+            },
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function frameworkConfig(): array
+    {
+        return [
+            'router' => [
+                'utf8' => true,
+                'resource' => __DIR__ . '/../../Fixtures/config/routes.php',
+            ],
+            'http_method_override' => false,
+            'handle_all_throwables' => true,
+        ];
+    }
+
+    /**
+     * @param array{enabled?: bool|null, capture_logs?: bool} $profilerConfig
+     *
+     * @return array<string, mixed>
+     */
+    private function flowConfig(array $profilerConfig): array
+    {
+        return [
+            'resource' => [],
+            'exporters' => ['memory' => ['memory' => null]],
+            'tracer_provider' => [
+                'processor' => ['type' => 'batching', 'batch_size' => 100, 'exporter' => 'memory'],
+            ],
+            'profiler' => $profilerConfig,
+            'instrumentation' => [
+                'http_kernel' => ['enabled' => true],
+                'console' => ['enabled' => false],
+                'messenger' => false,
+            ],
+        ];
+    }
+
+    private function publishProfilerService(TestKernel $kernel): void
+    {
+        $kernel->addTestContainerConfigurator(static function (ContainerBuilder $container): void {
+            $container->addCompilerPass(
+                new class implements CompilerPassInterface {
+                    public function process(ContainerBuilder $container): void
+                    {
+                        if ($container->hasDefinition('profiler')) {
+                            $container->getDefinition('profiler')->setPublic(true);
+                        }
+                    }
+                },
+                PassConfig::TYPE_BEFORE_OPTIMIZATION,
+                -256,
+            );
+        });
+    }
+}

--- a/src/bridge/symfony/telemetry-bundle/tests/Flow/Bridge/Symfony/TelemetryBundle/Tests/Integration/Profiler/FlowTelemetryProfilerTest.php
+++ b/src/bridge/symfony/telemetry-bundle/tests/Flow/Bridge/Symfony/TelemetryBundle/Tests/Integration/Profiler/FlowTelemetryProfilerTest.php
@@ -153,6 +153,50 @@ final class FlowTelemetryProfilerTest extends KernelTestCase
         static::assertGreaterThanOrEqual(1, $collector->getSpanCount());
     }
 
+    public function test_capture_logs_and_composite_processor_exporters_are_decorated(): void
+    {
+        $kernel = $this->bootKernel([
+            'config' => function (TestKernel $kernel): void {
+                $kernel->addTestBundle(FrameworkBundle::class);
+                $kernel->addTestBundle(TwigBundle::class);
+                $kernel->addTestBundle(WebProfilerBundle::class);
+                $kernel->addTestExtensionConfig('framework', array_merge($this->frameworkConfig(), [
+                    'profiler' => ['enabled' => true, 'collect' => true],
+                ]));
+                $kernel->addTestExtensionConfig('twig', ['debug' => true, 'strict_variables' => true]);
+                $kernel->addTestExtensionConfig('web_profiler', ['toolbar' => false, 'intercept_redirects' => false]);
+                $kernel->addTestExtensionConfig('flow_telemetry', [
+                    'resource' => [],
+                    'exporters' => [
+                        'traces_a' => ['memory' => null],
+                        'traces_b' => ['memory' => null],
+                        'app_logs' => ['memory' => null],
+                    ],
+                    // Composite processor exercises the recursive exporter-id collection.
+                    'tracer_provider' => [
+                        'processor' => [
+                            'type' => 'composite',
+                            'processors' => [
+                                ['type' => 'batching', 'exporter' => 'traces_a'],
+                                ['type' => 'batching', 'exporter' => 'traces_b'],
+                            ],
+                        ],
+                    ],
+                    'logger_provider' => [
+                        'processor' => ['type' => 'batching', 'exporter' => 'app_logs'],
+                    ],
+                    'profiler' => ['enabled' => true, 'capture_logs' => true],
+                ]);
+                $this->publishProfilerService($kernel);
+            },
+        ]);
+        $container = $kernel->getContainer();
+
+        static::assertInstanceOf(CompositeExporter::class, $container->get('flow.telemetry.exporter.traces_a'));
+        static::assertInstanceOf(CompositeExporter::class, $container->get('flow.telemetry.exporter.traces_b'));
+        static::assertInstanceOf(CompositeExporter::class, $container->get('flow.telemetry.exporter.app_logs'));
+    }
+
     /**
      * @param array{enabled?: bool|null, capture_logs?: bool} $profilerConfig
      */

--- a/src/bridge/symfony/telemetry-bundle/tests/Flow/Bridge/Symfony/TelemetryBundle/Tests/Unit/DependencyInjection/Compiler/ProfilerSignalCapturePassTest.php
+++ b/src/bridge/symfony/telemetry-bundle/tests/Flow/Bridge/Symfony/TelemetryBundle/Tests/Unit/DependencyInjection/Compiler/ProfilerSignalCapturePassTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\Bridge\Symfony\TelemetryBundle\Tests\Unit\DependencyInjection\Compiler;
+
+use Flow\Bridge\Symfony\TelemetryBundle\DependencyInjection\Compiler\ProfilerSignalCapturePass;
+use Flow\Bridge\Symfony\TelemetryBundle\Exception\RuntimeException;
+use Flow\Telemetry\Provider\Composite\CompositeExporter;
+use Flow\Telemetry\Provider\Void\VoidExporter;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+#[CoversClass(ProfilerSignalCapturePass::class)]
+final class ProfilerSignalCapturePassTest extends TestCase
+{
+    public function test_no_op_when_parameter_absent(): void
+    {
+        $container = new ContainerBuilder();
+        $container->setDefinition('flow.telemetry.exporter.primary', new Definition(VoidExporter::class));
+
+        (new ProfilerSignalCapturePass())->process($container);
+
+        static::assertFalse($container->hasDefinition('flow.telemetry.exporter.primary.profiler_tee'));
+    }
+
+    public function test_no_op_when_captured_list_empty(): void
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('flow.telemetry.profiler.captured_exporters', []);
+
+        (new ProfilerSignalCapturePass())->process($container);
+
+        static::assertFalse($container->hasDefinition('flow.telemetry.exporter.primary.profiler_tee'));
+    }
+
+    public function test_decorates_captured_exporter_into_a_composite(): void
+    {
+        $container = new ContainerBuilder();
+        $container->setDefinition('flow.telemetry.exporter.primary', new Definition(VoidExporter::class));
+        $container->setParameter('flow.telemetry.profiler.captured_exporters', ['flow.telemetry.exporter.primary']);
+
+        (new ProfilerSignalCapturePass())->process($container);
+
+        $decorator = $container->getDefinition('flow.telemetry.exporter.primary.profiler_tee');
+        static::assertSame(CompositeExporter::class, $decorator->getClass());
+        $decorated = $decorator->getDecoratedService();
+        static::assertNotNull($decorated);
+        static::assertSame('flow.telemetry.exporter.primary', $decorated[0]);
+        static::assertSame('flow.telemetry.exporter.primary.profiler_tee.inner', $decorated[1]);
+    }
+
+    public function test_throws_when_captured_exporter_is_an_alias(): void
+    {
+        $container = new ContainerBuilder();
+        $container->setAlias('flow.telemetry.exporter.primary', 'some.real.exporter');
+        $container->setParameter('flow.telemetry.profiler.captured_exporters', ['flow.telemetry.exporter.primary']);
+
+        $this->expectException(RuntimeException::class);
+
+        (new ProfilerSignalCapturePass())->process($container);
+    }
+
+    public function test_throws_when_captured_exporter_is_not_defined(): void
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('flow.telemetry.profiler.captured_exporters', ['flow.telemetry.exporter.missing']);
+
+        $this->expectException(RuntimeException::class);
+
+        (new ProfilerSignalCapturePass())->process($container);
+    }
+}

--- a/src/bridge/symfony/telemetry-bundle/tests/Flow/Bridge/Symfony/TelemetryBundle/Tests/Unit/Profiler/FlowTelemetryDataCollectorTest.php
+++ b/src/bridge/symfony/telemetry-bundle/tests/Flow/Bridge/Symfony/TelemetryBundle/Tests/Unit/Profiler/FlowTelemetryDataCollectorTest.php
@@ -1,0 +1,252 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\Bridge\Symfony\TelemetryBundle\Tests\Unit\Profiler;
+
+use DateTimeImmutable;
+use Flow\Bridge\Symfony\TelemetryBundle\Profiler\FlowTelemetryDataCollector;
+use Flow\Telemetry\Context\SpanId;
+use Flow\Telemetry\Context\TraceId;
+use Flow\Telemetry\Logger\Severity;
+use Flow\Telemetry\Provider\Memory\MemoryExporter;
+use Flow\Telemetry\Signal\Signals;
+use Flow\Telemetry\Tests\Mother\LogEntryMother;
+use Flow\Telemetry\Tests\Mother\MetricMother;
+use Flow\Telemetry\Tests\Mother\ResourceMother;
+use Flow\Telemetry\Tests\Mother\SpanMother;
+use Flow\Telemetry\Tracer\Span;
+use Flow\Telemetry\Tracer\SpanKind;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+use function array_map;
+use function Flow\Telemetry\DSL\telemetry;
+use function sprintf;
+
+#[CoversClass(FlowTelemetryDataCollector::class)]
+final class FlowTelemetryDataCollectorTest extends TestCase
+{
+    private const string TRACE_ID = '0123456789abcdef0123456789abcdef';
+
+    private const string ROOT_ID = '1111111111111111';
+
+    private const string CHILD_ID = '2222222222222222';
+
+    private const string GRANDCHILD_ID = '3333333333333333';
+
+    public function test_get_name_is_flow_telemetry(): void
+    {
+        $store = new MemoryExporter();
+
+        static::assertSame('flow_telemetry', $this->collector($store)->getName());
+    }
+
+    public function test_late_collect_orders_span_rows_by_start_time(): void
+    {
+        $store = $this->storeWithSpanTree();
+        $collector = $this->collector($store);
+
+        $collector->lateCollect();
+
+        $names = array_map(static fn(array $row): string => $row['name'], $collector->getSpans());
+        static::assertSame(['root', 'child', 'grandchild'], $names);
+    }
+
+    public function test_late_collect_computes_depth_from_parent_chain(): void
+    {
+        $store = $this->storeWithSpanTree();
+        $collector = $this->collector($store);
+
+        $collector->lateCollect();
+
+        $depthByName = [];
+
+        foreach ($collector->getSpans() as $row) {
+            $depthByName[$row['name']] = $row['depth'];
+        }
+
+        static::assertSame(['root' => 0, 'child' => 1, 'grandchild' => 2], $depthByName);
+    }
+
+    public function test_late_collect_offsets_are_relative_to_earliest_span(): void
+    {
+        $store = $this->storeWithSpanTree();
+        $collector = $this->collector($store);
+
+        $collector->lateCollect();
+
+        $offsetByName = [];
+
+        foreach ($collector->getSpans() as $row) {
+            $offsetByName[$row['name']] = $row['offsetMs'];
+        }
+
+        static::assertSame(0.0, $offsetByName['root']);
+        static::assertSame(5.0, $offsetByName['child']);
+        static::assertSame(8.0, $offsetByName['grandchild']);
+    }
+
+    public function test_late_collect_computes_timeline_window_from_latest_end(): void
+    {
+        $store = $this->storeWithSpanTree();
+        $collector = $this->collector($store);
+
+        $collector->lateCollect();
+
+        static::assertSame(50.0, $collector->getTimelineDurationMs());
+    }
+
+    public function test_late_collect_totals_span_durations(): void
+    {
+        $store = $this->storeWithSpanTree();
+        $collector = $this->collector($store);
+
+        $collector->lateCollect();
+
+        static::assertSame(3, $collector->getSpanCount());
+        static::assertSame(69.0, $collector->getTotalDurationMs());
+    }
+
+    public function test_late_collect_normalizes_metric_rows(): void
+    {
+        $store = new MemoryExporter();
+        $store->export(Signals::metrics([MetricMother::counter('app.requests', 5, 'count')]));
+        $collector = $this->collector($store);
+
+        $collector->lateCollect();
+
+        static::assertSame(1, $collector->getMetricCount());
+        $metric = $collector->getMetrics()[0];
+        static::assertSame('app.requests', $metric['name']);
+        static::assertSame(5, $metric['value']);
+        static::assertSame('count', $metric['unit']);
+    }
+
+    public function test_late_collect_normalizes_log_rows(): void
+    {
+        $store = new MemoryExporter();
+        $store->export(Signals::logs([LogEntryMother::create('something happened', Severity::WARN)]));
+        $collector = $this->collector($store);
+
+        $collector->lateCollect();
+
+        static::assertSame(1, $collector->getLogCount());
+        $log = $collector->getLogs()[0];
+        static::assertSame('something happened', $log['message']);
+        static::assertSame('WARN', $log['severity']);
+        static::assertSame(13, $log['severityCode']);
+        static::assertFalse($log['hasAttributes']);
+    }
+
+    public function test_late_collect_flags_logs_with_attributes(): void
+    {
+        $store = new MemoryExporter();
+        $store->export(Signals::logs([LogEntryMother::create('with ctx', Severity::INFO, ['user_id' => 7])]));
+        $collector = $this->collector($store);
+
+        $collector->lateCollect();
+
+        static::assertTrue($collector->getLogs()[0]['hasAttributes']);
+    }
+
+    public function test_logs_are_empty_when_none_captured(): void
+    {
+        $collector = $this->collector(new MemoryExporter());
+
+        $collector->lateCollect();
+
+        static::assertSame(0, $collector->getLogCount());
+        static::assertSame([], $collector->getLogs());
+    }
+
+    public function test_signal_count_sums_spans_metrics_and_logs(): void
+    {
+        $store = $this->storeWithSpanTree();
+        $store->export(Signals::metrics([MetricMother::counter('app.requests', 1)]));
+        $store->export(Signals::logs([LogEntryMother::create('hello', Severity::INFO)]));
+        $collector = $this->collector($store);
+
+        $collector->lateCollect();
+
+        static::assertSame(3, $collector->getSpanCount());
+        static::assertSame(1, $collector->getMetricCount());
+        static::assertSame(1, $collector->getLogCount());
+        static::assertSame(5, $collector->getSignalCount());
+    }
+
+    public function test_reset_clears_data_and_store(): void
+    {
+        $store = $this->storeWithSpanTree();
+        $collector = $this->collector($store);
+        $collector->lateCollect();
+
+        $collector->reset();
+
+        static::assertSame([], $collector->getSpans());
+        static::assertSame(0, $collector->getSpanCount());
+        static::assertSame([], $store->spans());
+    }
+
+    public function test_empty_store_yields_no_rows(): void
+    {
+        $collector = $this->collector(new MemoryExporter());
+
+        $collector->lateCollect();
+
+        static::assertSame([], $collector->getSpans());
+        static::assertSame(0, $collector->getSpanCount());
+        static::assertSame(0.0, $collector->getTimelineDurationMs());
+    }
+
+    private function collector(MemoryExporter $store): FlowTelemetryDataCollector
+    {
+        return new FlowTelemetryDataCollector(telemetry(ResourceMother::default()), $store);
+    }
+
+    private function storeWithSpanTree(): MemoryExporter
+    {
+        $traceId = TraceId::fromHex(self::TRACE_ID);
+        $base = new DateTimeImmutable('2024-01-01T00:00:00.000000+00:00');
+
+        $root = $this->endedSpan('root', $traceId, SpanId::fromHex(self::ROOT_ID), null, SpanKind::SERVER, $base, 50.0);
+        $child = $this->endedSpan(
+            'child',
+            $traceId,
+            SpanId::fromHex(self::CHILD_ID),
+            SpanId::fromHex(self::ROOT_ID),
+            SpanKind::INTERNAL,
+            $base->modify('+5000 microseconds'),
+            15.0,
+        );
+        $grandchild = $this->endedSpan(
+            'grandchild',
+            $traceId,
+            SpanId::fromHex(self::GRANDCHILD_ID),
+            SpanId::fromHex(self::CHILD_ID),
+            SpanKind::CLIENT,
+            $base->modify('+8000 microseconds'),
+            4.0,
+        );
+
+        $store = new MemoryExporter();
+        // Inserted out of start order to prove the collector sorts by start time.
+        $store->export(Signals::traces([$grandchild, $root, $child]));
+
+        return $store;
+    }
+
+    private function endedSpan(
+        string $name,
+        TraceId $traceId,
+        SpanId $spanId,
+        ?SpanId $parentSpanId,
+        SpanKind $kind,
+        DateTimeImmutable $startTime,
+        float $durationMs,
+    ): Span {
+        $span = SpanMother::create($name, $traceId, $spanId, $parentSpanId, $kind, $startTime);
+
+        return $span->end($startTime->modify(sprintf('+%d microseconds', (int) ($durationMs * 1000))));
+    }
+}

--- a/src/lib/postgresql/src/Flow/PostgreSql/Client/Debug/QueryLog.php
+++ b/src/lib/postgresql/src/Flow/PostgreSql/Client/Debug/QueryLog.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\PostgreSql\Client\Debug;
+
+final class QueryLog
+{
+    /**
+     * @var list<RecordedQuery>
+     */
+    private array $queries = [];
+
+    public function add(RecordedQuery $query): void
+    {
+        $this->queries[] = $query;
+    }
+
+    /**
+     * @return list<RecordedQuery>
+     */
+    public function queries(): array
+    {
+        return $this->queries;
+    }
+
+    public function reset(): void
+    {
+        $this->queries = [];
+    }
+}

--- a/src/lib/postgresql/src/Flow/PostgreSql/Client/Debug/RecordedQuery.php
+++ b/src/lib/postgresql/src/Flow/PostgreSql/Client/Debug/RecordedQuery.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\PostgreSql\Client\Debug;
+
+final readonly class RecordedQuery
+{
+    /**
+     * @param list<mixed> $parameters values bound to $1, $2, ... placeholders
+     * @param null|int $rowCount affected rows for writes, returned rows for reads, null when unknown (e.g. cursors)
+     * @param string $connection name of the connection the query ran on
+     * @param null|string $caller "file:line" of the first application frame that issued the query, null when undetected
+     */
+    public function __construct(
+        public string $sql,
+        public array $parameters,
+        public float $durationMs,
+        public ?int $rowCount,
+        public bool $failed,
+        public ?string $error,
+        public string $connection = 'default',
+        public ?string $caller = null,
+    ) {}
+}

--- a/src/lib/postgresql/src/Flow/PostgreSql/Client/Debug/RecordingClient.php
+++ b/src/lib/postgresql/src/Flow/PostgreSql/Client/Debug/RecordingClient.php
@@ -1,0 +1,387 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\PostgreSql\Client\Debug;
+
+use Flow\PostgreSql\AST\Transformers\ExplainConfig;
+use Flow\PostgreSql\Client\Client;
+use Flow\PostgreSql\Client\ConnectionParameters;
+use Flow\PostgreSql\Client\Cursor;
+use Flow\PostgreSql\Client\Notification;
+use Flow\PostgreSql\Client\RowMapper;
+use Flow\PostgreSql\Client\Types\ValueConverters;
+use Flow\PostgreSql\Explain\Plan\Plan;
+use Flow\PostgreSql\QueryBuilder\Sql;
+use Throwable;
+
+use function count;
+use function debug_backtrace;
+use function hrtime;
+use function is_array;
+use function is_int;
+use function is_string;
+use function str_starts_with;
+
+use const DEBUG_BACKTRACE_IGNORE_ARGS;
+
+final class RecordingClient implements Client
+{
+    public function __construct(
+        private readonly Client $client,
+        private readonly QueryLog $log,
+        private readonly string $connection = 'default',
+    ) {}
+
+    public function beginTransaction(): void
+    {
+        $this->client->beginTransaction();
+    }
+
+    public function close(): void
+    {
+        $this->client->close();
+    }
+
+    public function commit(): void
+    {
+        $this->client->commit();
+    }
+
+    public function converters(): ValueConverters
+    {
+        return $this->client->converters();
+    }
+
+    public function cursor(Sql|string $sql, array $parameters = []): Cursor
+    {
+        $statement = $sql instanceof Sql ? $sql->toSql() : $sql;
+        $start = hrtime(true);
+
+        try {
+            $cursor = $this->client->cursor($sql, $parameters);
+        } catch (Throwable $e) {
+            $this->log->add($this->failure($statement, $parameters, $start, $e));
+
+            throw $e;
+        }
+
+        // Cursors are lazy; record the statement without consuming rows.
+        $this->log->add(
+            new RecordedQuery(
+                $statement,
+                $parameters,
+                $this->elapsedMs($start),
+                null,
+                false,
+                null,
+                $this->connection,
+                $this->callerLocation(),
+            ),
+        );
+
+        return $cursor;
+    }
+
+    public function execute(Sql|string $sql, array $parameters = []): int
+    {
+        return $this->record(
+            $sql,
+            $parameters,
+            fn(): int => $this->client->execute($sql, $parameters),
+            static fn(int $affected): int => $affected,
+        );
+    }
+
+    public function explain(Sql|string $sql, array $parameters = [], ?ExplainConfig $config = null): Plan
+    {
+        return $this->record($sql, $parameters, fn(): Plan => $this->client->explain($sql, $parameters, $config), null);
+    }
+
+    public function fetch(Sql|string $sql, array $parameters = []): ?array
+    {
+        return $this->record(
+            $sql,
+            $parameters,
+            fn(): ?array => $this->client->fetch($sql, $parameters),
+            static fn(?array $row): int => $row !== null ? 1 : 0,
+        );
+    }
+
+    public function fetchAll(Sql|string $sql, array $parameters = []): array
+    {
+        return $this->record(
+            $sql,
+            $parameters,
+            fn(): array => $this->client->fetchAll($sql, $parameters),
+            static fn(array $rows): int => count($rows),
+        );
+    }
+
+    public function fetchAllInto(RowMapper $mapper, Sql|string $sql, array $parameters = []): array
+    {
+        return $this->record(
+            $sql,
+            $parameters,
+            fn(): array => $this->client->fetchAllInto($mapper, $sql, $parameters),
+            static fn(array $rows): int => count($rows),
+        );
+    }
+
+    public function fetchInto(RowMapper $mapper, Sql|string $sql, array $parameters = []): mixed
+    {
+        return $this->record(
+            $sql,
+            $parameters,
+            fn(): mixed => $this->client->fetchInto($mapper, $sql, $parameters),
+            static fn(mixed $result): int => $result !== null ? 1 : 0,
+        );
+    }
+
+    public function fetchOne(Sql|string $sql, array $parameters = []): ?array
+    {
+        return $this->record(
+            $sql,
+            $parameters,
+            fn(): ?array => $this->client->fetchOne($sql, $parameters),
+            static fn(?array $row): int => $row !== null ? 1 : 0,
+        );
+    }
+
+    public function fetchOneInto(RowMapper $mapper, Sql|string $sql, array $parameters = []): mixed
+    {
+        return $this->record(
+            $sql,
+            $parameters,
+            fn(): mixed => $this->client->fetchOneInto($mapper, $sql, $parameters),
+            static fn(mixed $result): int => $result !== null ? 1 : 0,
+        );
+    }
+
+    public function fetchScalar(Sql|string $sql, array $parameters = []): mixed
+    {
+        return $this->record(
+            $sql,
+            $parameters,
+            fn(): mixed => $this->client->fetchScalar($sql, $parameters),
+            static fn(mixed $value): int => $value !== null ? 1 : 0,
+        );
+    }
+
+    public function fetchScalarBool(Sql|string $sql, array $parameters = []): bool
+    {
+        return $this->record(
+            $sql,
+            $parameters,
+            fn(): bool => $this->client->fetchScalarBool($sql, $parameters),
+            static fn(bool $value): int => 1,
+        );
+    }
+
+    public function fetchScalarFloat(Sql|string $sql, array $parameters = []): float
+    {
+        return $this->record(
+            $sql,
+            $parameters,
+            fn(): float => $this->client->fetchScalarFloat($sql, $parameters),
+            static fn(float $value): int => 1,
+        );
+    }
+
+    public function fetchScalarInt(Sql|string $sql, array $parameters = []): int
+    {
+        return $this->record(
+            $sql,
+            $parameters,
+            fn(): int => $this->client->fetchScalarInt($sql, $parameters),
+            static fn(int $value): int => 1,
+        );
+    }
+
+    public function fetchScalarString(Sql|string $sql, array $parameters = []): string
+    {
+        return $this->record(
+            $sql,
+            $parameters,
+            fn(): string => $this->client->fetchScalarString($sql, $parameters),
+            static fn(string $value): int => 1,
+        );
+    }
+
+    public function fetchSingle(Sql|string $sql, array $parameters = []): array
+    {
+        return $this->record(
+            $sql,
+            $parameters,
+            fn(): array => $this->client->fetchSingle($sql, $parameters),
+            static fn(array $row): int => 1,
+        );
+    }
+
+    public function fetchSingleInto(RowMapper $mapper, Sql|string $sql, array $parameters = []): mixed
+    {
+        return $this->record(
+            $sql,
+            $parameters,
+            fn(): mixed => $this->client->fetchSingleInto($mapper, $sql, $parameters),
+            static fn(mixed $result): int => $result !== null ? 1 : 0,
+        );
+    }
+
+    public function getTransactionNestingLevel(): int
+    {
+        return $this->client->getTransactionNestingLevel();
+    }
+
+    public function isAutoCommit(): bool
+    {
+        return $this->client->isAutoCommit();
+    }
+
+    public function isConnected(): bool
+    {
+        return $this->client->isConnected();
+    }
+
+    public function lastInsertId(string $sequenceName): int|string
+    {
+        return $this->client->lastInsertId($sequenceName);
+    }
+
+    public function listen(string $channel): void
+    {
+        $this->client->listen($channel);
+    }
+
+    public function parameters(): ConnectionParameters
+    {
+        return $this->client->parameters();
+    }
+
+    public function rollBack(): void
+    {
+        $this->client->rollBack();
+    }
+
+    public function setAutoCommit(bool $autoCommit): void
+    {
+        $this->client->setAutoCommit($autoCommit);
+    }
+
+    public function transaction(callable $callback): mixed
+    {
+        return $this->client->transaction($callback);
+    }
+
+    public function unlisten(string $channel): void
+    {
+        $this->client->unlisten($channel);
+    }
+
+    public function wait(int $milliseconds): ?Notification
+    {
+        return $this->client->wait($milliseconds);
+    }
+
+    /**
+     * @template T
+     *
+     * @param list<mixed> $parameters
+     * @param callable(): T $operation
+     * @param null|callable(T): int $rowCountExtractor
+     *
+     * @return T
+     */
+    private function record(
+        Sql|string $sql,
+        array $parameters,
+        callable $operation,
+        ?callable $rowCountExtractor,
+    ): mixed {
+        $statement = $sql instanceof Sql ? $sql->toSql() : $sql;
+        $start = hrtime(true);
+
+        try {
+            $result = $operation();
+        } catch (Throwable $e) {
+            $this->log->add($this->failure($statement, $parameters, $start, $e));
+
+            throw $e;
+        }
+
+        $this->log->add(
+            new RecordedQuery(
+                $statement,
+                $parameters,
+                $this->elapsedMs($start),
+                $rowCountExtractor === null ? null : $rowCountExtractor($result),
+                false,
+                null,
+                $this->connection,
+                $this->callerLocation(),
+            ),
+        );
+
+        return $result;
+    }
+
+    /**
+     * @param list<mixed> $parameters
+     */
+    private function failure(string $statement, array $parameters, int|float $start, Throwable $e): RecordedQuery
+    {
+        return new RecordedQuery(
+            $statement,
+            $parameters,
+            $this->elapsedMs($start),
+            null,
+            true,
+            $e->getMessage(),
+            $this->connection,
+            $this->callerLocation(),
+        );
+    }
+
+    private function elapsedMs(int|float $start): float
+    {
+        return (hrtime(true) - $start) / 1_000_000;
+    }
+
+    /**
+     * Application code location that issued the query, for the Web Profiler "caller" column.
+     *
+     * A backtrace frame's file/line is the *call site* (where the frame's function was called from),
+     * while class/function is the callee. So the application caller is the file/line of the
+     * shallowest library frame — i.e. the last `Flow\PostgreSql\` frame before control crosses into
+     * application code.
+     */
+    private function callerLocation(): ?string
+    {
+        $candidate = null;
+
+        // @mago-expect analysis:mixed-assignment
+        foreach (debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 20) as $frame) {
+            if (!is_array($frame)) {
+                continue;
+            }
+
+            // @mago-expect analysis:mixed-assignment
+            $class = $frame['class'] ?? null;
+
+            if (!is_string($class) || !str_starts_with($class, 'Flow\\PostgreSql\\')) {
+                return $candidate;
+            }
+
+            // @mago-expect analysis:mixed-assignment
+            $file = $frame['file'] ?? null;
+
+            if (is_string($file)) {
+                // @mago-expect analysis:mixed-assignment
+                $line = $frame['line'] ?? 0;
+                $candidate = $file . ':' . (is_int($line) ? $line : 0);
+            }
+        }
+
+        return $candidate;
+    }
+}

--- a/src/lib/postgresql/tests/Flow/PostgreSql/Tests/Mother/FakeClient.php
+++ b/src/lib/postgresql/tests/Flow/PostgreSql/Tests/Mother/FakeClient.php
@@ -12,9 +12,14 @@ use Flow\PostgreSql\Client\Exception\QueryException;
 use Flow\PostgreSql\Client\Notification;
 use Flow\PostgreSql\Client\RowMapper;
 use Flow\PostgreSql\Client\Types\ValueConverters;
+use Flow\PostgreSql\Explain\Plan\Cost;
 use Flow\PostgreSql\Explain\Plan\Plan;
+use Flow\PostgreSql\Explain\Plan\PlanNode;
+use Flow\PostgreSql\Explain\Plan\PlanNodeType;
 use Flow\PostgreSql\QueryBuilder\Sql;
 use RuntimeException;
+
+use function Flow\PostgreSql\DSL\pgsql_connection_params;
 
 /**
  * Configurable {@see Client} test double for exercising decorators. Query methods return canned
@@ -64,7 +69,9 @@ final class FakeClient implements Client
 
     public function converters(): ValueConverters
     {
-        throw new RuntimeException('not configured');
+        $this->delegated[] = 'converters';
+
+        return ValueConverters::create();
     }
 
     public function cursor(Sql|string $sql, array $parameters = []): Cursor
@@ -87,7 +94,9 @@ final class FakeClient implements Client
 
     public function explain(Sql|string $sql, array $parameters = [], ?ExplainConfig $config = null): Plan
     {
-        throw new RuntimeException('not configured');
+        $this->guard();
+
+        return new Plan(new PlanNode(PlanNodeType::SEQ_SCAN, new Cost(0.0, 10.0), 100, 8));
     }
 
     public function fetch(Sql|string $sql, array $parameters = []): ?array
@@ -210,7 +219,9 @@ final class FakeClient implements Client
 
     public function parameters(): ConnectionParameters
     {
-        throw new RuntimeException('not configured');
+        $this->delegated[] = 'parameters';
+
+        return pgsql_connection_params('testdb', 'localhost', 5432, 'user');
     }
 
     public function rollBack(): void

--- a/src/lib/postgresql/tests/Flow/PostgreSql/Tests/Mother/FakeClient.php
+++ b/src/lib/postgresql/tests/Flow/PostgreSql/Tests/Mother/FakeClient.php
@@ -1,0 +1,252 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\PostgreSql\Tests\Mother;
+
+use Flow\PostgreSql\AST\Transformers\ExplainConfig;
+use Flow\PostgreSql\Client\Client;
+use Flow\PostgreSql\Client\ConnectionParameters;
+use Flow\PostgreSql\Client\Cursor;
+use Flow\PostgreSql\Client\Exception\QueryException;
+use Flow\PostgreSql\Client\Notification;
+use Flow\PostgreSql\Client\RowMapper;
+use Flow\PostgreSql\Client\Types\ValueConverters;
+use Flow\PostgreSql\Explain\Plan\Plan;
+use Flow\PostgreSql\QueryBuilder\Sql;
+use RuntimeException;
+
+/**
+ * Configurable {@see Client} test double for exercising decorators. Query methods return canned
+ * values (or throw a {@see QueryException} when armed via {@see self::failNextQuery()}); transaction
+ * and connection methods record that they were called.
+ */
+final class FakeClient implements Client
+{
+    /** @var list<string> */
+    public array $delegated = [];
+
+    public int $executeReturn = 1;
+
+    /** @var null|array<string, mixed> */
+    public ?array $fetchReturn = null;
+
+    /** @var array<int, array<string, mixed>> */
+    public array $fetchAllReturn = [];
+
+    public int $fetchScalarIntReturn = 0;
+
+    private ?QueryException $failure = null;
+
+    public function __construct(
+        private readonly ?Cursor $cursor = null,
+    ) {}
+
+    public function failNextQuery(QueryException $exception): void
+    {
+        $this->failure = $exception;
+    }
+
+    public function beginTransaction(): void
+    {
+        $this->delegated[] = 'beginTransaction';
+    }
+
+    public function close(): void
+    {
+        $this->delegated[] = 'close';
+    }
+
+    public function commit(): void
+    {
+        $this->delegated[] = 'commit';
+    }
+
+    public function converters(): ValueConverters
+    {
+        throw new RuntimeException('not configured');
+    }
+
+    public function cursor(Sql|string $sql, array $parameters = []): Cursor
+    {
+        $this->guard();
+
+        if ($this->cursor === null) {
+            throw new RuntimeException('no cursor configured');
+        }
+
+        return $this->cursor;
+    }
+
+    public function execute(Sql|string $sql, array $parameters = []): int
+    {
+        $this->guard();
+
+        return $this->executeReturn;
+    }
+
+    public function explain(Sql|string $sql, array $parameters = [], ?ExplainConfig $config = null): Plan
+    {
+        throw new RuntimeException('not configured');
+    }
+
+    public function fetch(Sql|string $sql, array $parameters = []): ?array
+    {
+        $this->guard();
+
+        return $this->fetchReturn;
+    }
+
+    public function fetchAll(Sql|string $sql, array $parameters = []): array
+    {
+        $this->guard();
+
+        return $this->fetchAllReturn;
+    }
+
+    public function fetchAllInto(RowMapper $mapper, Sql|string $sql, array $parameters = []): array
+    {
+        $this->guard();
+
+        return [];
+    }
+
+    public function fetchInto(RowMapper $mapper, Sql|string $sql, array $parameters = []): mixed
+    {
+        $this->guard();
+
+        return null;
+    }
+
+    public function fetchOne(Sql|string $sql, array $parameters = []): ?array
+    {
+        $this->guard();
+
+        return $this->fetchReturn;
+    }
+
+    public function fetchOneInto(RowMapper $mapper, Sql|string $sql, array $parameters = []): mixed
+    {
+        $this->guard();
+
+        return null;
+    }
+
+    public function fetchScalar(Sql|string $sql, array $parameters = []): mixed
+    {
+        $this->guard();
+
+        return $this->fetchScalarIntReturn;
+    }
+
+    public function fetchScalarBool(Sql|string $sql, array $parameters = []): bool
+    {
+        $this->guard();
+
+        return true;
+    }
+
+    public function fetchScalarFloat(Sql|string $sql, array $parameters = []): float
+    {
+        $this->guard();
+
+        return 0.0;
+    }
+
+    public function fetchScalarInt(Sql|string $sql, array $parameters = []): int
+    {
+        $this->guard();
+
+        return $this->fetchScalarIntReturn;
+    }
+
+    public function fetchScalarString(Sql|string $sql, array $parameters = []): string
+    {
+        $this->guard();
+
+        return '';
+    }
+
+    public function fetchSingle(Sql|string $sql, array $parameters = []): array
+    {
+        $this->guard();
+
+        return $this->fetchReturn ?? [];
+    }
+
+    public function fetchSingleInto(RowMapper $mapper, Sql|string $sql, array $parameters = []): mixed
+    {
+        $this->guard();
+
+        return null;
+    }
+
+    public function getTransactionNestingLevel(): int
+    {
+        return 0;
+    }
+
+    public function isAutoCommit(): bool
+    {
+        return true;
+    }
+
+    public function isConnected(): bool
+    {
+        $this->delegated[] = 'isConnected';
+
+        return true;
+    }
+
+    public function lastInsertId(string $sequenceName): int|string
+    {
+        return 0;
+    }
+
+    public function listen(string $channel): void
+    {
+        $this->delegated[] = 'listen';
+    }
+
+    public function parameters(): ConnectionParameters
+    {
+        throw new RuntimeException('not configured');
+    }
+
+    public function rollBack(): void
+    {
+        $this->delegated[] = 'rollBack';
+    }
+
+    public function setAutoCommit(bool $autoCommit): void
+    {
+        $this->delegated[] = 'setAutoCommit';
+    }
+
+    public function transaction(callable $callback): mixed
+    {
+        $this->delegated[] = 'transaction';
+
+        return $callback($this);
+    }
+
+    public function unlisten(string $channel): void
+    {
+        $this->delegated[] = 'unlisten';
+    }
+
+    public function wait(int $milliseconds): ?Notification
+    {
+        return null;
+    }
+
+    private function guard(): void
+    {
+        if ($this->failure !== null) {
+            $failure = $this->failure;
+            $this->failure = null;
+
+            throw $failure;
+        }
+    }
+}

--- a/src/lib/postgresql/tests/Flow/PostgreSql/Tests/Unit/Client/Debug/QueryLogTest.php
+++ b/src/lib/postgresql/tests/Flow/PostgreSql/Tests/Unit/Client/Debug/QueryLogTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\PostgreSql\Tests\Unit\Client\Debug;
+
+use Flow\PostgreSql\Client\Debug\QueryLog;
+use Flow\PostgreSql\Client\Debug\RecordedQuery;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(QueryLog::class)]
+#[CoversClass(RecordedQuery::class)]
+final class QueryLogTest extends TestCase
+{
+    public function test_starts_empty(): void
+    {
+        static::assertSame([], (new QueryLog())->queries());
+    }
+
+    public function test_add_appends_in_order(): void
+    {
+        $log = new QueryLog();
+        $first = new RecordedQuery('SELECT 1', [], 0.5, 1, false, null);
+        $second = new RecordedQuery('SELECT 2', [7], 1.5, 0, false, null);
+
+        $log->add($first);
+        $log->add($second);
+
+        static::assertSame([$first, $second], $log->queries());
+    }
+
+    public function test_reset_clears_entries(): void
+    {
+        $log = new QueryLog();
+        $log->add(new RecordedQuery('SELECT 1', [], 0.5, 1, false, null));
+
+        $log->reset();
+
+        static::assertSame([], $log->queries());
+    }
+
+    public function test_recorded_query_exposes_values(): void
+    {
+        $query = new RecordedQuery('SELECT * FROM t WHERE id = $1', [42], 2.25, 1, true, 'boom');
+
+        static::assertSame('SELECT * FROM t WHERE id = $1', $query->sql);
+        static::assertSame([42], $query->parameters);
+        static::assertSame(2.25, $query->durationMs);
+        static::assertSame(1, $query->rowCount);
+        static::assertTrue($query->failed);
+        static::assertSame('boom', $query->error);
+    }
+}

--- a/src/lib/postgresql/tests/Flow/PostgreSql/Tests/Unit/Client/Debug/RecordingClientTest.php
+++ b/src/lib/postgresql/tests/Flow/PostgreSql/Tests/Unit/Client/Debug/RecordingClientTest.php
@@ -1,0 +1,169 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\PostgreSql\Tests\Unit\Client\Debug;
+
+use Flow\PostgreSql\Client\Cursor;
+use Flow\PostgreSql\Client\Debug\QueryLog;
+use Flow\PostgreSql\Client\Debug\RecordingClient;
+use Flow\PostgreSql\Client\Exception\PostgreSqlError;
+use Flow\PostgreSql\Client\Exception\QueryException;
+use Flow\PostgreSql\QueryBuilder\Sql;
+use Flow\PostgreSql\Tests\Mother\FakeClient;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(RecordingClient::class)]
+final class RecordingClientTest extends TestCase
+{
+    public function test_execute_records_statement_parameters_and_affected_rows(): void
+    {
+        $log = new QueryLog();
+        $inner = new FakeClient();
+        $inner->executeReturn = 3;
+
+        $affected = (new RecordingClient($inner, $log))->execute('DELETE FROM users WHERE id = $1', [42]);
+
+        static::assertSame(3, $affected);
+        static::assertCount(1, $log->queries());
+        $query = $log->queries()[0];
+        static::assertSame('DELETE FROM users WHERE id = $1', $query->sql);
+        static::assertSame([42], $query->parameters);
+        static::assertSame(3, $query->rowCount);
+        static::assertFalse($query->failed);
+        static::assertNull($query->error);
+        static::assertGreaterThanOrEqual(0.0, $query->durationMs);
+        static::assertSame('default', $query->connection);
+        // Caller is captured and points outside the library decorator (lib frames are skipped).
+        static::assertNotNull($query->caller);
+        static::assertStringNotContainsString('Debug/RecordingClient.php', $query->caller);
+    }
+
+    public function test_records_the_configured_connection_name(): void
+    {
+        $log = new QueryLog();
+
+        (new RecordingClient(new FakeClient(), $log, 'analytics'))->execute('SELECT 1');
+
+        static::assertSame('analytics', $log->queries()[0]->connection);
+    }
+
+    public function test_fetch_records_one_row_when_row_returned(): void
+    {
+        $log = new QueryLog();
+        $inner = new FakeClient();
+        $inner->fetchReturn = ['id' => 1];
+
+        $row = (new RecordingClient($inner, $log))->fetch('SELECT * FROM users LIMIT 1');
+
+        static::assertSame(['id' => 1], $row);
+        static::assertSame(1, $log->queries()[0]->rowCount);
+    }
+
+    public function test_fetch_records_zero_rows_when_null(): void
+    {
+        $log = new QueryLog();
+        $inner = new FakeClient();
+        $inner->fetchReturn = null;
+
+        (new RecordingClient($inner, $log))->fetch('SELECT * FROM users WHERE 1 = 0');
+
+        static::assertSame(0, $log->queries()[0]->rowCount);
+    }
+
+    public function test_fetch_all_records_returned_row_count(): void
+    {
+        $log = new QueryLog();
+        $inner = new FakeClient();
+        $inner->fetchAllReturn = [['id' => 1], ['id' => 2], ['id' => 3]];
+
+        $rows = (new RecordingClient($inner, $log))->fetchAll('SELECT * FROM users');
+
+        static::assertCount(3, $rows);
+        static::assertSame(3, $log->queries()[0]->rowCount);
+    }
+
+    public function test_fetch_scalar_int_records_query(): void
+    {
+        $log = new QueryLog();
+        $inner = new FakeClient();
+        $inner->fetchScalarIntReturn = 7;
+
+        $count = (new RecordingClient($inner, $log))->fetchScalarInt('SELECT COUNT(*) FROM users');
+
+        static::assertSame(7, $count);
+        static::assertSame('SELECT COUNT(*) FROM users', $log->queries()[0]->sql);
+        static::assertSame(1, $log->queries()[0]->rowCount);
+    }
+
+    public function test_sql_object_is_recorded_via_to_sql(): void
+    {
+        $log = new QueryLog();
+        $sql = new class implements Sql {
+            public function toSql(): string
+            {
+                return 'SELECT 1';
+            }
+        };
+
+        (new RecordingClient(new FakeClient(), $log))->execute($sql);
+
+        static::assertSame('SELECT 1', $log->queries()[0]->sql);
+    }
+
+    public function test_failed_query_records_failure_and_rethrows(): void
+    {
+        $log = new QueryLog();
+        $inner = new FakeClient();
+        $inner->failNextQuery(QueryException::executionFailed('SELECT bad', PostgreSqlError::unknown('boom')));
+        $client = new RecordingClient($inner, $log);
+        $thrown = null;
+
+        try {
+            $client->fetch('SELECT bad');
+            static::fail('Expected QueryException to be re-thrown');
+        } catch (QueryException $e) {
+            $thrown = $e;
+        }
+
+        $query = $log->queries()[0];
+        static::assertTrue($query->failed);
+        static::assertSame('SELECT bad', $query->sql);
+        static::assertSame($thrown->getMessage(), $query->error);
+        static::assertNull($query->rowCount);
+    }
+
+    public function test_cursor_records_statement_with_unknown_row_count_and_returns_inner_cursor(): void
+    {
+        $log = new QueryLog();
+        $cursor = $this->createMock(Cursor::class);
+        $inner = new FakeClient($cursor);
+
+        $returned = (new RecordingClient($inner, $log))->cursor('SELECT * FROM big_table');
+
+        static::assertSame($cursor, $returned);
+        static::assertCount(1, $log->queries());
+        static::assertSame('SELECT * FROM big_table', $log->queries()[0]->sql);
+        static::assertNull($log->queries()[0]->rowCount);
+    }
+
+    public function test_transaction_control_and_connection_methods_delegate_without_recording(): void
+    {
+        $log = new QueryLog();
+        $inner = new FakeClient();
+        $client = new RecordingClient($inner, $log);
+
+        $client->beginTransaction();
+        $client->commit();
+        $client->rollBack();
+        $client->setAutoCommit(false);
+        static::assertTrue($client->isConnected());
+
+        static::assertSame([], $log->queries());
+        static::assertSame(
+            ['beginTransaction', 'commit', 'rollBack', 'setAutoCommit', 'isConnected'],
+            $inner->delegated,
+        );
+    }
+}

--- a/src/lib/postgresql/tests/Flow/PostgreSql/Tests/Unit/Client/Debug/RecordingClientTest.php
+++ b/src/lib/postgresql/tests/Flow/PostgreSql/Tests/Unit/Client/Debug/RecordingClientTest.php
@@ -9,6 +9,7 @@ use Flow\PostgreSql\Client\Debug\QueryLog;
 use Flow\PostgreSql\Client\Debug\RecordingClient;
 use Flow\PostgreSql\Client\Exception\PostgreSqlError;
 use Flow\PostgreSql\Client\Exception\QueryException;
+use Flow\PostgreSql\Client\RowMapper;
 use Flow\PostgreSql\QueryBuilder\Sql;
 use Flow\PostgreSql\Tests\Mother\FakeClient;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -47,6 +48,76 @@ final class RecordingClientTest extends TestCase
         (new RecordingClient(new FakeClient(), $log, 'analytics'))->execute('SELECT 1');
 
         static::assertSame('analytics', $log->queries()[0]->connection);
+    }
+
+    public function test_every_statement_bearing_method_is_recorded(): void
+    {
+        $log = new QueryLog();
+        $client = new RecordingClient(new FakeClient($this->createMock(Cursor::class)), $log);
+        $mapper = $this->createMock(RowMapper::class);
+
+        $client->execute('UPDATE t SET a = 1');
+        $client->explain('SELECT 1');
+        $client->fetch('SELECT 1');
+        $client->fetchAll('SELECT 1');
+        $client->fetchAllInto($mapper, 'SELECT 1');
+        $client->fetchInto($mapper, 'SELECT 1');
+        $client->fetchOne('SELECT 1');
+        $client->fetchOneInto($mapper, 'SELECT 1');
+        $client->fetchScalar('SELECT 1');
+        $client->fetchScalarBool('SELECT 1');
+        $client->fetchScalarFloat('SELECT 1');
+        $client->fetchScalarInt('SELECT 1');
+        $client->fetchScalarString('SELECT 1');
+        $client->fetchSingle('SELECT 1');
+        $client->fetchSingleInto($mapper, 'SELECT 1');
+        $client->cursor('SELECT 1');
+
+        static::assertCount(16, $log->queries());
+    }
+
+    public function test_failed_cursor_records_failure_and_rethrows(): void
+    {
+        $log = new QueryLog();
+        $inner = new FakeClient($this->createMock(Cursor::class));
+        $inner->failNextQuery(QueryException::executionFailed('SELECT bad', PostgreSqlError::unknown('boom')));
+        $client = new RecordingClient($inner, $log);
+
+        try {
+            $client->cursor('SELECT bad');
+            static::fail('Expected QueryException to be re-thrown');
+        } catch (QueryException) {
+            // expected
+        }
+
+        static::assertTrue($log->queries()[0]->failed);
+        static::assertNull($log->queries()[0]->rowCount);
+    }
+
+    public function test_delegation_methods_forward_without_recording(): void
+    {
+        $log = new QueryLog();
+        $inner = new FakeClient();
+        $client = new RecordingClient($inner, $log);
+
+        $client->beginTransaction();
+        $client->commit();
+        $client->rollBack();
+        $client->setAutoCommit(true);
+        $client->close();
+        $client->converters();
+        $client->parameters();
+        $client->listen('channel');
+        $client->unlisten('channel');
+        $client->wait(0);
+
+        static::assertSame(0, $client->getTransactionNestingLevel());
+        static::assertTrue($client->isAutoCommit());
+        static::assertTrue($client->isConnected());
+        static::assertSame(0, $client->lastInsertId('seq'));
+        static::assertSame('result', $client->transaction(static fn(): string => 'result'));
+
+        static::assertSame([], $log->queries());
     }
 
     public function test_fetch_records_one_row_when_row_returned(): void

--- a/src/lib/telemetry/src/Flow/Telemetry/Provider/Composite/CompositeExporter.php
+++ b/src/lib/telemetry/src/Flow/Telemetry/Provider/Composite/CompositeExporter.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\Telemetry\Provider\Composite;
+
+use Flow\Telemetry\Exporter\Exporter;
+use Flow\Telemetry\Signal\Signals;
+
+/**
+ * Fans every exported batch out to multiple exporters.
+ */
+final readonly class CompositeExporter implements Exporter
+{
+    /**
+     * @param array<Exporter> $exporters
+     */
+    public function __construct(
+        private array $exporters,
+    ) {}
+
+    public function export(Signals $signal): bool
+    {
+        $ok = true;
+
+        foreach ($this->exporters as $exporter) {
+            $ok = $exporter->export($signal) && $ok;
+        }
+
+        return $ok;
+    }
+
+    public function shutdown(): void
+    {
+        foreach ($this->exporters as $exporter) {
+            $exporter->shutdown();
+        }
+    }
+}

--- a/src/lib/telemetry/tests/Flow/Telemetry/Tests/Mother/ExporterSpy.php
+++ b/src/lib/telemetry/tests/Flow/Telemetry/Tests/Mother/ExporterSpy.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\Telemetry\Tests\Mother;
+
+use Flow\Telemetry\Exporter\Exporter;
+use Flow\Telemetry\Signal\Signals;
+
+use function count;
+
+final class ExporterSpy implements Exporter
+{
+    /** @var list<Signals> */
+    private array $exported = [];
+
+    private int $shutdownCount = 0;
+
+    public function __construct(
+        private readonly bool $result = true,
+    ) {}
+
+    public function export(Signals $signal): bool
+    {
+        $this->exported[] = $signal;
+
+        return $this->result;
+    }
+
+    public function shutdown(): void
+    {
+        $this->shutdownCount++;
+    }
+
+    /**
+     * @return list<Signals>
+     */
+    public function exported(): array
+    {
+        return $this->exported;
+    }
+
+    public function exportedCount(): int
+    {
+        return count($this->exported);
+    }
+
+    public function shutdownCount(): int
+    {
+        return $this->shutdownCount;
+    }
+}

--- a/src/lib/telemetry/tests/Flow/Telemetry/Tests/Unit/Provider/Composite/CompositeExporterTest.php
+++ b/src/lib/telemetry/tests/Flow/Telemetry/Tests/Unit/Provider/Composite/CompositeExporterTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\Telemetry\Tests\Unit\Provider\Composite;
+
+use Flow\Telemetry\Exporter\Exporter;
+use Flow\Telemetry\Logger\Severity;
+use Flow\Telemetry\Provider\Composite\CompositeExporter;
+use Flow\Telemetry\Provider\Memory\MemoryExporter;
+use Flow\Telemetry\Signal\Signals;
+use Flow\Telemetry\Tests\Mother\ExporterSpy;
+use Flow\Telemetry\Tests\Mother\LogEntryMother;
+use Flow\Telemetry\Tests\Mother\MetricMother;
+use Flow\Telemetry\Tests\Mother\SpanMother;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(CompositeExporter::class)]
+final class CompositeExporterTest extends TestCase
+{
+    public function test_implements_exporter(): void
+    {
+        static::assertInstanceOf(Exporter::class, new CompositeExporter([]));
+    }
+
+    public function test_forwards_logs_batch_to_every_exporter(): void
+    {
+        $first = new ExporterSpy();
+        $second = new ExporterSpy();
+        $signal = Signals::logs([LogEntryMother::create('Log', Severity::INFO)]);
+
+        (new CompositeExporter([$first, $second]))->export($signal);
+
+        static::assertSame([$signal], $first->exported());
+        static::assertSame([$signal], $second->exported());
+    }
+
+    public function test_forwards_metrics_batch_to_every_exporter(): void
+    {
+        $first = new ExporterSpy();
+        $second = new ExporterSpy();
+        $signal = Signals::metrics([MetricMother::counter('test.metric', 1)]);
+
+        (new CompositeExporter([$first, $second]))->export($signal);
+
+        static::assertSame([$signal], $first->exported());
+        static::assertSame([$signal], $second->exported());
+    }
+
+    public function test_forwards_traces_batch_to_every_exporter(): void
+    {
+        $first = new ExporterSpy();
+        $second = new ExporterSpy();
+        $signal = Signals::traces([SpanMother::withName('span')]);
+
+        (new CompositeExporter([$first, $second]))->export($signal);
+
+        static::assertSame([$signal], $first->exported());
+        static::assertSame([$signal], $second->exported());
+    }
+
+    public function test_export_returns_false_when_any_exporter_returns_false(): void
+    {
+        $exporter = new CompositeExporter([new ExporterSpy(true), new ExporterSpy(false)]);
+
+        static::assertFalse($exporter->export(Signals::traces([SpanMother::withName('span')])));
+    }
+
+    public function test_export_returns_true_when_all_exporters_return_true(): void
+    {
+        $exporter = new CompositeExporter([new ExporterSpy(true), new ExporterSpy(true)]);
+
+        static::assertTrue($exporter->export(Signals::traces([SpanMother::withName('span')])));
+    }
+
+    public function test_export_does_not_short_circuit_on_failure(): void
+    {
+        $failing = new ExporterSpy(false);
+        $trailing = new ExporterSpy(true);
+
+        (new CompositeExporter([$failing, $trailing]))->export(Signals::traces([SpanMother::withName('span')]));
+
+        static::assertSame(1, $trailing->exportedCount());
+    }
+
+    public function test_shutdown_shuts_down_every_exporter(): void
+    {
+        $first = new ExporterSpy();
+        $second = new ExporterSpy();
+
+        (new CompositeExporter([$first, $second]))->shutdown();
+
+        static::assertSame(1, $first->shutdownCount());
+        static::assertSame(1, $second->shutdownCount());
+    }
+
+    public function test_empty_exporter_list_export_is_noop_returning_true(): void
+    {
+        static::assertTrue((new CompositeExporter([]))->export(Signals::traces([SpanMother::withName('span')])));
+    }
+
+    public function test_empty_exporter_list_shutdown_is_noop(): void
+    {
+        (new CompositeExporter([]))->shutdown();
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function test_captures_into_memory_while_other_exporter_still_receives_batch(): void
+    {
+        $store = new MemoryExporter();
+        $fake = new ExporterSpy();
+        $span = SpanMother::withName('span');
+
+        (new CompositeExporter([$fake, $store]))->export(Signals::traces([$span]));
+
+        static::assertSame([$span], $store->spans());
+        static::assertSame(1, $fake->exportedCount());
+    }
+}

--- a/tools/box/composer.lock
+++ b/tools/box/composer.lock
@@ -826,28 +826,29 @@
         },
         {
             "name": "composer/pcre",
-            "version": "3.3.2",
+            "version": "3.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/pcre.git",
-                "reference": "b2bed4734f0cc156ee1fe9c0da2550420d99a21e"
+                "reference": "d5a341b3fb61f3001970940afb1d332968a183ed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/pcre/zipball/b2bed4734f0cc156ee1fe9c0da2550420d99a21e",
-                "reference": "b2bed4734f0cc156ee1fe9c0da2550420d99a21e",
+                "url": "https://api.github.com/repos/composer/pcre/zipball/d5a341b3fb61f3001970940afb1d332968a183ed",
+                "reference": "d5a341b3fb61f3001970940afb1d332968a183ed",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.4 || ^8.0"
             },
             "conflict": {
-                "phpstan/phpstan": "<1.11.10"
+                "phpstan/phpstan": "<2.2.2"
             },
             "require-dev": {
-                "phpstan/phpstan": "^1.12 || ^2",
-                "phpstan/phpstan-strict-rules": "^1 || ^2",
-                "phpunit/phpunit": "^8 || ^9"
+                "phpstan/phpstan": "^2",
+                "phpstan/phpstan-deprecation-rules": "^2",
+                "phpstan/phpstan-strict-rules": "^2",
+                "phpunit/phpunit": "^9"
             },
             "type": "library",
             "extra": {
@@ -885,7 +886,7 @@
             ],
             "support": {
                 "issues": "https://github.com/composer/pcre/issues",
-                "source": "https://github.com/composer/pcre/tree/3.3.2"
+                "source": "https://github.com/composer/pcre/tree/3.4.0"
             },
             "funding": [
                 {
@@ -895,13 +896,9 @@
                 {
                     "url": "https://github.com/composer",
                     "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
-                    "type": "tidelift"
                 }
             ],
-            "time": "2024-11-12T16:29:46+00:00"
+            "time": "2026-06-07T11:47:49+00:00"
         },
         {
             "name": "composer/semver",
@@ -1537,16 +1534,16 @@
         },
         {
             "name": "justinrainbow/json-schema",
-            "version": "6.8.2",
+            "version": "6.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/jsonrainbow/json-schema.git",
-                "reference": "2c89ebb95ca9cedc9347f780333f7b25792dcb76"
+                "reference": "bd1bda2ebfc8bff418565941771ea8f03c557886"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jsonrainbow/json-schema/zipball/2c89ebb95ca9cedc9347f780333f7b25792dcb76",
-                "reference": "2c89ebb95ca9cedc9347f780333f7b25792dcb76",
+                "url": "https://api.github.com/repos/jsonrainbow/json-schema/zipball/bd1bda2ebfc8bff418565941771ea8f03c557886",
+                "reference": "bd1bda2ebfc8bff418565941771ea8f03c557886",
                 "shasum": ""
             },
             "require": {
@@ -1556,7 +1553,7 @@
             },
             "require-dev": {
                 "friendsofphp/php-cs-fixer": "3.3.0",
-                "json-schema/json-schema-test-suite": "dev-main",
+                "json-schema/json-schema-test-suite": "^23.2",
                 "marc-mabe/php-enum-phpstan": "^2.0",
                 "phpspec/prophecy": "^1.19",
                 "phpstan/phpstan": "^1.12",
@@ -1606,9 +1603,9 @@
             ],
             "support": {
                 "issues": "https://github.com/jsonrainbow/json-schema/issues",
-                "source": "https://github.com/jsonrainbow/json-schema/tree/6.8.2"
+                "source": "https://github.com/jsonrainbow/json-schema/tree/6.9.0"
             },
-            "time": "2026-05-05T05:39:01+00:00"
+            "time": "2026-06-05T14:05:24+00:00"
         },
         {
             "name": "kelunik/certificate",
@@ -2657,16 +2654,16 @@
         },
         {
             "name": "seld/jsonlint",
-            "version": "1.11.0",
+            "version": "1.12.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Seldaek/jsonlint.git",
-                "reference": "1748aaf847fc731cfad7725aec413ee46f0cc3a2"
+                "reference": "9a90eb5d32d5a500296bf43f946d60246444d5f7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/jsonlint/zipball/1748aaf847fc731cfad7725aec413ee46f0cc3a2",
-                "reference": "1748aaf847fc731cfad7725aec413ee46f0cc3a2",
+                "url": "https://api.github.com/repos/Seldaek/jsonlint/zipball/9a90eb5d32d5a500296bf43f946d60246444d5f7",
+                "reference": "9a90eb5d32d5a500296bf43f946d60246444d5f7",
                 "shasum": ""
             },
             "require": {
@@ -2705,7 +2702,7 @@
             ],
             "support": {
                 "issues": "https://github.com/Seldaek/jsonlint/issues",
-                "source": "https://github.com/Seldaek/jsonlint/tree/1.11.0"
+                "source": "https://github.com/Seldaek/jsonlint/tree/1.12.1"
             },
             "funding": [
                 {
@@ -2717,7 +2714,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-07-11T14:55:45+00:00"
+            "time": "2026-06-12T11:32:29+00:00"
         },
         {
             "name": "seld/phar-utils",
@@ -3490,16 +3487,16 @@
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.38.1",
+            "version": "v1.38.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "14c5439eec4ccff081ac14eca2dc57feb2a66d92"
+                "reference": "d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/14c5439eec4ccff081ac14eca2dc57feb2a66d92",
-                "reference": "14c5439eec4ccff081ac14eca2dc57feb2a66d92",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6",
+                "reference": "d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6",
                 "shasum": ""
             },
             "require": {
@@ -3551,7 +3548,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.38.1"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.38.2"
             },
             "funding": [
                 {
@@ -3571,7 +3568,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-26T12:51:13+00:00"
+            "time": "2026-05-27T06:59:30+00:00"
         },
         {
             "name": "symfony/polyfill-php84",

--- a/tools/infection/composer.lock
+++ b/tools/infection/composer.lock
@@ -97,28 +97,29 @@
         },
         {
             "name": "composer/pcre",
-            "version": "3.3.2",
+            "version": "3.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/pcre.git",
-                "reference": "b2bed4734f0cc156ee1fe9c0da2550420d99a21e"
+                "reference": "d5a341b3fb61f3001970940afb1d332968a183ed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/pcre/zipball/b2bed4734f0cc156ee1fe9c0da2550420d99a21e",
-                "reference": "b2bed4734f0cc156ee1fe9c0da2550420d99a21e",
+                "url": "https://api.github.com/repos/composer/pcre/zipball/d5a341b3fb61f3001970940afb1d332968a183ed",
+                "reference": "d5a341b3fb61f3001970940afb1d332968a183ed",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.4 || ^8.0"
             },
             "conflict": {
-                "phpstan/phpstan": "<1.11.10"
+                "phpstan/phpstan": "<2.2.2"
             },
             "require-dev": {
-                "phpstan/phpstan": "^1.12 || ^2",
-                "phpstan/phpstan-strict-rules": "^1 || ^2",
-                "phpunit/phpunit": "^8 || ^9"
+                "phpstan/phpstan": "^2",
+                "phpstan/phpstan-deprecation-rules": "^2",
+                "phpstan/phpstan-strict-rules": "^2",
+                "phpunit/phpunit": "^9"
             },
             "type": "library",
             "extra": {
@@ -156,7 +157,7 @@
             ],
             "support": {
                 "issues": "https://github.com/composer/pcre/issues",
-                "source": "https://github.com/composer/pcre/tree/3.3.2"
+                "source": "https://github.com/composer/pcre/tree/3.4.0"
             },
             "funding": [
                 {
@@ -166,13 +167,9 @@
                 {
                     "url": "https://github.com/composer",
                     "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
-                    "type": "tidelift"
                 }
             ],
-            "time": "2024-11-12T16:29:46+00:00"
+            "time": "2026-06-07T11:47:49+00:00"
         },
         {
             "name": "composer/xdebug-handler",
@@ -673,16 +670,16 @@
         },
         {
             "name": "justinrainbow/json-schema",
-            "version": "6.8.2",
+            "version": "6.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/jsonrainbow/json-schema.git",
-                "reference": "2c89ebb95ca9cedc9347f780333f7b25792dcb76"
+                "reference": "bd1bda2ebfc8bff418565941771ea8f03c557886"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jsonrainbow/json-schema/zipball/2c89ebb95ca9cedc9347f780333f7b25792dcb76",
-                "reference": "2c89ebb95ca9cedc9347f780333f7b25792dcb76",
+                "url": "https://api.github.com/repos/jsonrainbow/json-schema/zipball/bd1bda2ebfc8bff418565941771ea8f03c557886",
+                "reference": "bd1bda2ebfc8bff418565941771ea8f03c557886",
                 "shasum": ""
             },
             "require": {
@@ -692,7 +689,7 @@
             },
             "require-dev": {
                 "friendsofphp/php-cs-fixer": "3.3.0",
-                "json-schema/json-schema-test-suite": "dev-main",
+                "json-schema/json-schema-test-suite": "^23.2",
                 "marc-mabe/php-enum-phpstan": "^2.0",
                 "phpspec/prophecy": "^1.19",
                 "phpstan/phpstan": "^1.12",
@@ -742,9 +739,9 @@
             ],
             "support": {
                 "issues": "https://github.com/jsonrainbow/json-schema/issues",
-                "source": "https://github.com/jsonrainbow/json-schema/tree/6.8.2"
+                "source": "https://github.com/jsonrainbow/json-schema/tree/6.9.0"
             },
-            "time": "2026-05-05T05:39:01+00:00"
+            "time": "2026-06-05T14:05:24+00:00"
         },
         {
             "name": "marc-mabe/php-enum",
@@ -2006,16 +2003,16 @@
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.38.1",
+            "version": "v1.38.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "14c5439eec4ccff081ac14eca2dc57feb2a66d92"
+                "reference": "d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/14c5439eec4ccff081ac14eca2dc57feb2a66d92",
-                "reference": "14c5439eec4ccff081ac14eca2dc57feb2a66d92",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6",
+                "reference": "d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6",
                 "shasum": ""
             },
             "require": {
@@ -2067,7 +2064,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.38.1"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.38.2"
             },
             "funding": [
                 {
@@ -2087,7 +2084,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-26T12:51:13+00:00"
+            "time": "2026-05-27T06:59:30+00:00"
         },
         {
             "name": "symfony/polyfill-php85",


### PR DESCRIPTION
<h2>Change Log</h2>
<hr />
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <li><code>flow-php/symfony-telemetry-bundle</code> - Web Profiler panel with spans, metrics and logs.</li>
    <li><code>flow-php/symfony-postgresql-bundle</code> - Web Profiler panel recording queries with EXPLAIN support.</li>
    <li><code>flow-php/postgresql</code> - RecordingClient and QueryLog to capture executed queries.</li>
    <li><code>flow-php/telemetry</code> - CompositeExporter fanning signals out to multiple exporters.</li>
  </ul>
  <h4>Fixed</h4>
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>
  <h4>Security</h4>
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>
</div>

This PR is bringing integration of postgresql and telemtry Symfony bundles with Symfony profiler:

<img width="1304" height="1202" alt="image" src="https://github.com/user-attachments/assets/74c52435-2b9b-4bed-af5b-394b2e2c96a8" />
