### PR TITLE
chore: Migrate Symfony XML configuration usage to the PHP one

### DIFF
--- a/src/bridge/symfony/postgresql-bundle/composer.json
+++ b/src/bridge/symfony/postgresql-bundle/composer.json
@@ -21,6 +21,8 @@
         "twig/twig": "^3.0"
     },
     "require-dev": {
+        "composer-runtime-api": "^2.2",
+        "composer/semver": "^3.4",
         "flow-php/phpunit-postgresql-bridge": "self.version",
         "flow-php/symfony-postgresql-cache-bridge": "self.version",
         "flow-php/symfony-postgresql-messenger-bridge": "self.version",

--- a/src/bridge/symfony/postgresql-bundle/tests/Flow/Bridge/Symfony/PostgreSqlBundle/Tests/Fixtures/config/profiler_panel_routes.php
+++ b/src/bridge/symfony/postgresql-bundle/tests/Flow/Bridge/Symfony/PostgreSqlBundle/Tests/Fixtures/config/profiler_panel_routes.php
@@ -2,8 +2,14 @@
 
 declare(strict_types=1);
 
+use Composer\InstalledVersions;
+use Composer\Semver\VersionParser;
 use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
 
 return static function (RoutingConfigurator $routes): void {
-    $routes->import('@WebProfilerBundle/Resources/config/routing/profiler.xml')->prefix('/_profiler');
+    if (InstalledVersions::satisfies(new VersionParser(), 'symfony/web-profiler-bundle', '^7.4')) {
+        $routes->import('@WebProfilerBundle/Resources/config/routing/profiler.php')->prefix('/_profiler');
+    } else {
+        $routes->import('@WebProfilerBundle/Resources/config/routing/profiler.xml')->prefix('/_profiler');
+    }
 };

--- a/src/bridge/symfony/telemetry-bundle/composer.json
+++ b/src/bridge/symfony/telemetry-bundle/composer.json
@@ -28,6 +28,8 @@
         "symfony/polyfill-mbstring": "^1.33"
     },
     "require-dev": {
+        "composer-runtime-api": "^2.2",
+        "composer/semver": "^3.4",
         "doctrine/dbal": "^4.4",
         "flow-php/psr18-telemetry-bridge": "self.version",
         "flow-php/telemetry-otlp-bridge": "self.version",

--- a/src/bridge/symfony/telemetry-bundle/tests/Flow/Bridge/Symfony/TelemetryBundle/Tests/Fixtures/config/profiler_panel_routes.php
+++ b/src/bridge/symfony/telemetry-bundle/tests/Flow/Bridge/Symfony/TelemetryBundle/Tests/Fixtures/config/profiler_panel_routes.php
@@ -2,8 +2,14 @@
 
 declare(strict_types=1);
 
+use Composer\InstalledVersions;
+use Composer\Semver\VersionParser;
 use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
 
 return static function (RoutingConfigurator $routes): void {
-    $routes->import('@WebProfilerBundle/Resources/config/routing/profiler.xml')->prefix('/_profiler');
+    if (InstalledVersions::satisfies(new VersionParser(), 'symfony/web-profiler-bundle', '^7.4')) {
+        $routes->import('@WebProfilerBundle/Resources/config/routing/profiler.php')->prefix('/_profiler');
+    } else {
+        $routes->import('@WebProfilerBundle/Resources/config/routing/profiler.xml')->prefix('/_profiler');
+    }
 };


### PR DESCRIPTION
<!-- 
    Please replace #xxx with a GitHub issue id from flow-php/flow repository. For example #1234 
    If there is no item in a roadmap related to this PR, please check our contributing guidelines first. 
-->
Symfony [deprecated the XML configuration format](https://symfony.com/blog/new-in-symfony-7-4-deprecated-xml-configuration) in release 7.4, and removed it in 8.0. The recommended format is PHP one.

Should fix issues in tests like:
```
Flow\Bridge\Symfony\PostgreSqlBundle\Tests\Integration\Profiler\FlowPostgreSqlProfilerTest::test_panel_renders_executed_queries_in_the_profiler
Symfony\Component\Config\Exception\LoaderLoadException: Cannot load resource "@WebProfilerBundle/Resources/config/routing/profiler.xml". Make sure the "WebProfilerBundle" bundle is correctly registered and loaded in the application kernel class. If the bundle is registered, make sure the bundle path "@WebProfilerBundle/Resources/config/routing/profiler.xml" is not empty.
```

<!-- 
    Below section will be used to automatically generate changelog, please do not modify HTML code structure
    DO NOT REMOVE that HTML STRUCTURE, INSTEAD ADD YOUR CHANGES INSIDE THE LISTS 
    PULL REQUESTS WITHOUT CHANGELOG CAN'T BE MERGED 
-->
<h2>Change Log</h2>
<hr /> 
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Migrate Symfony XML configuration usage to the PHP one</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>