### PR TITLE
chore: Fallback to the Symfony XML configuration only at `^6.4.0`

### DIFF
--- a/src/bridge/symfony/postgresql-bundle/tests/Flow/Bridge/Symfony/PostgreSqlBundle/Tests/Fixtures/config/profiler_panel_routes.php
+++ b/src/bridge/symfony/postgresql-bundle/tests/Flow/Bridge/Symfony/PostgreSqlBundle/Tests/Fixtures/config/profiler_panel_routes.php
@@ -7,9 +7,9 @@ use Composer\Semver\VersionParser;
 use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
 
 return static function (RoutingConfigurator $routes): void {
-    if (InstalledVersions::satisfies(new VersionParser(), 'symfony/web-profiler-bundle', '^7.4')) {
-        $routes->import('@WebProfilerBundle/Resources/config/routing/profiler.php')->prefix('/_profiler');
-    } else {
+    if (InstalledVersions::satisfies(new VersionParser(), 'symfony/web-profiler-bundle', '^6.4.0')) {
         $routes->import('@WebProfilerBundle/Resources/config/routing/profiler.xml')->prefix('/_profiler');
+    } else {
+        $routes->import('@WebProfilerBundle/Resources/config/routing/profiler.php')->prefix('/_profiler');
     }
 };

--- a/src/bridge/symfony/telemetry-bundle/tests/Flow/Bridge/Symfony/TelemetryBundle/Tests/Fixtures/config/profiler_panel_routes.php
+++ b/src/bridge/symfony/telemetry-bundle/tests/Flow/Bridge/Symfony/TelemetryBundle/Tests/Fixtures/config/profiler_panel_routes.php
@@ -7,9 +7,9 @@ use Composer\Semver\VersionParser;
 use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
 
 return static function (RoutingConfigurator $routes): void {
-    if (InstalledVersions::satisfies(new VersionParser(), 'symfony/web-profiler-bundle', '^7.4')) {
-        $routes->import('@WebProfilerBundle/Resources/config/routing/profiler.php')->prefix('/_profiler');
-    } else {
+    if (InstalledVersions::satisfies(new VersionParser(), 'symfony/web-profiler-bundle', '^6.4.0')) {
         $routes->import('@WebProfilerBundle/Resources/config/routing/profiler.xml')->prefix('/_profiler');
+    } else {
+        $routes->import('@WebProfilerBundle/Resources/config/routing/profiler.php')->prefix('/_profiler');
     }
 };


### PR DESCRIPTION
<!-- 
    Please replace #xxx with a GitHub issue id from flow-php/flow repository. For example #1234 
    If there is no item in a roadmap related to this PR, please check our contributing guidelines first. 
-->
The previous change did not correctly handle cases with Symfony 8+, now the old format is enforced only on old Symfony.

<details>

Failing tests: [https://github.com/flow-php/flow/actions/runs/27538039321/job/81392383775#step:10:1](https://github.com/flow-php/flow/actions/runs/27538039321/job/81392383775#step:10:1)

Running locally:
```
flow on  chore/sf-migrate-xml-1 [$!?] via 🐘 v8.4.20 via ❄️  impure (nix-shell) took 3s 
just test --filter=FlowPostgreSqlProfilerTest
tools/phpunit/vendor/bin/phpunit --filter=FlowPostgreSqlProfilerTest
PHPUnit 11.5.55 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.4.20
Configuration: /Users/stloyd/Documents/flow/phpunit.xml.dist

..........                                                        10 / 10 (100%)


Time: 00:01.767, Memory: 253.00 MB

OK (10 tests, 27 assertions)
```
</details>

<!-- 
    Below section will be used to automatically generate changelog, please do not modify HTML code structure
    DO NOT REMOVE that HTML STRUCTURE, INSTEAD ADD YOUR CHANGES INSIDE THE LISTS 
    PULL REQUESTS WITHOUT CHANGELOG CAN'T BE MERGED 
-->
<h2>Change Log</h2>
<hr /> 
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Fallback to the Symfony XML configuration only at `^6.4.0`</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>