### PR TITLE
fix(flow-php/postgresql): lower BulkInsert upsert with empty update set to ON CONFLICT DO NOTHING

### DIFF
--- a/src/lib/postgresql/src/Flow/PostgreSql/QueryBuilder/Insert/BulkInsert.php
+++ b/src/lib/postgresql/src/Flow/PostgreSql/QueryBuilder/Insert/BulkInsert.php
@@ -76,6 +76,10 @@ final readonly class BulkInsert implements Sql
             $assignments[$column] = 'EXCLUDED."' . $column . '"';
         }
 
+        if ($assignments === []) {
+            return new self($this->table, $this->columns, $this->rowCount, $target, true, []);
+        }
+
         return new self($this->table, $this->columns, $this->rowCount, $target, false, $assignments);
     }
 

--- a/src/lib/postgresql/tests/Flow/PostgreSql/Tests/Unit/QueryBuilder/Insert/BulkInsertTest.php
+++ b/src/lib/postgresql/tests/Flow/PostgreSql/Tests/Unit/QueryBuilder/Insert/BulkInsertTest.php
@@ -149,6 +149,51 @@ final class BulkInsertTest extends TestCase
         );
     }
 
+    public function test_on_conflict_do_update_with_all_columns_as_conflict_target_emits_do_nothing(): void
+    {
+        $query = BulkInsert::into('t', ['a', 'b'], 1)->onConflictDoUpdate(ConflictTarget::columns(['a', 'b']));
+
+        static::assertSame(
+            'INSERT INTO "t" ("a", "b") VALUES ($1, $2) ON CONFLICT ("a", "b") DO NOTHING',
+            $query->toSql(),
+        );
+    }
+
+    public function test_on_conflict_do_update_with_constraint_and_empty_update_columns_emits_do_nothing(): void
+    {
+        $query = BulkInsert::into('t', ['a', 'b'], 1)->onConflictDoUpdate(ConflictTarget::constraint('t_pkey'), []);
+
+        static::assertSame(
+            'INSERT INTO "t" ("a", "b") VALUES ($1, $2) ON CONFLICT ON CONSTRAINT "t_pkey" DO NOTHING',
+            $query->toSql(),
+        );
+    }
+
+    public function test_on_conflict_do_update_with_empty_update_columns_emits_do_nothing(): void
+    {
+        $query = BulkInsert::into('users', ['email', 'name'], 1)->onConflictDoUpdate(
+            ConflictTarget::columns(['email']),
+            [],
+        );
+
+        static::assertSame(
+            'INSERT INTO "users" ("email", "name") VALUES ($1, $2) ON CONFLICT ("email") DO NOTHING',
+            $query->toSql(),
+        );
+    }
+
+    public function test_on_conflict_do_update_with_subset_target_still_emits_do_update(): void
+    {
+        $query = BulkInsert::into('users', ['email', 'name'], 1)->onConflictDoUpdate(ConflictTarget::columns([
+            'email',
+        ]));
+
+        static::assertSame(
+            'INSERT INTO "users" ("email", "name") VALUES ($1, $2) ON CONFLICT ("email") DO UPDATE SET "name" = EXCLUDED."name"',
+            $query->toSql(),
+        );
+    }
+
     public function test_on_conflict_do_update_with_constraint(): void
     {
         $query = BulkInsert::into('users', ['email', 'name'], 1)->onConflictDoUpdate(


### PR DESCRIPTION
<!-- 
    Please replace #xxx with a GitHub issue id from flow-php/flow repository. For example #1234 
    If there is no item in a roadmap related to this PR, please check our contributing guidelines first. 
-->
<h2>Change Log</h2>
<hr />
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul>
  <h4>Fixed</h4>
  <ul id="fixed">
    <li><code>flow-php/postgresql</code> - BulkInsert upsert with an empty update set now emits ON CONFLICT DO NOTHING instead of a plain INSERT.</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>
  <h4>Security</h4>
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>
</div>