### PR TITLE
fix(flow-php/symfony-telemetry-bundle): run DBALTelemetryPass before DoctrineBundle's MiddlewaresPass

### DIFF
--- a/src/bridge/symfony/telemetry-bundle/src/Flow/Bridge/Symfony/TelemetryBundle/FlowTelemetryBundle.php
+++ b/src/bridge/symfony/telemetry-bundle/src/Flow/Bridge/Symfony/TelemetryBundle/FlowTelemetryBundle.php
@@ -184,7 +184,7 @@ final class FlowTelemetryBundle extends AbstractBundle
         }
 
         if (interface_exists(self::DBAL_MIDDLEWARE_INTERFACE)) {
-            $container->addCompilerPass(new DBALTelemetryPass());
+            $container->addCompilerPass(new DBALTelemetryPass(), priority: 10);
         }
 
         if (interface_exists(self::CACHE_ADAPTER_INTERFACE)) {


### PR DESCRIPTION
Both passes run at TYPE_BEFORE_OPTIMIZATION priority 0, so Symfony executes them in insertion order.

When DoctrineBundle is registered before FlowTelemetryBundle (likely to be a common case), MiddlewaresPass scans for doctrine.middleware tags before DBALTelemetryPass has registered the tracing middleware, silently producing no DBAL spans despite the service appearing correctly in debug:container.

Raising DBALTelemetryPass to priority 10 ensures it always runs first, regardless of bundle registration order.

<!-- 
    Please replace #xxx with a GitHub issue id from flow-php/flow repository. For example #1234 
    If there is no item in a roadmap related to this PR, please check our contributing guidelines first. 
-->
Resolves: #xxx

<!-- 
    Below section will be used to automatically generate changelog, please do not modify HTML code structure
    DO NOT REMOVE that HTML STRUCTURE, INSTEAD ADD YOUR CHANGES INSIDE THE LISTS 
    PULL REQUESTS WITHOUT CHANGELOG CAN'T BE MERGED 
-->
<h2>Change Log</h2>
<hr /> 
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>DBALTelemetryPass is now registered at priority 10 to guarantee it runs before DoctrineBundle's MiddlewaresPass, fixing silent DBAL tracing failure when DoctrineBundle precedes FlowTelemetryBundle in the kernel.</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>