### PR TITLE
fix(flow-php/symfony-telemetry-bundle): defer http client span completion until response is consume

### DIFF
--- a/src/bridge/symfony/telemetry-bundle/src/Flow/Bridge/Symfony/TelemetryBundle/Instrumentation/HttpClient/ResponseStream.php
+++ b/src/bridge/symfony/telemetry-bundle/src/Flow/Bridge/Symfony/TelemetryBundle/Instrumentation/HttpClient/ResponseStream.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\Bridge\Symfony\TelemetryBundle\Instrumentation\HttpClient;
+
+use Generator;
+use Symfony\Contracts\HttpClient\ChunkInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+use Symfony\Contracts\HttpClient\ResponseStreamInterface;
+
+final readonly class ResponseStream implements ResponseStreamInterface
+{
+    /**
+     * @param Generator<ResponseInterface, ChunkInterface> $generator
+     */
+    public function __construct(
+        private Generator $generator,
+    ) {}
+
+    public function current(): ChunkInterface
+    {
+        return $this->generator->current();
+    }
+
+    public function key(): ResponseInterface
+    {
+        return $this->generator->key();
+    }
+
+    public function next(): void
+    {
+        $this->generator->next();
+    }
+
+    public function rewind(): void
+    {
+        $this->generator->rewind();
+    }
+
+    public function valid(): bool
+    {
+        return $this->generator->valid();
+    }
+}

--- a/src/bridge/symfony/telemetry-bundle/src/Flow/Bridge/Symfony/TelemetryBundle/Instrumentation/HttpClient/TracableHttpClient.php
+++ b/src/bridge/symfony/telemetry-bundle/src/Flow/Bridge/Symfony/TelemetryBundle/Instrumentation/HttpClient/TracableHttpClient.php
@@ -52,30 +52,24 @@ final readonly class TracableHttpClient implements HttpClientInterface
 
         try {
             $response = $this->client->request($method, $url, $options);
-
-            $statusCode = $response->getStatusCode();
-            $span->setAttribute('http.response.status_code', $statusCode);
-
-            if ($statusCode >= 400) {
-                $span->setStatus(SpanStatus::error("HTTP {$statusCode}"));
-            } else {
-                $span->setStatus(SpanStatus::ok());
-            }
-
-            return $response;
         } catch (Throwable $exception) {
             $span->recordException($exception, new DateTimeImmutable());
             $span->setStatus(SpanStatus::error($exception->getMessage()));
+            $tracer->complete($span);
 
             throw $exception;
-        } finally {
-            $tracer->complete($span);
         }
+
+        return new TraceableResponse($tracer, $response, $span);
     }
 
     public function stream(ResponseInterface|iterable $responses, ?float $timeout = null): ResponseStreamInterface
     {
-        return $this->client->stream($responses, $timeout);
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
+
+        return new ResponseStream(TraceableResponse::stream($this->client, $responses, $timeout));
     }
 
     /**

--- a/src/bridge/symfony/telemetry-bundle/src/Flow/Bridge/Symfony/TelemetryBundle/Instrumentation/HttpClient/TraceableResponse.php
+++ b/src/bridge/symfony/telemetry-bundle/src/Flow/Bridge/Symfony/TelemetryBundle/Instrumentation/HttpClient/TraceableResponse.php
@@ -1,0 +1,218 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\Bridge\Symfony\TelemetryBundle\Instrumentation\HttpClient;
+
+use DateTimeImmutable;
+use Flow\Bridge\Symfony\TelemetryBundle\Exception\RuntimeException;
+use Flow\Telemetry\Tracer\Span;
+use Flow\Telemetry\Tracer\SpanStatus;
+use Flow\Telemetry\Tracer\Tracer;
+use Generator;
+use SplObjectStorage;
+use Symfony\Contracts\HttpClient\ChunkInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+use Throwable;
+use TypeError;
+
+use function get_debug_type;
+use function is_int;
+use function method_exists;
+use function sprintf;
+
+/**
+ * Lazy response decorator that finalizes a CLIENT span when the response is actually consumed.
+ */
+final class TraceableResponse implements ResponseInterface
+{
+    private bool $completed = false;
+
+    private bool $statusRecorded = false;
+
+    public function __construct(
+        private readonly Tracer $tracer,
+        private readonly ResponseInterface $response,
+        private readonly Span $span,
+    ) {}
+
+    public function __destruct()
+    {
+        try {
+            if (method_exists($this->response, '__destruct')) {
+                $this->response->__destruct();
+            }
+        } finally {
+            $this->recordStatusFromInfo();
+            $this->complete();
+        }
+    }
+
+    public function cancel(): void
+    {
+        $this->response->cancel();
+        $this->recordStatusFromInfo();
+        $this->complete();
+    }
+
+    public function getContent(bool $throw = true): string
+    {
+        try {
+            $content = $this->response->getContent($throw);
+            $this->recordStatus($this->response->getStatusCode());
+
+            return $content;
+        } catch (Throwable $exception) {
+            $this->failAndComplete($exception);
+
+            throw $exception;
+        } finally {
+            $this->complete();
+        }
+    }
+
+    /**
+     * @return array<string, list<string>>
+     */
+    public function getHeaders(bool $throw = true): array
+    {
+        try {
+            $headers = $this->response->getHeaders($throw);
+            $this->recordStatus($this->response->getStatusCode());
+
+            return $headers;
+        } catch (Throwable $exception) {
+            $this->failAndComplete($exception);
+
+            throw $exception;
+        }
+    }
+
+    public function getInfo(?string $type = null): mixed
+    {
+        return $this->response->getInfo($type);
+    }
+
+    public function getStatusCode(): int
+    {
+        try {
+            $statusCode = $this->response->getStatusCode();
+            $this->recordStatus($statusCode);
+
+            return $statusCode;
+        } catch (Throwable $exception) {
+            $this->failAndComplete($exception);
+
+            throw $exception;
+        }
+    }
+
+    /**
+     * @return array<array-key, mixed>
+     */
+    public function toArray(bool $throw = true): array
+    {
+        try {
+            $data = $this->response->toArray($throw);
+            $this->recordStatus($this->response->getStatusCode());
+
+            return $data;
+        } catch (Throwable $exception) {
+            $this->failAndComplete($exception);
+
+            throw $exception;
+        } finally {
+            $this->complete();
+        }
+    }
+
+    /**
+     * Drives a multiplexed stream over wrapped responses, finalizing each span when its stream ends.
+     *
+     * @param iterable<array-key, ResponseInterface> $responses
+     *
+     * @return Generator<TraceableResponse, ChunkInterface>
+     */
+    public static function stream(HttpClientInterface $client, iterable $responses, ?float $timeout): Generator
+    {
+        $wrappedResponses = [];
+        /** @var SplObjectStorage<ResponseInterface, self> $traceableMap */
+        $traceableMap = new SplObjectStorage();
+
+        foreach ($responses as $response) {
+            if (!$response instanceof self) {
+                throw new TypeError(sprintf(
+                    '"%s::stream()" expects parameter 1 to be an iterable of TracableResponse objects, "%s" given.',
+                    TracableHttpClient::class,
+                    get_debug_type($response),
+                ));
+            }
+
+            $traceableMap[$response->response] = $response;
+            $wrappedResponses[] = $response->response;
+        }
+
+        foreach ($client->stream($wrappedResponses, $timeout) as $response => $chunk) {
+            $wrapper = $traceableMap[$response];
+
+            $error = $chunk->getError();
+
+            if ($error !== null) {
+                $wrapper->failAndComplete(new RuntimeException($error));
+            } elseif ($chunk->isFirst()) {
+                $wrapper->recordStatus($response->getStatusCode());
+            } elseif ($chunk->isLast()) {
+                $wrapper->recordStatus($response->getStatusCode());
+                $wrapper->complete();
+            }
+
+            yield $wrapper => $chunk;
+        }
+    }
+
+    private function complete(): void
+    {
+        if ($this->completed) {
+            return;
+        }
+
+        $this->completed = true;
+        $this->tracer->complete($this->span);
+    }
+
+    private function failAndComplete(Throwable $exception): void
+    {
+        $this->span->recordException($exception, new DateTimeImmutable());
+        $this->span->setStatus(SpanStatus::error($exception->getMessage()));
+        $this->complete();
+    }
+
+    private function recordStatus(int $statusCode): void
+    {
+        if ($this->statusRecorded) {
+            return;
+        }
+
+        $this->statusRecorded = true;
+        $this->span->setAttribute('http.response.status_code', $statusCode);
+
+        if ($statusCode >= 400) {
+            $this->span->setStatus(SpanStatus::error("HTTP {$statusCode}"));
+        } else {
+            $this->span->setStatus(SpanStatus::ok());
+        }
+    }
+
+    private function recordStatusFromInfo(): void
+    {
+        $this->recordResolvedStatus($this->response->getInfo('http_code'));
+    }
+
+    private function recordResolvedStatus(mixed $statusCode): void
+    {
+        if (is_int($statusCode) && $statusCode > 0) {
+            $this->recordStatus($statusCode);
+        }
+    }
+}

--- a/src/bridge/symfony/telemetry-bundle/tests/Flow/Bridge/Symfony/TelemetryBundle/Tests/Fixtures/HttpClient/Chunk.php
+++ b/src/bridge/symfony/telemetry-bundle/tests/Flow/Bridge/Symfony/TelemetryBundle/Tests/Fixtures/HttpClient/Chunk.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\Bridge\Symfony\TelemetryBundle\Tests\Fixtures\HttpClient;
+
+use Symfony\Contracts\HttpClient\ChunkInterface;
+
+final readonly class Chunk implements ChunkInterface
+{
+    public function __construct(
+        private bool $isFirst = false,
+        private bool $isLast = false,
+        private bool $isTimeout = false,
+        private ?string $error = null,
+        private string $content = '',
+        private int $offset = 0,
+    ) {}
+
+    public function getContent(): string
+    {
+        return $this->content;
+    }
+
+    public function getError(): ?string
+    {
+        return $this->error;
+    }
+
+    public function getInformationalStatus(): ?array
+    {
+        return null;
+    }
+
+    public function getOffset(): int
+    {
+        return $this->offset;
+    }
+
+    public function isFirst(): bool
+    {
+        return $this->isFirst;
+    }
+
+    public function isLast(): bool
+    {
+        return $this->isLast;
+    }
+
+    public function isTimeout(): bool
+    {
+        return $this->isTimeout;
+    }
+}

--- a/src/bridge/symfony/telemetry-bundle/tests/Flow/Bridge/Symfony/TelemetryBundle/Tests/Fixtures/HttpClient/MockResponse.php
+++ b/src/bridge/symfony/telemetry-bundle/tests/Flow/Bridge/Symfony/TelemetryBundle/Tests/Fixtures/HttpClient/MockResponse.php
@@ -27,12 +27,17 @@ final readonly class MockResponse implements ResponseInterface
         return [];
     }
 
-    /**
-     * @return array<string, mixed>
-     */
     public function getInfo(?string $type = null): mixed
     {
-        return [];
+        if ($type === 'http_code') {
+            return $this->statusCode;
+        }
+
+        if ($type === null) {
+            return ['http_code' => $this->statusCode];
+        }
+
+        return null;
     }
 
     public function getStatusCode(): int

--- a/src/bridge/symfony/telemetry-bundle/tests/Flow/Bridge/Symfony/TelemetryBundle/Tests/Fixtures/HttpClient/SpyResponse.php
+++ b/src/bridge/symfony/telemetry-bundle/tests/Flow/Bridge/Symfony/TelemetryBundle/Tests/Fixtures/HttpClient/SpyResponse.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\Bridge\Symfony\TelemetryBundle\Tests\Fixtures\HttpClient;
+
+use Symfony\Contracts\HttpClient\ResponseInterface;
+use Throwable;
+
+final class SpyResponse implements ResponseInterface
+{
+    public bool $cancelCalled = false;
+
+    public bool $destructCalled = false;
+
+    public bool $getContentCalled = false;
+
+    public bool $getHeadersCalled = false;
+
+    public bool $getInfoCalled = false;
+
+    public bool $getStatusCodeCalled = false;
+
+    public bool $toArrayCalled = false;
+
+    public function __construct(
+        private readonly int $statusCode = 200,
+        private readonly ?Throwable $throwOnAccess = null,
+    ) {}
+
+    public function __destruct()
+    {
+        $this->destructCalled = true;
+    }
+
+    public function anyMethodCalled(): bool
+    {
+        return (
+            $this->getStatusCodeCalled
+            || $this->getHeadersCalled
+            || $this->getContentCalled
+            || $this->toArrayCalled
+            || $this->cancelCalled
+            || $this->getInfoCalled
+        );
+    }
+
+    public function cancel(): void
+    {
+        $this->cancelCalled = true;
+    }
+
+    public function getContent(bool $throw = true): string
+    {
+        $this->getContentCalled = true;
+
+        if ($this->throwOnAccess !== null) {
+            throw $this->throwOnAccess;
+        }
+
+        return '';
+    }
+
+    /**
+     * @return array<string, list<string>>
+     */
+    public function getHeaders(bool $throw = true): array
+    {
+        $this->getHeadersCalled = true;
+
+        if ($this->throwOnAccess !== null) {
+            throw $this->throwOnAccess;
+        }
+
+        return [];
+    }
+
+    public function getInfo(?string $type = null): mixed
+    {
+        $this->getInfoCalled = true;
+
+        if ($type === 'http_code') {
+            return $this->statusCode;
+        }
+
+        if ($type === null) {
+            return ['http_code' => $this->statusCode];
+        }
+
+        return null;
+    }
+
+    public function getStatusCode(): int
+    {
+        $this->getStatusCodeCalled = true;
+
+        if ($this->throwOnAccess !== null) {
+            throw $this->throwOnAccess;
+        }
+
+        return $this->statusCode;
+    }
+
+    /**
+     * @return array<array-key, mixed>
+     */
+    public function toArray(bool $throw = true): array
+    {
+        $this->toArrayCalled = true;
+
+        if ($this->throwOnAccess !== null) {
+            throw $this->throwOnAccess;
+        }
+
+        return [];
+    }
+}

--- a/src/bridge/symfony/telemetry-bundle/tests/Flow/Bridge/Symfony/TelemetryBundle/Tests/Fixtures/HttpClient/StreamingHttpClient.php
+++ b/src/bridge/symfony/telemetry-bundle/tests/Flow/Bridge/Symfony/TelemetryBundle/Tests/Fixtures/HttpClient/StreamingHttpClient.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\Bridge\Symfony\TelemetryBundle\Tests\Fixtures\HttpClient;
+
+use Flow\Bridge\Symfony\TelemetryBundle\Instrumentation\HttpClient\ResponseStream;
+use Generator;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+use Symfony\Contracts\HttpClient\ResponseStreamInterface;
+
+final readonly class StreamingHttpClient implements HttpClientInterface
+{
+    public function __construct(
+        private int $statusCode = 200,
+        private ?string $error = null,
+    ) {}
+
+    /**
+     * @param array<array-key, mixed> $options
+     */
+    public function request(string $method, string $url, array $options = []): ResponseInterface
+    {
+        return new MockResponse($this->statusCode);
+    }
+
+    public function stream(ResponseInterface|iterable $responses, ?float $timeout = null): ResponseStreamInterface
+    {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
+
+        return new ResponseStream($this->generate($responses));
+    }
+
+    /**
+     * @param array<array-key, mixed> $options
+     */
+    public function withOptions(array $options): static
+    {
+        return $this;
+    }
+
+    /**
+     * @param iterable<ResponseInterface> $responses
+     *
+     * @return Generator<ResponseInterface, Chunk>
+     */
+    private function generate(iterable $responses): Generator
+    {
+        foreach ($responses as $response) {
+            if ($this->error !== null) {
+                yield $response => new Chunk(error: $this->error);
+
+                continue;
+            }
+
+            yield $response => new Chunk(isFirst: true);
+            yield $response => new Chunk(isLast: true);
+        }
+    }
+}

--- a/src/bridge/symfony/telemetry-bundle/tests/Flow/Bridge/Symfony/TelemetryBundle/Tests/Integration/Instrumentation/HttpClient/TracableHttpClientTest.php
+++ b/src/bridge/symfony/telemetry-bundle/tests/Flow/Bridge/Symfony/TelemetryBundle/Tests/Integration/Instrumentation/HttpClient/TracableHttpClientTest.php
@@ -218,7 +218,7 @@ final class TracableHttpClientTest extends KernelTestCase
 
         /** @var HttpClientInterface $client */
         $client = $container->get('test.error_client');
-        $client->request('POST', 'http://localhost:8080/api/data');
+        $client->request('POST', 'http://localhost:8080/api/data')->getContent();
 
         /** @var MemorySpanProcessor $processor */
         $processor = $container->get('flow.telemetry.tracer_provider.processor');
@@ -271,7 +271,7 @@ final class TracableHttpClientTest extends KernelTestCase
 
         /** @var HttpClientInterface $client */
         $client = $container->get('test.api_client');
-        $client->request('GET', 'https://api.example.com/users?page=1');
+        $client->request('GET', 'https://api.example.com/users?page=1')->getContent();
 
         /** @var MemorySpanProcessor $processor */
         $processor = $container->get('flow.telemetry.tracer_provider.processor');

--- a/src/bridge/symfony/telemetry-bundle/tests/Flow/Bridge/Symfony/TelemetryBundle/Tests/Unit/Instrumentation/HttpClient/ResponseStreamTest.php
+++ b/src/bridge/symfony/telemetry-bundle/tests/Flow/Bridge/Symfony/TelemetryBundle/Tests/Unit/Instrumentation/HttpClient/ResponseStreamTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\Bridge\Symfony\TelemetryBundle\Tests\Unit\Instrumentation\HttpClient;
+
+use Flow\Bridge\Symfony\TelemetryBundle\Instrumentation\HttpClient\ResponseStream;
+use Flow\Bridge\Symfony\TelemetryBundle\Tests\Fixtures\HttpClient\Chunk;
+use Flow\Bridge\Symfony\TelemetryBundle\Tests\Fixtures\HttpClient\MockResponse;
+use Generator;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ResponseStream::class)]
+final class ResponseStreamTest extends TestCase
+{
+    public function test_delegates_iterator_methods_to_generator(): void
+    {
+        $response = new MockResponse(200);
+        $chunk = new Chunk(isLast: true);
+
+        $stream = new ResponseStream(
+            (static function () use ($response, $chunk): Generator {
+                yield $response => $chunk;
+            })(),
+        );
+
+        $stream->rewind();
+
+        static::assertTrue($stream->valid());
+        static::assertSame($response, $stream->key());
+        static::assertSame($chunk, $stream->current());
+
+        $stream->next();
+
+        static::assertFalse($stream->valid());
+    }
+}

--- a/src/bridge/symfony/telemetry-bundle/tests/Flow/Bridge/Symfony/TelemetryBundle/Tests/Unit/Instrumentation/HttpClient/TracableHttpClientTest.php
+++ b/src/bridge/symfony/telemetry-bundle/tests/Flow/Bridge/Symfony/TelemetryBundle/Tests/Unit/Instrumentation/HttpClient/TracableHttpClientTest.php
@@ -4,39 +4,35 @@ declare(strict_types=1);
 
 namespace Flow\Bridge\Symfony\TelemetryBundle\Tests\Unit\Instrumentation\HttpClient;
 
+use Flow\Bridge\Symfony\TelemetryBundle\Instrumentation\HttpClient\ResponseStream;
 use Flow\Bridge\Symfony\TelemetryBundle\Instrumentation\HttpClient\TracableHttpClient;
-use Flow\Telemetry\Context\MemoryContextStorage;
-use Flow\Telemetry\Logger\LoggerProvider;
-use Flow\Telemetry\Meter\MeterProvider;
-use Flow\Telemetry\Provider\Clock\SystemClock;
+use Flow\Bridge\Symfony\TelemetryBundle\Instrumentation\HttpClient\TraceableResponse;
+use Flow\Bridge\Symfony\TelemetryBundle\Tests\Fixtures\HttpClient\FailingHttpClient;
+use Flow\Bridge\Symfony\TelemetryBundle\Tests\Fixtures\HttpClient\StreamingHttpClient;
+use Flow\Bridge\Symfony\TelemetryBundle\Tests\Fixtures\HttpClient\SuccessHttpClient;
+use Flow\Bridge\Symfony\TelemetryBundle\Tests\Mother\TelemetryMother;
 use Flow\Telemetry\Provider\Memory\MemoryExporter;
 use Flow\Telemetry\Provider\Memory\MemorySpanProcessor;
-use Flow\Telemetry\Provider\Void\VoidLogProcessor;
-use Flow\Telemetry\Provider\Void\VoidMetricProcessor;
-use Flow\Telemetry\Resource;
-use Flow\Telemetry\Telemetry;
 use Flow\Telemetry\Tracer\SpanKind;
-use Flow\Telemetry\Tracer\TracerProvider;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
-use Symfony\Contracts\HttpClient\ChunkInterface;
-use Symfony\Contracts\HttpClient\HttpClientInterface;
-use Symfony\Contracts\HttpClient\ResponseInterface;
-use Symfony\Contracts\HttpClient\ResponseStreamInterface;
 
 #[CoversClass(TracableHttpClient::class)]
+#[CoversClass(TraceableResponse::class)]
+#[CoversClass(ResponseStream::class)]
 final class TracableHttpClientTest extends TestCase
 {
     public function test_request_defaults_host_to_unknown_when_missing(): void
     {
         $spanProcessor = new MemorySpanProcessor(new MemoryExporter());
-        $telemetry = $this->createTelemetry($spanProcessor);
+        $tracable = new TracableHttpClient(
+            new SuccessHttpClient(200),
+            TelemetryMother::withSpanProcessor($spanProcessor),
+            'test.client',
+        );
 
-        $innerClient = $this->createMockHttpClient(200);
-        $tracable = new TracableHttpClient($innerClient, $telemetry, 'test.client');
-
-        $tracable->request('GET', '/users');
+        $tracable->request('GET', '/users')->getContent();
 
         $spans = $spanProcessor->endedSpans();
         static::assertCount(1, $spans);
@@ -46,27 +42,48 @@ final class TracableHttpClientTest extends TestCase
     public function test_request_defaults_scheme_to_http_when_missing(): void
     {
         $spanProcessor = new MemorySpanProcessor(new MemoryExporter());
-        $telemetry = $this->createTelemetry($spanProcessor);
+        $tracable = new TracableHttpClient(
+            new SuccessHttpClient(200),
+            TelemetryMother::withSpanProcessor($spanProcessor),
+            'test.client',
+        );
 
-        $innerClient = $this->createMockHttpClient(200);
-        $tracable = new TracableHttpClient($innerClient, $telemetry, 'test.client');
-
-        $tracable->request('GET', '/users');
+        $tracable->request('GET', '/users')->getContent();
 
         $spans = $spanProcessor->endedSpans();
         static::assertCount(1, $spans);
         static::assertSame('http', $spans[0]->attributes()['url.scheme']);
     }
 
+    public function test_request_does_not_complete_span_before_response_is_consumed(): void
+    {
+        $spanProcessor = new MemorySpanProcessor(new MemoryExporter());
+        $tracable = new TracableHttpClient(
+            new SuccessHttpClient(200),
+            TelemetryMother::withSpanProcessor($spanProcessor),
+            'test.client',
+        );
+
+        $response = $tracable->request('GET', 'https://api.example.com/users');
+
+        static::assertInstanceOf(TraceableResponse::class, $response);
+        static::assertCount(0, $spanProcessor->endedSpans());
+
+        $response->getContent();
+
+        static::assertCount(1, $spanProcessor->endedSpans());
+    }
+
     public function test_request_extracts_host_from_url(): void
     {
         $spanProcessor = new MemorySpanProcessor(new MemoryExporter());
-        $telemetry = $this->createTelemetry($spanProcessor);
+        $tracable = new TracableHttpClient(
+            new SuccessHttpClient(200),
+            TelemetryMother::withSpanProcessor($spanProcessor),
+            'test.client',
+        );
 
-        $innerClient = $this->createMockHttpClient(200);
-        $tracable = new TracableHttpClient($innerClient, $telemetry, 'test.client');
-
-        $tracable->request('GET', 'https://api.example.com/users');
+        $tracable->request('GET', 'https://api.example.com/users')->getContent();
 
         $spans = $spanProcessor->endedSpans();
         static::assertCount(1, $spans);
@@ -76,61 +93,13 @@ final class TracableHttpClientTest extends TestCase
     public function test_request_extracts_scheme_from_url(): void
     {
         $spanProcessor = new MemorySpanProcessor(new MemoryExporter());
-        $telemetry = $this->createTelemetry($spanProcessor);
+        $tracable = new TracableHttpClient(
+            new SuccessHttpClient(200),
+            TelemetryMother::withSpanProcessor($spanProcessor),
+            'test.client',
+        );
 
-        $innerClient = new class implements HttpClientInterface {
-            /** @param array<array-key, mixed> $options */
-            public function request(string $method, string $url, array $options = []): ResponseInterface
-            {
-                return new class implements ResponseInterface {
-                    public function cancel(): void {}
-
-                    public function getContent(bool $throw = true): string
-                    {
-                        return '';
-                    }
-
-                    /** @return array<string, list<string>> */
-                    public function getHeaders(bool $throw = true): array
-                    {
-                        return [];
-                    }
-
-                    public function getInfo(?string $type = null): mixed
-                    {
-                        return null;
-                    }
-
-                    public function getStatusCode(): int
-                    {
-                        return 200;
-                    }
-
-                    /** @return array<string, mixed> */
-                    public function toArray(bool $throw = true): array
-                    {
-                        return [];
-                    }
-                };
-            }
-
-            public function stream(
-                ResponseInterface|iterable $responses,
-                ?float $timeout = null,
-            ): ResponseStreamInterface {
-                throw new RuntimeException('Not implemented');
-            }
-
-            /** @param array<array-key, mixed> $options */
-            public function withOptions(array $options): static
-            {
-                return $this;
-            }
-        };
-
-        $tracable = new TracableHttpClient($innerClient, $telemetry, 'test.client');
-
-        $tracable->request('GET', 'https://api.example.com/users');
+        $tracable->request('GET', 'https://api.example.com/users')->getContent();
 
         $spans = $spanProcessor->endedSpans();
         static::assertCount(1, $spans);
@@ -140,12 +109,13 @@ final class TracableHttpClientTest extends TestCase
     public function test_request_includes_client_name_attribute(): void
     {
         $spanProcessor = new MemorySpanProcessor(new MemoryExporter());
-        $telemetry = $this->createTelemetry($spanProcessor);
+        $tracable = new TracableHttpClient(
+            new SuccessHttpClient(200),
+            TelemetryMother::withSpanProcessor($spanProcessor),
+            'my_api_client',
+        );
 
-        $innerClient = $this->createMockHttpClient(200);
-        $tracable = new TracableHttpClient($innerClient, $telemetry, 'my_api_client');
-
-        $tracable->request('GET', 'https://api.example.com/users');
+        $tracable->request('GET', 'https://api.example.com/users')->getContent();
 
         $spans = $spanProcessor->endedSpans();
         static::assertCount(1, $spans);
@@ -155,12 +125,13 @@ final class TracableHttpClientTest extends TestCase
     public function test_request_includes_http_status_code_attribute(): void
     {
         $spanProcessor = new MemorySpanProcessor(new MemoryExporter());
-        $telemetry = $this->createTelemetry($spanProcessor);
+        $tracable = new TracableHttpClient(
+            new SuccessHttpClient(200),
+            TelemetryMother::withSpanProcessor($spanProcessor),
+            'test.client',
+        );
 
-        $innerClient = $this->createMockHttpClient(200);
-        $tracable = new TracableHttpClient($innerClient, $telemetry, 'test.client');
-
-        $tracable->request('GET', 'https://api.example.com/users');
+        $tracable->request('GET', 'https://api.example.com/users')->getContent();
 
         $spans = $spanProcessor->endedSpans();
         static::assertCount(1, $spans);
@@ -170,12 +141,13 @@ final class TracableHttpClientTest extends TestCase
     public function test_request_includes_method_and_url_attributes(): void
     {
         $spanProcessor = new MemorySpanProcessor(new MemoryExporter());
-        $telemetry = $this->createTelemetry($spanProcessor);
+        $tracable = new TracableHttpClient(
+            new SuccessHttpClient(200),
+            TelemetryMother::withSpanProcessor($spanProcessor),
+            'test.client',
+        );
 
-        $innerClient = $this->createMockHttpClient(200);
-        $tracable = new TracableHttpClient($innerClient, $telemetry, 'test.client');
-
-        $tracable->request('POST', 'https://api.example.com/users');
+        $tracable->request('POST', 'https://api.example.com/users')->getContent();
 
         $spans = $spanProcessor->endedSpans();
         static::assertCount(1, $spans);
@@ -183,33 +155,14 @@ final class TracableHttpClientTest extends TestCase
         static::assertSame('https://api.example.com/users', $spans[0]->attributes()['url.full']);
     }
 
-    public function test_request_records_exception_on_failure(): void
+    public function test_request_records_exception_on_synchronous_failure(): void
     {
         $spanProcessor = new MemorySpanProcessor(new MemoryExporter());
-        $telemetry = $this->createTelemetry($spanProcessor);
-
-        $innerClient = new class implements HttpClientInterface {
-            /** @param array<array-key, mixed> $options */
-            public function request(string $method, string $url, array $options = []): ResponseInterface
-            {
-                throw new RuntimeException('Connection timeout');
-            }
-
-            public function stream(
-                ResponseInterface|iterable $responses,
-                ?float $timeout = null,
-            ): ResponseStreamInterface {
-                throw new RuntimeException('Not implemented');
-            }
-
-            /** @param array<array-key, mixed> $options */
-            public function withOptions(array $options): static
-            {
-                return $this;
-            }
-        };
-
-        $tracable = new TracableHttpClient($innerClient, $telemetry, 'test.client');
+        $tracable = new TracableHttpClient(
+            new FailingHttpClient('Connection timeout'),
+            TelemetryMother::withSpanProcessor($spanProcessor),
+            'test.client',
+        );
 
         $exceptionThrown = false;
 
@@ -237,12 +190,13 @@ final class TracableHttpClientTest extends TestCase
     public function test_request_sets_error_status_for_4xx_codes(): void
     {
         $spanProcessor = new MemorySpanProcessor(new MemoryExporter());
-        $telemetry = $this->createTelemetry($spanProcessor);
+        $tracable = new TracableHttpClient(
+            new SuccessHttpClient(404),
+            TelemetryMother::withSpanProcessor($spanProcessor),
+            'test.client',
+        );
 
-        $innerClient = $this->createMockHttpClient(404);
-        $tracable = new TracableHttpClient($innerClient, $telemetry, 'test.client');
-
-        $tracable->request('GET', 'https://api.example.com/missing');
+        $tracable->request('GET', 'https://api.example.com/missing')->getContent();
 
         $spans = $spanProcessor->endedSpans();
         static::assertCount(1, $spans);
@@ -256,12 +210,13 @@ final class TracableHttpClientTest extends TestCase
     public function test_request_sets_error_status_for_5xx_codes(): void
     {
         $spanProcessor = new MemorySpanProcessor(new MemoryExporter());
-        $telemetry = $this->createTelemetry($spanProcessor);
+        $tracable = new TracableHttpClient(
+            new SuccessHttpClient(500),
+            TelemetryMother::withSpanProcessor($spanProcessor),
+            'test.client',
+        );
 
-        $innerClient = $this->createMockHttpClient(500);
-        $tracable = new TracableHttpClient($innerClient, $telemetry, 'test.client');
-
-        $tracable->request('GET', 'https://api.example.com/error');
+        $tracable->request('GET', 'https://api.example.com/error')->getContent();
 
         $spans = $spanProcessor->endedSpans();
         static::assertCount(1, $spans);
@@ -275,12 +230,13 @@ final class TracableHttpClientTest extends TestCase
     public function test_request_sets_ok_status_for_2xx_codes(): void
     {
         $spanProcessor = new MemorySpanProcessor(new MemoryExporter());
-        $telemetry = $this->createTelemetry($spanProcessor);
+        $tracable = new TracableHttpClient(
+            new SuccessHttpClient(201),
+            TelemetryMother::withSpanProcessor($spanProcessor),
+            'test.client',
+        );
 
-        $innerClient = $this->createMockHttpClient(201);
-        $tracable = new TracableHttpClient($innerClient, $telemetry, 'test.client');
-
-        $tracable->request('POST', 'https://api.example.com/users');
+        $tracable->request('POST', 'https://api.example.com/users')->getContent();
 
         $spans = $spanProcessor->endedSpans();
         static::assertCount(1, $spans);
@@ -293,12 +249,13 @@ final class TracableHttpClientTest extends TestCase
     public function test_request_sets_ok_status_for_3xx_codes(): void
     {
         $spanProcessor = new MemorySpanProcessor(new MemoryExporter());
-        $telemetry = $this->createTelemetry($spanProcessor);
+        $tracable = new TracableHttpClient(
+            new SuccessHttpClient(302),
+            TelemetryMother::withSpanProcessor($spanProcessor),
+            'test.client',
+        );
 
-        $innerClient = $this->createMockHttpClient(302);
-        $tracable = new TracableHttpClient($innerClient, $telemetry, 'test.client');
-
-        $tracable->request('GET', 'https://api.example.com/redirect');
+        $tracable->request('GET', 'https://api.example.com/redirect')->getContent();
 
         $spans = $spanProcessor->endedSpans();
         static::assertCount(1, $spans);
@@ -311,12 +268,13 @@ final class TracableHttpClientTest extends TestCase
     public function test_request_span_name_includes_method_and_host(): void
     {
         $spanProcessor = new MemorySpanProcessor(new MemoryExporter());
-        $telemetry = $this->createTelemetry($spanProcessor);
+        $tracable = new TracableHttpClient(
+            new SuccessHttpClient(200),
+            TelemetryMother::withSpanProcessor($spanProcessor),
+            'test.client',
+        );
 
-        $innerClient = $this->createMockHttpClient(200);
-        $tracable = new TracableHttpClient($innerClient, $telemetry, 'test.client');
-
-        $tracable->request('POST', 'https://api.example.com/users');
+        $tracable->request('POST', 'https://api.example.com/users')->getContent();
 
         $spans = $spanProcessor->endedSpans();
         static::assertCount(1, $spans);
@@ -326,169 +284,86 @@ final class TracableHttpClientTest extends TestCase
     public function test_span_kind_is_client(): void
     {
         $spanProcessor = new MemorySpanProcessor(new MemoryExporter());
-        $telemetry = $this->createTelemetry($spanProcessor);
+        $tracable = new TracableHttpClient(
+            new SuccessHttpClient(200),
+            TelemetryMother::withSpanProcessor($spanProcessor),
+            'test.client',
+        );
 
-        $innerClient = $this->createMockHttpClient(200);
-        $tracable = new TracableHttpClient($innerClient, $telemetry, 'test.client');
-
-        $tracable->request('GET', 'https://api.example.com/users');
+        $tracable->request('GET', 'https://api.example.com/users')->getContent();
 
         $spans = $spanProcessor->endedSpans();
         static::assertCount(1, $spans);
         static::assertSame(SpanKind::CLIENT, $spans[0]->kind());
     }
 
-    public function test_stream_delegates_to_inner_client(): void
+    public function test_stream_completes_span_with_error_when_chunk_reports_error(): void
     {
         $spanProcessor = new MemorySpanProcessor(new MemoryExporter());
-        $telemetry = $this->createTelemetry($spanProcessor);
+        $tracable = new TracableHttpClient(
+            new StreamingHttpClient(200, 'Network is down'),
+            TelemetryMother::withSpanProcessor($spanProcessor),
+            'test.client',
+        );
 
-        $mockResponse = $this->createMock(ResponseInterface::class);
+        $response = $tracable->request('GET', 'https://api.example.com/users');
 
-        $streamResponse = new readonly class($mockResponse, $this->createMock(ChunkInterface::class)) implements
-            ResponseStreamInterface {
-            public function __construct(
-                private ResponseInterface $response,
-                private ChunkInterface $chunk,
-            ) {}
+        foreach ($tracable->stream($response) as $chunk) {
+            static::assertSame('Network is down', $chunk->getError());
+        }
 
-            public function key(): ResponseInterface
-            {
-                return $this->response;
-            }
+        $spans = $spanProcessor->endedSpans();
+        static::assertCount(1, $spans);
 
-            public function current(): ChunkInterface
-            {
-                return $this->chunk;
-            }
+        $status = $spans[0]->status();
+        static::assertNotNull($status);
+        static::assertTrue($status->isError());
+        static::assertSame('Network is down', $status->description);
+    }
 
-            public function next(): void {}
+    public function test_stream_unwraps_tracable_response_and_completes_span_on_last_chunk(): void
+    {
+        $spanProcessor = new MemorySpanProcessor(new MemoryExporter());
+        $tracable = new TracableHttpClient(
+            new StreamingHttpClient(200),
+            TelemetryMother::withSpanProcessor($spanProcessor),
+            'test.client',
+        );
 
-            public function rewind(): void {}
+        $response = $tracable->request('GET', 'https://api.example.com/users');
 
-            public function valid(): bool
-            {
-                return false;
-            }
-        };
+        static::assertInstanceOf(TraceableResponse::class, $response);
+        static::assertCount(0, $spanProcessor->endedSpans());
 
-        $innerClient = new readonly class($streamResponse) implements HttpClientInterface {
-            public function __construct(
-                private ResponseStreamInterface $stream,
-            ) {}
+        $stream = $tracable->stream($response);
+        static::assertInstanceOf(ResponseStream::class, $stream);
 
-            /** @param array<array-key, mixed> $options */
-            public function request(string $method, string $url, array $options = []): ResponseInterface
-            {
-                throw new RuntimeException('Not implemented');
-            }
+        $chunks = 0;
 
-            public function stream(
-                ResponseInterface|iterable $responses,
-                ?float $timeout = null,
-            ): ResponseStreamInterface {
-                return $this->stream;
-            }
+        foreach ($stream as $key => $_chunk) {
+            static::assertSame($response, $key);
+            $chunks++;
+        }
 
-            /** @param array<array-key, mixed> $options */
-            public function withOptions(array $options): static
-            {
-                return $this;
-            }
-        };
+        static::assertSame(2, $chunks);
 
-        $tracable = new TracableHttpClient($innerClient, $telemetry, 'test.client');
-
-        $result = $tracable->stream($mockResponse);
-
-        static::assertSame($streamResponse, $result);
+        $spans = $spanProcessor->endedSpans();
+        static::assertCount(1, $spans);
+        static::assertSame(200, $spans[0]->attributes()['http.response.status_code']);
     }
 
     public function test_with_options_creates_new_instance(): void
     {
         $spanProcessor = new MemorySpanProcessor(new MemoryExporter());
-        $telemetry = $this->createTelemetry($spanProcessor);
-
-        $innerClient = $this->createMockHttpClient(200);
-        $tracable = new TracableHttpClient($innerClient, $telemetry, 'test.client');
+        $tracable = new TracableHttpClient(
+            new SuccessHttpClient(200),
+            TelemetryMother::withSpanProcessor($spanProcessor),
+            'test.client',
+        );
 
         $newTracable = $tracable->withOptions(['timeout' => 30]);
 
         static::assertNotSame($tracable, $newTracable);
         static::assertInstanceOf(TracableHttpClient::class, $newTracable);
-    }
-
-    private function createMockHttpClient(int $statusCode): HttpClientInterface
-    {
-        return new readonly class($statusCode) implements HttpClientInterface {
-            public function __construct(
-                private int $statusCode,
-            ) {}
-
-            /** @param array<array-key, mixed> $options */
-            public function request(string $method, string $url, array $options = []): ResponseInterface
-            {
-                return new readonly class($this->statusCode) implements ResponseInterface {
-                    public function __construct(
-                        private int $statusCode,
-                    ) {}
-
-                    public function cancel(): void {}
-
-                    public function getContent(bool $throw = true): string
-                    {
-                        return '';
-                    }
-
-                    /** @return array<string, list<string>> */
-                    public function getHeaders(bool $throw = true): array
-                    {
-                        return [];
-                    }
-
-                    public function getInfo(?string $type = null): mixed
-                    {
-                        return null;
-                    }
-
-                    public function getStatusCode(): int
-                    {
-                        return $this->statusCode;
-                    }
-
-                    /** @return array<string, mixed> */
-                    public function toArray(bool $throw = true): array
-                    {
-                        return [];
-                    }
-                };
-            }
-
-            public function stream(
-                ResponseInterface|iterable $responses,
-                ?float $timeout = null,
-            ): ResponseStreamInterface {
-                throw new RuntimeException('Not implemented');
-            }
-
-            /** @param array<array-key, mixed> $options */
-            public function withOptions(array $options): static
-            {
-                return new self($this->statusCode);
-            }
-        };
-    }
-
-    private function createTelemetry(MemorySpanProcessor $spanProcessor): Telemetry
-    {
-        $clock = new SystemClock();
-        $contextStorage = new MemoryContextStorage();
-
-        return new Telemetry(
-            Resource::create(['service.name' => 'test']),
-            new TracerProvider($spanProcessor, $clock, $contextStorage),
-            new MeterProvider(new VoidMetricProcessor(), $clock),
-            new LoggerProvider(new VoidLogProcessor(), $clock, $contextStorage),
-        );
     }
 }

--- a/src/bridge/symfony/telemetry-bundle/tests/Flow/Bridge/Symfony/TelemetryBundle/Tests/Unit/Instrumentation/HttpClient/TracableResponseTest.php
+++ b/src/bridge/symfony/telemetry-bundle/tests/Flow/Bridge/Symfony/TelemetryBundle/Tests/Unit/Instrumentation/HttpClient/TracableResponseTest.php
@@ -1,0 +1,296 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\Bridge\Symfony\TelemetryBundle\Tests\Unit\Instrumentation\HttpClient;
+
+use Flow\Bridge\Symfony\TelemetryBundle\Instrumentation\HttpClient\TraceableResponse;
+use Flow\Bridge\Symfony\TelemetryBundle\Tests\Fixtures\HttpClient\MockResponse;
+use Flow\Bridge\Symfony\TelemetryBundle\Tests\Fixtures\HttpClient\SpyResponse;
+use Flow\Bridge\Symfony\TelemetryBundle\Tests\Fixtures\HttpClient\SuccessHttpClient;
+use Flow\Bridge\Symfony\TelemetryBundle\Tests\Mother\TelemetryMother;
+use Flow\Telemetry\Provider\Memory\MemoryExporter;
+use Flow\Telemetry\Provider\Memory\MemorySpanProcessor;
+use Flow\Telemetry\Tracer\SpanKind;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use TypeError;
+
+#[CoversClass(TraceableResponse::class)]
+final class TracableResponseTest extends TestCase
+{
+    public function test_cancel_completes_span_and_records_status_without_calling_get_status_code(): void
+    {
+        $processor = new MemorySpanProcessor(new MemoryExporter());
+        $tracer = TelemetryMother::withSpanProcessor($processor)->tracer('test');
+        $span = $tracer->span('GET host', SpanKind::CLIENT);
+        $spy = new SpyResponse(200);
+
+        $response = new TraceableResponse($tracer, $spy, $span);
+        $response->cancel();
+
+        static::assertTrue($spy->cancelCalled);
+        static::assertFalse($spy->getStatusCodeCalled);
+        static::assertTrue($span->isEnded());
+        static::assertCount(1, $processor->endedSpans());
+        static::assertSame(200, $span->attributes()['http.response.status_code']);
+    }
+
+    public function test_construction_does_not_touch_inner_response(): void
+    {
+        $processor = new MemorySpanProcessor(new MemoryExporter());
+        $tracer = TelemetryMother::withSpanProcessor($processor)->tracer('test');
+        $span = $tracer->span('GET host', SpanKind::CLIENT);
+        $spy = new SpyResponse(200);
+
+        $response = new TraceableResponse($tracer, $spy, $span);
+
+        static::assertFalse($spy->anyMethodCalled());
+        static::assertFalse($span->isEnded());
+        static::assertCount(0, $processor->endedSpans());
+        static::assertInstanceOf(TraceableResponse::class, $response);
+    }
+
+    public function test_destruct_completes_span_as_backstop(): void
+    {
+        $processor = new MemorySpanProcessor(new MemoryExporter());
+        $tracer = TelemetryMother::withSpanProcessor($processor)->tracer('test');
+        $span = $tracer->span('GET host', SpanKind::CLIENT);
+
+        $spy = new SpyResponse(200);
+        $response = new TraceableResponse($tracer, $spy, $span);
+        unset($response);
+
+        static::assertTrue($spy->destructCalled);
+        static::assertTrue($span->isEnded());
+        static::assertCount(1, $processor->endedSpans());
+        static::assertSame(200, $span->attributes()['http.response.status_code']);
+    }
+
+    public function test_get_content_completes_span_with_error_status_for_4xx(): void
+    {
+        $processor = new MemorySpanProcessor(new MemoryExporter());
+        $tracer = TelemetryMother::withSpanProcessor($processor)->tracer('test');
+        $span = $tracer->span('GET host', SpanKind::CLIENT);
+
+        $response = new TraceableResponse($tracer, new SpyResponse(404), $span);
+        $response->getContent();
+
+        static::assertTrue($span->isEnded());
+        static::assertCount(1, $processor->endedSpans());
+
+        $status = $span->status();
+        static::assertNotNull($status);
+        static::assertTrue($status->isError());
+        static::assertSame('HTTP 404', $status->description);
+    }
+
+    public function test_get_content_completes_span_with_ok_status(): void
+    {
+        $processor = new MemorySpanProcessor(new MemoryExporter());
+        $tracer = TelemetryMother::withSpanProcessor($processor)->tracer('test');
+        $span = $tracer->span('GET host', SpanKind::CLIENT);
+
+        $response = new TraceableResponse($tracer, new SpyResponse(200), $span);
+        $response->getContent();
+
+        static::assertTrue($span->isEnded());
+        static::assertCount(1, $processor->endedSpans());
+        static::assertSame(200, $span->attributes()['http.response.status_code']);
+
+        $status = $span->status();
+        static::assertNotNull($status);
+        static::assertTrue($status->isOk());
+    }
+
+    public function test_get_headers_records_status_without_completing_span(): void
+    {
+        $processor = new MemorySpanProcessor(new MemoryExporter());
+        $tracer = TelemetryMother::withSpanProcessor($processor)->tracer('test');
+        $span = $tracer->span('GET host', SpanKind::CLIENT);
+
+        $response = new TraceableResponse($tracer, new SpyResponse(200), $span);
+        $response->getHeaders();
+
+        static::assertFalse($span->isEnded());
+        static::assertCount(0, $processor->endedSpans());
+        static::assertSame(200, $span->attributes()['http.response.status_code']);
+    }
+
+    public function test_get_info_delegates_without_span_effect(): void
+    {
+        $processor = new MemorySpanProcessor(new MemoryExporter());
+        $tracer = TelemetryMother::withSpanProcessor($processor)->tracer('test');
+        $span = $tracer->span('GET host', SpanKind::CLIENT);
+
+        $response = new TraceableResponse($tracer, new SpyResponse(200), $span);
+
+        static::assertSame(200, $response->getInfo('http_code'));
+        static::assertFalse($span->isEnded());
+        static::assertCount(0, $processor->endedSpans());
+        static::assertArrayNotHasKey('http.response.status_code', $span->attributes());
+    }
+
+    public function test_get_headers_throwable_records_exception_and_completes(): void
+    {
+        $processor = new MemorySpanProcessor(new MemoryExporter());
+        $tracer = TelemetryMother::withSpanProcessor($processor)->tracer('test');
+        $span = $tracer->span('GET host', SpanKind::CLIENT);
+
+        $response = new TraceableResponse($tracer, new SpyResponse(200, new RuntimeException('boom')), $span);
+
+        $exceptionThrown = false;
+
+        try {
+            $response->getHeaders();
+        } catch (RuntimeException) {
+            $exceptionThrown = true;
+        }
+
+        static::assertTrue($exceptionThrown);
+        static::assertTrue($span->isEnded());
+        static::assertCount(1, $processor->endedSpans());
+        static::assertCount(1, $span->events());
+
+        $status = $span->status();
+        static::assertNotNull($status);
+        static::assertTrue($status->isError());
+        static::assertSame('boom', $status->description);
+    }
+
+    public function test_get_status_code_records_status_without_completing_span(): void
+    {
+        $processor = new MemorySpanProcessor(new MemoryExporter());
+        $tracer = TelemetryMother::withSpanProcessor($processor)->tracer('test');
+        $span = $tracer->span('GET host', SpanKind::CLIENT);
+
+        $response = new TraceableResponse($tracer, new SpyResponse(200), $span);
+
+        static::assertSame(200, $response->getStatusCode());
+        static::assertFalse($span->isEnded());
+        static::assertCount(0, $processor->endedSpans());
+        static::assertSame(200, $span->attributes()['http.response.status_code']);
+    }
+
+    public function test_get_status_code_throwable_records_exception_and_completes(): void
+    {
+        $processor = new MemorySpanProcessor(new MemoryExporter());
+        $tracer = TelemetryMother::withSpanProcessor($processor)->tracer('test');
+        $span = $tracer->span('GET host', SpanKind::CLIENT);
+
+        $response = new TraceableResponse($tracer, new SpyResponse(200, new RuntimeException('boom')), $span);
+
+        $exceptionThrown = false;
+
+        try {
+            $response->getStatusCode();
+        } catch (RuntimeException) {
+            $exceptionThrown = true;
+        }
+
+        static::assertTrue($exceptionThrown);
+        static::assertTrue($span->isEnded());
+        static::assertCount(1, $processor->endedSpans());
+        static::assertCount(1, $span->events());
+
+        $status = $span->status();
+        static::assertNotNull($status);
+        static::assertTrue($status->isError());
+        static::assertSame('boom', $status->description);
+    }
+
+    public function test_span_is_completed_exactly_once(): void
+    {
+        $processor = new MemorySpanProcessor(new MemoryExporter());
+        $tracer = TelemetryMother::withSpanProcessor($processor)->tracer('test');
+        $span = $tracer->span('GET host', SpanKind::CLIENT);
+
+        $response = new TraceableResponse($tracer, new SpyResponse(200), $span);
+        $response->getContent();
+        $response->getContent();
+        unset($response);
+
+        static::assertCount(1, $processor->endedSpans());
+    }
+
+    public function test_throwable_during_access_records_exception_and_completes(): void
+    {
+        $processor = new MemorySpanProcessor(new MemoryExporter());
+        $tracer = TelemetryMother::withSpanProcessor($processor)->tracer('test');
+        $span = $tracer->span('GET host', SpanKind::CLIENT);
+
+        $response = new TraceableResponse($tracer, new SpyResponse(200, new RuntimeException('boom')), $span);
+
+        $exceptionThrown = false;
+
+        try {
+            $response->getContent();
+        } catch (RuntimeException) {
+            $exceptionThrown = true;
+        }
+
+        static::assertTrue($exceptionThrown);
+        static::assertTrue($span->isEnded());
+        static::assertCount(1, $processor->endedSpans());
+
+        $events = $span->events();
+        static::assertCount(1, $events);
+        static::assertSame('exception', $events[0]->name());
+
+        $status = $span->status();
+        static::assertNotNull($status);
+        static::assertTrue($status->isError());
+        static::assertSame('boom', $status->description);
+    }
+
+    public function test_stream_rejects_non_tracable_response(): void
+    {
+        $this->expectException(TypeError::class);
+
+        foreach (TraceableResponse::stream(new SuccessHttpClient(200), [new MockResponse(200)], null) as $_chunk) {
+            // iteration triggers the generator, which rejects the non-TracableResponse item
+        }
+    }
+
+    public function test_to_array_completes_span(): void
+    {
+        $processor = new MemorySpanProcessor(new MemoryExporter());
+        $tracer = TelemetryMother::withSpanProcessor($processor)->tracer('test');
+        $span = $tracer->span('GET host', SpanKind::CLIENT);
+
+        $response = new TraceableResponse($tracer, new SpyResponse(200), $span);
+        $response->toArray();
+
+        static::assertTrue($span->isEnded());
+        static::assertCount(1, $processor->endedSpans());
+        static::assertSame(200, $span->attributes()['http.response.status_code']);
+    }
+
+    public function test_to_array_throwable_records_exception_and_completes(): void
+    {
+        $processor = new MemorySpanProcessor(new MemoryExporter());
+        $tracer = TelemetryMother::withSpanProcessor($processor)->tracer('test');
+        $span = $tracer->span('GET host', SpanKind::CLIENT);
+
+        $response = new TraceableResponse($tracer, new SpyResponse(200, new RuntimeException('boom')), $span);
+
+        $exceptionThrown = false;
+
+        try {
+            $response->toArray();
+        } catch (RuntimeException) {
+            $exceptionThrown = true;
+        }
+
+        static::assertTrue($exceptionThrown);
+        static::assertTrue($span->isEnded());
+        static::assertCount(1, $processor->endedSpans());
+        static::assertCount(1, $span->events());
+
+        $status = $span->status();
+        static::assertNotNull($status);
+        static::assertTrue($status->isError());
+        static::assertSame('boom', $status->description);
+    }
+}


### PR DESCRIPTION

<h2>Change Log</h2>
<hr />
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul>
  <h4>Fixed</h4>
  <ul id="fixed">
    <li><code>flow-php/symfony-telemetry-bundle</code> - http client decorator no longer reads the response inside request(), restoring async and concurrency</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li><code>flow-php/symfony-telemetry-bundle</code> - http client span now completes when the response is consumed, not at request() return</li>
  </ul>
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>
  <h4>Security</h4>
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>
</div>
