### PR TITLE
Make `NativePHPHash` singleton

### DIFF
--- a/src/core/etl/src/Flow/ETL/Hash/NativePHPHash.php
+++ b/src/core/etl/src/Flow/ETL/Hash/NativePHPHash.php
@@ -11,24 +11,31 @@ use function hash_algos;
 use function in_array;
 use function sprintf;
 
-final readonly class NativePHPHash implements Algorithm
+final class NativePHPHash implements Algorithm
 {
+    private static ?self $instance = null;
+    private static ?array $algorithms = null;
+
     /**
      * @param array<array-key, mixed> $options
      */
     public function __construct(
-        private string $algorithm = 'xxh128',
-        private bool $binary = false,
-        private array $options = [],
+        private readonly string $algorithm = 'xxh128',
+        private readonly bool $binary = false,
+        private readonly array $options = [],
     ) {
-        if (!in_array($algorithm, hash_algos(), true)) {
+        self::$algorithms ??= hash_algos();
+
+        if (!in_array($algorithm, self::$algorithms, true)) {
             throw new InvalidArgumentException(sprintf('Hashing algorithm "%s" is not supported', $algorithm));
         }
     }
 
     public static function xxh128(string $string): string
     {
-        return (new self('xxh128'))->hash($string);
+        self::$instance ??= new self('xxh128');
+
+        return self::$instance->hash($string);
     }
 
     public function hash(string $value): string

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Hash/NativePHPHashTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Hash/NativePHPHashTest.php
@@ -6,6 +6,7 @@ namespace Flow\ETL\Tests\Unit\Hash;
 
 use Flow\ETL\Hash\NativePHPHash;
 use Flow\ETL\Tests\FlowTestCase;
+use InvalidArgumentException;
 
 final class NativePHPHashTest extends FlowTestCase
 {
@@ -25,5 +26,12 @@ final class NativePHPHashTest extends FlowTestCase
             'ee26b0dd4af7e749aa1a8ee3c10ae9923f618980772e473f8819a5d4940e0db27ac185f8a0e1d5f84f88bc887fd67b143732c304cc5fa9ad8e6f57f50028a8ff',
             (new NativePHPHash('sha512'))->hash('test'),
         );
+    }
+
+    public function test_hashing_unknown_algorithm(): void
+    {
+        static::expectException(InvalidArgumentException::class);
+
+        new NativePHPHash('unknown');
     }
 }


### PR DESCRIPTION
<!-- 
    Please replace #xxx with a GitHub issue id from flow-php/flow repository. For example #1234 
    If there is no item in a roadmap related to this PR, please check our contributing guidelines first. 
-->

Running benchmark with 1M iterations:

<table>
<tr>
 <td>NativePHPHash::xxh128()</td>
 <td>non-static
 <td>0.5040 seconds
<tr>
 <td>NativePHPHash::xxh128() 
 <td>static
 <td>0.2383 seconds
<tr>
 <td>new NativePHPHash()->hash()
 <td>ask for algorithms
 <td>0.7743 seconds
<tr>
 <td>new NativePHPHash()->hash()
 <td>re-use algorithms
 <td>0.4724 seconds
</table>

Resolves: #xxx

<!-- 
    Below section will be used to automatically generate changelog, please do not modify HTML code structure
    DO NOT REMOVE that HTML STRUCTURE, INSTEAD ADD YOUR CHANGES INSIDE THE LISTS 
    PULL REQUESTS WITHOUT CHANGELOG CAN'T BE MERGED 
-->
<h2>Change Log</h2>
<hr /> 
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Make `NativePHPHash` singleton</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>