### PR TITLE
refactor: replace switch statements with match expressions

### DIFF
--- a/src/adapter/etl-adapter-http/src/Flow/ETL/Adapter/Http/RequestEntriesFactory.php
+++ b/src/adapter/etl-adapter-http/src/Flow/ETL/Adapter/Http/RequestEntriesFactory.php
@@ -60,28 +60,20 @@ final class RequestEntriesFactory
             }
 
             if (!empty($requestBodyContent)) {
-                switch ($requestType) {
-                    case 'json':
-                        if (class_exists(JsonEntry::class)) {
-                            $decodedJson = type_array()->assert(json_decode(
+                $requestBodyEntry = match ($requestType) {
+                    'json' => class_exists(JsonEntry::class)
+                        ? new JsonEntry(
+                            'request_body',
+                            Json::fromArray(type_array()->assert(json_decode(
                                 $requestBodyContent,
                                 true,
                                 512,
                                 JSON_THROW_ON_ERROR,
-                            ));
-
-                            $requestBodyEntry = new JsonEntry('request_body', Json::fromArray($decodedJson));
-                        } else {
-                            $requestBodyEntry = string_entry('request_body', $requestBodyContent);
-                        }
-
-                        break;
-
-                    default:
-                        $requestBodyEntry = string_entry('request_body', $requestBodyContent);
-
-                        break;
-                }
+                            ))),
+                        )
+                        : string_entry('request_body', $requestBodyContent),
+                    default => string_entry('request_body', $requestBodyContent),
+                };
             }
         }
 

--- a/src/adapter/etl-adapter-parquet/src/Flow/ETL/Adapter/Parquet/SchemaConverter.php
+++ b/src/adapter/etl-adapter-parquet/src/Flow/ETL/Adapter/Parquet/SchemaConverter.php
@@ -95,95 +95,58 @@ final class SchemaConverter
      */
     private function flowToParquet(string $name, Type $type, bool $nullable): Column
     {
-        switch ($type::class) {
-            case FloatType::class:
-                return FlatColumn::float(
-                    $name,
-                    $nullable ? ParquetSchema\Repetition::OPTIONAL : ParquetSchema\Repetition::REQUIRED,
-                );
-            case IntegerType::class:
-                return FlatColumn::int64(
-                    $name,
-                    $nullable ? ParquetSchema\Repetition::OPTIONAL : ParquetSchema\Repetition::REQUIRED,
-                );
-            case HTMLType::class:
-            case HTMLElementType::class:
-            case XMLElementType::class:
-            case XMLType::class:
-            case StringType::class:
-                return FlatColumn::string(
-                    $name,
-                    $nullable ? ParquetSchema\Repetition::OPTIONAL : ParquetSchema\Repetition::REQUIRED,
-                );
-            case BooleanType::class:
-                return FlatColumn::boolean(
-                    $name,
-                    $nullable ? ParquetSchema\Repetition::OPTIONAL : ParquetSchema\Repetition::REQUIRED,
-                );
-            case TimeType::class:
-                return FlatColumn::time(
-                    $name,
-                    $nullable ? ParquetSchema\Repetition::OPTIONAL : ParquetSchema\Repetition::REQUIRED,
-                );
-            case DateType::class:
-                return FlatColumn::date(
-                    $name,
-                    $nullable ? ParquetSchema\Repetition::OPTIONAL : ParquetSchema\Repetition::REQUIRED,
-                );
-            case DateTimeType::class:
-                return FlatColumn::datetime(
-                    $name,
-                    $nullable ? ParquetSchema\Repetition::OPTIONAL : ParquetSchema\Repetition::REQUIRED,
-                );
-            case UuidType::class:
-                return FlatColumn::uuid(
-                    $name,
-                    $nullable ? ParquetSchema\Repetition::OPTIONAL : ParquetSchema\Repetition::REQUIRED,
-                );
-            case JsonType::class:
-                return FlatColumn::json(
-                    $name,
-                    $nullable ? ParquetSchema\Repetition::OPTIONAL : ParquetSchema\Repetition::REQUIRED,
-                );
-            case ListType::class:
-                $elementType = $type->element();
-                $elementOptional = $elementType instanceof OptionalType;
-                $elementType = $elementType instanceof OptionalType ? $elementType->base() : $elementType;
+        $repetition = $nullable ? ParquetSchema\Repetition::OPTIONAL : ParquetSchema\Repetition::REQUIRED;
 
-                return NestedColumn::list(
-                    $name,
-                    new ListElement($this->flowToParquet('element', $elementType, $elementOptional)),
-                    $nullable ? ParquetSchema\Repetition::OPTIONAL : ParquetSchema\Repetition::REQUIRED,
-                );
-            case MapType::class:
-                $valueType = $type->value();
-                $valueOptional = $valueType instanceof OptionalType;
-                $valueType = $valueType instanceof OptionalType ? $valueType->base() : $valueType;
+        return match ($type::class) {
+            FloatType::class => FlatColumn::float($name, $repetition),
+            IntegerType::class => FlatColumn::int64($name, $repetition),
+            HTMLType::class,
+            HTMLElementType::class,
+            XMLElementType::class,
+            XMLType::class,
+            StringType::class,
+                => FlatColumn::string($name, $repetition),
+            BooleanType::class => FlatColumn::boolean($name, $repetition),
+            TimeType::class => FlatColumn::time($name, $repetition),
+            DateType::class => FlatColumn::date($name, $repetition),
+            DateTimeType::class => FlatColumn::datetime($name, $repetition),
+            UuidType::class => FlatColumn::uuid($name, $repetition),
+            JsonType::class => FlatColumn::json($name, $repetition),
+            ListType::class => NestedColumn::list(
+                $name,
+                new ListElement($this->flowToParquet(
+                    'element',
+                    $this->unwrapOptional($type->element()),
+                    $type->element() instanceof OptionalType,
+                )),
+                $repetition,
+            ),
+            MapType::class => NestedColumn::map(
+                $name,
+                new ParquetSchema\MapKey($this->flowToParquet('key', $type->key(), false)),
+                new ParquetSchema\MapValue($this->flowToParquet(
+                    'value',
+                    $this->unwrapOptional($type->value()),
+                    $type->value() instanceof OptionalType,
+                )),
+                $repetition,
+            ),
+            StructureType::class => NestedColumn::struct(
+                $name,
+                array_map(
+                    function (int|string $elementName, Type $elementType) {
+                        $elementOptional = $elementType instanceof OptionalType;
+                        $elementType = $elementType instanceof OptionalType ? $elementType->base() : $elementType;
 
-                return NestedColumn::map(
-                    $name,
-                    new ParquetSchema\MapKey($this->flowToParquet('key', $type->key(), false)),
-                    new ParquetSchema\MapValue($this->flowToParquet('value', $valueType, $valueOptional)),
-                    $nullable ? ParquetSchema\Repetition::OPTIONAL : ParquetSchema\Repetition::REQUIRED,
-                );
-            case StructureType::class:
-                return NestedColumn::struct(
-                    $name,
-                    array_map(
-                        function (int|string $elementName, Type $elementType) {
-                            $elementOptional = $elementType instanceof OptionalType;
-                            $elementType = $elementType instanceof OptionalType ? $elementType->base() : $elementType;
-
-                            return $this->flowToParquet((string) $elementName, $elementType, $elementOptional);
-                        },
-                        array_keys($type->elements()),
-                        $type->elements(),
-                    ),
-                    $nullable ? ParquetSchema\Repetition::OPTIONAL : ParquetSchema\Repetition::REQUIRED,
-                );
-        }
-
-        throw new RuntimeException($type::class . ' is not supported.');
+                        return $this->flowToParquet((string) $elementName, $elementType, $elementOptional);
+                    },
+                    array_keys($type->elements()),
+                    $type->elements(),
+                ),
+                $repetition,
+            ),
+            default => throw new RuntimeException($type::class . ' is not supported.'),
+        };
     }
 
     /**
@@ -332,5 +295,15 @@ final class SchemaConverter
         }
 
         return $nullable ? type_optional(type_structure($elements)) : type_structure($elements);
+    }
+
+    /**
+     * @param Type<mixed> $type
+     *
+     * @return Type<mixed>
+     */
+    private function unwrapOptional(Type $type): Type
+    {
+        return $type instanceof OptionalType ? $type->base() : $type;
     }
 }

--- a/src/adapter/etl-adapter-seal/src/Flow/ETL/Adapter/Seal/SchemaConverter.php
+++ b/src/adapter/etl-adapter-seal/src/Flow/ETL/Adapter/Seal/SchemaConverter.php
@@ -102,73 +102,60 @@ final class SchemaConverter
      */
     private function flowToSealField(string $name, Type $type, bool $multiple, Metadata $metadata): AbstractField
     {
-        switch ($type::class) {
-            case EnumType::class:
-            case HTMLElementType::class:
-            case HTMLType::class:
-            case StringType::class:
-            case UuidType::class:
-            case XMLElementType::class:
-            case XMLType::class:
-                return new Field\TextField(
-                    $name,
-                    multiple: $multiple,
-                    searchable: $this->flag($metadata, SealMetadata::SEARCHABLE, true),
-                    filterable: $this->flag($metadata, SealMetadata::FILTERABLE, false),
-                    sortable: $this->flag($metadata, SealMetadata::SORTABLE, false),
-                    distinct: $this->flag($metadata, SealMetadata::DISTINCT, false),
-                    facet: $this->flag($metadata, SealMetadata::FACET, false),
-                );
-            case IntegerType::class:
-                return new Field\IntegerField(
-                    $name,
-                    multiple: $multiple,
-                    filterable: $this->flag($metadata, SealMetadata::FILTERABLE, true),
-                    sortable: $this->flag($metadata, SealMetadata::SORTABLE, true),
-                    distinct: $this->flag($metadata, SealMetadata::DISTINCT, false),
-                    facet: $this->flag($metadata, SealMetadata::FACET, false),
-                );
-            case FloatType::class:
-                return new Field\FloatField(
-                    $name,
-                    multiple: $multiple,
-                    filterable: $this->flag($metadata, SealMetadata::FILTERABLE, true),
-                    sortable: $this->flag($metadata, SealMetadata::SORTABLE, true),
-                    distinct: $this->flag($metadata, SealMetadata::DISTINCT, false),
-                    facet: $this->flag($metadata, SealMetadata::FACET, false),
-                );
-            case BooleanType::class:
-                return new Field\BooleanField(
-                    $name,
-                    multiple: $multiple,
-                    filterable: $this->flag($metadata, SealMetadata::FILTERABLE, true),
-                    sortable: $this->flag($metadata, SealMetadata::SORTABLE, false),
-                    distinct: $this->flag($metadata, SealMetadata::DISTINCT, false),
-                    facet: $this->flag($metadata, SealMetadata::FACET, false),
-                );
-            case DateTimeType::class:
-            case DateType::class:
-                return new Field\DateTimeField(
-                    $name,
-                    multiple: $multiple,
-                    filterable: $this->flag($metadata, SealMetadata::FILTERABLE, true),
-                    sortable: $this->flag($metadata, SealMetadata::SORTABLE, true),
-                    distinct: $this->flag($metadata, SealMetadata::DISTINCT, false),
-                    facet: $this->flag($metadata, SealMetadata::FACET, false),
-                );
-            case JsonType::class:
-            case MapType::class:
-                return new Field\JsonObjectField($name);
-            case ListType::class:
-                $element = $type->element();
-                $element = $element instanceof OptionalType ? $element->base() : $element;
-
-                return $this->flowToSealField($name, $element, true, $metadata);
-            case StructureType::class:
-                return new Field\ObjectField($name, $this->structureFields($type), multiple: $multiple);
-        }
-
-        throw new RuntimeException($type::class . ' is not supported.');
+        return match ($type::class) {
+            EnumType::class,
+            HTMLElementType::class,
+            HTMLType::class,
+            StringType::class,
+            UuidType::class,
+            XMLElementType::class,
+            XMLType::class,
+                => new Field\TextField(
+                $name,
+                multiple: $multiple,
+                searchable: $this->flag($metadata, SealMetadata::SEARCHABLE, true),
+                filterable: $this->flag($metadata, SealMetadata::FILTERABLE, false),
+                sortable: $this->flag($metadata, SealMetadata::SORTABLE, false),
+                distinct: $this->flag($metadata, SealMetadata::DISTINCT, false),
+                facet: $this->flag($metadata, SealMetadata::FACET, false),
+            ),
+            IntegerType::class => new Field\IntegerField(
+                $name,
+                multiple: $multiple,
+                filterable: $this->flag($metadata, SealMetadata::FILTERABLE, true),
+                sortable: $this->flag($metadata, SealMetadata::SORTABLE, true),
+                distinct: $this->flag($metadata, SealMetadata::DISTINCT, false),
+                facet: $this->flag($metadata, SealMetadata::FACET, false),
+            ),
+            FloatType::class => new Field\FloatField(
+                $name,
+                multiple: $multiple,
+                filterable: $this->flag($metadata, SealMetadata::FILTERABLE, true),
+                sortable: $this->flag($metadata, SealMetadata::SORTABLE, true),
+                distinct: $this->flag($metadata, SealMetadata::DISTINCT, false),
+                facet: $this->flag($metadata, SealMetadata::FACET, false),
+            ),
+            BooleanType::class => new Field\BooleanField(
+                $name,
+                multiple: $multiple,
+                filterable: $this->flag($metadata, SealMetadata::FILTERABLE, true),
+                sortable: $this->flag($metadata, SealMetadata::SORTABLE, false),
+                distinct: $this->flag($metadata, SealMetadata::DISTINCT, false),
+                facet: $this->flag($metadata, SealMetadata::FACET, false),
+            ),
+            DateTimeType::class, DateType::class => new Field\DateTimeField(
+                $name,
+                multiple: $multiple,
+                filterable: $this->flag($metadata, SealMetadata::FILTERABLE, true),
+                sortable: $this->flag($metadata, SealMetadata::SORTABLE, true),
+                distinct: $this->flag($metadata, SealMetadata::DISTINCT, false),
+                facet: $this->flag($metadata, SealMetadata::FACET, false),
+            ),
+            JsonType::class, MapType::class => new Field\JsonObjectField($name),
+            ListType::class => $this->flowToSealField($name, $this->unwrapOptional($type->element()), true, $metadata),
+            StructureType::class => new Field\ObjectField($name, $this->structureFields($type), multiple: $multiple),
+            default => throw new RuntimeException($type::class . ' is not supported.'),
+        };
     }
 
     /**
@@ -225,5 +212,15 @@ final class SchemaConverter
         }
 
         return $fields;
+    }
+
+    /**
+     * @param Type<mixed> $type
+     *
+     * @return Type<mixed>
+     */
+    private function unwrapOptional(Type $type): Type
+    {
+        return $type instanceof OptionalType ? $type->base() : $type;
     }
 }

--- a/src/core/etl/src/Flow/ETL/Dataset/Memory/Unit.php
+++ b/src/core/etl/src/Flow/ETL/Dataset/Memory/Unit.php
@@ -48,24 +48,16 @@ final readonly class Unit
 
         $unit = substr($limit, -1);
 
-        switch (strtoupper($unit)) {
-            case 'K':
-            case 'B':
-                return self::fromKb((int) substr($limit, 0, -1));
-            case 'M':
-            case 'MB':
-                return self::fromMb((int) substr($limit, 0, -1));
-            case 'G':
-            case 'GB':
-                return self::fromGb((int) substr($limit, 0, -1));
-
-            default:
-                if (ctype_digit($limit)) {
-                    return self::fromBytes((int) $limit);
-                }
-
-                throw new InvalidArgumentException("Can't extract memory limit in bytes from php ini value: {$limit}");
-        }
+        return match (strtoupper($unit)) {
+            'K', 'B' => self::fromKb((int) substr($limit, 0, -1)),
+            'M', 'MB' => self::fromMb((int) substr($limit, 0, -1)),
+            'G', 'GB' => self::fromGb((int) substr($limit, 0, -1)),
+            default => ctype_digit($limit)
+                ? self::fromBytes((int) $limit)
+                : throw new InvalidArgumentException(
+                    "Can't extract memory limit in bytes from php ini value: {$limit}",
+                ),
+        };
     }
 
     public function absolute(): self

--- a/src/core/etl/src/Flow/ETL/Formatter/ASCII/ASCIIValue.php
+++ b/src/core/etl/src/Flow/ETL/Formatter/ASCII/ASCIIValue.php
@@ -54,26 +54,24 @@ final class ASCIIValue
         $result = $input;
 
         if (($paddingRequired = $length - mb_strlen($input, $encoding)) > 0) {
-            switch ($padType) {
-                case STR_PAD_LEFT:
-                    return mb_substr(str_repeat($padding, $paddingRequired), 0, $paddingRequired, $encoding) . $input;
-                case STR_PAD_RIGHT:
-                    return $input . mb_substr(str_repeat($padding, $paddingRequired), 0, $paddingRequired, $encoding);
-                case STR_PAD_BOTH:
-                    $leftPaddingLength = (int) floor($paddingRequired / 2);
-                    $rightPaddingLength = $paddingRequired - $leftPaddingLength;
+            $leftPaddingLength = (int) floor($paddingRequired / 2);
+            $rightPaddingLength = $paddingRequired - $leftPaddingLength;
 
-                    return (
-                        mb_substr(str_repeat($padding, max(0, $leftPaddingLength)), 0, $leftPaddingLength, $encoding)
-                        . $input
-                        . mb_substr(
-                            str_repeat($padding, max(0, $rightPaddingLength)),
-                            0,
-                            $rightPaddingLength,
-                            $encoding,
-                        )
-                    );
-            }
+            return match ($padType) {
+                STR_PAD_LEFT => mb_substr(str_repeat($padding, $paddingRequired), 0, $paddingRequired, $encoding)
+                    . $input,
+                STR_PAD_RIGHT => $input
+                    . mb_substr(str_repeat($padding, $paddingRequired), 0, $paddingRequired, $encoding),
+                STR_PAD_BOTH => mb_substr(
+                    str_repeat($padding, max(0, $leftPaddingLength)),
+                    0,
+                    $leftPaddingLength,
+                    $encoding,
+                )
+                    . $input
+                    . mb_substr(str_repeat($padding, max(0, $rightPaddingLength)), 0, $rightPaddingLength, $encoding),
+                default => $result,
+            };
         }
 
         return $result;

--- a/src/lib/parquet/src/Flow/Parquet/Dremel/Validator/ColumnDataValidator.php
+++ b/src/lib/parquet/src/Flow/Parquet/Dremel/Validator/ColumnDataValidator.php
@@ -131,77 +131,47 @@ final class ColumnDataValidator implements Validator
         $type = $column->type();
         $logicalTypeName = $column->logicalType()?->name();
 
-        switch ($type) {
-            case PhysicalType::BOOLEAN:
-                if (!is_bool($data)) {
-                    throw new ValidationException(sprintf('Column "%s" is not boolean', $column->flatPath()));
-                }
-
-                break;
-            case PhysicalType::INT64:
-            case PhysicalType::INT32:
-                switch ($logicalTypeName) {
-                    case LogicalType::DATE:
-                    case LogicalType::TIMESTAMP:
-                        if (!$data instanceof DateTimeInterface) {
-                            throw new ValidationException(sprintf(
-                                'Column "%s" require \DateTimeInterface as value',
-                                $column->flatPath(),
-                            ));
-                        }
-
-                        break;
-                    case LogicalType::TIME:
-                        if (!$data instanceof DateInterval) {
-                            throw new ValidationException(sprintf(
-                                'Column "%s" require \DateInterval as value',
-                                $column->flatPath(),
-                            ));
-                        }
-
-                        break;
-                    case null:
-                        if (!is_int($data)) {
-                            throw new ValidationException(sprintf(
-                                'Column "%s" require integer as value, got: %s instead',
-                                $column->flatPath(),
-                                gettype($data),
-                            ));
-                        }
-
-                        break;
-                }
-
-                break;
-            case PhysicalType::FLOAT:
-            case PhysicalType::DOUBLE:
-                if (!is_float($data)) {
-                    throw new ValidationException(sprintf('Column "%s" is not float', $column->flatPath()));
-                }
-
-                break;
-            case PhysicalType::BYTE_ARRAY:
-                switch ($logicalTypeName) {
-                    case LogicalType::STRING:
-                    case LogicalType::JSON:
-                    case LogicalType::UUID:
-                        if (!is_string($data)) {
-                            throw new ValidationException(sprintf(
-                                'Column "%s" is not string, got "%s" instead',
-                                $column->flatPath(),
-                                gettype($data),
-                            ));
-                        }
-
-                        break;
-                }
-
-                break;
-            case PhysicalType::FIXED_LEN_BYTE_ARRAY:
-                break;
-
-            default:
-                throw new ValidationException(sprintf('Unknown column type "%s"', $type->name));
-        }
+        match ($type) {
+            PhysicalType::BOOLEAN => is_bool($data)
+                ? null
+                : throw new ValidationException(sprintf('Column "%s" is not boolean', $column->flatPath())),
+            PhysicalType::INT64, PhysicalType::INT32 => match ($logicalTypeName) {
+                LogicalType::DATE, LogicalType::TIMESTAMP => $data instanceof DateTimeInterface
+                    ? null
+                    : throw new ValidationException(sprintf(
+                        'Column "%s" require \DateTimeInterface as value',
+                        $column->flatPath(),
+                    )),
+                LogicalType::TIME => $data instanceof DateInterval
+                    ? null
+                    : throw new ValidationException(sprintf(
+                        'Column "%s" require \DateInterval as value',
+                        $column->flatPath(),
+                    )),
+                null => is_int($data)
+                    ? null
+                    : throw new ValidationException(sprintf(
+                        'Column "%s" require integer as value, got: %s instead',
+                        $column->flatPath(),
+                        gettype($data),
+                    )),
+                default => null,
+            },
+            PhysicalType::FLOAT, PhysicalType::DOUBLE => is_float($data)
+                ? null
+                : throw new ValidationException(sprintf('Column "%s" is not float', $column->flatPath())),
+            PhysicalType::BYTE_ARRAY => match ($logicalTypeName) {
+                LogicalType::STRING, LogicalType::JSON, LogicalType::UUID => is_string($data)
+                    ? null
+                    : throw new ValidationException(sprintf(
+                        'Column "%s" is not string, got "%s" instead',
+                        $column->flatPath(),
+                        gettype($data),
+                    )),
+                default => null,
+            },
+            PhysicalType::FIXED_LEN_BYTE_ARRAY => null,
+            default => throw new ValidationException(sprintf('Unknown column type "%s"', $type->name)),
+        };
     }
 }

--- a/src/lib/parquet/src/Flow/Parquet/Writer.php
+++ b/src/lib/parquet/src/Flow/Parquet/Writer.php
@@ -26,19 +26,19 @@ final class Writer
         private readonly Options $options = new Options(),
         private readonly ParquetEngine $engine = new AdaptiveParquetEngine(),
     ) {
-        switch ($this->compression) {
-            case Compressions::UNCOMPRESSED:
-            case Compressions::SNAPPY:
-            case Compressions::BROTLI:
-            case Compressions::GZIP:
-            case Compressions::LZ4:
-            case Compressions::LZ4_RAW:
-            case Compressions::ZSTD:
-                break;
-
-            default:
-                throw new InvalidArgumentException("Compression \"{$this->compression->name}\" is not supported yet");
-        }
+        match ($this->compression) {
+            Compressions::UNCOMPRESSED,
+            Compressions::SNAPPY,
+            Compressions::BROTLI,
+            Compressions::GZIP,
+            Compressions::LZ4,
+            Compressions::LZ4_RAW,
+            Compressions::ZSTD,
+                => null,
+            default => throw new InvalidArgumentException(
+                "Compression \"{$this->compression->name}\" is not supported yet",
+            ),
+        };
     }
 
     public static function arrow(

--- a/src/lib/parquet/src/Flow/Parquet/Writer/ColumnChunkBuilderFactory.php
+++ b/src/lib/parquet/src/Flow/Parquet/Writer/ColumnChunkBuilderFactory.php
@@ -86,35 +86,24 @@ final class ColumnChunkBuilderFactory
         $encodingName = $encoding->name;
         $flatPath = $column->flatPath();
 
-        switch ($encoding) {
-            case Encodings::DELTA_BINARY_PACKED:
-                if ($columnType !== PhysicalType::INT32 && $columnType !== PhysicalType::INT64) {
-                    throw new InvalidArgumentException(
-                        'DELTA_BINARY_PACKED encoding is only supported for INT32 and INT64 columns. '
-                        . "Column '{$flatPath}' has type: {$columnType->name}",
-                    );
-                }
-
-                break;
-
-            case Encodings::RLE_DICTIONARY:
-                if ($columnType === PhysicalType::FIXED_LEN_BYTE_ARRAY) {
-                    throw new InvalidArgumentException(
-                        'RLE_DICTIONARY encoding is not supported for FIXED_LEN_BYTE_ARRAY columns. '
-                        . "Column '{$flatPath}' has type: {$columnType->name}",
-                    );
-                }
-
-                break;
-
-            case Encodings::PLAIN:
-                break;
-
-            default:
-                throw new InvalidArgumentException(
-                    "Encoding '{$encodingName}' is not implemented. "
-                    . 'Supported encodings: PLAIN, RLE_DICTIONARY, DELTA_BINARY_PACKED',
-                );
-        }
+        match ($encoding) {
+            Encodings::DELTA_BINARY_PACKED => $columnType !== PhysicalType::INT32 && $columnType !== PhysicalType::INT64
+                ? throw new InvalidArgumentException(
+                    'DELTA_BINARY_PACKED encoding is only supported for INT32 and INT64 columns. '
+                    . "Column '{$flatPath}' has type: {$columnType->name}",
+                )
+                : null,
+            Encodings::RLE_DICTIONARY => $columnType === PhysicalType::FIXED_LEN_BYTE_ARRAY
+                ? throw new InvalidArgumentException(
+                    'RLE_DICTIONARY encoding is not supported for FIXED_LEN_BYTE_ARRAY columns. '
+                    . "Column '{$flatPath}' has type: {$columnType->name}",
+                )
+                : null,
+            Encodings::PLAIN => null,
+            default => throw new InvalidArgumentException(
+                "Encoding '{$encodingName}' is not implemented. "
+                . 'Supported encodings: PLAIN, RLE_DICTIONARY, DELTA_BINARY_PACKED',
+            ),
+        };
     }
 }

--- a/src/lib/parquet/src/Flow/Parquet/Writer/PageBuilder/DictionaryBuilder.php
+++ b/src/lib/parquet/src/Flow/Parquet/Writer/PageBuilder/DictionaryBuilder.php
@@ -17,44 +17,33 @@ final class DictionaryBuilder
 {
     public function build(FlatColumn $column, WriteFlatColumnValues $data): Dictionary
     {
-        switch ($column->type()) {
-            case PhysicalType::INT64:
-            case PhysicalType::INT32:
-                return match ($column->logicalType()?->name()) {
-                    LogicalType::DATE,
-                    LogicalType::TIME,
-                    LogicalType::TIMESTAMP,
-                        => (new ObjectDictionaryBuilder())->build($data),
-                    default => (new ScalarDictionaryBuilder())->build($data),
-                };
-            case PhysicalType::BOOLEAN:
-                return (new ScalarDictionaryBuilder())->build($data);
-            case PhysicalType::FLOAT:
-            case PhysicalType::DOUBLE:
-                return (new FloatDictionaryBuilder())->build($data);
-            case PhysicalType::FIXED_LEN_BYTE_ARRAY:
-            case PhysicalType::BYTE_ARRAY:
-                return match ($column->logicalType()?->name()) {
-                    LogicalType::STRING,
-                    LogicalType::JSON,
-                    LogicalType::BSON,
-                    LogicalType::UUID,
-                    LogicalType::ENUM,
-                        => (new ScalarDictionaryBuilder())->build($data),
-                    LogicalType::DECIMAL => (new FloatDictionaryBuilder())->build($data),
-                    LogicalType::DATE,
-                    LogicalType::TIME,
-                    LogicalType::TIMESTAMP,
-                        => (new ObjectDictionaryBuilder())->build($data),
-                    default => throw new RuntimeException(
-                        'Building dictionary for "'
-                        . ($column->logicalType()?->name() ?? 'null')
-                        . '" is not supported',
-                    ),
-                };
-
-            default:
-                throw new RuntimeException('Building dictionary for "' . $column->type()->name . '" is not supported');
-        }
+        return match ($column->type()) {
+            PhysicalType::INT64, PhysicalType::INT32 => match ($column->logicalType()?->name()) {
+                LogicalType::DATE, LogicalType::TIME, LogicalType::TIMESTAMP => (new ObjectDictionaryBuilder())->build(
+                    $data,
+                ),
+                default => (new ScalarDictionaryBuilder())->build($data),
+            },
+            PhysicalType::BOOLEAN => (new ScalarDictionaryBuilder())->build($data),
+            PhysicalType::FLOAT, PhysicalType::DOUBLE => (new FloatDictionaryBuilder())->build($data),
+            PhysicalType::FIXED_LEN_BYTE_ARRAY, PhysicalType::BYTE_ARRAY => match ($column->logicalType()?->name()) {
+                LogicalType::STRING,
+                LogicalType::JSON,
+                LogicalType::BSON,
+                LogicalType::UUID,
+                LogicalType::ENUM,
+                    => (new ScalarDictionaryBuilder())->build($data),
+                LogicalType::DECIMAL => (new FloatDictionaryBuilder())->build($data),
+                LogicalType::DATE, LogicalType::TIME, LogicalType::TIMESTAMP => (new ObjectDictionaryBuilder())->build(
+                    $data,
+                ),
+                default => throw new RuntimeException(
+                    'Building dictionary for "' . ($column->logicalType()?->name() ?? 'null') . '" is not supported',
+                ),
+            },
+            default => throw new RuntimeException(
+                'Building dictionary for "' . $column->type()->name . '" is not supported',
+            ),
+        };
     }
 }


### PR DESCRIPTION
## Summary

Replaces `switch` statements with `match` expressions.

## Changes

- `Flow\ETL\Dataset\Memory\Unit::fromString()` — dispatch and the default *digit-or-throw* branch as one `match` (throw-as-expression),
- `Flow\ETL\Formatter\ASCII\ASCIIValue::mb_str_pad()` — padding lengths hoisted above the `match`; `default => $result` reproduces the original no-default fall-through,
- `Flow\ETL\Adapter\Http\RequestEntriesFactory` — body-entry selection as a `match` assignment,
- `Flow\ETL\Adapter\Parquet\SchemaConverter::flowToParquet()` — 14-arm `match`; the `$nullable ? OPTIONAL : REQUIRED` ternary repeated in every case is hoisted into `$repetition`; `ListType`/`MapType` arms unwrap optionals through a small `unwrapOptional()` helper (repeated accessor calls defeat static-analysis narrowing inside a single arm expression),
- `Flow\ETL\Adapter\Seal\SchemaConverter::flowToSealField()` — same treatment,
- `Flow\Parquet\Writer` and `Flow\Parquet\Writer\ColumnChunkBuilderFactory` — compression/encoding validation as `match` with `condition ? throw : null` arms,
- `Flow\Parquet\Writer\PageBuilder\DictionaryBuilder` — previously a hybrid `switch` around nested `match`es, now a single nested `match`,
- `Flow\Parquet\Dremel\Validator\ColumnDataValidator` — nested validation `match`es; inner switches had no `default`, so the arms get an explicit `default => null` to preserve the silent pass-through, and `case null:` becomes a strict `null` arm.

Left as `switch` on purpose: `ThriftModel/*` and `CompactProtocol` (Thrift protocol field-id dispatch with multi-statement bodies / by-ref temporaries), `SnappyDecompressor` (hot loop with multi-variable assignments per case), `PageReader`, `FlowTelemetryBundle` (multi-statement DI configuration cases) and `PlainValuesPacker` (per-case `@var` assertions that static analysis relies on). None of these can become a `match` without restructuring beyond a mechanical conversion.

No public API changes. Every converted switch was checked for loose-vs-strict comparison hazards (subjects are enums, `::class` strings or `strtoupper()` results) and for missing-`default` fall-throughs (`match` throws `UnhandledMatchError` where `switch` falls through — explicit `default` arms preserve the original behavior).

## Verification & Benchmarks

Standard pipeline on 1M rows (`from_csv` → `batchSize(1000)` → `withEntry(concat)` → `filter(endsWith)` → write), PHP 8.3 + opcache, fresh process per run, medians of 3:

| Scenario | `1.x` | this PR | Δ |
|---|---|---|---|
| write CSV | 11.81 s | 11.67 s | within noise |
| write Parquet | 13.10 s | 13.30 s | within noise |

Peak memory unchanged (16/18 MB). **Output files are byte-identical** before and after the change (matching md5 for the 91 MB CSV and the 24.2 MB parquet output — the parquet variant deliberately routes through the converted `SchemaConverter`, `DictionaryBuilder` and per-value `ColumnDataValidator`). As expected for switch→match, this is a readability/strictness refactor, not a performance change — the benchmark is regression evidence.

<!--
    Please replace #xxx with a GitHub issue id from flow-php/flow repository. For example #1234
    If there is no item in a roadmap related to this PR, please check our contributing guidelines first.
-->
Resolves: no related roadmap item — standalone modernization refactor

<!--
    Below section will be used to automatically generate changelog, please do not modify HTML code structure
    DO NOT REMOVE that HTML STRUCTURE, INSTEAD ADD YOUR CHANGES INSIDE THE LISTS
    PULL REQUESTS WITHOUT CHANGELOG CAN'T BE MERGED
-->
<h2>Change Log</h2>
<hr />
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
  </ul>
  <h4>Fixed</h4>
  <ul id="fixed">
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Replaced switch statements with match expressions across core ETL, parquet lib and http/parquet/seal adapters (no behavior change, outputs byte-identical)</li>
  </ul>
  <h4>Removed</h4>
  <ul id="removed">
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
  </ul>
  <h4>Security</h4>
  <ul id="security">
  </ul>
</div>
