### PR TITLE
fix: correct telemetry span nesting and lifecycle

### DIFF
--- a/documentation/components/core/transformations.md
+++ b/documentation/components/core/transformations.md
@@ -232,6 +232,14 @@ This pattern is particularly useful when you need to:
 - Create transformation pipelines that can be reused
 - Separate transformation logic from extraction and loading
 
+The `Transformation` is expanded **once per loader instance**, on the first batch, and every subsequent batch is
+streamed through that same pipeline. Stateful transformations - `limit()`, `add_row_index()` - therefore apply across
+the whole stream, not per batch.
+
+Batching transformations (`batch_size()`, `batch_by()`) expand to a `Processor`, which re-batches only within the
+batches the outer pipeline hands the loader - a `Loader` never sees the stream. To re-batch the pipeline itself, use
+`$df->batchSize(...)` instead of `to_transformation(batch_size(...), ...)`.
+
 ## Creating Custom Transformations
 
 You can create custom transformations by implementing the `Transformation` interface:

--- a/documentation/components/libs/telemetry.md
+++ b/documentation/components/libs/telemetry.md
@@ -286,6 +286,36 @@ $span->setAttribute('order.total', 99.99);
 $tracer->complete($span);
 ```
 
+**Nesting spans:**
+
+Creating a span does not make it the current one — per the OpenTelemetry specification, span creation must not
+change the active context. A span created inside another becomes its child only if the outer span was activated:
+
+```php
+<?php
+
+$order = $tracer->span('process-order');
+$scope = $tracer->activate($order);
+
+try {
+    // child of 'process-order'
+    $tracer->complete($tracer->span('charge-card'));
+} finally {
+    $scope->detach();
+    $tracer->complete($order);
+}
+```
+
+Without `activate()`, `charge-card` is a sibling of `process-order`, not a child.
+
+Detach scopes in reverse order of activation, and before completing the span. `Scope::detach()` returns
+`Scope::DETACHED` on success, `Scope::INACTIVE` if the scope was already detached, and `Scope::MISMATCH` if it was
+not the innermost active scope.
+
+Do **not** activate a span whose lifetime is an object rather than a block — a file stream, a database cursor, a
+long-running transaction handle. Several of those are open at once, so activating them makes each the parent of
+whichever is opened next, producing a staircase instead of siblings. Start such spans and leave them inactive.
+
 For automatic exception handling and span completion, use the `trace()` method:
 
 ```php

--- a/documentation/components/libs/telemetry/contracts.md
+++ b/documentation/components/libs/telemetry/contracts.md
@@ -67,8 +67,9 @@ Three small immutable value objects in `Flow\Telemetry\Batch` carry the payload 
 
 **Interface:** `Flow\Telemetry\Context\ContextStorage`
 
-Stores and retrieves telemetry context (active span, baggage) within a request lifecycle. Enables automatic context
-propagation to child spans.
+Stores and retrieves telemetry context (active span, baggage) within a request lifecycle. `attach()` returns a
+`Scope` that must be detached in reverse order; a span becomes the parent of later spans only while its scope is
+attached — see `Tracer::activate()`.
 
 | Implementation         | Package              | Description                                |
 |------------------------|----------------------|--------------------------------------------|
@@ -102,12 +103,12 @@ sits between the Tracer and the unified `Exporter`. The `exporter()` accessor re
 Makes sampling decisions for traces. Determines whether a span should be recorded and exported based on configurable
 rules.
 
-| Implementation             | Package              | Description                                         |
-|----------------------------|----------------------|-----------------------------------------------------|
-| `AlwaysOnSampler`          | `flow-php/telemetry` | Records all traces                                  |
-| `AlwaysOffSampler`         | `flow-php/telemetry` | Records no traces                                   |
-| `TraceIdRatioBasedSampler` | `flow-php/telemetry` | Records a configurable percentage of traces         |
-| `ParentBasedSampler`       | `flow-php/telemetry` | Inherits sampling decision from parent span context |
+| Implementation             | Package              | Description                                                                                              |
+|----------------------------|----------------------|----------------------------------------------------------------------------------------------------------|
+| `AlwaysOnSampler`          | `flow-php/telemetry` | Records all traces                                                                                       |
+| `AlwaysOffSampler`         | `flow-php/telemetry` | Records no traces                                                                                        |
+| `TraceIdRatioBasedSampler` | `flow-php/telemetry` | Records a configurable percentage of traces                                                              |
+| `ParentBasedSampler`       | `flow-php/telemetry` | Inherits sampling decision from parent span context                                                      |
 | `AttributeMatchingSampler` | `flow-php/telemetry` | Drops spans matching an `AttributeFilter` (start-time attributes), defers the rest to a delegate sampler |
 
 ---
@@ -168,13 +169,13 @@ Processes log records from loggers. Determines how logs are buffered and when th
 (marker interface extending `LogProcessor`) identifies the terminal/leaf processors; `PipelineLogProcessor` runs an
 ordered chain of `LogMiddleware` and forwards survivors to one `LogSink`.
 
-| Implementation            | Package              | Sink? | Description                                          |
-|---------------------------|----------------------|-------|------------------------------------------------------|
-| `PassThroughLogProcessor` | `flow-php/telemetry` | yes   | Exports each log immediately when recorded           |
-| `BatchingLogProcessor`    | `flow-php/telemetry` | yes   | Buffers logs and exports in configurable batches     |
-| `CompositeLogProcessor`   | `flow-php/telemetry` | yes   | Delegates to multiple processors                     |
-| `MemoryLogProcessor`      | `flow-php/telemetry` | yes   | Stores logs in memory for testing                    |
-| `VoidLogProcessor`        | `flow-php/telemetry` | yes   | No-op processor that discards all logs               |
+| Implementation            | Package              | Sink? | Description                                            |
+|---------------------------|----------------------|-------|--------------------------------------------------------|
+| `PassThroughLogProcessor` | `flow-php/telemetry` | yes   | Exports each log immediately when recorded             |
+| `BatchingLogProcessor`    | `flow-php/telemetry` | yes   | Buffers logs and exports in configurable batches       |
+| `CompositeLogProcessor`   | `flow-php/telemetry` | yes   | Delegates to multiple processors                       |
+| `MemoryLogProcessor`      | `flow-php/telemetry` | yes   | Stores logs in memory for testing                      |
+| `VoidLogProcessor`        | `flow-php/telemetry` | yes   | No-op processor that discards all logs                 |
 | `PipelineLogProcessor`    | `flow-php/telemetry` | no    | Runs middleware in order, then forwards to a `LogSink` |
 
 ### LogMiddleware
@@ -184,11 +185,11 @@ ordered chain of `LogMiddleware` and forwards survivors to one `LogSink`.
 A chainable step inside a `PipelineLogProcessor`. `process(LogEntry): ?LogEntry` returns the entry to pass on (possibly
 enriched) or `null` to drop it. Stateless - flush/shutdown belong to the pipeline's `LogSink`.
 
-| Implementation                     | Package              | Description                                          |
-|------------------------------------|----------------------|------------------------------------------------------|
-| `EnrichingLogMiddleware`           | `flow-php/telemetry` | Merges default attributes (call-site values win)     |
-| `SeverityFilteringLogMiddleware`   | `flow-php/telemetry` | Drops log entries below a minimum severity threshold |
-| `AttributeFilteringLogMiddleware`  | `flow-php/telemetry` | Drops/keeps log entries by an `AttributeFilter`      |
+| Implementation                    | Package              | Description                                          |
+|-----------------------------------|----------------------|------------------------------------------------------|
+| `EnrichingLogMiddleware`          | `flow-php/telemetry` | Merges default attributes (call-site values win)     |
+| `SeverityFilteringLogMiddleware`  | `flow-php/telemetry` | Drops log entries below a minimum severity threshold |
+| `AttributeFilteringLogMiddleware` | `flow-php/telemetry` | Drops/keeps log entries by an `AttributeFilter`      |
 
 ---
 

--- a/documentation/upgrading.md
+++ b/documentation/upgrading.md
@@ -7,6 +7,59 @@ specific version to ensure a smooth upgrade process.
 
 ---
 
+## Upgrading from 0.42.x to 0.43.x
+
+### 1) `flow-php/etl` - `to_transformation()` expands a `Transformation` once per loader, not once per batch
+
+| Before                                                                            | After                   |
+|-----------------------------------------------------------------------------------|-------------------------|
+| `to_transformation(limit(3), $loader)`, 6 batches → 6 rows loaded                 | 3 rows loaded           |
+| `to_transformation(add_row_index('n'), $loader)`, 6 batches → `n = [1,1,1,1,1,1]` | `n = [1,2,3,4,5,6]`     |
+| nested `DataFrame` span per batch                                                 | one nested span per run |
+
+Unchanged: any pipeline using `->collect()`, `drop()`, `select()`, `mask_columns()`, `batch_size()`, `batch_by()`.
+
+### 2) `flow-php/telemetry` - `Tracer::span()` no longer activates the span
+
+| Before                                             | After                                                             |
+|----------------------------------------------------|-------------------------------------------------------------------|
+| `$tracer->span('x')` makes the span current        | does not; `$tracer->activate($span): Scope` does                  |
+| `$tracer->complete($span)` also detaches the scope | ends the span only                                                |
+| `span(…, SpanContext $parentContext)`              | `span(…, Context $parent)`                                        |
+| `trace(…, SpanContext $parentContext)`             | `trace(…, Context $parent)`                                       |
+| `Scope::detach()` always returns `0`               | returns `Scope::DETACHED`, `Scope::INACTIVE` or `Scope::MISMATCH` |
+
+Call sites relying on implicit nesting still compile and silently produce siblings. Rewrite each one that needs
+children:
+
+Before:
+
+```php
+$span = $tracer->span('parent');
+
+try {
+    // ...
+} finally {
+    $tracer->complete($span);
+}
+```
+
+After:
+
+```php
+$span = $tracer->span('parent');
+$scope = $tracer->activate($span);
+
+try {
+    // ...
+} finally {
+    $scope->detach();
+    $tracer->complete($span);
+}
+```
+
+---
+
 ## Upgrading from 0.41.x to 0.42.x
 
 ### 1) `flow-php/symfony-telemetry-bundle` - messenger tracing simplified
@@ -479,6 +532,7 @@ Custom aggregators must implement `references()` - return the references the agg
 | `DataFrame::pivot()`                              | removed; `GroupedDataFrame::pivot()` only         |
 
 ### 32) `flow-php/etl-adapter-csv`, `-excel`, `-json`,
+
 `-xml` - explicit schema no longer projects partition columns away
 
 | Before                                                           | After                                                |
@@ -499,16 +553,6 @@ Assign the result of every `Schema` mutator - `add`, `addAfter`, `addBefore`, `a
 `insertAt`, `keep`, `makeNullable`, `merge`, `moveAfter`, `moveBefore`, `moveTo`, `prepend`, `remove`, `rename`,
 `reorder`, `replace`, `setMetadata`, `sort` - and of `Definition::addMetadata()` / `Definition::setMetadata()`.
 Discarding it is a silent no-op.
-
-### 34) `flow-php/etl` - `to_transformation()` expands a `Transformation` once per loader, not once per batch
-
-| Before                                                                           | After                   |
-|----------------------------------------------------------------------------------|-------------------------|
-| `to_transformation(limit(3), $loader)`, 6 batches → 6 rows loaded                | 3 rows loaded           |
-| `to_transformation(add_row_index('n'), $loader)`, 6 batches → `n = [1,1,1,1,1,1]` | `n = [1,2,3,4,5,6]`     |
-| nested `DataFrame` span per batch                                                | one nested span per run |
-
-Unchanged: any pipeline using `->collect()`, `drop()`, `select()`, `mask_columns()`, `batch_size()`, `batch_by()`.
 
 ---
 
@@ -2265,7 +2309,7 @@ After:
     ->run();
 ```
 
-### 4) ConfigBuilder::putInputIntoRows () output is now prefixed with _   (underscore)
+### 4) ConfigBuilder::putInputIntoRows () output is now prefixed with _    (underscore)
 
 In order to avoid collisions with datasets columns, additional columns created after using putInputIntoRows ()
 would now be prefixed with `_` (underscore) symbol.

--- a/documentation/upgrading.md
+++ b/documentation/upgrading.md
@@ -500,6 +500,16 @@ Assign the result of every `Schema` mutator - `add`, `addAfter`, `addBefore`, `a
 `reorder`, `replace`, `setMetadata`, `sort` - and of `Definition::addMetadata()` / `Definition::setMetadata()`.
 Discarding it is a silent no-op.
 
+### 34) `flow-php/etl` - `to_transformation()` expands a `Transformation` once per loader, not once per batch
+
+| Before                                                                           | After                   |
+|----------------------------------------------------------------------------------|-------------------------|
+| `to_transformation(limit(3), $loader)`, 6 batches → 6 rows loaded                | 3 rows loaded           |
+| `to_transformation(add_row_index('n'), $loader)`, 6 batches → `n = [1,1,1,1,1,1]` | `n = [1,2,3,4,5,6]`     |
+| nested `DataFrame` span per batch                                                | one nested span per run |
+
+Unchanged: any pipeline using `->collect()`, `drop()`, `select()`, `mask_columns()`, `batch_size()`, `batch_by()`.
+
 ---
 
 ## Upgrading from 0.40.x to 0.41.x

--- a/src/bridge/monolog/telemetry/tests/Flow/Bridge/Monolog/Telemetry/Tests/Integration/TelemetryHandlerIntegrationTest.php
+++ b/src/bridge/monolog/telemetry/tests/Flow/Bridge/Monolog/Telemetry/Tests/Integration/TelemetryHandlerIntegrationTest.php
@@ -233,7 +233,9 @@ final class TelemetryHandlerIntegrationTest extends TestCase
         $monolog->pushHandler(telemetry_handler($context->logger));
 
         $span = $tracer->span('short-operation');
+        $scope = $tracer->activate($span);
         $monolog->info('Inside span');
+        $scope->detach();
         $tracer->complete($span);
 
         $monolog->info('After span completed');
@@ -255,10 +257,12 @@ final class TelemetryHandlerIntegrationTest extends TestCase
         $monolog->pushHandler(telemetry_handler($context->logger));
 
         $span = $tracer->span('process-order');
+        $scope = $tracer->activate($span);
 
         $monolog->info('Processing order', ['order_id' => 123]);
         $monolog->warning('Low inventory', ['product_id' => 456]);
 
+        $scope->detach();
         $tracer->complete($span);
 
         $entries = $context->processor->entries();
@@ -436,14 +440,18 @@ final class TelemetryHandlerIntegrationTest extends TestCase
         $monolog->pushHandler(telemetry_handler($context->logger));
 
         $parentSpan = $tracer->span('parent-operation');
+        $parentScope = $tracer->activate($parentSpan);
         $monolog->info('In parent span');
 
         $childSpan = $tracer->span('child-operation');
+        $childScope = $tracer->activate($childSpan);
         $monolog->info('In child span');
 
+        $childScope->detach();
         $tracer->complete($childSpan);
         $monolog->info('Back in parent span');
 
+        $parentScope->detach();
         $tracer->complete($parentSpan);
 
         $entries = $context->processor->entries();

--- a/src/bridge/phpunit/telemetry/src/Flow/Bridge/PHPUnit/Telemetry/SpanStack.php
+++ b/src/bridge/phpunit/telemetry/src/Flow/Bridge/PHPUnit/Telemetry/SpanStack.php
@@ -4,13 +4,14 @@ declare(strict_types=1);
 
 namespace Flow\Bridge\PHPUnit\Telemetry;
 
+use Flow\Telemetry\Context\Scope;
 use Flow\Telemetry\Tracer\Span;
 use SplStack;
 
 final class SpanStack
 {
     /**
-     * @var \SplStack<Span>
+     * @var \SplStack<array{span: Span, scope: Scope}>
      */
     private SplStack $stack;
 
@@ -21,14 +22,14 @@ final class SpanStack
 
     public function __construct()
     {
-        /** @var \SplStack<Span> $stack */
+        /** @var \SplStack<array{span: Span, scope: Scope}> $stack */
         $stack = new SplStack();
         $this->stack = $stack;
     }
 
     public function clear(): void
     {
-        /** @var \SplStack<Span> $stack */
+        /** @var \SplStack<array{span: Span, scope: Scope}> $stack */
         $stack = new SplStack();
         $this->stack = $stack;
         $this->suiteSpans = [];
@@ -40,7 +41,7 @@ final class SpanStack
             return null;
         }
 
-        return $this->stack->top();
+        return $this->stack->top()['span'];
     }
 
     public function getSuiteSpan(string $suiteName): ?Span
@@ -53,18 +54,25 @@ final class SpanStack
         return $this->stack->isEmpty();
     }
 
+    /**
+     * Detaches the entry's context scope before returning it, so the stack owns the LIFO ordering that
+     * Scope::detach() requires.
+     */
     public function pop(): ?Span
     {
         if ($this->stack->isEmpty()) {
             return null;
         }
 
-        return $this->stack->pop();
+        $entry = $this->stack->pop();
+        $entry['scope']->detach();
+
+        return $entry['span'];
     }
 
-    public function push(Span $span): void
+    public function push(Span $span, Scope $scope): void
     {
-        $this->stack->push($span);
+        $this->stack->push(['span' => $span, 'scope' => $scope]);
     }
 
     public function removeSuiteSpan(string $suiteName): void

--- a/src/bridge/phpunit/telemetry/src/Flow/Bridge/PHPUnit/Telemetry/Subscriber/TestPreparationStartedSubscriber.php
+++ b/src/bridge/phpunit/telemetry/src/Flow/Bridge/PHPUnit/Telemetry/Subscriber/TestPreparationStartedSubscriber.php
@@ -58,7 +58,8 @@ final readonly class TestPreparationStartedSubscriber implements PreparationStar
                 PHPUnitTelemetryAttributes::ATTR_TEST_METHOD => $methodName,
             ]);
 
-            $this->spanStack->push($span);
+            // activated: spans the test itself emits must nest under the test span
+            $this->spanStack->push($span, $tracer->activate($span));
         } catch (Throwable) {
             // Silent failure - telemetry must never break tests
         }

--- a/src/bridge/phpunit/telemetry/src/Flow/Bridge/PHPUnit/Telemetry/Subscriber/TestSuiteFinishedSubscriber.php
+++ b/src/bridge/phpunit/telemetry/src/Flow/Bridge/PHPUnit/Telemetry/Subscriber/TestSuiteFinishedSubscriber.php
@@ -84,9 +84,10 @@ final readonly class TestSuiteFinishedSubscriber implements FinishedSubscriber
                     ]);
                 }
 
+                // pop first: it detaches the context scope, which must happen before the span completes
+                $this->spanStack->pop();
                 $tracer->complete($span);
 
-                $this->spanStack->pop();
                 $this->spanStack->removeSuiteSpan($suiteName);
             }
 

--- a/src/bridge/phpunit/telemetry/src/Flow/Bridge/PHPUnit/Telemetry/Subscriber/TestSuiteStartedSubscriber.php
+++ b/src/bridge/phpunit/telemetry/src/Flow/Bridge/PHPUnit/Telemetry/Subscriber/TestSuiteStartedSubscriber.php
@@ -53,8 +53,9 @@ final readonly class TestSuiteStartedSubscriber implements StartedSubscriber
                 PHPUnitTelemetryAttributes::ATTR_SUITE_IS_ROOT => $isRoot,
             ]);
 
+            // activated: suites nest, and test spans must nest under their suite
             $this->spanStack->setSuiteSpan($suite->name(), $span);
-            $this->spanStack->push($span);
+            $this->spanStack->push($span, $tracer->activate($span));
             $this->suiteOutcomes->push();
         } catch (Throwable) {
             // Silent failure - telemetry must never break tests

--- a/src/bridge/phpunit/telemetry/tests/Flow/Bridge/PHPUnit/Telemetry/Tests/Unit/SpanStackTest.php
+++ b/src/bridge/phpunit/telemetry/tests/Flow/Bridge/PHPUnit/Telemetry/Tests/Unit/SpanStackTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Flow\Bridge\PHPUnit\Telemetry\Tests\Unit;
 
 use Flow\Bridge\PHPUnit\Telemetry\SpanStack;
+use Flow\Telemetry\Tests\Mother\ScopeMother;
 use Flow\Telemetry\Tests\Mother\SpanMother;
 use PHPUnit\Framework\TestCase;
 
@@ -17,8 +18,8 @@ final class SpanStackTest extends TestCase
         $span2 = SpanMother::create('span-2');
         $suiteSpan = SpanMother::create('suite-span');
 
-        $stack->push($span1);
-        $stack->push($span2);
+        $stack->push($span1, ScopeMother::attached());
+        $stack->push($span2, ScopeMother::attached());
         $stack->setSuiteSpan('TestSuite', $suiteSpan);
 
         $stack->clear();
@@ -32,7 +33,7 @@ final class SpanStackTest extends TestCase
         $stack = new SpanStack();
         $span = SpanMother::create('test-span');
 
-        $stack->push($span);
+        $stack->push($span, ScopeMother::attached());
 
         static::assertSame($span, $stack->current());
         static::assertSame($span, $stack->current());
@@ -46,9 +47,9 @@ final class SpanStackTest extends TestCase
         $span2 = SpanMother::create('span-2');
         $span3 = SpanMother::create('span-3');
 
-        $stack->push($span1);
-        $stack->push($span2);
-        $stack->push($span3);
+        $stack->push($span1, ScopeMother::attached());
+        $stack->push($span2, ScopeMother::attached());
+        $stack->push($span3, ScopeMother::attached());
 
         static::assertSame($span3, $stack->pop());
         static::assertSame($span2, $stack->pop());
@@ -61,7 +62,7 @@ final class SpanStackTest extends TestCase
         $stack = new SpanStack();
         $span = SpanMother::create('test-span');
 
-        $stack->push($span);
+        $stack->push($span, ScopeMother::attached());
 
         static::assertFalse($stack->isEmpty());
         static::assertSame($span, $stack->current());

--- a/src/bridge/phpunit/telemetry/tests/Flow/Bridge/PHPUnit/Telemetry/Tests/Unit/Subscriber/TestFinishedSubscriberTest.php
+++ b/src/bridge/phpunit/telemetry/tests/Flow/Bridge/PHPUnit/Telemetry/Tests/Unit/Subscriber/TestFinishedSubscriberTest.php
@@ -12,6 +12,7 @@ use Flow\Bridge\PHPUnit\Telemetry\Tests\Mother\ConfigurationMother;
 use Flow\Bridge\PHPUnit\Telemetry\Tests\Mother\TelemetryMother;
 use Flow\Bridge\PHPUnit\Telemetry\Tests\Mother\TestEventMother;
 use Flow\Bridge\PHPUnit\Telemetry\TestStatusRegistry;
+use Flow\Telemetry\Tests\Mother\ScopeMother;
 use Flow\Telemetry\Tests\Mother\SpanMother;
 use PHPUnit\Framework\TestCase;
 
@@ -56,7 +57,7 @@ final class TestFinishedSubscriberTest extends TestCase
         $memoryRegistry = new TestMemoryRegistry();
 
         $testSpan = SpanMother::create('test-span');
-        $spanStack->push($testSpan);
+        $spanStack->push($testSpan, ScopeMother::attached());
 
         $event = TestEventMother::finished();
         $statusRegistry->setStatus($event->test()->id(), 'passed');
@@ -85,7 +86,7 @@ final class TestFinishedSubscriberTest extends TestCase
         $memoryRegistry = new TestMemoryRegistry();
 
         $suiteSpan = SpanMother::create('suite-span');
-        $spanStack->push($suiteSpan);
+        $spanStack->push($suiteSpan, ScopeMother::attached());
 
         $event = TestEventMother::finished();
         $statusRegistry->setStatus($event->test()->id(), 'passed');
@@ -114,7 +115,7 @@ final class TestFinishedSubscriberTest extends TestCase
         $memoryRegistry = new TestMemoryRegistry();
 
         $testSpan = SpanMother::create('test-span');
-        $spanStack->push($testSpan);
+        $spanStack->push($testSpan, ScopeMother::attached());
 
         $event = TestEventMother::finished();
         $statusRegistry->setStatus($event->test()->id(), 'passed');
@@ -142,7 +143,7 @@ final class TestFinishedSubscriberTest extends TestCase
         $statusRegistry = new TestStatusRegistry();
         $memoryRegistry = new TestMemoryRegistry();
 
-        $spanStack->push(SpanMother::create('test-span'));
+        $spanStack->push(SpanMother::create('test-span'), ScopeMother::attached());
 
         $event = TestEventMother::finished();
         $statusRegistry->setStatus($event->test()->id(), 'passed');
@@ -201,7 +202,7 @@ final class TestFinishedSubscriberTest extends TestCase
         $statusRegistry = new TestStatusRegistry();
         $memoryRegistry = new TestMemoryRegistry();
 
-        $spanStack->push($telemetry->tracer('phpunit')->span('test-span'));
+        $spanStack->push($telemetry->tracer('phpunit')->span('test-span'), ScopeMother::attached());
 
         $event = TestEventMother::finished();
         $statusRegistry->setStatus($event->test()->id(), 'passed');
@@ -244,7 +245,7 @@ final class TestFinishedSubscriberTest extends TestCase
         $statusRegistry = new TestStatusRegistry();
         $memoryRegistry = new TestMemoryRegistry();
 
-        $spanStack->push(SpanMother::create('test-span'));
+        $spanStack->push(SpanMother::create('test-span'), ScopeMother::attached());
 
         $event = TestEventMother::finished();
         $statusRegistry->setStatus($event->test()->id(), 'failed', 'some error');
@@ -278,7 +279,7 @@ final class TestFinishedSubscriberTest extends TestCase
         $statusRegistry = new TestStatusRegistry();
         $memoryRegistry = new TestMemoryRegistry();
 
-        $spanStack->push(SpanMother::create('test-span'));
+        $spanStack->push(SpanMother::create('test-span'), ScopeMother::attached());
 
         $event = TestEventMother::finished();
         $statusRegistry->setStatus($event->test()->id(), 'passed');

--- a/src/bridge/psr18/telemetry/src/Flow/Bridge/Psr18/Telemetry/PSR18TraceableClient.php
+++ b/src/bridge/psr18/telemetry/src/Flow/Bridge/Psr18/Telemetry/PSR18TraceableClient.php
@@ -51,6 +51,7 @@ final readonly class PSR18TraceableClient implements ClientInterface
 
         // OTEL HTTP semconv: client span name is "{method}" - host would be per-host cardinality.
         $span = $this->tracer->span($method, SpanKind::CLIENT, $attributes);
+        $scope = $this->tracer->activate($span);
 
         try {
             $response = $this->client->sendRequest($request);
@@ -72,6 +73,7 @@ final readonly class PSR18TraceableClient implements ClientInterface
 
             throw $exception;
         } finally {
+            $scope->detach();
             $this->tracer->complete($span);
         }
     }

--- a/src/bridge/symfony/telemetry-bundle/src/Flow/Bridge/Symfony/TelemetryBundle/Instrumentation/Cache/CacheDeferredFlushSubscriber.php
+++ b/src/bridge/symfony/telemetry-bundle/src/Flow/Bridge/Symfony/TelemetryBundle/Instrumentation/Cache/CacheDeferredFlushSubscriber.php
@@ -63,12 +63,14 @@ final readonly class CacheDeferredFlushSubscriber implements EventSubscriberInte
     {
         $tracer = $this->telemetry->tracer('flow.symfony.cache', PackageVersion::get('symfony/cache'));
         $span = $tracer->span('cache.flush', SpanKind::INTERNAL, [CacheAttributes::CACHE_OPERATION => 'flush']);
+        $scope = $tracer->activate($span);
 
         try {
             foreach ($this->pools as $pool) {
                 $pool->commit();
             }
         } finally {
+            $scope->detach();
             $tracer->complete($span);
         }
     }

--- a/src/bridge/symfony/telemetry-bundle/src/Flow/Bridge/Symfony/TelemetryBundle/Instrumentation/Cache/TagAwareTraceableCacheAdapter.php
+++ b/src/bridge/symfony/telemetry-bundle/src/Flow/Bridge/Symfony/TelemetryBundle/Instrumentation/Cache/TagAwareTraceableCacheAdapter.php
@@ -63,6 +63,7 @@ final readonly class TagAwareTraceableCacheAdapter implements
         }
 
         $span = $this->tracer->span('cache.clear', SpanKind::CLIENT, $attributes);
+        $scope = $this->tracer->activate($span);
 
         try {
             return $this->adapter->clear($prefix);
@@ -73,6 +74,7 @@ final readonly class TagAwareTraceableCacheAdapter implements
 
             throw $exception;
         } finally {
+            $scope->detach();
             $this->tracer->complete($span);
         }
     }
@@ -83,6 +85,7 @@ final readonly class TagAwareTraceableCacheAdapter implements
             CacheAttributes::CACHE_OPERATION => 'commit',
             CacheAttributes::CACHE_POOL => $this->poolName,
         ]);
+        $scope = $this->tracer->activate($span);
 
         try {
             return $this->adapter->commit();
@@ -93,6 +96,7 @@ final readonly class TagAwareTraceableCacheAdapter implements
 
             throw $exception;
         } finally {
+            $scope->detach();
             $this->tracer->complete($span);
         }
     }
@@ -112,6 +116,7 @@ final readonly class TagAwareTraceableCacheAdapter implements
             CacheAttributes::CACHE_POOL => $this->poolName,
             CacheAttributes::CACHE_KEY => $key,
         ]);
+        $scope = $this->tracer->activate($span);
 
         try {
             return $this->adapter->delete($key);
@@ -122,6 +127,7 @@ final readonly class TagAwareTraceableCacheAdapter implements
 
             throw $exception;
         } finally {
+            $scope->detach();
             $this->tracer->complete($span);
         }
     }
@@ -135,6 +141,7 @@ final readonly class TagAwareTraceableCacheAdapter implements
             CacheAttributes::CACHE_POOL => $this->poolName,
             CacheAttributes::CACHE_KEY => $keyString,
         ]);
+        $scope = $this->tracer->activate($span);
 
         try {
             return $this->adapter->deleteItem($keyString);
@@ -145,6 +152,7 @@ final readonly class TagAwareTraceableCacheAdapter implements
 
             throw $exception;
         } finally {
+            $scope->detach();
             $this->tracer->complete($span);
         }
     }
@@ -159,6 +167,7 @@ final readonly class TagAwareTraceableCacheAdapter implements
             CacheAttributes::CACHE_POOL => $this->poolName,
             CacheAttributes::CACHE_KEY_COUNT => count($keys),
         ]);
+        $scope = $this->tracer->activate($span);
 
         try {
             return $this->adapter->deleteItems($keys);
@@ -169,6 +178,7 @@ final readonly class TagAwareTraceableCacheAdapter implements
 
             throw $exception;
         } finally {
+            $scope->detach();
             $this->tracer->complete($span);
         }
     }
@@ -271,6 +281,7 @@ final readonly class TagAwareTraceableCacheAdapter implements
             CacheAttributes::CACHE_TAGS => $tags,
             CacheAttributes::CACHE_TAG_COUNT => count($tags),
         ]);
+        $scope = $this->tracer->activate($span);
 
         try {
             return $this->adapter->invalidateTags($tags);
@@ -281,6 +292,7 @@ final readonly class TagAwareTraceableCacheAdapter implements
 
             throw $exception;
         } finally {
+            $scope->detach();
             $this->tracer->complete($span);
         }
     }
@@ -295,6 +307,7 @@ final readonly class TagAwareTraceableCacheAdapter implements
             CacheAttributes::CACHE_OPERATION => 'prune',
             CacheAttributes::CACHE_POOL => $this->poolName,
         ]);
+        $scope = $this->tracer->activate($span);
 
         try {
             return $this->adapter->prune();
@@ -305,6 +318,7 @@ final readonly class TagAwareTraceableCacheAdapter implements
 
             throw $exception;
         } finally {
+            $scope->detach();
             $this->tracer->complete($span);
         }
     }
@@ -319,6 +333,7 @@ final readonly class TagAwareTraceableCacheAdapter implements
             CacheAttributes::CACHE_OPERATION => 'reset',
             CacheAttributes::CACHE_POOL => $this->poolName,
         ]);
+        $scope = $this->tracer->activate($span);
 
         try {
             $this->adapter->reset();
@@ -329,6 +344,7 @@ final readonly class TagAwareTraceableCacheAdapter implements
 
             throw $exception;
         } finally {
+            $scope->detach();
             $this->tracer->complete($span);
         }
     }
@@ -341,6 +357,7 @@ final readonly class TagAwareTraceableCacheAdapter implements
             CacheAttributes::CACHE_POOL => $this->poolName,
             CacheAttributes::CACHE_KEY => $key,
         ]);
+        $scope = $this->tracer->activate($span);
 
         try {
             return $this->adapter->save($item);
@@ -351,6 +368,7 @@ final readonly class TagAwareTraceableCacheAdapter implements
 
             throw $exception;
         } finally {
+            $scope->detach();
             $this->tracer->complete($span);
         }
     }
@@ -363,6 +381,7 @@ final readonly class TagAwareTraceableCacheAdapter implements
             CacheAttributes::CACHE_POOL => $this->poolName,
             CacheAttributes::CACHE_KEY => $key,
         ]);
+        $scope = $this->tracer->activate($span);
 
         try {
             return $this->adapter->saveDeferred($item);
@@ -373,6 +392,7 @@ final readonly class TagAwareTraceableCacheAdapter implements
 
             throw $exception;
         } finally {
+            $scope->detach();
             $this->tracer->complete($span);
         }
     }

--- a/src/bridge/symfony/telemetry-bundle/src/Flow/Bridge/Symfony/TelemetryBundle/Instrumentation/Cache/TraceableCacheAdapter.php
+++ b/src/bridge/symfony/telemetry-bundle/src/Flow/Bridge/Symfony/TelemetryBundle/Instrumentation/Cache/TraceableCacheAdapter.php
@@ -63,6 +63,7 @@ final readonly class TraceableCacheAdapter implements
         }
 
         $span = $this->tracer->span('cache.clear', SpanKind::CLIENT, $attributes);
+        $scope = $this->tracer->activate($span);
 
         try {
             return $this->adapter->clear($prefix);
@@ -73,6 +74,7 @@ final readonly class TraceableCacheAdapter implements
 
             throw $exception;
         } finally {
+            $scope->detach();
             $this->tracer->complete($span);
         }
     }
@@ -83,6 +85,7 @@ final readonly class TraceableCacheAdapter implements
             CacheAttributes::CACHE_OPERATION => 'commit',
             CacheAttributes::CACHE_POOL => $this->poolName,
         ]);
+        $scope = $this->tracer->activate($span);
 
         try {
             return $this->adapter->commit();
@@ -93,6 +96,7 @@ final readonly class TraceableCacheAdapter implements
 
             throw $exception;
         } finally {
+            $scope->detach();
             $this->tracer->complete($span);
         }
     }
@@ -112,6 +116,7 @@ final readonly class TraceableCacheAdapter implements
             CacheAttributes::CACHE_POOL => $this->poolName,
             CacheAttributes::CACHE_KEY => $key,
         ]);
+        $scope = $this->tracer->activate($span);
 
         try {
             return $this->adapter->delete($key);
@@ -122,6 +127,7 @@ final readonly class TraceableCacheAdapter implements
 
             throw $exception;
         } finally {
+            $scope->detach();
             $this->tracer->complete($span);
         }
     }
@@ -135,6 +141,7 @@ final readonly class TraceableCacheAdapter implements
             CacheAttributes::CACHE_POOL => $this->poolName,
             CacheAttributes::CACHE_KEY => $keyString,
         ]);
+        $scope = $this->tracer->activate($span);
 
         try {
             return $this->adapter->deleteItem($keyString);
@@ -145,6 +152,7 @@ final readonly class TraceableCacheAdapter implements
 
             throw $exception;
         } finally {
+            $scope->detach();
             $this->tracer->complete($span);
         }
     }
@@ -159,6 +167,7 @@ final readonly class TraceableCacheAdapter implements
             CacheAttributes::CACHE_POOL => $this->poolName,
             CacheAttributes::CACHE_KEY_COUNT => count($keys),
         ]);
+        $scope = $this->tracer->activate($span);
 
         try {
             return $this->adapter->deleteItems($keys);
@@ -169,6 +178,7 @@ final readonly class TraceableCacheAdapter implements
 
             throw $exception;
         } finally {
+            $scope->detach();
             $this->tracer->complete($span);
         }
     }
@@ -270,6 +280,7 @@ final readonly class TraceableCacheAdapter implements
             CacheAttributes::CACHE_OPERATION => 'prune',
             CacheAttributes::CACHE_POOL => $this->poolName,
         ]);
+        $scope = $this->tracer->activate($span);
 
         try {
             return $this->adapter->prune();
@@ -280,6 +291,7 @@ final readonly class TraceableCacheAdapter implements
 
             throw $exception;
         } finally {
+            $scope->detach();
             $this->tracer->complete($span);
         }
     }
@@ -294,6 +306,7 @@ final readonly class TraceableCacheAdapter implements
             CacheAttributes::CACHE_OPERATION => 'reset',
             CacheAttributes::CACHE_POOL => $this->poolName,
         ]);
+        $scope = $this->tracer->activate($span);
 
         try {
             $this->adapter->reset();
@@ -304,6 +317,7 @@ final readonly class TraceableCacheAdapter implements
 
             throw $exception;
         } finally {
+            $scope->detach();
             $this->tracer->complete($span);
         }
     }
@@ -316,6 +330,7 @@ final readonly class TraceableCacheAdapter implements
             CacheAttributes::CACHE_POOL => $this->poolName,
             CacheAttributes::CACHE_KEY => $key,
         ]);
+        $scope = $this->tracer->activate($span);
 
         try {
             return $this->adapter->save($item);
@@ -326,6 +341,7 @@ final readonly class TraceableCacheAdapter implements
 
             throw $exception;
         } finally {
+            $scope->detach();
             $this->tracer->complete($span);
         }
     }
@@ -338,6 +354,7 @@ final readonly class TraceableCacheAdapter implements
             CacheAttributes::CACHE_POOL => $this->poolName,
             CacheAttributes::CACHE_KEY => $key,
         ]);
+        $scope = $this->tracer->activate($span);
 
         try {
             return $this->adapter->saveDeferred($item);
@@ -348,6 +365,7 @@ final readonly class TraceableCacheAdapter implements
 
             throw $exception;
         } finally {
+            $scope->detach();
             $this->tracer->complete($span);
         }
     }

--- a/src/bridge/symfony/telemetry-bundle/src/Flow/Bridge/Symfony/TelemetryBundle/Instrumentation/Console/ConsoleSpanSubscriber.php
+++ b/src/bridge/symfony/telemetry-bundle/src/Flow/Bridge/Symfony/TelemetryBundle/Instrumentation/Console/ConsoleSpanSubscriber.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Flow\Bridge\Symfony\TelemetryBundle\Instrumentation\Console;
 
 use DateTimeImmutable;
+use Flow\Telemetry\Context\Scope;
 use Flow\Telemetry\PackageVersion;
 use Flow\Telemetry\SemConvAttributes;
 use Flow\Telemetry\Telemetry;
@@ -34,7 +35,7 @@ final class ConsoleSpanSubscriber implements EventSubscriberInterface
      * stacked — a nested command's TERMINATE completes its own span, not the enclosing command's.
      * Excluded commands push null to keep the pairs balanced.
      *
-     * @var array<null|array{span: Span, tracer: Tracer, error: null|Throwable}>
+     * @var array<null|array{span: Span, tracer: Tracer, scope: Scope, error: null|Throwable}>
      */
     private array $stack = [];
 
@@ -82,9 +83,13 @@ final class ConsoleSpanSubscriber implements EventSubscriberInterface
             $attributes[ConsoleAttributes::ATTR_COMMAND_CLASS] = $command::class;
         }
 
+        $span = $tracer->span($commandName, SpanKind::INTERNAL, $attributes);
+
+        // activated: a command span is a logical scope - everything the command does belongs under it
         $this->stack[] = [
-            'span' => $tracer->span($commandName, SpanKind::INTERNAL, $attributes),
+            'span' => $span,
             'tracer' => $tracer,
+            'scope' => $tracer->activate($span),
             'error' => null,
         ];
     }
@@ -137,6 +142,7 @@ final class ConsoleSpanSubscriber implements EventSubscriberInterface
             $span->setStatus(SpanStatus::error($error !== null ? $error->getMessage() : "Exit code: {$exitCode}"));
         }
 
+        $entry['scope']->detach();
         $entry['tracer']->complete($span);
     }
 

--- a/src/bridge/symfony/telemetry-bundle/src/Flow/Bridge/Symfony/TelemetryBundle/Instrumentation/Doctrine/DBAL/TracingConnection.php
+++ b/src/bridge/symfony/telemetry-bundle/src/Flow/Bridge/Symfony/TelemetryBundle/Instrumentation/Doctrine/DBAL/TracingConnection.php
@@ -9,6 +9,7 @@ use Doctrine\DBAL\Driver\Connection as ConnectionInterface;
 use Doctrine\DBAL\Driver\Middleware\AbstractConnectionMiddleware;
 use Doctrine\DBAL\Driver\Result;
 use Doctrine\DBAL\Driver\Statement as DriverStatement;
+use Flow\Telemetry\Context\Scope;
 use Flow\Telemetry\SemConvAttributes;
 use Flow\Telemetry\Tracer\Span;
 use Flow\Telemetry\Tracer\SpanKind;
@@ -27,6 +28,8 @@ final class TracingConnection extends AbstractConnectionMiddleware
      * The open span for the current transaction in GROUPED mode, held between
      * beginTransaction() and commit()/rollBack() so query spans nest under it.
      */
+    private ?Scope $transactionScope = null;
+
     private ?Span $transactionSpan = null;
 
     /**
@@ -78,12 +81,17 @@ final class TracingConnection extends AbstractConnectionMiddleware
 
             $tracer = $this->queryTracer->tracer();
             $span = $tracer->span('BEGIN TRANSACTION', SpanKind::CLIENT, $this->transactionSpanAttributes());
+            // activated: a grouped transaction span is a logical scope - every statement until
+            // commit/rollback belongs under it
+            $scope = $tracer->activate($span);
 
             try {
                 parent::beginTransaction();
                 $this->transactionSpan = $span;
+                $this->transactionScope = $scope;
             } catch (Throwable $exception) {
                 $this->queryTracer->recordError($span, $exception);
+                $scope->detach();
                 $tracer->complete($span);
 
                 throw $exception;
@@ -133,6 +141,7 @@ final class TracingConnection extends AbstractConnectionMiddleware
             SpanKind::CLIENT,
             $this->queryTracer->queryAttributes($sql, $sqlAttributes),
         );
+        $scope = $tracer->activate($span);
 
         try {
             return new TracingStatement(parent::prepare($sql), $this->queryTracer, $sql, $sqlAttributes);
@@ -141,6 +150,7 @@ final class TracingConnection extends AbstractConnectionMiddleware
 
             throw $exception;
         } finally {
+            $scope->detach();
             $tracer->complete($span);
         }
     }
@@ -177,6 +187,7 @@ final class TracingConnection extends AbstractConnectionMiddleware
             SpanKind::CLIENT,
             $this->queryTracer->queryAttributes($sql, $sqlAttributes),
         );
+        $scope = $tracer->activate($span);
 
         try {
             $result = $execute();
@@ -191,6 +202,7 @@ final class TracingConnection extends AbstractConnectionMiddleware
 
             throw $exception;
         } finally {
+            $scope->detach();
             $tracer->complete($span);
         }
     }
@@ -216,7 +228,9 @@ final class TracingConnection extends AbstractConnectionMiddleware
             }
 
             $span = $this->transactionSpan;
+            $scope = $this->transactionScope;
             $this->transactionSpan = null;
+            $this->transactionScope = null;
 
             if ($span === null) {
                 $execute();
@@ -233,6 +247,7 @@ final class TracingConnection extends AbstractConnectionMiddleware
 
                 throw $exception;
             } finally {
+                $scope?->detach();
                 $tracer->complete($span);
             }
         } finally {
@@ -248,6 +263,7 @@ final class TracingConnection extends AbstractConnectionMiddleware
         $tracer = $this->queryTracer->tracer();
         $span = $tracer->span($spanName, SpanKind::CLIENT, [SemConvAttributes::DB_OPERATION_NAME => $operation]
         + $this->transactionSpanAttributes());
+        $scope = $tracer->activate($span);
 
         try {
             $execute();
@@ -256,6 +272,7 @@ final class TracingConnection extends AbstractConnectionMiddleware
 
             throw $exception;
         } finally {
+            $scope->detach();
             $tracer->complete($span);
         }
     }

--- a/src/bridge/symfony/telemetry-bundle/src/Flow/Bridge/Symfony/TelemetryBundle/Instrumentation/Doctrine/DBAL/TracingDriver.php
+++ b/src/bridge/symfony/telemetry-bundle/src/Flow/Bridge/Symfony/TelemetryBundle/Instrumentation/Doctrine/DBAL/TracingDriver.php
@@ -62,6 +62,7 @@ final class TracingDriver extends AbstractDriverMiddleware
             SemConvAttributes::DB_NAMESPACE => $namespace,
             DbAttributes::DB_CONNECTION_NAME => $this->connectionName,
         ]);
+        $scope = $tracer->activate($span);
 
         try {
             $connection = parent::connect($params);
@@ -108,6 +109,7 @@ final class TracingDriver extends AbstractDriverMiddleware
 
             throw $exception;
         } finally {
+            $scope->detach();
             $tracer->complete($span);
         }
     }

--- a/src/bridge/symfony/telemetry-bundle/src/Flow/Bridge/Symfony/TelemetryBundle/Instrumentation/Doctrine/DBAL/TracingStatement.php
+++ b/src/bridge/symfony/telemetry-bundle/src/Flow/Bridge/Symfony/TelemetryBundle/Instrumentation/Doctrine/DBAL/TracingStatement.php
@@ -50,6 +50,7 @@ final class TracingStatement extends AbstractStatementMiddleware
             $this->queryTracer->queryAttributes($this->sql, $this->sqlAttributes)
             + $this->queryTracer->parameterAttributes($this->boundParameters),
         );
+        $scope = $tracer->activate($span);
 
         try {
             $result = parent::execute();
@@ -64,6 +65,7 @@ final class TracingStatement extends AbstractStatementMiddleware
 
             throw $exception;
         } finally {
+            $scope->detach();
             $tracer->complete($span);
         }
     }

--- a/src/bridge/symfony/telemetry-bundle/src/Flow/Bridge/Symfony/TelemetryBundle/Instrumentation/HttpClient/TracableHttpClient.php
+++ b/src/bridge/symfony/telemetry-bundle/src/Flow/Bridge/Symfony/TelemetryBundle/Instrumentation/HttpClient/TracableHttpClient.php
@@ -50,12 +50,14 @@ final readonly class TracableHttpClient implements HttpClientInterface
 
         // OTEL HTTP semconv: client span name is "{method}" - host would be per-host cardinality.
         $span = $tracer->span($method, SpanKind::CLIENT, $attributes);
+        $scope = $tracer->activate($span);
 
         try {
             $response = $this->client->request($method, $url, $options);
         } catch (Throwable $exception) {
             $span->recordException($exception, new DateTimeImmutable());
             $span->setStatus(SpanStatus::error($exception->getMessage()));
+            $scope->detach();
             $tracer->complete($span);
 
             throw $exception;

--- a/src/bridge/symfony/telemetry-bundle/src/Flow/Bridge/Symfony/TelemetryBundle/Instrumentation/HttpKernel/ControllerSpanSubscriber.php
+++ b/src/bridge/symfony/telemetry-bundle/src/Flow/Bridge/Symfony/TelemetryBundle/Instrumentation/HttpKernel/ControllerSpanSubscriber.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Flow\Bridge\Symfony\TelemetryBundle\Instrumentation\HttpKernel;
 
 use DateTimeImmutable;
+use Flow\Telemetry\Context\Scope;
 use Flow\Telemetry\PackageVersion;
 use Flow\Telemetry\SemConvAttributes;
 use Flow\Telemetry\Telemetry;
@@ -13,6 +14,7 @@ use Flow\Telemetry\Tracer\SpanKind;
 use Flow\Telemetry\Tracer\SpanStatus;
 use Flow\Telemetry\Tracer\Tracer;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\ControllerArgumentsEvent;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
@@ -23,6 +25,8 @@ use function is_string;
 
 final readonly class ControllerSpanSubscriber implements EventSubscriberInterface
 {
+    private const string CONTROLLER_SCOPE_ATTRIBUTE = '_flow_telemetry_controller_scope';
+
     private const string CONTROLLER_SPAN_ATTRIBUTE = '_flow_telemetry_controller_span';
 
     public function __construct(
@@ -82,7 +86,9 @@ final readonly class ControllerSpanSubscriber implements EventSubscriberInterfac
 
         $span = $this->tracer()->span($name, SpanKind::INTERNAL, $attributes);
 
+        // activated: a controller span is a logical scope - queries, cache and template spans nest under it
         $request->attributes->set(self::CONTROLLER_SPAN_ATTRIBUTE, $span);
+        $request->attributes->set(self::CONTROLLER_SCOPE_ATTRIBUTE, $this->tracer()->activate($span));
     }
 
     public function onComplete(ViewEvent|ResponseEvent $event): void
@@ -95,6 +101,7 @@ final readonly class ControllerSpanSubscriber implements EventSubscriberInterfac
         }
 
         // OTEL spec: instrumentation leaves the status Unset on success.
+        $this->detachControllerScope($request);
         $this->tracer()->complete($span);
 
         $request->attributes->remove(self::CONTROLLER_SPAN_ATTRIBUTE);
@@ -113,9 +120,20 @@ final readonly class ControllerSpanSubscriber implements EventSubscriberInterfac
         $span->recordException($throwable, new DateTimeImmutable());
         $span->setAttribute(SemConvAttributes::ERROR_TYPE, $throwable::class);
         $span->setStatus(SpanStatus::error($throwable->getMessage()));
+        $this->detachControllerScope($request);
         $this->tracer()->complete($span);
 
         $request->attributes->remove(self::CONTROLLER_SPAN_ATTRIBUTE);
+    }
+
+    private function detachControllerScope(Request $request): void
+    {
+        // @mago-expect analysis:mixed-assignment
+        if (($scope = $request->attributes->get(self::CONTROLLER_SCOPE_ATTRIBUTE)) instanceof Scope) {
+            $scope->detach();
+        }
+
+        $request->attributes->remove(self::CONTROLLER_SCOPE_ATTRIBUTE);
     }
 
     private function tracer(): Tracer

--- a/src/bridge/symfony/telemetry-bundle/src/Flow/Bridge/Symfony/TelemetryBundle/Instrumentation/HttpKernel/HttpKernelSpanSubscriber.php
+++ b/src/bridge/symfony/telemetry-bundle/src/Flow/Bridge/Symfony/TelemetryBundle/Instrumentation/HttpKernel/HttpKernelSpanSubscriber.php
@@ -43,6 +43,8 @@ final readonly class HttpKernelSpanSubscriber implements EventSubscriberInterfac
 
     private const string PROPAGATION_SCOPE_ATTRIBUTE = '_flow_telemetry_propagation_scope';
 
+    private const string REQUEST_SCOPE_ATTRIBUTE = '_flow_telemetry_request_scope';
+
     private const string SUPPRESSION_SCOPE_ATTRIBUTE = '_flow_telemetry_suppression_scope';
 
     /** @var array<PathExclusionRule> */
@@ -170,6 +172,9 @@ final readonly class HttpKernelSpanSubscriber implements EventSubscriberInterfac
 
         $request->attributes->set(self::SPAN_ATTRIBUTE, $span);
         $request->attributes->set(self::TRACER_ATTRIBUTE, $tracer);
+        // activated: the request span is the root logical scope - controller, DBAL and cache spans nest under
+        // it. Attached after the propagation scope, so it must be detached before it.
+        $request->attributes->set(self::REQUEST_SCOPE_ATTRIBUTE, $tracer->activate($span));
     }
 
     public function onResponse(ResponseEvent $event): void
@@ -241,6 +246,12 @@ final readonly class HttpKernelSpanSubscriber implements EventSubscriberInterfac
         // @mago-expect analysis:mixed-assignment
         if (!($tracer = $request->attributes->get(self::TRACER_ATTRIBUTE)) instanceof Tracer) {
             return;
+        }
+
+        // @mago-expect analysis:mixed-assignment
+        if (($requestScope = $request->attributes->get(self::REQUEST_SCOPE_ATTRIBUTE)) instanceof Scope) {
+            $requestScope->detach();
+            $request->attributes->remove(self::REQUEST_SCOPE_ATTRIBUTE);
         }
 
         try {

--- a/src/bridge/symfony/telemetry-bundle/src/Flow/Bridge/Symfony/TelemetryBundle/Instrumentation/HttpKernel/TracingArgumentResolver.php
+++ b/src/bridge/symfony/telemetry-bundle/src/Flow/Bridge/Symfony/TelemetryBundle/Instrumentation/HttpKernel/TracingArgumentResolver.php
@@ -34,6 +34,7 @@ final readonly class TracingArgumentResolver implements ArgumentResolverInterfac
 
         $tracer = $this->telemetry->tracer('flow.symfony.http_kernel', PackageVersion::get('symfony/http-kernel'));
         $span = $tracer->span('controller.get_arguments', SpanKind::INTERNAL);
+        $scope = $tracer->activate($span);
 
         try {
             return $this->resolver->getArguments($request, $controller, $reflector);
@@ -45,6 +46,7 @@ final readonly class TracingArgumentResolver implements ArgumentResolverInterfac
             throw $exception;
         } finally {
             // OTEL spec: instrumentation leaves the status Unset on success.
+            $scope->detach();
             $tracer->complete($span);
         }
     }

--- a/src/bridge/symfony/telemetry-bundle/src/Flow/Bridge/Symfony/TelemetryBundle/Instrumentation/HttpKernel/TracingControllerResolver.php
+++ b/src/bridge/symfony/telemetry-bundle/src/Flow/Bridge/Symfony/TelemetryBundle/Instrumentation/HttpKernel/TracingControllerResolver.php
@@ -30,6 +30,7 @@ final readonly class TracingControllerResolver implements ControllerResolverInte
 
         $tracer = $this->telemetry->tracer('flow.symfony.http_kernel', PackageVersion::get('symfony/http-kernel'));
         $span = $tracer->span('controller.get_callable', SpanKind::INTERNAL);
+        $scope = $tracer->activate($span);
 
         try {
             return $this->resolver->getController($request);
@@ -41,6 +42,7 @@ final readonly class TracingControllerResolver implements ControllerResolverInte
             throw $exception;
         } finally {
             // OTEL spec: instrumentation leaves the status Unset on success.
+            $scope->detach();
             $tracer->complete($span);
         }
     }

--- a/src/bridge/symfony/telemetry-bundle/src/Flow/Bridge/Symfony/TelemetryBundle/Instrumentation/HttpKernel/TracingValueResolver.php
+++ b/src/bridge/symfony/telemetry-bundle/src/Flow/Bridge/Symfony/TelemetryBundle/Instrumentation/HttpKernel/TracingValueResolver.php
@@ -36,6 +36,7 @@ final readonly class TracingValueResolver implements ValueResolverInterface
             SemConvAttributes::CODE_FUNCTION_NAME => $this->inner::class . '::resolve',
             HttpKernelAttributes::ATTR_CONTROLLER_ARGUMENT => $argument->getName(),
         ]);
+        $scope = $tracer->activate($span);
 
         try {
             yield from $this->inner->resolve($request, $argument);
@@ -47,6 +48,7 @@ final readonly class TracingValueResolver implements ValueResolverInterface
             throw $exception;
         } finally {
             // OTEL spec: instrumentation leaves the status Unset on success.
+            $scope->detach();
             $tracer->complete($span);
         }
     }

--- a/src/bridge/symfony/telemetry-bundle/src/Flow/Bridge/Symfony/TelemetryBundle/Instrumentation/Messenger/TracingMiddleware.php
+++ b/src/bridge/symfony/telemetry-bundle/src/Flow/Bridge/Symfony/TelemetryBundle/Instrumentation/Messenger/TracingMiddleware.php
@@ -182,6 +182,9 @@ final readonly class TracingMiddleware implements MiddlewareInterface
         $span = $this->traceHandler
             ? $tracer->span($spanName, $kind, $attributes, $links, $isWorkerConsumed ? false : null)
             : null;
+        // activated: the handler span is a logical scope - everything the handler does nests under it.
+        // Attached after $propagationScope, so it must be detached before it.
+        $spanScope = $span === null ? null : $tracer->activate($span);
 
         if (!$isReceived) {
             $envelope = $this->injectContext($envelope);
@@ -227,6 +230,7 @@ final readonly class TracingMiddleware implements MiddlewareInterface
                     $this->finalizeProducerSpan($span, $resultEnvelope, $destination);
                 }
 
+                $spanScope?->detach();
                 $tracer->complete($span);
             }
 

--- a/src/bridge/symfony/telemetry-bundle/src/Flow/Bridge/Symfony/TelemetryBundle/Instrumentation/Twig/TracingTwigExtension.php
+++ b/src/bridge/symfony/telemetry-bundle/src/Flow/Bridge/Symfony/TelemetryBundle/Instrumentation/Twig/TracingTwigExtension.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Flow\Bridge\Symfony\TelemetryBundle\Instrumentation\Twig;
 
+use Flow\Telemetry\Context\Scope;
 use Flow\Telemetry\PackageVersion;
 use Flow\Telemetry\Telemetry;
 use Flow\Telemetry\Tracer\Span;
@@ -69,7 +70,8 @@ final class TracingTwigExtension extends AbstractExtension
 
         $span = $tracer->span($spanName, SpanKind::INTERNAL, $attributes);
 
-        $this->activeSpans[$profile] = ['span' => $span, 'tracer' => $tracer];
+        // activated: templates nest, so an included template's span belongs under the including one
+        $this->activeSpans[$profile] = ['span' => $span, 'tracer' => $tracer, 'scope' => $tracer->activate($span)];
     }
 
     #[Override]
@@ -96,6 +98,7 @@ final class TracingTwigExtension extends AbstractExtension
         // @mago-expect analysis:no-value,redundant-type-comparison,redundant-logical-operation(2)
         if (is_array($spanData) && $spanData['tracer'] instanceof Tracer && $spanData['span'] instanceof Span) {
             // OTEL spec: instrumentation leaves the status Unset on success.
+            $spanData['scope']->detach();
             $spanData['tracer']->complete($spanData['span']);
         }
 
@@ -111,6 +114,11 @@ final class TracingTwigExtension extends AbstractExtension
             if (is_array($spanData) && $spanData['tracer'] instanceof Tracer && $spanData['span'] instanceof Span) {
                 $spanData['span']->setAttribute('error.type', 'incomplete_render');
                 $spanData['span']->setStatus(SpanStatus::error('Twig rendering did not complete'));
+
+                if ($spanData['scope'] instanceof Scope) {
+                    $spanData['scope']->detach();
+                }
+
                 $spanData['tracer']->complete($spanData['span']);
             }
         }

--- a/src/bridge/symfony/telemetry-bundle/tests/Flow/Bridge/Symfony/TelemetryBundle/Tests/Integration/Instrumentation/Messenger/TracingMiddlewareTest.php
+++ b/src/bridge/symfony/telemetry-bundle/tests/Flow/Bridge/Symfony/TelemetryBundle/Tests/Integration/Instrumentation/Messenger/TracingMiddlewareTest.php
@@ -330,6 +330,7 @@ final class TracingMiddlewareTest extends KernelTestCase
 
         $tracer = $telemetry->tracer('test');
         $span = $tracer->span('parent-span');
+        $tracer->activate($span);
 
         $capturingMiddleware = new CapturingMiddleware();
 
@@ -388,6 +389,7 @@ final class TracingMiddlewareTest extends KernelTestCase
 
         $tracer = $telemetry->tracer('test');
         $span = $tracer->span('parent-span');
+        $tracer->activate($span);
 
         $handler = new TestMessageHandler();
         $capturingMiddleware = new CapturingMiddleware();

--- a/src/bridge/symfony/telemetry-bundle/tests/Flow/Bridge/Symfony/TelemetryBundle/Tests/Unit/Instrumentation/HttpKernel/ControllerSpanSubscriberTest.php
+++ b/src/bridge/symfony/telemetry-bundle/tests/Flow/Bridge/Symfony/TelemetryBundle/Tests/Unit/Instrumentation/HttpKernel/ControllerSpanSubscriberTest.php
@@ -45,6 +45,12 @@ final class ControllerSpanSubscriberTest extends TestCase
             'GET /test',
             SpanKind::SERVER,
         );
+        $telemetry
+            ->tracer('flow.symfony.http_kernel', PackageVersion::get('symfony/http-kernel'))
+            ->activate($requestSpan);
+        $telemetry
+            ->tracer('flow.symfony.http_kernel', PackageVersion::get('symfony/http-kernel'))
+            ->activate($requestSpan);
 
         $request = new Request();
         $request->attributes->set(HttpKernelSpanSubscriber::SPAN_ATTRIBUTE, $requestSpan);
@@ -93,6 +99,12 @@ final class ControllerSpanSubscriberTest extends TestCase
             'GET /test',
             SpanKind::SERVER,
         );
+        $telemetry
+            ->tracer('flow.symfony.http_kernel', PackageVersion::get('symfony/http-kernel'))
+            ->activate($requestSpan);
+        $telemetry
+            ->tracer('flow.symfony.http_kernel', PackageVersion::get('symfony/http-kernel'))
+            ->activate($requestSpan);
 
         $request = new Request();
         $request->attributes->set(HttpKernelSpanSubscriber::SPAN_ATTRIBUTE, $requestSpan);
@@ -122,6 +134,12 @@ final class ControllerSpanSubscriberTest extends TestCase
             'GET /test',
             SpanKind::SERVER,
         );
+        $telemetry
+            ->tracer('flow.symfony.http_kernel', PackageVersion::get('symfony/http-kernel'))
+            ->activate($requestSpan);
+        $telemetry
+            ->tracer('flow.symfony.http_kernel', PackageVersion::get('symfony/http-kernel'))
+            ->activate($requestSpan);
 
         $request = new Request();
         $request->attributes->set(HttpKernelSpanSubscriber::SPAN_ATTRIBUTE, $requestSpan);
@@ -154,6 +172,12 @@ final class ControllerSpanSubscriberTest extends TestCase
             'GET /test',
             SpanKind::SERVER,
         );
+        $telemetry
+            ->tracer('flow.symfony.http_kernel', PackageVersion::get('symfony/http-kernel'))
+            ->activate($requestSpan);
+        $telemetry
+            ->tracer('flow.symfony.http_kernel', PackageVersion::get('symfony/http-kernel'))
+            ->activate($requestSpan);
 
         $request = new Request();
         $request->attributes->set(HttpKernelSpanSubscriber::SPAN_ATTRIBUTE, $requestSpan);
@@ -191,6 +215,12 @@ final class ControllerSpanSubscriberTest extends TestCase
             'GET /test',
             SpanKind::SERVER,
         );
+        $telemetry
+            ->tracer('flow.symfony.http_kernel', PackageVersion::get('symfony/http-kernel'))
+            ->activate($requestSpan);
+        $telemetry
+            ->tracer('flow.symfony.http_kernel', PackageVersion::get('symfony/http-kernel'))
+            ->activate($requestSpan);
 
         $request = new Request();
         $request->attributes->set(HttpKernelSpanSubscriber::SPAN_ATTRIBUTE, $requestSpan);

--- a/src/bridge/symfony/telemetry-bundle/tests/Flow/Bridge/Symfony/TelemetryBundle/Tests/Unit/Instrumentation/HttpKernel/TracingArgumentResolverTest.php
+++ b/src/bridge/symfony/telemetry-bundle/tests/Flow/Bridge/Symfony/TelemetryBundle/Tests/Unit/Instrumentation/HttpKernel/TracingArgumentResolverTest.php
@@ -28,6 +28,12 @@ final class TracingArgumentResolverTest extends TestCase
             'GET /test',
             SpanKind::SERVER,
         );
+        $telemetry
+            ->tracer('flow.symfony.http_kernel', PackageVersion::get('symfony/http-kernel'))
+            ->activate($requestSpan);
+        $telemetry
+            ->tracer('flow.symfony.http_kernel', PackageVersion::get('symfony/http-kernel'))
+            ->activate($requestSpan);
 
         $inner = $this->createStub(ArgumentResolverInterface::class);
         $inner->method('getArguments')->willReturn(['a', 'b']);
@@ -74,6 +80,12 @@ final class TracingArgumentResolverTest extends TestCase
             'GET /test',
             SpanKind::SERVER,
         );
+        $telemetry
+            ->tracer('flow.symfony.http_kernel', PackageVersion::get('symfony/http-kernel'))
+            ->activate($requestSpan);
+        $telemetry
+            ->tracer('flow.symfony.http_kernel', PackageVersion::get('symfony/http-kernel'))
+            ->activate($requestSpan);
 
         $inner = $this->createStub(ArgumentResolverInterface::class);
         $inner->method('getArguments')->willThrowException(new RuntimeException('arguments failed'));

--- a/src/bridge/symfony/telemetry-bundle/tests/Flow/Bridge/Symfony/TelemetryBundle/Tests/Unit/Instrumentation/HttpKernel/TracingControllerResolverTest.php
+++ b/src/bridge/symfony/telemetry-bundle/tests/Flow/Bridge/Symfony/TelemetryBundle/Tests/Unit/Instrumentation/HttpKernel/TracingControllerResolverTest.php
@@ -28,6 +28,12 @@ final class TracingControllerResolverTest extends TestCase
             'GET /test',
             SpanKind::SERVER,
         );
+        $telemetry
+            ->tracer('flow.symfony.http_kernel', PackageVersion::get('symfony/http-kernel'))
+            ->activate($requestSpan);
+        $telemetry
+            ->tracer('flow.symfony.http_kernel', PackageVersion::get('symfony/http-kernel'))
+            ->activate($requestSpan);
 
         $controller = static fn(): string => 'ok';
         $inner = $this->createStub(ControllerResolverInterface::class);
@@ -69,6 +75,12 @@ final class TracingControllerResolverTest extends TestCase
             'GET /test',
             SpanKind::SERVER,
         );
+        $telemetry
+            ->tracer('flow.symfony.http_kernel', PackageVersion::get('symfony/http-kernel'))
+            ->activate($requestSpan);
+        $telemetry
+            ->tracer('flow.symfony.http_kernel', PackageVersion::get('symfony/http-kernel'))
+            ->activate($requestSpan);
 
         $inner = $this->createStub(ControllerResolverInterface::class);
         $inner->method('getController')->willThrowException(new RuntimeException('controller failed'));

--- a/src/bridge/symfony/telemetry-bundle/tests/Flow/Bridge/Symfony/TelemetryBundle/Tests/Unit/Instrumentation/HttpKernel/TracingValueResolverTest.php
+++ b/src/bridge/symfony/telemetry-bundle/tests/Flow/Bridge/Symfony/TelemetryBundle/Tests/Unit/Instrumentation/HttpKernel/TracingValueResolverTest.php
@@ -31,6 +31,12 @@ final class TracingValueResolverTest extends TestCase
             'GET /test',
             SpanKind::SERVER,
         );
+        $telemetry
+            ->tracer('flow.symfony.http_kernel', PackageVersion::get('symfony/http-kernel'))
+            ->activate($requestSpan);
+        $telemetry
+            ->tracer('flow.symfony.http_kernel', PackageVersion::get('symfony/http-kernel'))
+            ->activate($requestSpan);
 
         $inner = $this->createStub(ValueResolverInterface::class);
         $inner->method('resolve')->willReturn(['resolved']);
@@ -77,6 +83,12 @@ final class TracingValueResolverTest extends TestCase
             'GET /test',
             SpanKind::SERVER,
         );
+        $telemetry
+            ->tracer('flow.symfony.http_kernel', PackageVersion::get('symfony/http-kernel'))
+            ->activate($requestSpan);
+        $telemetry
+            ->tracer('flow.symfony.http_kernel', PackageVersion::get('symfony/http-kernel'))
+            ->activate($requestSpan);
 
         $inner = $this->createStub(ValueResolverInterface::class);
         $inner->method('resolve')->willThrowException(new RuntimeException('resolver failed'));

--- a/src/bridge/symfony/telemetry-bundle/tests/Flow/Bridge/Symfony/TelemetryBundle/Tests/Unit/Instrumentation/Messenger/TracingMiddlewareTest.php
+++ b/src/bridge/symfony/telemetry-bundle/tests/Flow/Bridge/Symfony/TelemetryBundle/Tests/Unit/Instrumentation/Messenger/TracingMiddlewareTest.php
@@ -319,6 +319,7 @@ final class TracingMiddlewareTest extends TestCase
         ]);
 
         $outer = $tracer->span('outer');
+        $tracer->activate($outer);
 
         // SyncTransport adds ReceivedStamp but not ConsumedByWorkerStamp: handling happens inside the
         // current request, so the process span must stay in the current trace instead of orphaning
@@ -347,6 +348,7 @@ final class TracingMiddlewareTest extends TestCase
         ]);
 
         $outer = $tracer->span('outer');
+        $tracer->activate($outer);
 
         $bus->dispatch(new Envelope(new TestMessage('hello'), [
             new ReceivedStamp('async'),

--- a/src/core/etl/src/Flow/ETL/Bucketing/Storage/FilesystemBuckets.php
+++ b/src/core/etl/src/Flow/ETL/Bucketing/Storage/FilesystemBuckets.php
@@ -72,8 +72,16 @@ final class FilesystemBuckets implements BucketsStorage
             return;
         }
 
-        foreach ($this->reader->read($path)->rows($this->batchSize, conform: false) as $batch) {
-            yield $batch;
+        $reader = $this->reader->read($path);
+
+        // finally, not a trailing close(): PHP runs it on generator destruction too, and a KWayMerge cursor is
+        // destroyed rather than exhausted when a merge throws
+        try {
+            foreach ($reader->rows($this->batchSize, conform: false) as $batch) {
+                yield $batch;
+            }
+        } finally {
+            $reader->close();
         }
     }
 

--- a/src/core/etl/src/Flow/ETL/Cache/Implementation/TraceableCache.php
+++ b/src/core/etl/src/Flow/ETL/Cache/Implementation/TraceableCache.php
@@ -114,6 +114,7 @@ final readonly class TraceableCache implements Cache
             CacheAttributes::CACHE_KEY => $key,
             CacheAttributes::CACHE_VALUE_TYPE => 'Rows',
         ]);
+        $scope = $this->tracer->activate($span);
 
         try {
             $this->cache->set($key, $value);
@@ -124,6 +125,7 @@ final readonly class TraceableCache implements Cache
 
             throw $exception;
         } finally {
+            $scope->detach();
             $this->tracer->complete($span);
         }
     }

--- a/src/core/etl/src/Flow/ETL/Config/Telemetry/SpanScope.php
+++ b/src/core/etl/src/Flow/ETL/Config/Telemetry/SpanScope.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Config\Telemetry;
+
+use Flow\Telemetry\Context\Scope;
+use Flow\Telemetry\Tracer\Span;
+
+final readonly class SpanScope
+{
+    public function __construct(
+        public Span $span,
+        public Scope $scope,
+    ) {}
+}

--- a/src/core/etl/src/Flow/ETL/Config/Telemetry/SpanStack.php
+++ b/src/core/etl/src/Flow/ETL/Config/Telemetry/SpanStack.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Config\Telemetry;
+
+use Flow\Telemetry\Tracer\Span;
+use Flow\Telemetry\Tracer\SpanStatus;
+use Flow\Telemetry\Tracer\Tracer;
+
+use function array_pop;
+
+final class SpanStack
+{
+    /**
+     * @var array<Span>
+     */
+    private array $spans = [];
+
+    public function drain(Tracer $tracer, string $reason): void
+    {
+        while (($span = array_pop($this->spans)) !== null) {
+            $tracer->complete($span->setStatus(SpanStatus::error($reason)));
+        }
+    }
+
+    public function pop(): ?Span
+    {
+        return array_pop($this->spans);
+    }
+
+    public function push(Span $span): void
+    {
+        $this->spans[] = $span;
+    }
+}

--- a/src/core/etl/src/Flow/ETL/Config/Telemetry/SpanStack.php
+++ b/src/core/etl/src/Flow/ETL/Config/Telemetry/SpanStack.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Flow\ETL\Config\Telemetry;
 
+use Flow\Telemetry\Context\Scope;
 use Flow\Telemetry\Tracer\Span;
 use Flow\Telemetry\Tracer\SpanStatus;
 use Flow\Telemetry\Tracer\Tracer;
@@ -13,24 +14,25 @@ use function array_pop;
 final class SpanStack
 {
     /**
-     * @var array<Span>
+     * @var array<SpanScope>
      */
     private array $spans = [];
 
     public function drain(Tracer $tracer, string $reason): void
     {
-        while (($span = array_pop($this->spans)) !== null) {
-            $tracer->complete($span->setStatus(SpanStatus::error($reason)));
+        while (($entry = array_pop($this->spans)) !== null) {
+            $entry->scope->detach();
+            $tracer->complete($entry->span->setStatus(SpanStatus::error($reason)));
         }
     }
 
-    public function pop(): ?Span
+    public function pop(): ?SpanScope
     {
         return array_pop($this->spans);
     }
 
-    public function push(Span $span): void
+    public function push(Span $span, Scope $scope): void
     {
-        $this->spans[] = $span;
+        $this->spans[] = new SpanScope($span, $scope);
     }
 }

--- a/src/core/etl/src/Flow/ETL/Config/Telemetry/TelemetryContext.php
+++ b/src/core/etl/src/Flow/ETL/Config/Telemetry/TelemetryContext.php
@@ -34,6 +34,8 @@ use function round;
  */
 final class TelemetryContext
 {
+    private const string SPAN_NEVER_COMPLETED = 'Span was never completed.';
+
     private ?FlowContext $context = null;
 
     private ?Counter $counterProcessedRows = null;
@@ -42,7 +44,7 @@ final class TelemetryContext
 
     private ?Span $dataFrameSpan = null;
 
-    private ?Span $loadingSpan = null;
+    private readonly SpanStack $loadingSpans;
 
     private Consumption $memory;
 
@@ -50,7 +52,7 @@ final class TelemetryContext
 
     private int $totalRowsProcessed = 0;
 
-    private ?Span $transformationSpan = null;
+    private readonly SpanStack $transformationSpans;
 
     public function __construct(
         private readonly Logger $logger,
@@ -59,12 +61,16 @@ final class TelemetryContext
         public readonly TelemetryOptions $options,
     ) {
         $this->memory = new Consumption();
+        $this->loadingSpans = new SpanStack();
+        $this->transformationSpans = new SpanStack();
     }
 
     public function dataFrameBatchProcessed(Rows $rows, FlowContext $context): void
     {
         $this->totalRowsProcessed += $rows->count();
         $this->memory->capture();
+
+        $this->drain();
 
         if ($this->options->collectMetrics) {
             $attributes = [TelemetryAttributes::ATTR_DATAFRAME_NAME => $context->config->name()];
@@ -83,6 +89,8 @@ final class TelemetryContext
         if ($dataFrameSpan === null) {
             return;
         }
+
+        $this->drain();
 
         $this->logger()->debug(
             'Data frame processing completed',
@@ -139,6 +147,8 @@ final class TelemetryContext
         if ($dataFrameSpan === null) {
             return;
         }
+
+        $this->drain();
 
         $this->logger->error('Data frame processing failed', [
             'exception' => $exception->getMessage(),
@@ -241,14 +251,23 @@ final class TelemetryContext
     /**
      * @param TAttributeValueMap $attributes
      */
+    public function limitReached(array $attributes = []): void
+    {
+        $this->logger->debug('Limit reached, stopping the pipeline execution.', $attributes);
+    }
+
+    /**
+     * @param TAttributeValueMap $attributes
+     */
     public function loadingCompleted(Loader $loader, array $attributes = []): void
     {
-        if ($this->loadingSpan === null) {
+        $span = $this->loadingSpans->pop();
+
+        if ($span === null) {
             return;
         }
-        $this->tracer->complete($this->loadingSpan->setAttributes($attributes));
 
-        $this->loadingSpan = null;
+        $this->tracer->complete($span->setAttributes($attributes));
     }
 
     /**
@@ -256,19 +275,19 @@ final class TelemetryContext
      */
     public function loadingFailed(Loader $loader, Throwable $exception, array $attributes = []): void
     {
-        if ($this->loadingSpan === null) {
+        $span = $this->loadingSpans->pop();
+
+        if ($span === null) {
             return;
         }
 
         $this->logger->error('Loading failed', ['exception' => $exception->getMessage(), 'loader' => $loader::class]);
         $this->tracer->complete(
-            $this->loadingSpan
+            $span
                 ->setAttributes($attributes)
                 ->setAttribute(SemConvAttributes::ERROR_TYPE, $exception::class)
                 ->setStatus(SpanStatus::error($exception->getMessage())),
         );
-
-        $this->loadingSpan = null;
     }
 
     /**
@@ -280,7 +299,7 @@ final class TelemetryContext
             return;
         }
 
-        $this->loadingSpan = $this->tracer->span(
+        $this->loadingSpans->push($this->tracer->span(
             ObjectExtractor::shortName($loader),
             SpanKind::INTERNAL,
             Attributes::create(array_merge([
@@ -288,7 +307,7 @@ final class TelemetryContext
                 TelemetryAttributes::ATTR_DATAFRAME_NAME => $this->context?->config->name(),
             ], $attributes)),
             parentContext: $this->dataFrameSpan?->context(),
-        );
+        ));
     }
 
     public function logger(): Logger
@@ -301,11 +320,13 @@ final class TelemetryContext
      */
     public function transformationCompleted(Transformer $transformer, array $attributes = []): void
     {
-        if ($this->transformationSpan === null) {
+        $span = $this->transformationSpans->pop();
+
+        if ($span === null) {
             return;
         }
 
-        $this->tracer->complete($this->transformationSpan->setAttributes($attributes));
+        $this->tracer->complete($span->setAttributes($attributes));
     }
 
     /**
@@ -313,7 +334,9 @@ final class TelemetryContext
      */
     public function transformationFailed(Transformer $transformer, Throwable $exception, array $attributes = []): void
     {
-        if ($this->transformationSpan === null) {
+        $span = $this->transformationSpans->pop();
+
+        if ($span === null) {
             return;
         }
 
@@ -322,13 +345,11 @@ final class TelemetryContext
             'transformer' => $transformer::class,
         ]);
         $this->tracer->complete(
-            $this->transformationSpan
+            $span
                 ->setAttributes($attributes)
                 ->setAttribute(SemConvAttributes::ERROR_TYPE, $exception::class)
                 ->setStatus(SpanStatus::error($exception->getMessage())),
         );
-
-        $this->transformationSpan = null;
     }
 
     /**
@@ -340,7 +361,7 @@ final class TelemetryContext
             return;
         }
 
-        $this->transformationSpan = $this->tracer->span(
+        $this->transformationSpans->push($this->tracer->span(
             ObjectExtractor::shortName($transformer),
             SpanKind::INTERNAL,
             Attributes::create(array_merge([
@@ -348,6 +369,16 @@ final class TelemetryContext
                 TelemetryAttributes::ATTR_DATAFRAME_NAME => $this->context?->config->name(),
             ], $attributes)),
             parentContext: $this->dataFrameSpan?->context(),
-        );
+        ));
+    }
+
+    /**
+     * Transformations drain first: TransformerLoader nests transform() inside load(), so a transformation
+     * scope is always the inner one and must be detached before the loading scope that wraps it.
+     */
+    private function drain(): void
+    {
+        $this->transformationSpans->drain($this->tracer, self::SPAN_NEVER_COMPLETED);
+        $this->loadingSpans->drain($this->tracer, self::SPAN_NEVER_COMPLETED);
     }
 }

--- a/src/core/etl/src/Flow/ETL/Config/Telemetry/TelemetryContext.php
+++ b/src/core/etl/src/Flow/ETL/Config/Telemetry/TelemetryContext.php
@@ -13,6 +13,8 @@ use Flow\ETL\Rows;
 use Flow\ETL\Transformer;
 use Flow\Filesystem\Filesystem;
 use Flow\Telemetry\Attributes;
+use Flow\Telemetry\Context\Context;
+use Flow\Telemetry\Context\Scope;
 use Flow\Telemetry\Logger\Logger;
 use Flow\Telemetry\Meter\Instrument\Counter;
 use Flow\Telemetry\Meter\Instrument\Throughput;
@@ -41,6 +43,8 @@ final class TelemetryContext
     private ?Counter $counterProcessedRows = null;
 
     private ?HighResolutionTime $dataFrameExecutionTime = null;
+
+    private ?Scope $dataFrameScope = null;
 
     private ?Span $dataFrameSpan = null;
 
@@ -91,6 +95,8 @@ final class TelemetryContext
         }
 
         $this->drain();
+        $this->dataFrameScope?->detach();
+        $this->dataFrameScope = null;
 
         $this->logger()->debug(
             'Data frame processing completed',
@@ -149,6 +155,8 @@ final class TelemetryContext
         }
 
         $this->drain();
+        $this->dataFrameScope?->detach();
+        $this->dataFrameScope = null;
 
         $this->logger->error('Data frame processing failed', [
             'exception' => $exception->getMessage(),
@@ -206,6 +214,9 @@ final class TelemetryContext
             ]),
         );
         $this->dataFrameSpan = $dataFrameSpan;
+        // activated so that everything started while the data frame runs - including filesystem streams, which
+        // never activate themselves - is parented to it
+        $this->dataFrameScope = $this->tracer->activate($dataFrameSpan);
 
         $this->logger()->debug(
             'Data frame processing started',
@@ -261,13 +272,14 @@ final class TelemetryContext
      */
     public function loadingCompleted(Loader $loader, array $attributes = []): void
     {
-        $span = $this->loadingSpans->pop();
+        $entry = $this->loadingSpans->pop();
 
-        if ($span === null) {
+        if ($entry === null) {
             return;
         }
 
-        $this->tracer->complete($span->setAttributes($attributes));
+        $entry->scope->detach();
+        $this->tracer->complete($entry->span->setAttributes($attributes));
     }
 
     /**
@@ -275,15 +287,17 @@ final class TelemetryContext
      */
     public function loadingFailed(Loader $loader, Throwable $exception, array $attributes = []): void
     {
-        $span = $this->loadingSpans->pop();
+        $entry = $this->loadingSpans->pop();
 
-        if ($span === null) {
+        if ($entry === null) {
             return;
         }
 
+        $entry->scope->detach();
         $this->logger->error('Loading failed', ['exception' => $exception->getMessage(), 'loader' => $loader::class]);
         $this->tracer->complete(
-            $span
+            $entry
+                ->span
                 ->setAttributes($attributes)
                 ->setAttribute(SemConvAttributes::ERROR_TYPE, $exception::class)
                 ->setStatus(SpanStatus::error($exception->getMessage())),
@@ -299,15 +313,17 @@ final class TelemetryContext
             return;
         }
 
-        $this->loadingSpans->push($this->tracer->span(
+        $span = $this->tracer->span(
             ObjectExtractor::shortName($loader),
             SpanKind::INTERNAL,
             Attributes::create(array_merge([
                 TelemetryAttributes::ATTR_LOADER_CLASS => $loader::class,
                 TelemetryAttributes::ATTR_DATAFRAME_NAME => $this->context?->config->name(),
             ], $attributes)),
-            parentContext: $this->dataFrameSpan?->context(),
-        ));
+            parent: $this->dataFrameParent(),
+        );
+
+        $this->loadingSpans->push($span, $this->tracer->activate($span));
     }
 
     public function logger(): Logger
@@ -320,13 +336,14 @@ final class TelemetryContext
      */
     public function transformationCompleted(Transformer $transformer, array $attributes = []): void
     {
-        $span = $this->transformationSpans->pop();
+        $entry = $this->transformationSpans->pop();
 
-        if ($span === null) {
+        if ($entry === null) {
             return;
         }
 
-        $this->tracer->complete($span->setAttributes($attributes));
+        $entry->scope->detach();
+        $this->tracer->complete($entry->span->setAttributes($attributes));
     }
 
     /**
@@ -334,18 +351,20 @@ final class TelemetryContext
      */
     public function transformationFailed(Transformer $transformer, Throwable $exception, array $attributes = []): void
     {
-        $span = $this->transformationSpans->pop();
+        $entry = $this->transformationSpans->pop();
 
-        if ($span === null) {
+        if ($entry === null) {
             return;
         }
 
+        $entry->scope->detach();
         $this->logger->error('Transformation failed', [
             'exception' => $exception->getMessage(),
             'transformer' => $transformer::class,
         ]);
         $this->tracer->complete(
-            $span
+            $entry
+                ->span
                 ->setAttributes($attributes)
                 ->setAttribute(SemConvAttributes::ERROR_TYPE, $exception::class)
                 ->setStatus(SpanStatus::error($exception->getMessage())),
@@ -361,15 +380,32 @@ final class TelemetryContext
             return;
         }
 
-        $this->transformationSpans->push($this->tracer->span(
+        $span = $this->tracer->span(
             ObjectExtractor::shortName($transformer),
             SpanKind::INTERNAL,
             Attributes::create(array_merge([
                 TelemetryAttributes::ATTR_TRANSFORMER_CLASS => $transformer::class,
                 TelemetryAttributes::ATTR_DATAFRAME_NAME => $this->context?->config->name(),
             ], $attributes)),
-            parentContext: $this->dataFrameSpan?->context(),
-        ));
+            parent: $this->dataFrameParent(),
+        );
+
+        $this->transformationSpans->push($span, $this->tracer->activate($span));
+    }
+
+    /**
+     * Pins loading/transformation spans to the data frame span regardless of what else has been activated in
+     * between. Derived from the current context so baggage and suppression are preserved.
+     */
+    private function dataFrameParent(): ?Context
+    {
+        $dataFrameSpan = $this->dataFrameSpan;
+
+        if ($dataFrameSpan === null) {
+            return null;
+        }
+
+        return $this->tracer->context()->withActiveSpan($dataFrameSpan->context());
     }
 
     /**

--- a/src/core/etl/src/Flow/ETL/Extractor/GeneratorExtractor.php
+++ b/src/core/etl/src/Flow/ETL/Extractor/GeneratorExtractor.php
@@ -10,9 +10,6 @@ use Flow\ETL\FlowContext;
 use Flow\ETL\Rows;
 use Generator;
 
-/**
- * @internal
- */
 final readonly class GeneratorExtractor implements Extractor
 {
     /**

--- a/src/core/etl/src/Flow/ETL/Extractor/RowsExtractor.php
+++ b/src/core/etl/src/Flow/ETL/Extractor/RowsExtractor.php
@@ -9,9 +9,6 @@ use Flow\ETL\FlowContext;
 use Flow\ETL\Rows;
 use Generator;
 
-/**
- * @internal
- */
 final readonly class RowsExtractor implements Extractor
 {
     /**

--- a/src/core/etl/src/Flow/ETL/Extractor/SwappableRowsExtractor.php
+++ b/src/core/etl/src/Flow/ETL/Extractor/SwappableRowsExtractor.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Extractor;
+
+use Flow\ETL\Extractor;
+use Flow\ETL\FlowContext;
+use Flow\ETL\Rows;
+use Generator;
+
+final class SwappableRowsExtractor implements Extractor
+{
+    private Rows $rows;
+
+    private bool $stopped = false;
+
+    public function __construct()
+    {
+        $this->rows = new Rows();
+    }
+
+    /**
+     * @return Generator<int, Rows, Signal|null, void>
+     */
+    public function extract(FlowContext $context): Generator
+    {
+        $signal = yield $this->rows;
+
+        if ($signal === Signal::STOP) {
+            $this->stopped = true;
+
+            return;
+        }
+
+        $signal = yield new Rows();
+
+        if ($signal === Signal::STOP) {
+            $this->stopped = true;
+        }
+    }
+
+    public function stopped(): bool
+    {
+        return $this->stopped;
+    }
+
+    public function swap(Rows $rows): void
+    {
+        $this->rows = $rows;
+    }
+}

--- a/src/core/etl/src/Flow/ETL/Loader/TransformerLoader.php
+++ b/src/core/etl/src/Flow/ETL/Loader/TransformerLoader.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace Flow\ETL\Loader;
 
 use Flow\ETL\Config\Telemetry\TelemetryAttributes;
+use Flow\ETL\DataFrame;
+use Flow\ETL\Exception\LimitReachedException;
+use Flow\ETL\Extractor\SwappableRowsExtractor;
 use Flow\ETL\FlowContext;
 use Flow\ETL\Loader;
 use Flow\ETL\Rows;
@@ -13,20 +16,31 @@ use Flow\ETL\Transformer;
 use Throwable;
 
 use function Flow\ETL\DSL\df;
-use function Flow\ETL\DSL\from_rows;
 
-final readonly class TransformerLoader implements Closure, Loader, OverridingLoader
+final class TransformerLoader implements Closure, Loader, OverridingLoader
 {
+    private bool $limitReached = false;
+
+    private ?DataFrame $transformationDataFrame = null;
+
+    private SwappableRowsExtractor $transformationRows;
+
     public function __construct(
-        private Transformer|Transformation $transformer,
-        private Loader $loader,
-    ) {}
+        private readonly Transformer|Transformation $transformer,
+        private readonly Loader $loader,
+    ) {
+        $this->transformationRows = new SwappableRowsExtractor();
+    }
 
     public function closure(FlowContext $context): void
     {
         if ($this->loader instanceof Closure) {
             $this->loader->closure($context);
         }
+
+        $this->transformationDataFrame = null;
+        $this->transformationRows = new SwappableRowsExtractor();
+        $this->limitReached = false;
     }
 
     public function load(Rows $rows, FlowContext $context): void
@@ -40,10 +54,24 @@ final readonly class TransformerLoader implements Closure, Loader, OverridingLoa
                 // @mago-ignore analysis:invalid-argument,too-many-arguments,possibly-invalid-argument
                 $this->loader->load($transformer->transform($rows, $context), $context);
             } else {
-                df($context->config)->from(from_rows($rows))->with($transformer)->load($this->loader)->run();
+                $this->transformationDataFrame ??= $transformer
+                    ->transform(df($context->config)->from($this->transformationRows))
+                    ->load($this->loader);
+
+                if (!$this->transformationRows->stopped()) {
+                    $this->transformationRows->swap($rows);
+                    $this->transformationDataFrame->run();
+                }
             }
 
             $context->telemetry()->loadingCompleted($this, [TelemetryAttributes::ATTR_LOADING_ROWS => $rows->count()]);
+        } catch (LimitReachedException $e) {
+            if (!$this->limitReached) {
+                $this->limitReached = true;
+                $context->telemetry()->limitReached(['limit' => $e->limit]);
+            }
+
+            $context->telemetry()->loadingCompleted($this, [TelemetryAttributes::ATTR_LOADING_ROWS => 0]);
         } catch (Throwable $e) {
             $context->telemetry()->loadingFailed($this, $e);
 

--- a/src/core/etl/src/Flow/ETL/Pipeline/Segment.php
+++ b/src/core/etl/src/Flow/ETL/Pipeline/Segment.php
@@ -81,10 +81,7 @@ final readonly class Segment
                         try {
                             $rows = $step->transform($rows, $context);
                         } catch (LimitReachedException $e) {
-                            $context
-                                ->telemetry()
-                                ->logger()
-                                ->debug('Limit reached, stopping the pipeline execution.', ['limit_exception' => $e]);
+                            $context->telemetry()->limitReached(['limit' => $e->limit]);
                             $rows = new Rows();
                             $input->send(Signal::STOP);
                         }

--- a/src/core/etl/src/Flow/Floe/FloeMerger.php
+++ b/src/core/etl/src/Flow/Floe/FloeMerger.php
@@ -157,8 +157,14 @@ final readonly class FloeMerger
         $reader = new FloeReader($this->filesystem, $this->codec, hydrator: $this->hydrator);
 
         foreach ($sources as $source) {
-            foreach ($reader->read($source)->rows() as $batch) {
-                $writer->write($batch);
+            $streamReader = $reader->read($source);
+
+            try {
+                foreach ($streamReader->rows() as $batch) {
+                    $writer->write($batch);
+                }
+            } finally {
+                $streamReader->close();
             }
         }
 
@@ -201,18 +207,21 @@ final readonly class FloeMerger
 
             if ($regionLength > 0) {
                 $sourceStream = $this->filesystem->readFrom($source);
-                $at = $copyStart;
-                $remaining = $regionLength;
 
-                while ($remaining > 0) {
-                    /** @var int<1, max> $length */
-                    $length = $remaining < self::COPY_CHUNK_SIZE ? $remaining : self::COPY_CHUNK_SIZE;
-                    $frameWriter->raw($sourceStream->read($length, $at));
-                    $at += $length;
-                    $remaining -= $length;
+                try {
+                    $at = $copyStart;
+                    $remaining = $regionLength;
+
+                    while ($remaining > 0) {
+                        /** @var int<1, max> $length */
+                        $length = $remaining < self::COPY_CHUNK_SIZE ? $remaining : self::COPY_CHUNK_SIZE;
+                        $frameWriter->raw($sourceStream->read($length, $at));
+                        $at += $length;
+                        $remaining -= $length;
+                    }
+                } finally {
+                    $sourceStream->close();
                 }
-
-                $sourceStream->close();
             }
 
             foreach ($footer->sections as $section) {
@@ -295,8 +304,12 @@ final readonly class FloeMerger
         }
 
         $stream = $this->filesystem->readFrom($source);
-        $location = (new FooterReader())->read($stream, $this->codec);
-        $stream->close();
+
+        try {
+            $location = (new FooterReader())->read($stream, $this->codec);
+        } finally {
+            $stream->close();
+        }
 
         return [
             'footer' => $location->footer,

--- a/src/core/etl/src/Flow/Floe/FloeStreamReader.php
+++ b/src/core/etl/src/Flow/Floe/FloeStreamReader.php
@@ -57,6 +57,11 @@ final class FloeStreamReader
         $this->hydrator = $hydrator ?? new AdaptiveRowHydrator();
     }
 
+    public function close(): void
+    {
+        $this->source->close();
+    }
+
     /**
      * @return Encoder<string>
      */

--- a/src/core/etl/tests/Flow/ETL/Tests/Context/MemoryTelemetryContext.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Context/MemoryTelemetryContext.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Tests\Context;
+
+use Flow\Clock\FakeClock;
+use Flow\ETL\Config;
+use Flow\ETL\Config\Telemetry\TelemetryContext;
+use Flow\ETL\Config\Telemetry\TelemetryOptions;
+use Flow\ETL\FlowContext;
+use Flow\Telemetry\Context\MemoryContextStorage;
+use Flow\Telemetry\Logger\LoggerProvider;
+use Flow\Telemetry\Meter\MeterProvider;
+use Flow\Telemetry\Provider\Memory\MemoryLogProcessor;
+use Flow\Telemetry\Provider\Memory\MemoryMetricProcessor;
+use Flow\Telemetry\Provider\Memory\MemorySpanProcessor;
+use Flow\Telemetry\Provider\Void\VoidExporter;
+use Flow\Telemetry\Resource;
+use Flow\Telemetry\Telemetry;
+use Flow\Telemetry\Tracer\TracerProvider;
+
+use function Flow\ETL\DSL\config_builder;
+use function Flow\ETL\DSL\flow_context;
+
+final class MemoryTelemetryContext
+{
+    public readonly Config $config;
+
+    public readonly FlowContext $flowContext;
+
+    public readonly MemoryLogProcessor $logs;
+
+    public readonly MemoryMetricProcessor $metrics;
+
+    public readonly MemorySpanProcessor $spans;
+
+    public readonly Telemetry $telemetry;
+
+    public readonly TelemetryContext $telemetryContext;
+
+    public function __construct(
+        public readonly TelemetryOptions $options = new TelemetryOptions(),
+    ) {
+        $this->spans = new MemorySpanProcessor(new VoidExporter());
+        $this->metrics = new MemoryMetricProcessor(new VoidExporter());
+        $this->logs = new MemoryLogProcessor(new VoidExporter());
+
+        $clock = new FakeClock();
+        $contextStorage = new MemoryContextStorage();
+
+        $this->telemetry = new Telemetry(
+            Resource::create(['service.name' => 'flow-test']),
+            new TracerProvider($this->spans, $clock, $contextStorage),
+            new MeterProvider($this->metrics, $clock),
+            new LoggerProvider($this->logs, $clock, $contextStorage),
+        );
+
+        $this->config = config_builder()->withTelemetry($this->telemetry, $this->options)->build();
+        $this->flowContext = flow_context($this->config);
+        $this->telemetryContext = new TelemetryContext(
+            $this->telemetry->logger('flow-php'),
+            $this->telemetry->tracer('flow-php'),
+            $this->telemetry->meter('flow-php'),
+            $this->options,
+        );
+    }
+}

--- a/src/core/etl/tests/Flow/ETL/Tests/Context/MemoryTelemetryContext.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Context/MemoryTelemetryContext.php
@@ -6,6 +6,7 @@ namespace Flow\ETL\Tests\Context;
 
 use Flow\Clock\FakeClock;
 use Flow\ETL\Config;
+use Flow\ETL\Config\Sort\SortAlgorithmBuilder;
 use Flow\ETL\Config\Telemetry\TelemetryContext;
 use Flow\ETL\Config\Telemetry\TelemetryOptions;
 use Flow\ETL\FlowContext;
@@ -41,6 +42,7 @@ final class MemoryTelemetryContext
 
     public function __construct(
         public readonly TelemetryOptions $options = new TelemetryOptions(),
+        ?SortAlgorithmBuilder $sortAlgorithm = null,
     ) {
         $this->spans = new MemorySpanProcessor(new VoidExporter());
         $this->metrics = new MemoryMetricProcessor(new VoidExporter());
@@ -56,7 +58,13 @@ final class MemoryTelemetryContext
             new LoggerProvider($this->logs, $clock, $contextStorage),
         );
 
-        $this->config = config_builder()->withTelemetry($this->telemetry, $this->options)->build();
+        $configBuilder = config_builder()->withTelemetry($this->telemetry, $this->options);
+
+        if ($sortAlgorithm !== null) {
+            $configBuilder->sort($sortAlgorithm);
+        }
+
+        $this->config = $configBuilder->build();
         $this->flowContext = flow_context($this->config);
         $this->telemetryContext = new TelemetryContext(
             $this->telemetry->logger('flow-php'),

--- a/src/core/etl/tests/Flow/ETL/Tests/Integration/Bucketing/BucketSourceStreamsTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Integration/Bucketing/BucketSourceStreamsTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Tests\Integration\Bucketing;
+
+use Flow\ETL\Tests\Context\MemoryTelemetryContext;
+use Flow\ETL\Tests\FlowTestCase;
+use Flow\Telemetry\Tracer\Span;
+
+use function array_filter;
+use function count;
+use function Flow\ETL\DSL\collect;
+use function Flow\ETL\DSL\df;
+use function Flow\ETL\DSL\external_sort;
+use function Flow\ETL\DSL\from_array;
+use function Flow\ETL\DSL\ref;
+use function Flow\ETL\DSL\sum;
+use function Flow\ETL\DSL\telemetry_options;
+use function Flow\ETL\DSL\to_array;
+
+/**
+ * A never-closed source stream is invisible in endedSpans() - it looks exactly like a stream that was never
+ * opened. Only comparing started against ended catches it.
+ */
+final class BucketSourceStreamsTest extends FlowTestCase
+{
+    public function test_bucket_source_streams_are_not_nested_into_each_other(): void
+    {
+        $context = new MemoryTelemetryContext(telemetry_options(collect_metrics: false));
+
+        $source = [];
+
+        for ($id = 1; $id <= 200; $id++) {
+            $source[] = ['group_id' => 'group-' . $id, 'value' => $id];
+        }
+
+        $output = [];
+        df($context->config)
+            ->read(from_array($source))
+            ->groupBy(ref('group_id'))
+            ->aggregate(collect(ref('value')->as('values')))
+            ->write(to_array($output))
+            ->run();
+
+        $isFilesystemSpan = static fn(Span $span): bool => (
+            $span->name() === 'filesystem.read'
+            || $span->name() === 'filesystem.write'
+        );
+
+        $filesystemSpanIds = [];
+
+        foreach (array_filter($context->spans->endedSpans(), $isFilesystemSpan) as $span) {
+            $filesystemSpanIds[(string) $span->context()->spanId] = true;
+        }
+
+        static::assertNotSame([], $filesystemSpanIds);
+
+        foreach (array_filter($context->spans->endedSpans(), $isFilesystemSpan) as $span) {
+            $parentSpanId = $span->context()->parentSpanId;
+
+            static::assertArrayNotHasKey(
+                $parentSpanId === null ? '' : (string) $parentSpanId,
+                $filesystemSpanIds,
+                'A filesystem span must never be the parent of another filesystem span.',
+            );
+        }
+    }
+
+    public function test_external_sort_closes_every_bucket_source_stream(): void
+    {
+        $context = new MemoryTelemetryContext(
+            telemetry_options(collect_metrics: false),
+            external_sort()->runSize(50)->bucketsCount(8),
+        );
+
+        $source = [];
+
+        for ($id = 1; $id <= 500; $id++) {
+            $source[] = ['id' => (1_000 - $id) % 337];
+        }
+
+        $output = [];
+        df($context->config)->read(from_array($source))->sortBy(ref('id'))->write(to_array($output))->run();
+
+        $isRead = static fn(Span $span): bool => $span->name() === 'filesystem.read';
+
+        static::assertNotSame(0, count(array_filter($context->spans->startedSpans(), $isRead)));
+        static::assertSame(
+            count(array_filter($context->spans->startedSpans(), $isRead)),
+            count(array_filter($context->spans->endedSpans(), $isRead)),
+        );
+    }
+
+    public function test_group_by_closes_every_bucket_source_stream(): void
+    {
+        $context = new MemoryTelemetryContext(telemetry_options(collect_metrics: false));
+
+        $source = [];
+
+        for ($id = 1; $id <= 200; $id++) {
+            $source[] = ['group_id' => 'group-' . $id, 'value' => $id];
+        }
+
+        $output = [];
+        df($context->config)
+            ->read(from_array($source))
+            ->groupBy(ref('group_id'))
+            ->aggregate(sum(ref('value')->as('total')))
+            ->write(to_array($output))
+            ->run();
+
+        $isRead = static fn(Span $span): bool => $span->name() === 'filesystem.read';
+
+        static::assertNotSame(0, count(array_filter($context->spans->startedSpans(), $isRead)));
+        static::assertSame(
+            count(array_filter($context->spans->startedSpans(), $isRead)),
+            count(array_filter($context->spans->endedSpans(), $isRead)),
+        );
+    }
+}

--- a/src/core/etl/tests/Flow/ETL/Tests/Integration/DataFrame/TelemetryTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Integration/DataFrame/TelemetryTest.php
@@ -5,7 +5,10 @@ declare(strict_types=1);
 namespace Flow\ETL\Tests\Integration\DataFrame;
 
 use DateTimeImmutable;
+use Flow\ETL\Loader\RetryLoader;
+use Flow\ETL\Tests\Context\MemoryTelemetryContext;
 use Flow\ETL\Tests\FlowTestCase;
+use Flow\ETL\Transformer\LimitTransformer;
 use Flow\Telemetry\Context\MemoryContextStorage;
 use Flow\Telemetry\Logger\LoggerProvider;
 use Flow\Telemetry\Logger\Severity;
@@ -16,18 +19,25 @@ use Flow\Telemetry\Provider\Memory\MemorySpanProcessor;
 use Flow\Telemetry\Provider\Void\VoidExporter;
 use Flow\Telemetry\Resource;
 use Flow\Telemetry\Telemetry;
+use Flow\Telemetry\Tracer\Span;
 use Flow\Telemetry\Tracer\TracerProvider;
 use Psr\Clock\ClockInterface;
 
+use function array_filter;
 use function count;
 use function Flow\ETL\DSL\config_builder;
 use function Flow\ETL\DSL\df;
 use function Flow\ETL\DSL\from_array;
+use function Flow\ETL\DSL\limit;
+use function Flow\ETL\DSL\lit;
 use function Flow\ETL\DSL\ref;
 use function Flow\ETL\DSL\telemetry_options;
 use function Flow\ETL\DSL\to_array;
+use function Flow\ETL\DSL\to_transformation;
+use function Flow\ETL\DSL\with_entry;
 use function str_contains;
 use function str_ends_with;
+use function str_starts_with;
 
 final class TelemetryTest extends FlowTestCase
 {
@@ -272,6 +282,116 @@ final class TelemetryTest extends FlowTestCase
         }
     }
 
+    public function test_duplicate_row_transformer_exports_nested_spans_once(): void
+    {
+        $context = new MemoryTelemetryContext(telemetry_options(trace_transformations: true));
+
+        $output = [];
+        df($context->config)
+            ->read(from_array([['id' => 1], ['id' => 2]]))
+            ->duplicateRow(condition: lit(true), entries: with_entry('id', ref('id')->multiply(lit(-1))))
+            ->write(to_array($output))
+            ->run();
+
+        $endedSpans = $context->spans->endedSpans();
+
+        static::assertCount(2, array_filter(
+            $endedSpans,
+            static fn(Span $span): bool => $span->name() === 'DuplicateRowTransformer',
+        ));
+        static::assertCount(2, array_filter(
+            $endedSpans,
+            static fn(Span $span): bool => $span->name() === 'ScalarFunctionTransformer',
+        ));
+    }
+
+    public function test_limit_reached_inside_transformer_loader_is_not_reported_as_failure(): void
+    {
+        $context = new MemoryTelemetryContext(telemetry_options(trace_loading: true));
+
+        $rows = [];
+
+        for ($id = 1; $id <= 20; $id++) {
+            $rows[] = ['id' => $id];
+        }
+
+        $output = [];
+        df($context->config)
+            ->read(from_array($rows))
+            ->load(to_transformation(new LimitTransformer(10), to_array($output)))
+            ->run();
+
+        static::assertEmpty($context->logs->entriesContaining('Loading failed'));
+        static::assertEmpty($context->logs->entriesContaining('Error during ETL segment execution.'));
+        static::assertEmpty($context->logs->entriesContaining('Data frame processing failed'));
+        static::assertCount(1, $context->logs->entriesContaining('Limit reached'));
+        static::assertEmpty(array_filter(
+            $context->spans->endedSpans(),
+            static fn(Span $span): bool => $span->status()?->isError() === true,
+        ));
+    }
+
+    public function test_limit_reached_inside_transformation_is_logged_once_across_batches(): void
+    {
+        $context = new MemoryTelemetryContext();
+
+        $source = [];
+
+        for ($id = 1; $id <= 20; $id++) {
+            $source[] = ['id' => $id];
+        }
+
+        $output = [];
+        df($context->config)
+            ->read(from_array($source))
+            ->write(to_transformation(limit(3), to_array($output)))
+            ->run();
+
+        static::assertCount(3, $output);
+        static::assertCount(1, $context->logs->entriesContaining('Limit reached'));
+    }
+
+    public function test_limit_reached_is_logged_without_exception_attribute(): void
+    {
+        $context = new MemoryTelemetryContext();
+
+        $rows = [];
+
+        for ($id = 1; $id <= 20; $id++) {
+            $rows[] = ['id' => $id];
+        }
+
+        df($context->config)->read(from_array($rows))->limit(5)->run();
+
+        $entries = $context->logs->entriesContaining('Limit reached');
+
+        static::assertCount(1, $entries);
+        static::assertFalse($entries[0]->record->attributes->has('limit_exception'));
+        static::assertSame(5, $entries[0]->record->attributes->get('limit'));
+    }
+
+    public function test_retry_loader_exports_nested_spans_once(): void
+    {
+        $context = new MemoryTelemetryContext(telemetry_options(trace_loading: true));
+
+        $output = [];
+        df($context->config)
+            ->read(from_array([['id' => 1], ['id' => 2]]))
+            ->load(new RetryLoader(to_array($output)))
+            ->run();
+
+        $endedSpans = $context->spans->endedSpans();
+
+        static::assertCount(2, array_filter(
+            $endedSpans,
+            static fn(Span $span): bool => $span->name() === 'RetryLoader',
+        ));
+        static::assertCount(2, array_filter(
+            $endedSpans,
+            static fn(Span $span): bool => $span->name() === 'ArrayLoader',
+        ));
+    }
+
     public function test_telemetry_disabled_by_default_uses_void_providers(): void
     {
         $config = config_builder()->build();
@@ -286,6 +406,51 @@ final class TelemetryTest extends FlowTestCase
 
         static::assertCount(1, $output);
         static::assertSame(1, $output[0]['id']);
+    }
+
+    public function test_transformation_loader_builds_one_nested_dataframe_span_per_run(): void
+    {
+        $context = new MemoryTelemetryContext();
+
+        $source = [];
+
+        for ($id = 1; $id <= 6; $id++) {
+            $source[] = ['id' => $id];
+        }
+
+        $output = [];
+        df($context->config)
+            ->read(from_array($source))
+            ->write(to_transformation(limit(3), to_array($output)))
+            ->run();
+
+        $isDataFrameSpan = static fn(Span $span): bool => str_starts_with($span->name(), 'DataFrame ');
+
+        static::assertCount(2, array_filter($context->spans->startedSpans(), $isDataFrameSpan));
+        static::assertCount(2, array_filter($context->spans->endedSpans(), $isDataFrameSpan));
+    }
+
+    public function test_until_condition_is_logged_without_exception_attribute(): void
+    {
+        $context = new MemoryTelemetryContext();
+
+        $rows = [];
+
+        for ($id = 1; $id <= 20; $id++) {
+            $rows[] = ['id' => $id];
+        }
+
+        df($context->config)
+            ->read(from_array($rows))
+            ->until(ref('id')->lessThan(lit(5)))
+            ->run();
+
+        $entries = $context->logs->entriesContaining('Limit reached');
+
+        static::assertCount(1, $entries);
+        static::assertFalse($entries[0]->record->attributes->has('limit_exception'));
+        // UntilTransformer has no limit to report and throws LimitReachedException(0).
+        static::assertSame(0, $entries[0]->record->attributes->get('limit'));
     }
 
     private function createFrozenClock(DateTimeImmutable $now = new DateTimeImmutable()): ClockInterface

--- a/src/core/etl/tests/Flow/ETL/Tests/Integration/Loader/TransformerLoaderTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Integration/Loader/TransformerLoaderTest.php
@@ -7,9 +7,12 @@ namespace Flow\ETL\Tests\Integration\Loader;
 use Flow\ETL\Loader;
 use Flow\ETL\Memory\ArrayMemory;
 use Flow\ETL\Tests\Double\FakeStaticOrdersExtractor;
+use Flow\ETL\Tests\Double\SpyLoader;
 use Flow\ETL\Tests\FlowTestCase;
 use Flow\ETL\Transformation\AddRowIndex\StartFrom;
+use Flow\ETL\Transformer\LimitTransformer;
 
+use function array_column;
 use function Flow\ETL\DSL\add_row_index;
 use function Flow\ETL\DSL\batch_size;
 use function Flow\ETL\DSL\df;
@@ -59,6 +62,42 @@ final class TransformerLoaderTest extends FlowTestCase
             ->run();
     }
 
+    public function test_transformer_loader_with_add_row_index_transformation_across_batches(): void
+    {
+        $source = [];
+
+        for ($id = 1; $id <= 6; $id++) {
+            $source[] = ['id' => $id];
+        }
+
+        $memory = new ArrayMemory();
+
+        df()
+            ->read(from_array($source))
+            ->write(to_transformation(add_row_index('n', StartFrom::ONE), to_memory($memory)))
+            ->run();
+
+        static::assertSame([1, 2, 3, 4, 5, 6], array_column($memory->dump(), 'n'));
+    }
+
+    public function test_transformer_loader_with_batch_size_transformation_across_batches(): void
+    {
+        $source = [];
+
+        for ($id = 1; $id <= 6; $id++) {
+            $source[] = ['id' => $id];
+        }
+
+        $loader = new SpyLoader();
+
+        df()
+            ->read(from_array($source))
+            ->write(to_transformation(batch_size(4), $loader))
+            ->run();
+
+        static::assertSame(6, $loader->loadsCount);
+    }
+
     public function test_transformer_loader_with_drop_transformation(): void
     {
         $memory = new ArrayMemory();
@@ -78,6 +117,27 @@ final class TransformerLoaderTest extends FlowTestCase
             ],
             $memory->dump(),
         );
+    }
+
+    public function test_transformer_loader_with_limit_transformer_does_not_stop_sibling_loaders(): void
+    {
+        $limited = new ArrayMemory();
+        $sibling = new ArrayMemory();
+
+        $source = [];
+
+        for ($id = 1; $id <= 20; $id++) {
+            $source[] = ['id' => $id];
+        }
+
+        df()
+            ->read(from_array($source))
+            ->load(to_transformation(new LimitTransformer(10), to_memory($limited)))
+            ->load(to_memory($sibling))
+            ->run();
+
+        static::assertCount(10, $limited->dump());
+        static::assertCount(20, $sibling->dump());
     }
 
     public function test_transformer_loader_with_limit_transformation(): void
@@ -104,6 +164,24 @@ final class TransformerLoaderTest extends FlowTestCase
             ],
             $memory->dump(),
         );
+    }
+
+    public function test_transformer_loader_with_limit_transformation_across_batches(): void
+    {
+        $source = [];
+
+        for ($id = 1; $id <= 6; $id++) {
+            $source[] = ['id' => $id];
+        }
+
+        $memory = new ArrayMemory();
+
+        df()
+            ->read(from_array($source))
+            ->write(to_transformation(limit(3), to_memory($memory)))
+            ->run();
+
+        static::assertSame([['id' => 1], ['id' => 2], ['id' => 3]], $memory->dump());
     }
 
     public function test_transformer_loader_with_mask_columns_transformation(): void

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Config/Telemetry/SpanStackTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Config/Telemetry/SpanStackTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Tests\Unit\Config\Telemetry;
+
+use Flow\ETL\Config\Telemetry\SpanStack;
+use Flow\ETL\Tests\Context\MemoryTelemetryContext;
+use Flow\ETL\Tests\FlowTestCase;
+use Flow\Telemetry\Tracer\Span;
+
+use function array_map;
+
+final class SpanStackTest extends FlowTestCase
+{
+    public function test_drain_completes_every_span_with_error_status(): void
+    {
+        $context = new MemoryTelemetryContext();
+        $tracer = $context->telemetry->tracer('flow-php');
+
+        $stack = new SpanStack();
+        $stack->push($tracer->span('outer'));
+        $stack->push($tracer->span('inner'));
+
+        $stack->drain($tracer, 'Span was never completed.');
+
+        $endedSpans = $context->spans->endedSpans();
+
+        static::assertCount(2, $endedSpans);
+
+        foreach ($endedSpans as $span) {
+            $status = $span->status();
+            static::assertNotNull($status);
+            static::assertTrue($status->isError());
+            static::assertSame('Span was never completed.', $status->description);
+        }
+    }
+
+    public function test_drain_completes_spans_in_last_in_first_out_order(): void
+    {
+        $context = new MemoryTelemetryContext();
+        $tracer = $context->telemetry->tracer('flow-php');
+
+        $stack = new SpanStack();
+        $stack->push($tracer->span('outer'));
+        $stack->push($tracer->span('inner'));
+
+        $stack->drain($tracer, 'Span was never completed.');
+
+        static::assertSame(
+            ['inner', 'outer'],
+            array_map(static fn(Span $span): string => $span->name(), $context->spans->endedSpans()),
+        );
+    }
+
+    public function test_drain_empties_the_stack(): void
+    {
+        $context = new MemoryTelemetryContext();
+        $tracer = $context->telemetry->tracer('flow-php');
+
+        $stack = new SpanStack();
+        $stack->push($tracer->span('outer'));
+
+        $stack->drain($tracer, 'Span was never completed.');
+
+        static::assertNull($stack->pop());
+    }
+
+    public function test_drain_on_empty_stack_completes_nothing(): void
+    {
+        $context = new MemoryTelemetryContext();
+
+        (new SpanStack())->drain($context->telemetry->tracer('flow-php'), 'Span was never completed.');
+
+        static::assertEmpty($context->spans->endedSpans());
+    }
+
+    public function test_pop_returns_null_when_stack_is_empty(): void
+    {
+        static::assertNull((new SpanStack())->pop());
+    }
+
+    public function test_pop_returns_spans_in_last_in_first_out_order(): void
+    {
+        $tracer = (new MemoryTelemetryContext())->telemetry->tracer('flow-php');
+
+        $outer = $tracer->span('outer');
+        $inner = $tracer->span('inner');
+
+        $stack = new SpanStack();
+        $stack->push($outer);
+        $stack->push($inner);
+
+        static::assertSame($inner, $stack->pop());
+        static::assertSame($outer, $stack->pop());
+        static::assertNull($stack->pop());
+    }
+}

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Config/Telemetry/SpanStackTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Config/Telemetry/SpanStackTest.php
@@ -19,8 +19,10 @@ final class SpanStackTest extends FlowTestCase
         $tracer = $context->telemetry->tracer('flow-php');
 
         $stack = new SpanStack();
-        $stack->push($tracer->span('outer'));
-        $stack->push($tracer->span('inner'));
+        $outer = $tracer->span('outer');
+        $stack->push($outer, $tracer->activate($outer));
+        $inner = $tracer->span('inner');
+        $stack->push($inner, $tracer->activate($inner));
 
         $stack->drain($tracer, 'Span was never completed.');
 
@@ -42,8 +44,10 @@ final class SpanStackTest extends FlowTestCase
         $tracer = $context->telemetry->tracer('flow-php');
 
         $stack = new SpanStack();
-        $stack->push($tracer->span('outer'));
-        $stack->push($tracer->span('inner'));
+        $outer = $tracer->span('outer');
+        $stack->push($outer, $tracer->activate($outer));
+        $inner = $tracer->span('inner');
+        $stack->push($inner, $tracer->activate($inner));
 
         $stack->drain($tracer, 'Span was never completed.');
 
@@ -59,7 +63,8 @@ final class SpanStackTest extends FlowTestCase
         $tracer = $context->telemetry->tracer('flow-php');
 
         $stack = new SpanStack();
-        $stack->push($tracer->span('outer'));
+        $outer = $tracer->span('outer');
+        $stack->push($outer, $tracer->activate($outer));
 
         $stack->drain($tracer, 'Span was never completed.');
 
@@ -88,11 +93,40 @@ final class SpanStackTest extends FlowTestCase
         $inner = $tracer->span('inner');
 
         $stack = new SpanStack();
-        $stack->push($outer);
-        $stack->push($inner);
+        $stack->push($outer, $tracer->activate($outer));
+        $stack->push($inner, $tracer->activate($inner));
 
-        static::assertSame($inner, $stack->pop());
-        static::assertSame($outer, $stack->pop());
+        static::assertSame($inner, $stack->pop()?->span);
+        static::assertSame($outer, $stack->pop()?->span);
         static::assertNull($stack->pop());
+    }
+
+    public function test_pop_returns_the_scope_alongside_the_span(): void
+    {
+        $tracer = (new MemoryTelemetryContext())->telemetry->tracer('flow-php');
+
+        $span = $tracer->span('outer');
+        $scope = $tracer->activate($span);
+
+        $stack = new SpanStack();
+        $stack->push($span, $scope);
+
+        static::assertSame($scope, $stack->pop()?->scope);
+    }
+
+    public function test_drain_detaches_every_scope(): void
+    {
+        $context = new MemoryTelemetryContext();
+        $tracer = $context->telemetry->tracer('flow-php');
+
+        $stack = new SpanStack();
+        $outer = $tracer->span('outer');
+        $stack->push($outer, $tracer->activate($outer));
+        $inner = $tracer->span('inner');
+        $stack->push($inner, $tracer->activate($inner));
+
+        $stack->drain($tracer, 'Span was never completed.');
+
+        static::assertNull($tracer->activeSpan());
     }
 }

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Config/Telemetry/TelemetryContextTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Config/Telemetry/TelemetryContextTest.php
@@ -8,8 +8,10 @@ use DateTimeImmutable;
 use Flow\ETL\Config\Telemetry\TelemetryContext;
 use Flow\ETL\Config\Telemetry\TelemetryOptions;
 use Flow\ETL\Loader\StreamLoader;
+use Flow\ETL\Tests\Context\MemoryTelemetryContext;
 use Flow\ETL\Tests\FlowTestCase;
 use Flow\ETL\Transformer\LimitTransformer;
+use Flow\ETL\Transformer\UntilTransformer;
 use Flow\Telemetry\Context\MemoryContextStorage;
 use Flow\Telemetry\Logger\LoggerProvider;
 use Flow\Telemetry\Logger\Severity;
@@ -20,20 +22,55 @@ use Flow\Telemetry\Provider\Memory\MemorySpanProcessor;
 use Flow\Telemetry\Provider\Void\VoidExporter;
 use Flow\Telemetry\Resource;
 use Flow\Telemetry\Telemetry;
+use Flow\Telemetry\Tracer\Span;
 use Flow\Telemetry\Tracer\TracerProvider;
 use Psr\Clock\ClockInterface;
 use RuntimeException;
 
+use function array_map;
 use function count;
 use function Flow\ETL\DSL\config_builder;
 use function Flow\ETL\DSL\flow_context;
 use function Flow\ETL\DSL\int_entry;
+use function Flow\ETL\DSL\lit;
+use function Flow\ETL\DSL\ref;
 use function Flow\ETL\DSL\row;
 use function Flow\ETL\DSL\rows;
 use function Flow\ETL\DSL\telemetry_options;
+use function Flow\ETL\DSL\to_array;
+use function Flow\ETL\DSL\to_stream;
 
 final class TelemetryContextTest extends FlowTestCase
 {
+    public function test_dataframe_batch_processed_drains_abandoned_spans(): void
+    {
+        $context = new MemoryTelemetryContext(telemetry_options(trace_transformations: true));
+
+        $context->telemetryContext->dataFrameStarted($context->flowContext);
+
+        $outer = new LimitTransformer(10);
+        $inner = new UntilTransformer(ref('id')->lessThan(lit(5)));
+
+        $context->telemetryContext->transformationStarted($outer);
+        $context->telemetryContext->transformationStarted($inner);
+        $context->telemetryContext->transformationCompleted($inner);
+
+        $context->telemetryContext->dataFrameBatchProcessed(rows(row(int_entry('id', 1))), $context->flowContext);
+
+        $endedSpans = $context->spans->endedSpans();
+
+        static::assertSame(
+            ['UntilTransformer', 'LimitTransformer'],
+            array_map(static fn(Span $span): string => $span->name(), $endedSpans),
+        );
+        static::assertNull($endedSpans[0]->status());
+
+        $status = $endedSpans[1]->status();
+        static::assertNotNull($status);
+        static::assertTrue($status->isError());
+        static::assertSame('Span was never completed.', $status->description);
+    }
+
     public function test_dataframe_batch_processed_tracks_rows_and_memory(): void
     {
         $spanProcessor = new MemorySpanProcessor(new VoidExporter());
@@ -75,6 +112,35 @@ final class TelemetryContextTest extends FlowTestCase
         $counterMetrics = $metricProcessor->metricsWithName('flow.etl.rows.processed');
         static::assertNotEmpty($counterMetrics, 'Counter metrics should be collected');
         static::assertSame(3, $counterMetrics[0]->value);
+    }
+
+    public function test_dataframe_completed_drains_abandoned_spans(): void
+    {
+        $context = new MemoryTelemetryContext(telemetry_options(trace_transformations: true));
+
+        $context->telemetryContext->dataFrameStarted($context->flowContext);
+
+        $outer = new LimitTransformer(10);
+        $inner = new UntilTransformer(ref('id')->lessThan(lit(5)));
+
+        $context->telemetryContext->transformationStarted($outer);
+        $context->telemetryContext->transformationStarted($inner);
+        $context->telemetryContext->transformationCompleted($inner);
+
+        $context->telemetryContext->dataFrameCompleted($context->flowContext);
+
+        $endedSpans = $context->spans->endedSpans();
+
+        static::assertSame(
+            ['UntilTransformer', 'LimitTransformer', 'DataFrame flow_dataframe'],
+            array_map(static fn(Span $span): string => $span->name(), $endedSpans),
+        );
+
+        $status = $endedSpans[1]->status();
+        static::assertNotNull($status);
+        static::assertTrue($status->isError());
+        static::assertSame('Span was never completed.', $status->description);
+        static::assertNull($endedSpans[2]->status());
     }
 
     public function test_dataframe_completed_finalizes_span_with_statistics(): void
@@ -126,6 +192,31 @@ final class TelemetryContextTest extends FlowTestCase
 
         $debugLogs = $logProcessor->entriesWithSeverity(Severity::DEBUG);
         static::assertGreaterThanOrEqual(2, count($debugLogs));
+    }
+
+    public function test_dataframe_failed_drains_abandoned_spans(): void
+    {
+        $context = new MemoryTelemetryContext(telemetry_options(trace_transformations: true));
+
+        $context->telemetryContext->dataFrameStarted($context->flowContext);
+
+        $outer = new LimitTransformer(10);
+        $inner = new UntilTransformer(ref('id')->lessThan(lit(5)));
+
+        $context->telemetryContext->transformationStarted($outer);
+        $context->telemetryContext->transformationStarted($inner);
+        $context->telemetryContext->transformationCompleted($inner);
+
+        $context->telemetryContext->dataFrameFailed($context->flowContext, new RuntimeException('boom'));
+
+        $endedSpans = $context->spans->endedSpans();
+
+        static::assertSame(
+            ['UntilTransformer', 'LimitTransformer', 'DataFrame flow_dataframe'],
+            array_map(static fn(Span $span): string => $span->name(), $endedSpans),
+        );
+        static::assertSame('Span was never completed.', $endedSpans[1]->status()?->description);
+        static::assertSame('boom', $endedSpans[2]->status()?->description);
     }
 
     public function test_dataframe_failed_logs_error_and_sets_span_status(): void
@@ -216,6 +307,28 @@ final class TelemetryContextTest extends FlowTestCase
         static::assertStringContainsString('Data frame processing started', $debugLogs[0]->record->body);
     }
 
+    public function test_limit_reached_logs_debug_message_without_attributes(): void
+    {
+        $context = new MemoryTelemetryContext();
+
+        $context->telemetryContext->limitReached();
+
+        $debugLogs = $context->logs->entriesWithSeverity(Severity::DEBUG);
+
+        static::assertCount(1, $debugLogs);
+        static::assertSame('Limit reached, stopping the pipeline execution.', $debugLogs[0]->record->body);
+        static::assertTrue($debugLogs[0]->record->attributes->isEmpty());
+    }
+
+    public function test_limit_reached_passes_through_attributes(): void
+    {
+        $context = new MemoryTelemetryContext();
+
+        $context->telemetryContext->limitReached(['limit' => 10]);
+
+        static::assertSame(10, $context->logs->entriesContaining('Limit reached')[0]->record->attributes->get('limit'));
+    }
+
     public function test_loading_completed_finalizes_span_with_ok_status(): void
     {
         $spanProcessor = new MemorySpanProcessor(new VoidExporter());
@@ -256,6 +369,30 @@ final class TelemetryContextTest extends FlowTestCase
         static::assertSame(StreamLoader::class, $endedSpans[0]->attributes()['flow.etl.loader.class']);
         // OTEL spec: instrumentation leaves the status Unset on success.
         static::assertNull($endedSpans[0]->status());
+    }
+
+    public function test_loading_completed_is_noop_when_tracing_disabled(): void
+    {
+        $context = new MemoryTelemetryContext(telemetry_options(trace_loading: false));
+
+        $context->telemetryContext->dataFrameStarted($context->flowContext);
+
+        $loader = to_stream('php://memory');
+
+        $context->telemetryContext->loadingStarted($loader);
+        $context->telemetryContext->loadingCompleted($loader);
+
+        static::assertEmpty($context->spans->endedSpans());
+    }
+
+    public function test_loading_completed_without_started_is_noop(): void
+    {
+        $context = new MemoryTelemetryContext(telemetry_options(trace_loading: true));
+
+        $context->telemetryContext->dataFrameStarted($context->flowContext);
+        $context->telemetryContext->loadingCompleted(to_stream('php://memory'));
+
+        static::assertEmpty($context->spans->endedSpans());
     }
 
     public function test_loading_failed_logs_error_and_sets_span_status(): void
@@ -303,6 +440,31 @@ final class TelemetryContextTest extends FlowTestCase
         static::assertTrue($status->isError());
         static::assertSame('Loading failed due to disk error', $status->description);
         static::assertSame(RuntimeException::class, $endedSpans[0]->attributes()['error.type']);
+    }
+
+    public function test_loading_failed_pops_the_innermost_span(): void
+    {
+        $context = new MemoryTelemetryContext(telemetry_options(trace_loading: true));
+
+        $context->telemetryContext->dataFrameStarted($context->flowContext);
+
+        $output = [];
+        $outer = to_stream('php://memory');
+        $inner = to_array($output);
+
+        $context->telemetryContext->loadingStarted($outer);
+        $context->telemetryContext->loadingStarted($inner);
+        $context->telemetryContext->loadingFailed($inner, new RuntimeException('Loading failed'));
+        $context->telemetryContext->loadingCompleted($outer);
+
+        $endedSpans = $context->spans->endedSpans();
+
+        static::assertSame(
+            ['ArrayLoader', 'StreamLoader'],
+            array_map(static fn(Span $span): string => $span->name(), $endedSpans),
+        );
+        static::assertTrue($endedSpans[0]->status()?->isError());
+        static::assertNull($endedSpans[1]->status());
     }
 
     public function test_loading_started_creates_span_when_trace_loading_enabled(): void
@@ -503,6 +665,53 @@ final class TelemetryContextTest extends FlowTestCase
         static::assertEmpty($metricProcessor->metrics(), 'No metrics should be collected when disabled');
     }
 
+    public function test_nested_loadings_complete_both_spans_once(): void
+    {
+        $context = new MemoryTelemetryContext(telemetry_options(trace_loading: true));
+
+        $context->telemetryContext->dataFrameStarted($context->flowContext);
+
+        $output = [];
+        $outer = to_stream('php://memory');
+        $inner = to_array($output);
+
+        $context->telemetryContext->loadingStarted($outer);
+        $context->telemetryContext->loadingStarted($inner);
+        $context->telemetryContext->loadingCompleted($inner, ['nesting' => 'inner']);
+        $context->telemetryContext->loadingCompleted($outer, ['nesting' => 'outer']);
+
+        $endedSpans = $context->spans->endedSpans();
+
+        static::assertCount(2, $endedSpans);
+        static::assertSame('ArrayLoader', $endedSpans[0]->name());
+        static::assertSame('inner', $endedSpans[0]->attributes()['nesting']);
+        static::assertSame('StreamLoader', $endedSpans[1]->name());
+        static::assertSame('outer', $endedSpans[1]->attributes()['nesting']);
+    }
+
+    public function test_nested_transformations_complete_both_spans_once(): void
+    {
+        $context = new MemoryTelemetryContext(telemetry_options(trace_transformations: true));
+
+        $context->telemetryContext->dataFrameStarted($context->flowContext);
+
+        $outer = new LimitTransformer(10);
+        $inner = new UntilTransformer(ref('id')->lessThan(lit(5)));
+
+        $context->telemetryContext->transformationStarted($outer);
+        $context->telemetryContext->transformationStarted($inner);
+        $context->telemetryContext->transformationCompleted($inner, ['nesting' => 'inner']);
+        $context->telemetryContext->transformationCompleted($outer, ['nesting' => 'outer']);
+
+        $endedSpans = $context->spans->endedSpans();
+
+        static::assertCount(2, $endedSpans);
+        static::assertSame('UntilTransformer', $endedSpans[0]->name());
+        static::assertSame('inner', $endedSpans[0]->attributes()['nesting']);
+        static::assertSame('LimitTransformer', $endedSpans[1]->name());
+        static::assertSame('outer', $endedSpans[1]->attributes()['nesting']);
+    }
+
     public function test_transformation_completed_finalizes_span(): void
     {
         $spanProcessor = new MemorySpanProcessor(new VoidExporter());
@@ -543,6 +752,30 @@ final class TelemetryContextTest extends FlowTestCase
         static::assertSame(LimitTransformer::class, $endedSpans[0]->attributes()['flow.etl.transformer.class']);
         // OTEL spec: instrumentation leaves the status Unset on success.
         static::assertNull($endedSpans[0]->status());
+    }
+
+    public function test_transformation_completed_is_noop_when_tracing_disabled(): void
+    {
+        $context = new MemoryTelemetryContext(telemetry_options(trace_transformations: false));
+
+        $context->telemetryContext->dataFrameStarted($context->flowContext);
+
+        $transformer = new LimitTransformer(10);
+
+        $context->telemetryContext->transformationStarted($transformer);
+        $context->telemetryContext->transformationCompleted($transformer);
+
+        static::assertEmpty($context->spans->endedSpans());
+    }
+
+    public function test_transformation_completed_without_started_is_noop(): void
+    {
+        $context = new MemoryTelemetryContext(telemetry_options(trace_transformations: true));
+
+        $context->telemetryContext->dataFrameStarted($context->flowContext);
+        $context->telemetryContext->transformationCompleted(new LimitTransformer(10));
+
+        static::assertEmpty($context->spans->endedSpans());
     }
 
     public function test_transformation_failed_logs_error_and_sets_span_status(): void
@@ -590,6 +823,30 @@ final class TelemetryContextTest extends FlowTestCase
         static::assertTrue($status->isError());
         static::assertSame('Transformation failed', $status->description);
         static::assertSame(RuntimeException::class, $endedSpans[0]->attributes()['error.type']);
+    }
+
+    public function test_transformation_failed_pops_the_innermost_span(): void
+    {
+        $context = new MemoryTelemetryContext(telemetry_options(trace_transformations: true));
+
+        $context->telemetryContext->dataFrameStarted($context->flowContext);
+
+        $outer = new LimitTransformer(10);
+        $inner = new UntilTransformer(ref('id')->lessThan(lit(5)));
+
+        $context->telemetryContext->transformationStarted($outer);
+        $context->telemetryContext->transformationStarted($inner);
+        $context->telemetryContext->transformationFailed($inner, new RuntimeException('Transformation failed'));
+        $context->telemetryContext->transformationCompleted($outer);
+
+        $endedSpans = $context->spans->endedSpans();
+
+        static::assertSame(
+            ['UntilTransformer', 'LimitTransformer'],
+            array_map(static fn(Span $span): string => $span->name(), $endedSpans),
+        );
+        static::assertTrue($endedSpans[0]->status()?->isError());
+        static::assertNull($endedSpans[1]->status());
     }
 
     public function test_transformation_started_creates_span_when_trace_transformations_enabled(): void

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Extractor/SwappableRowsExtractorTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Extractor/SwappableRowsExtractorTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\ETL\Tests\Unit\Extractor;
+
+use Flow\ETL\Extractor\Signal;
+use Flow\ETL\Extractor\SwappableRowsExtractor;
+use Flow\ETL\Tests\FlowTestCase;
+
+use function Flow\ETL\DSL\config_builder;
+use function Flow\ETL\DSL\execution_context;
+use function Flow\ETL\DSL\int_entry;
+use function Flow\ETL\DSL\row;
+use function Flow\ETL\DSL\rows;
+use function iterator_to_array;
+
+final class SwappableRowsExtractorTest extends FlowTestCase
+{
+    public function test_is_not_stopped_when_extraction_completes_without_a_signal(): void
+    {
+        $extractor = new SwappableRowsExtractor();
+        $extractor->swap(rows(row(int_entry('id', 1))));
+
+        iterator_to_array($extractor->extract(execution_context(config_builder()->build())));
+
+        static::assertFalse($extractor->stopped());
+    }
+
+    public function test_stops_on_stop_signal_sent_on_the_first_yield(): void
+    {
+        $extractor = new SwappableRowsExtractor();
+        $extractor->swap(rows(row(int_entry('id', 1))));
+
+        $generator = $extractor->extract(execution_context(config_builder()->build()));
+
+        static::assertTrue($generator->valid());
+
+        $generator->send(Signal::STOP);
+
+        static::assertFalse($generator->valid());
+        static::assertTrue($extractor->stopped());
+    }
+
+    public function test_stops_on_stop_signal_sent_after_the_batch_was_consumed(): void
+    {
+        $extractor = new SwappableRowsExtractor();
+        $extractor->swap(rows(row(int_entry('id', 1))));
+
+        $generator = $extractor->extract(execution_context(config_builder()->build()));
+        $generator->next();
+
+        static::assertTrue($generator->valid());
+        static::assertCount(0, $generator->current());
+
+        $generator->send(Signal::STOP);
+
+        static::assertFalse($generator->valid());
+        static::assertTrue($extractor->stopped());
+    }
+
+    public function test_yields_currently_held_rows_followed_by_an_empty_batch(): void
+    {
+        $extractor = new SwappableRowsExtractor();
+        $extractor->swap(rows(row(int_entry('id', 1)), row(int_entry('id', 2))));
+
+        $extracted = iterator_to_array($extractor->extract(execution_context(config_builder()->build())));
+
+        static::assertCount(2, $extracted);
+        static::assertSame([['id' => 1], ['id' => 2]], $extracted[0]->toArray());
+        static::assertCount(0, $extracted[1]);
+    }
+
+    public function test_yields_empty_rows_before_first_swap(): void
+    {
+        $extracted = iterator_to_array((new SwappableRowsExtractor())->extract(
+            execution_context(config_builder()->build()),
+        ));
+
+        static::assertCount(0, $extracted[0]);
+    }
+
+    public function test_yields_swapped_rows_on_next_extraction(): void
+    {
+        $context = execution_context(config_builder()->build());
+        $extractor = new SwappableRowsExtractor();
+
+        $extractor->swap(rows(row(int_entry('id', 1))));
+        $first = iterator_to_array($extractor->extract($context));
+
+        $extractor->swap(rows(row(int_entry('id', 2))));
+        $second = iterator_to_array($extractor->extract($context));
+
+        static::assertSame([['id' => 1]], $first[0]->toArray());
+        static::assertSame([['id' => 2]], $second[0]->toArray());
+    }
+}

--- a/src/core/etl/tests/Flow/ETL/Tests/Unit/Loader/TransformerLoaderTest.php
+++ b/src/core/etl/tests/Flow/ETL/Tests/Unit/Loader/TransformerLoaderTest.php
@@ -7,22 +7,135 @@ namespace Flow\ETL\Tests\Unit\Loader;
 use Flow\ETL\DataFrame;
 use Flow\ETL\Loader;
 use Flow\ETL\Memory\ArrayMemory;
+use Flow\ETL\Rows;
+use Flow\ETL\Tests\Context\MemoryTelemetryContext;
+use Flow\ETL\Tests\Double\SpyLoader;
 use Flow\ETL\Tests\FlowTestCase;
 use Flow\ETL\Transformation;
+use Flow\ETL\Transformation\AddRowIndex\StartFrom;
 use Flow\ETL\Transformer;
+use Flow\ETL\Transformer\LimitTransformer;
+use Flow\Telemetry\Tracer\Span;
 
+use function array_filter;
+use function array_map;
+use function count;
+use function Flow\ETL\DSL\add_row_index;
 use function Flow\ETL\DSL\config;
 use function Flow\ETL\DSL\df;
 use function Flow\ETL\DSL\flow_context;
 use function Flow\ETL\DSL\from_array;
+use function Flow\ETL\DSL\int_entry;
 use function Flow\ETL\DSL\ref;
+use function Flow\ETL\DSL\row;
 use function Flow\ETL\DSL\rows;
+use function Flow\ETL\DSL\select;
+use function Flow\ETL\DSL\str_entry;
+use function Flow\ETL\DSL\telemetry_options;
 use function Flow\ETL\DSL\to_memory;
 use function Flow\ETL\DSL\to_transformation;
 use function Flow\Types\DSL\type_string;
 
 final class TransformerLoaderTest extends FlowTestCase
 {
+    public function test_limit_reached_is_reported_once_per_loader(): void
+    {
+        $context = new MemoryTelemetryContext(telemetry_options(trace_loading: true));
+
+        $loader = to_transformation(new LimitTransformer(1), to_memory(new ArrayMemory()));
+        $batch = rows(row(int_entry('id', 1)), row(int_entry('id', 2)));
+
+        $loader->load($batch, $context->flowContext);
+        $loader->load($batch, $context->flowContext);
+        $loader->load($batch, $context->flowContext);
+
+        static::assertCount(1, $context->logs->entriesContaining('Limit reached'));
+        static::assertEmpty($context->logs->entriesContaining('Loading failed'));
+
+        $endedSpans = $context->spans->endedSpans();
+
+        // MemoryLoader runs only on the first call; the other two throw before reaching it.
+        static::assertSame(
+            ['MemoryLoader', 'TransformerLoader', 'TransformerLoader', 'TransformerLoader'],
+            array_map(static fn(Span $span): string => $span->name(), $endedSpans),
+        );
+
+        foreach ($endedSpans as $span) {
+            static::assertNull($span->status());
+        }
+    }
+
+    public function test_closure_rebuilds_the_transformation_against_the_next_context(): void
+    {
+        $first = new MemoryTelemetryContext(telemetry_options(trace_loading: true));
+        $second = new MemoryTelemetryContext(telemetry_options(trace_loading: true));
+
+        $loader = to_transformation(select('id'), to_memory(new ArrayMemory()));
+
+        $loader->load(rows(row(int_entry('id', 1))), $first->flowContext);
+        $loader->closure($first->flowContext);
+        $loader->load(rows(row(int_entry('id', 2))), $second->flowContext);
+
+        $memoryLoaderSpans = static fn(MemoryTelemetryContext $context): int => count(array_filter(
+            $context->spans->endedSpans(),
+            static fn(Span $span): bool => $span->name() === 'MemoryLoader',
+        ));
+
+        static::assertSame(1, $memoryLoaderSpans($first));
+        static::assertSame(1, $memoryLoaderSpans($second));
+    }
+
+    public function test_closure_resets_stateful_transformation_state(): void
+    {
+        $context = flow_context(config());
+        $spy = new SpyLoader();
+        $loader = to_transformation(add_row_index('n', StartFrom::ONE), $spy);
+
+        $loader->load(rows(row(int_entry('id', 1))), $context);
+        $loader->load(rows(row(int_entry('id', 2))), $context);
+        $loader->closure($context);
+        $loader->load(rows(row(int_entry('id', 3))), $context);
+
+        static::assertSame(
+            [[['id' => 1, 'n' => 1]], [['id' => 2, 'n' => 2]], [['id' => 3, 'n' => 1]]],
+            array_map(static fn(Rows $rows): array => $rows->toArray(), $spy->loadedRows),
+        );
+    }
+
+    public function test_stateful_transformation_keeps_state_across_batches(): void
+    {
+        $context = flow_context(config());
+        $spy = new SpyLoader();
+        $loader = to_transformation(add_row_index('n', StartFrom::ONE), $spy);
+
+        for ($id = 1; $id <= 3; $id++) {
+            $loader->load(rows(row(int_entry('id', $id))), $context);
+        }
+
+        static::assertSame(3, $spy->loadsCount);
+        static::assertSame(
+            [[['id' => 1, 'n' => 1]], [['id' => 2, 'n' => 2]], [['id' => 3, 'n' => 3]]],
+            array_map(static fn(Rows $rows): array => $rows->toArray(), $spy->loadedRows),
+        );
+    }
+
+    public function test_stateless_transformation_applies_to_every_batch(): void
+    {
+        $context = flow_context(config());
+        $spy = new SpyLoader();
+        $loader = to_transformation(select('id'), $spy);
+
+        for ($id = 1; $id <= 3; $id++) {
+            $loader->load(rows(row(int_entry('id', $id), str_entry('name', 'name-' . $id))), $context);
+        }
+
+        static::assertSame(3, $spy->loadsCount);
+        static::assertSame(
+            [[['id' => 1]], [['id' => 2]], [['id' => 3]]],
+            array_map(static fn(Rows $rows): array => $rows->toArray(), $spy->loadedRows),
+        );
+    }
+
     public function test_transformer_loader(): void
     {
         $transformerMock = $this->createMock(Transformer::class);

--- a/src/core/etl/tests/Flow/Floe/Tests/Unit/FloeStreamReaderTest.php
+++ b/src/core/etl/tests/Flow/Floe/Tests/Unit/FloeStreamReaderTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\Floe\Tests\Unit;
+
+use Flow\Floe\Codec\NoopCodec;
+use Flow\Floe\FloeStreamReader;
+use Flow\Floe\FloeStreamWriter;
+use Flow\Floe\FloeWriter;
+use Flow\Floe\Tests\Double\ClosingSpySourceStream;
+use PHPUnit\Framework\TestCase;
+
+use function Flow\ETL\DSL\int_entry;
+use function Flow\ETL\DSL\row;
+use function Flow\ETL\DSL\rows;
+use function Flow\Filesystem\DSL\memory_filesystem;
+use function Flow\Filesystem\DSL\path;
+
+final class FloeStreamReaderTest extends TestCase
+{
+    public function test_close_closes_the_source_stream(): void
+    {
+        $filesystem = memory_filesystem();
+        $path = path('memory://close.floe');
+
+        $data = rows(row(int_entry('id', 1)));
+        $writer = new FloeWriter($filesystem, FloeStreamWriter::unionSchema($data));
+        $writer->create($path);
+        $writer->write($data);
+        $writer->close();
+
+        $source = new ClosingSpySourceStream($filesystem->readFrom($path));
+
+        (new FloeStreamReader($source, new NoopCodec(), 65_536))->close();
+
+        static::assertSame(1, $source->closeCount);
+    }
+}

--- a/src/lib/filesystem/src/Flow/Filesystem/Telemetry/TraceableDestinationStream.php
+++ b/src/lib/filesystem/src/Flow/Filesystem/Telemetry/TraceableDestinationStream.php
@@ -43,6 +43,8 @@ final class TraceableDestinationStream implements DestinationStream
                 PackageVersion::get('flow-php/filesystem'),
             );
 
+            // deliberately not activated: streams outlive their lexical scope, so making them current would
+            // parent every later span to whichever stream happens to still be open
             $this->span = $this->tracer->span('filesystem.write', SpanKind::INTERNAL, [
                 FilesystemTelemetryAttributes::ATTR_STREAM_TYPE => 'destination',
                 FilesystemTelemetryAttributes::ATTR_PATH_URI => $this->stream->path()->uri(),

--- a/src/lib/filesystem/src/Flow/Filesystem/Telemetry/TraceableSourceStream.php
+++ b/src/lib/filesystem/src/Flow/Filesystem/Telemetry/TraceableSourceStream.php
@@ -43,6 +43,8 @@ final class TraceableSourceStream implements SourceStream
                 PackageVersion::get('flow-php/filesystem'),
             );
 
+            // deliberately not activated: streams outlive their lexical scope, so making them current would
+            // parent every later span to whichever stream happens to still be open
             $this->span = $this->tracer->span('filesystem.read', SpanKind::INTERNAL, [
                 FilesystemTelemetryAttributes::ATTR_STREAM_TYPE => 'source',
                 FilesystemTelemetryAttributes::ATTR_PATH_URI => $this->stream->path()->uri(),

--- a/src/lib/filesystem/tests/Flow/Filesystem/Tests/Unit/Telemetry/ConcurrentStreamSpanNestingTest.php
+++ b/src/lib/filesystem/tests/Flow/Filesystem/Tests/Unit/Telemetry/ConcurrentStreamSpanNestingTest.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\Filesystem\Tests\Unit\Telemetry;
+
+use Flow\Filesystem\DestinationStream;
+use Flow\Filesystem\Path;
+use Flow\Filesystem\SourceStream;
+use Flow\Filesystem\Telemetry\TraceableDestinationStream;
+use Flow\Filesystem\Telemetry\TraceableSourceStream;
+use Flow\Filesystem\Tests\Mother\FilesystemTelemetryConfigMother;
+use PHPUnit\Framework\TestCase;
+
+use function Flow\Telemetry\DSL\memory_span_processor;
+use function Flow\Telemetry\DSL\void_exporter;
+
+/**
+ * Streams outlive their lexical scope, so several are open at once - one bucket writer per hash bucket, one
+ * partition writer per partition, one cursor per merged run. If a stream span became the active span, each
+ * later stream would be parented to whichever one happened to still be open, producing a staircase as deep as
+ * the number of concurrent streams instead of a flat list of siblings.
+ */
+final class ConcurrentStreamSpanNestingTest extends TestCase
+{
+    public function test_concurrently_open_destination_streams_produce_sibling_spans(): void
+    {
+        $spanProcessor = memory_span_processor(void_exporter());
+        $config = FilesystemTelemetryConfigMother::create($spanProcessor);
+
+        $streams = [];
+
+        for ($i = 0; $i < 5; $i++) {
+            $inner = $this->createMock(DestinationStream::class);
+            $inner->method('path')->willReturn(Path::realpath("/tmp/bucket-{$i}.floe"));
+
+            $streams[] = new TraceableDestinationStream($inner, $config);
+        }
+
+        foreach ($streams as $stream) {
+            $stream->close();
+        }
+
+        $spanIds = [];
+
+        foreach ($spanProcessor->endedSpans() as $span) {
+            $spanIds[(string) $span->context()->spanId] = true;
+        }
+
+        static::assertCount(5, $spanIds);
+
+        foreach ($spanProcessor->endedSpans() as $span) {
+            $parentSpanId = $span->context()->parentSpanId;
+
+            static::assertArrayNotHasKey(
+                $parentSpanId === null ? '' : (string) $parentSpanId,
+                $spanIds,
+                'A filesystem span must never be the parent of another filesystem span.',
+            );
+        }
+    }
+
+    public function test_concurrently_open_source_streams_produce_sibling_spans(): void
+    {
+        $spanProcessor = memory_span_processor(void_exporter());
+        $config = FilesystemTelemetryConfigMother::create($spanProcessor);
+
+        $streams = [];
+
+        for ($i = 0; $i < 5; $i++) {
+            $inner = $this->createMock(SourceStream::class);
+            $inner->method('path')->willReturn(Path::realpath("/tmp/run-{$i}.floe"));
+
+            $streams[] = new TraceableSourceStream($inner, $config);
+        }
+
+        foreach ($streams as $stream) {
+            $stream->close();
+        }
+
+        $spanIds = [];
+
+        foreach ($spanProcessor->endedSpans() as $span) {
+            $spanIds[(string) $span->context()->spanId] = true;
+        }
+
+        static::assertCount(5, $spanIds);
+
+        foreach ($spanProcessor->endedSpans() as $span) {
+            $parentSpanId = $span->context()->parentSpanId;
+
+            static::assertArrayNotHasKey(
+                $parentSpanId === null ? '' : (string) $parentSpanId,
+                $spanIds,
+                'A filesystem span must never be the parent of another filesystem span.',
+            );
+        }
+    }
+
+    public function test_opening_a_stream_does_not_change_the_active_span(): void
+    {
+        $spanProcessor = memory_span_processor(void_exporter());
+        $config = FilesystemTelemetryConfigMother::create($spanProcessor);
+
+        $tracer = $config->telemetry->tracer('test');
+        $outer = $tracer->span('outer');
+        $tracer->activate($outer);
+
+        $inner = $this->createMock(DestinationStream::class);
+        $inner->method('path')->willReturn(Path::realpath('/tmp/bucket.floe'));
+
+        $stream = new TraceableDestinationStream($inner, $config);
+
+        $activeSpan = $tracer->activeSpan();
+        static::assertNotNull($activeSpan);
+        static::assertTrue($activeSpan->spanId->equals($outer->context()->spanId));
+
+        $stream->close();
+    }
+}

--- a/src/lib/postgresql/src/Flow/PostgreSql/Client/Telemetry/TraceableClient.php
+++ b/src/lib/postgresql/src/Flow/PostgreSql/Client/Telemetry/TraceableClient.php
@@ -15,6 +15,7 @@ use Flow\PostgreSql\Client\RowMapper;
 use Flow\PostgreSql\Client\Types\ValueConverters;
 use Flow\PostgreSql\Explain\Plan\Plan;
 use Flow\PostgreSql\QueryBuilder\Sql;
+use Flow\Telemetry\Context\Scope;
 use Flow\Telemetry\Logger\Logger;
 use Flow\Telemetry\Meter\Instrument\Histogram;
 use Flow\Telemetry\PackageVersion;
@@ -57,7 +58,9 @@ final class TraceableClient implements Client
     private ?Tracer $tracer = null;
 
     /**
-     * @var array<int, Span>
+     * Keyed by nesting level; span and scope are always set and unset together.
+     *
+     * @var array<int, array{span: Span, scope: Scope}>
      */
     private array $transactionSpans = [];
 
@@ -116,15 +119,23 @@ final class TraceableClient implements Client
             } else {
                 $this->client->beginTransaction();
 
+                $tracer = $this->tracer;
+
                 if (
                     $this->telemetryConfig->options->transactionSpans === TransactionSpanMode::GROUPED
-                    && $this->tracer !== null
+                    && $tracer !== null
                 ) {
-                    $this->transactionSpans[$nestingLevel] = $this->tracer->span(
+                    // activated: a grouped transaction span is a logical scope - every query and nested
+                    // savepoint until commit/rollback belongs under it
+                    $transactionSpan = $tracer->span(
                         $this->buildTransactionSpanName('BEGIN', $nestingLevel),
                         SpanKind::CLIENT,
                         $this->buildTransactionAttributes($nestingLevel),
                     );
+                    $this->transactionSpans[$nestingLevel] = [
+                        'span' => $transactionSpan,
+                        'scope' => $tracer->activate($transactionSpan),
+                    ];
                 }
             }
 
@@ -142,10 +153,11 @@ final class TraceableClient implements Client
         rsort($levels);
 
         foreach ($levels as $level) {
-            $span = $this->transactionSpans[$level];
+            $span = $this->transactionSpans[$level]['span'];
             $span->setStatus(SpanStatus::error(
                 'Transaction was neither committed nor rolled back before the connection was closed',
             ));
+            $this->transactionSpans[$level]['scope']->detach();
             $this->tracer?->complete($span);
             unset($this->transactionSpans[$level]);
         }
@@ -707,13 +719,14 @@ final class TraceableClient implements Client
             return;
         }
 
-        $span = $this->transactionSpans[$nestingLevel];
+        $span = $this->transactionSpans[$nestingLevel]['span'];
 
         // OTEL spec: instrumentation leaves the status Unset on success; only errors set a status.
         if ($exception !== null) {
             $this->recordFailure($span, $exception);
         }
 
+        $this->transactionSpans[$nestingLevel]['scope']->detach();
         $tracer->complete($span);
         unset($this->transactionSpans[$nestingLevel]);
     }

--- a/src/lib/postgresql/src/Flow/PostgreSql/Client/Telemetry/TraceableCursor.php
+++ b/src/lib/postgresql/src/Flow/PostgreSql/Client/Telemetry/TraceableCursor.php
@@ -68,6 +68,7 @@ final class TraceableCursor implements Cursor
                 PackageVersion::get('flow-php/postgresql'),
             );
 
+            // deliberately not activated: a cursor is a resource handle that outlives its lexical scope
             $this->span = $this->tracer->span($this->buildSpanName(), SpanKind::CLIENT, $this->buildQueryAttributes());
         }
 

--- a/src/lib/telemetry/src/Flow/Telemetry/Context/ContextScope.php
+++ b/src/lib/telemetry/src/Flow/Telemetry/Context/ContextScope.php
@@ -6,24 +6,21 @@ namespace Flow\Telemetry\Context;
 
 final class ContextScope implements Scope
 {
-    public const int DETACHED = 0;
-
     private bool $detached = false;
 
     public function __construct(
-        private readonly Context $previous,
+        private readonly int $depth,
         private readonly MemoryContextStorage $storage,
     ) {}
 
     public function detach(): int
     {
         if ($this->detached) {
-            return self::DETACHED;
+            return self::INACTIVE;
         }
 
         $this->detached = true;
-        $this->storage->store($this->previous);
 
-        return self::DETACHED;
+        return $this->storage->detachAt($this->depth);
     }
 }

--- a/src/lib/telemetry/src/Flow/Telemetry/Context/MemoryContextStorage.php
+++ b/src/lib/telemetry/src/Flow/Telemetry/Context/MemoryContextStorage.php
@@ -4,35 +4,55 @@ declare(strict_types=1);
 
 namespace Flow\Telemetry\Context;
 
+use function array_key_exists;
+use function array_key_last;
+use function array_splice;
+
 final class MemoryContextStorage implements ContextStorage
 {
-    private Context $context;
+    private readonly Context $root;
+
+    /**
+     * One entry per attach; the root context is held separately so the stack can drain to empty.
+     *
+     * @var array<int, Context>
+     */
+    private array $stack = [];
 
     public function __construct(?Context $context = null)
     {
-        $this->context = $context ?? Context::root();
+        $this->root = $context ?? Context::root();
     }
 
     public function attach(Context $context): Scope
     {
-        $previous = $this->context;
-        $this->context = $context;
+        $this->stack[] = $context;
 
-        return new ContextScope($previous, $this);
+        return new ContextScope(array_key_last($this->stack), $this);
     }
 
     public function current(): Context
     {
-        return $this->context;
+        $last = array_key_last($this->stack);
+
+        return $last === null ? $this->root : $this->stack[$last];
     }
 
     /**
-     * Internal method for scope detachment.
+     * Detaching out of order still restores, per the OTEL context spec - the return value is the only signal.
      *
      * @internal
      */
-    public function store(Context $context): void
+    public function detachAt(int $depth): int
     {
-        $this->context = $context;
+        if (!array_key_exists($depth, $this->stack)) {
+            return Scope::INACTIVE;
+        }
+
+        $mismatch = $depth !== array_key_last($this->stack);
+
+        array_splice($this->stack, $depth);
+
+        return $mismatch ? Scope::MISMATCH : Scope::DETACHED;
     }
 }

--- a/src/lib/telemetry/src/Flow/Telemetry/Context/Scope.php
+++ b/src/lib/telemetry/src/Flow/Telemetry/Context/Scope.php
@@ -6,5 +6,11 @@ namespace Flow\Telemetry\Context;
 
 interface Scope
 {
+    public const int DETACHED = 0;
+
+    public const int INACTIVE = 1;
+
+    public const int MISMATCH = 2;
+
     public function detach(): int;
 }

--- a/src/lib/telemetry/src/Flow/Telemetry/Tracer/Span.php
+++ b/src/lib/telemetry/src/Flow/Telemetry/Tracer/Span.php
@@ -8,7 +8,6 @@ use DateTimeImmutable;
 use DateTimeInterface;
 use Flow\Telemetry\AttributeLimitsEnforcer;
 use Flow\Telemetry\Attributes;
-use Flow\Telemetry\Context\Scope;
 use Flow\Telemetry\InstrumentationScope;
 use Flow\Telemetry\Resource;
 use Throwable;
@@ -45,7 +44,7 @@ final class Span
 {
     private Attributes $attributes;
 
-    private ?Scope $contextScope = null;
+    private bool $completed = false;
 
     private int $droppedAttributeCount = 0;
 
@@ -202,14 +201,6 @@ final class Span
     }
 
     /**
-     * Get the context scope for this span.
-     */
-    public function contextScope(): ?Scope
-    {
-        return $this->contextScope;
-    }
-
-    /**
      * Get the count of attributes that were dropped due to limits.
      */
     public function droppedAttributeCount(): int
@@ -290,6 +281,25 @@ final class Span
     public function isEnded(): bool
     {
         return $this->endTime !== null;
+    }
+
+    /**
+     * Whether the span was already handed to the processor. Distinct from isEnded(): callers may end a span to
+     * read its duration and complete it later.
+     */
+    public function isCompleted(): bool
+    {
+        return $this->completed;
+    }
+
+    /**
+     * @internal used by Tracer::complete() to keep completion idempotent
+     */
+    public function markCompleted(): self
+    {
+        $this->completed = true;
+
+        return $this;
     }
 
     /**
@@ -527,18 +537,6 @@ final class Span
 
         $this->attributes = $result->attributes;
         $this->droppedAttributeCount += $result->droppedAttributeCount;
-
-        return $this;
-    }
-
-    /**
-     * Set the context scope for this span.
-     *
-     * @return $this
-     */
-    public function setContextScope(Scope $scope): self
-    {
-        $this->contextScope = $scope;
 
         return $this;
     }

--- a/src/lib/telemetry/src/Flow/Telemetry/Tracer/Tracer.php
+++ b/src/lib/telemetry/src/Flow/Telemetry/Tracer/Tracer.php
@@ -7,6 +7,7 @@ namespace Flow\Telemetry\Tracer;
 use Flow\Telemetry\Attributes;
 use Flow\Telemetry\Context\Context;
 use Flow\Telemetry\Context\ContextStorage;
+use Flow\Telemetry\Context\Scope;
 use Flow\Telemetry\Context\SpanId;
 use Flow\Telemetry\Context\TraceFlags;
 use Flow\Telemetry\Context\TraceId;
@@ -25,7 +26,7 @@ use Throwable;
  * manages parent-child relationships through the shared Context (the active span lives in the Context and
  * the parent is derived from it), and delegates span lifecycle events to a SpanProcessor.
  *
- * Example usage:
+ * Example usage - a leaf span, which never needs to become the active span:
  * ```php
  * $span = $tracer->span('process-order');
  * try {
@@ -35,6 +36,18 @@ use Throwable;
  *     $span->recordException($e)->setStatus(SpanStatus::error($e->getMessage()));
  *     throw $e;
  * } finally {
+ *     $tracer->complete($span);
+ * }
+ * ```
+ *
+ * When spans created inside must nest under this one, activate it and detach the scope before completing:
+ * ```php
+ * $span = $tracer->span('process-order');
+ * $scope = $tracer->activate($span);
+ * try {
+ *     // spans started here become children of $span
+ * } finally {
+ *     $scope->detach();
  *     $tracer->complete($span);
  * }
  * ```
@@ -64,6 +77,16 @@ final class Tracer
     ) {}
 
     /**
+     * Make a span the active span in the current Context.
+     *
+     * The returned Scope must be detached by the caller, in LIFO order, before the span is completed.
+     */
+    public function activate(Span $span): Scope
+    {
+        return $this->contextStorage->attach($this->contextStorage->current()->withActiveSpan($span->context()));
+    }
+
+    /**
      * Get the currently active span context from the shared Context, or null if none.
      */
     public function activeSpan(): ?SpanContext
@@ -74,16 +97,22 @@ final class Tracer
     /**
      * Complete a span and pass it to the processor.
      *
-     * This ends the span (if not already ended), detaches its Context scope
-     * (restoring the parent context), and notifies the processor.
+     * This ends the span (if not already ended) and notifies the processor. Detaching the Context scope is the
+     * responsibility of whoever called activate().
      */
     public function complete(Span $span): void
     {
+        // OTEL spec: End "MUST be called only once per span"; subsequent calls are ignored rather than
+        // re-exporting. isEnded() alone is not the guard - callers may end a span to read its duration first.
+        if ($span->isCompleted()) {
+            return;
+        }
+
         if (!$span->isEnded()) {
             $span->end($this->clock->now());
         }
 
-        $span->contextScope()?->detach();
+        $span->markCompleted();
 
         if ($span->isRecording()) {
             try {
@@ -141,34 +170,39 @@ final class Tracer
     }
 
     /**
-     * Start a new span.
+     * Start a new span, without making it the active span.
      *
-     * If there's an active span, it becomes the parent of the new span.
-     * The new span is attached to the Context and becomes the active span.
+     * OTEL trace API: "Span creation MUST NOT set the newly created Span as the active Span in the current
+     * Context by default, but this functionality MAY be offered additionally as a separate operation."
+     * That separate operation is activate().
      *
      * @param string $name The span name
      * @param SpanKind $kind The span kind
      * @param TAttributeValueMap|Attributes $attributes Initial attributes
      * @param array<SpanLink> $links Links to other spans
-     * @param null|false|SpanContext $parentContext Explicit parent control:
-     *                                              - null (default): automatic detection from the Context's active span
-     *                                              - SpanContext: use as explicit parent
-     *                                              - false: create root span (no parent)
+     * @param null|false|Context $parent Explicit parent control:
+     *                                   - null (default): automatic detection from the current Context's active span
+     *                                   - Context: use that Context's active span as parent
+     *                                   - false: create root span (no parent)
      */
     public function span(
         string $name,
         SpanKind $kind = SpanKind::INTERNAL,
         Attributes|array $attributes = [],
         array $links = [],
-        SpanContext|false|null $parentContext = null,
+        Context|false|null $parent = null,
     ): Span {
         $context = $this->contextStorage->current();
 
-        $parentSpanContext = match (true) {
-            $parentContext === false => null,
-            $parentContext !== null => $parentContext,
-            default => $context->activeSpan(),
+        // OTEL spec: the sampler receives the parent Context, not the ambient one. Dropping only the active
+        // span for a root span keeps suppression and baggage, which are not parent-child properties.
+        $parentContext = match (true) {
+            $parent === false => $context->withoutActiveSpan(),
+            $parent !== null => $parent,
+            default => $context,
         };
+
+        $parentSpanContext = $parentContext->activeSpan();
 
         // OpenTelemetry: a span inherits its parent's trace id; a root span (no parent) starts a new trace.
         $traceId = $parentSpanContext !== null ? $parentSpanContext->traceId : TraceId::generate();
@@ -209,7 +243,7 @@ final class Tracer
         }
 
         if ($this->sampler !== null) {
-            $samplingResult = $this->sampler->shouldSample($context, $span);
+            $samplingResult = $this->sampler->shouldSample($parentContext, $span);
 
             $isRecording = $samplingResult->decision->isRecording();
             $traceFlags = $samplingResult->decision->isSampled() ? TraceFlags::sampled() : TraceFlags::default();
@@ -243,8 +277,6 @@ final class Tracer
             }
         }
 
-        $span->setContextScope($this->contextStorage->attach($context->withActiveSpan($span->context())));
-
         if ($span->isRecording()) {
             try {
                 $this->processor->onStart($span);
@@ -268,7 +300,7 @@ final class Tracer
      * @param string $name The span name
      * @param callable(): T $callback The callable to execute
      * @param SpanKind $kind The span kind
-     * @param null|false|SpanContext $parentContext Explicit parent control (see span() for details)
+     * @param null|false|Context $parent Explicit parent control (see span() for details)
      *
      * @throws \Throwable Rethrows any exception from the callback
      *
@@ -278,9 +310,10 @@ final class Tracer
         string $name,
         callable $callback,
         SpanKind $kind = SpanKind::INTERNAL,
-        SpanContext|false|null $parentContext = null,
+        Context|false|null $parent = null,
     ): mixed {
-        $span = $this->span($name, $kind, [], [], $parentContext);
+        $span = $this->span($name, $kind, [], [], $parent);
+        $scope = $this->activate($span);
 
         try {
             // OTEL spec: instrumentation leaves the status Unset on success; only errors set a status.
@@ -292,6 +325,7 @@ final class Tracer
 
             throw $e;
         } finally {
+            $scope->detach();
             $this->complete($span);
         }
     }

--- a/src/lib/telemetry/tests/Flow/Telemetry/Tests/Integration/Tracer/TracingIntegrationTest.php
+++ b/src/lib/telemetry/tests/Flow/Telemetry/Tests/Integration/Tracer/TracingIntegrationTest.php
@@ -36,16 +36,20 @@ final class TracingIntegrationTest extends TestCase
         $tracer = $provider->tracer($this->resource, 'my-service', '1.0.0');
 
         $rootSpan = $tracer->span('handle-request', SpanKind::SERVER);
+        $rootScope = $tracer->activate($rootSpan);
         $rootSpan->setAttribute('http.method', 'POST');
         $rootSpan->setAttribute('http.url', '/api/orders');
 
         $dbSpan = $tracer->span('database-query', SpanKind::CLIENT);
+        $dbScope = $tracer->activate($dbSpan);
         $dbSpan->setAttribute('db.system', 'postgresql');
         $dbSpan->setAttribute('db.statement', 'SELECT * FROM orders');
         $dbSpan->setStatus(SpanStatus::ok());
+        $dbScope->detach();
         $tracer->complete($dbSpan);
 
         $rootSpan->setStatus(SpanStatus::ok());
+        $rootScope->detach();
         $tracer->complete($rootSpan);
 
         static::assertCount(2, $processor->endedSpans());
@@ -70,13 +74,21 @@ final class TracingIntegrationTest extends TestCase
         $tracer = $provider->tracer($this->resource, 'test');
 
         $level1 = $tracer->span('level-1');
+        $scope1 = $tracer->activate($level1);
         $level2 = $tracer->span('level-2');
+        $scope2 = $tracer->activate($level2);
         $level3 = $tracer->span('level-3');
+        $scope3 = $tracer->activate($level3);
         $level4 = $tracer->span('level-4');
+        $scope4 = $tracer->activate($level4);
 
+        $scope4->detach();
         $tracer->complete($level4);
+        $scope3->detach();
         $tracer->complete($level3);
+        $scope2->detach();
         $tracer->complete($level2);
+        $scope1->detach();
         $tracer->complete($level1);
 
         static::assertCount(4, $processor->endedSpans());
@@ -134,22 +146,26 @@ final class TracingIntegrationTest extends TestCase
         $tracerB = $provider->tracer($this->resource, 'tracer-b', '1.0.0');
 
         $spanA = $tracerA->span('span-a');
+        $scopeA = $tracerA->activate($spanA);
 
         $activeSpanId = $storage->current()->activeSpanId();
         static::assertNotNull($activeSpanId);
         static::assertTrue($spanA->context()->spanId->equals($activeSpanId));
 
         $spanB = $tracerB->span('span-b');
+        $scopeB = $tracerB->activate($spanB);
         $activeSpanIdAfterB = $storage->current()->activeSpanId();
         static::assertNotNull($activeSpanIdAfterB);
         static::assertTrue($spanB->context()->spanId->equals($activeSpanIdAfterB));
 
+        $scopeB->detach();
         $tracerB->complete($spanB);
 
         $activeSpanIdAfterBComplete = $storage->current()->activeSpanId();
         static::assertNotNull($activeSpanIdAfterBComplete);
         static::assertTrue($spanA->context()->spanId->equals($activeSpanIdAfterBComplete));
 
+        $scopeA->detach();
         $tracerA->complete($spanA);
 
         static::assertNull($storage->current()->activeSpanId());
@@ -166,13 +182,17 @@ final class TracingIntegrationTest extends TestCase
         $dbTracer = $provider->tracer($this->resource, 'database', '2.0.0');
 
         $httpSpan = $httpTracer->span('http-request');
+        $httpScope = $httpTracer->activate($httpSpan);
         $dbSpan = $dbTracer->span('db-query');
+        $dbScope = $dbTracer->activate($dbSpan);
 
         static::assertTrue($dbSpan->context()->traceId->equals($httpSpan->context()->traceId));
         static::assertSame($httpSpan->context()->spanId->toHex(), $dbSpan->context()->parentSpanId?->toHex());
 
-        $httpTracer->complete($httpSpan);
+        $dbScope->detach();
         $dbTracer->complete($dbSpan);
+        $httpScope->detach();
+        $httpTracer->complete($httpSpan);
     }
 
     public function test_provider_creates_new_tracer_each_time(): void

--- a/src/lib/telemetry/tests/Flow/Telemetry/Tests/Mother/ScopeMother.php
+++ b/src/lib/telemetry/tests/Flow/Telemetry/Tests/Mother/ScopeMother.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\Telemetry\Tests\Mother;
+
+use Flow\Telemetry\Context\Context;
+use Flow\Telemetry\Context\MemoryContextStorage;
+use Flow\Telemetry\Context\Scope;
+
+final class ScopeMother
+{
+    /**
+     * A real, attached Scope backed by its own storage - detaching it cannot disturb anything else.
+     */
+    public static function attached(): Scope
+    {
+        return (new MemoryContextStorage())->attach(Context::root());
+    }
+}

--- a/src/lib/telemetry/tests/Flow/Telemetry/Tests/Unit/Context/ContextScopeTest.php
+++ b/src/lib/telemetry/tests/Flow/Telemetry/Tests/Unit/Context/ContextScopeTest.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Flow\Telemetry\Tests\Unit\Context;
 
 use Flow\Telemetry\Context\Context;
-use Flow\Telemetry\Context\ContextScope;
 use Flow\Telemetry\Context\MemoryContextStorage;
+use Flow\Telemetry\Context\Scope;
 use Flow\Telemetry\Context\SpanId;
 use Flow\Telemetry\Context\TraceId;
 use Flow\Telemetry\Tracer\SpanContext;
@@ -38,7 +38,19 @@ final class ContextScopeTest extends TestCase
         static::assertSame($context1->activeSpan(), $storage->current()->activeSpan());
     }
 
-    public function test_detach_is_idempotent(): void
+    public function test_detach_returns_detached_when_in_order(): void
+    {
+        $storage = new MemoryContextStorage();
+
+        $scope = $storage->attach(Context::root()->withActiveSpan(SpanContext::create(
+            TraceId::generate(),
+            SpanId::generate(),
+        )));
+
+        static::assertSame(Scope::DETACHED, $scope->detach());
+    }
+
+    public function test_detach_returns_inactive_when_already_detached(): void
     {
         $storage = new MemoryContextStorage();
         $originalContext = $storage->current();
@@ -48,9 +60,38 @@ final class ContextScopeTest extends TestCase
             SpanId::generate(),
         )));
 
-        static::assertSame(ContextScope::DETACHED, $scope->detach());
-        static::assertSame(ContextScope::DETACHED, $scope->detach());
-        static::assertSame(ContextScope::DETACHED, $scope->detach());
+        static::assertSame(Scope::DETACHED, $scope->detach());
+        static::assertSame(Scope::INACTIVE, $scope->detach());
+        static::assertSame(Scope::INACTIVE, $scope->detach());
+
+        static::assertSame($originalContext->activeSpan(), $storage->current()->activeSpan());
+    }
+
+    public function test_detach_returns_mismatch_when_out_of_order(): void
+    {
+        $storage = new MemoryContextStorage();
+
+        $scopeA = $storage->attach(Context::root()->withActiveSpan(SpanContext::create(
+            TraceId::generate(),
+            SpanId::generate(),
+        )));
+        $storage->attach(Context::root()->withActiveSpan(SpanContext::create(TraceId::generate(), SpanId::generate())));
+
+        static::assertSame(Scope::MISMATCH, $scopeA->detach());
+    }
+
+    public function test_detach_out_of_order_still_restores_the_previous_context(): void
+    {
+        $storage = new MemoryContextStorage();
+        $originalContext = $storage->current();
+
+        $scopeA = $storage->attach(Context::root()->withActiveSpan(SpanContext::create(
+            TraceId::generate(),
+            SpanId::generate(),
+        )));
+        $storage->attach(Context::root()->withActiveSpan(SpanContext::create(TraceId::generate(), SpanId::generate())));
+
+        $scopeA->detach();
 
         static::assertSame($originalContext->activeSpan(), $storage->current()->activeSpan());
     }

--- a/src/lib/telemetry/tests/Flow/Telemetry/Tests/Unit/Tracer/TracerTest.php
+++ b/src/lib/telemetry/tests/Flow/Telemetry/Tests/Unit/Tracer/TracerTest.php
@@ -25,10 +25,19 @@ final class TracerTest extends TestCase
     {
         $tracer = TracerMother::create();
         $span = $tracer->span('test-span');
+        $tracer->activate($span);
 
         $active = $tracer->activeSpan();
         static::assertNotNull($active);
         static::assertTrue($active->spanId->equals($span->context()->spanId));
+    }
+
+    public function test_active_span_is_unchanged_by_an_unactivated_span(): void
+    {
+        $tracer = TracerMother::create();
+        $tracer->span('test-span');
+
+        static::assertNull($tracer->activeSpan());
     }
 
     public function test_active_span_returns_null_when_no_active_span(): void
@@ -62,7 +71,9 @@ final class TracerTest extends TestCase
         $tracerB = $provider->tracer($resource, 'tracerB');
 
         $a1 = $tracerA->span('A1');
+        $tracerA->activate($a1);
         $b1 = $tracerB->span('B1');
+        $tracerB->activate($b1);
         $a2 = $tracerA->span('A2');
 
         $parentSpanId = $a2->context()->parentSpanId;
@@ -81,6 +92,32 @@ final class TracerTest extends TestCase
         $tracer->complete($tracer->span('test-span'));
     }
 
+    public function test_complete_is_idempotent_and_exports_once(): void
+    {
+        $processor = $this->createMock(SpanProcessor::class);
+        $processor->expects(self::once())->method('onEnd');
+
+        $tracer = TracerMother::withProcessor($processor);
+        $span = $tracer->span('test-span');
+
+        $tracer->complete($span);
+        $tracer->complete($span);
+        $tracer->complete($span);
+    }
+
+    public function test_complete_exports_a_span_that_was_ended_by_the_caller(): void
+    {
+        $processor = $this->createMock(SpanProcessor::class);
+        $processor->expects(self::once())->method('onEnd');
+
+        $tracer = TracerMother::withProcessor($processor);
+        $span = $tracer->span('test-span');
+        // callers end a span early to read its duration, then complete it
+        $span->end();
+
+        $tracer->complete($span);
+    }
+
     public function test_complete_ends_span(): void
     {
         $tracer = TracerMother::create();
@@ -93,17 +130,68 @@ final class TracerTest extends TestCase
         static::assertTrue($span->isEnded());
     }
 
-    public function test_complete_restores_parent_context_after_child(): void
+    public function test_detaching_a_child_scope_restores_the_parent_context(): void
     {
         $tracer = TracerMother::create();
-        $tracer->span('test-span');
+        $parent = $tracer->span('parent');
+        $tracer->activate($parent);
 
         static::assertNotNull($tracer->activeSpan());
 
-        $tracer->complete($tracer->span('test-span'));
-        $tracer->complete($tracer->span('test-span'));
+        foreach (['first-child', 'second-child'] as $name) {
+            $child = $tracer->span($name);
+            $scope = $tracer->activate($child);
+            $scope->detach();
+            $tracer->complete($child);
+        }
 
-        static::assertNotNull($tracer->activeSpan());
+        $active = $tracer->activeSpan();
+        static::assertNotNull($active);
+        static::assertTrue($active->spanId->equals($parent->context()->spanId));
+    }
+
+    public function test_complete_does_not_detach_the_scope(): void
+    {
+        $tracer = TracerMother::create();
+        $span = $tracer->span('test-span');
+        $tracer->activate($span);
+
+        $tracer->complete($span);
+
+        $active = $tracer->activeSpan();
+        static::assertNotNull($active);
+        static::assertTrue($active->spanId->equals($span->context()->spanId));
+    }
+
+    public function test_explicit_parent_context_is_passed_to_the_sampler(): void
+    {
+        $storage = new MemoryContextStorage();
+        $tracer = TracerMother::withContextStorage($storage);
+
+        // ambient is suppressed, the explicitly declared parent is not
+        $storage->attach(Context::root()->withSuppressedTracing());
+
+        static::assertTrue($tracer->span('child', parent: Context::root())->isRecording());
+    }
+
+    public function test_ambient_context_is_passed_to_the_sampler_when_no_parent_is_given(): void
+    {
+        $storage = new MemoryContextStorage();
+        $tracer = TracerMother::withContextStorage($storage);
+
+        $storage->attach(Context::root()->withSuppressedTracing());
+
+        static::assertFalse($tracer->span('child')->isRecording());
+    }
+
+    public function test_root_span_keeps_suppression_from_the_ambient_context(): void
+    {
+        $storage = new MemoryContextStorage();
+        $tracer = TracerMother::withContextStorage($storage);
+
+        $storage->attach(Context::root()->withSuppressedTracing());
+
+        static::assertFalse($tracer->span('root', parent: false)->isRecording());
     }
 
     public function test_context_returns_tracer_context(): void
@@ -124,6 +212,7 @@ final class TracerTest extends TestCase
     {
         $tracer = TracerMother::create();
         $parent = $tracer->span('parent');
+        $tracer->activate($parent);
         $child = $tracer->span('child');
 
         $parentSpanId = $child->context()->parentSpanId;
@@ -131,10 +220,22 @@ final class TracerTest extends TestCase
         static::assertTrue($parentSpanId->equals($parent->context()->spanId));
     }
 
+    public function test_unactivated_spans_are_siblings_not_parent_and_child(): void
+    {
+        $tracer = TracerMother::create();
+        $first = $tracer->span('first');
+        $second = $tracer->span('second');
+
+        static::assertNull($second->context()->parentSpanId);
+        static::assertNull($first->context()->parentSpanId);
+        static::assertFalse($second->context()->traceId->equals($first->context()->traceId));
+    }
+
     public function test_nested_spans_share_trace_id(): void
     {
         $tracer = TracerMother::create();
         $parent = $tracer->span('parent');
+        $tracer->activate($parent);
         $child = $tracer->span('child');
 
         static::assertTrue($child->context()->traceId->equals($parent->context()->traceId));


### PR DESCRIPTION
<h2>Change Log</h2>                                                                                                                                                                                                                                                                                          
<hr />                                                                                                                                                                                                                                                                                                       
<div id="change-log">                                                                                                                                                                                                                                                                                        
  <h4>Added</h4>                                                                                                                                                                                                                                                                                             
  <ul id="added">                                                                                                                                                                                                                                                                                            
    <!-- <li>Feature making everything better</li> -->                                                                                                                                                                                                                                                       
    <li><code>flow-php/telemetry</code> - <code>Tracer::activate()</code> returning a detachable <code>Scope</code></li>                                                                                                                                                                                     
    <li><code>flow-php/telemetry</code> - <code>Scope::DETACHED</code>, <code>Scope::INACTIVE</code> and <code>Scope::MISMATCH</code> detach results</li>                                                                                                                                                    
    <li><code>flow-php/etl</code> - <code>FloeStreamReader::close()</code></li>                                                                                                                                                                                                                              
  </ul>                                                                                                                                                                                                                                                                                                      
  <h4>Fixed</h4>                                                                                                                                                                                                                                                                                             
  <ul id="fixed">                                                                                                                                                                                                                                                                                            
    <!-- <li>Behavior that was incorrect</li> -->                                                                                                                                                                                                                                                            
    <li><code>flow-php/filesystem</code> - concurrently open stream spans no longer nest into each other</li>                                                                                                                                                                                                
    <li><code>flow-php/etl</code> - bucket source streams are closed, so their spans complete</li>                                                                                                                                                                                                           
    <li><code>flow-php/telemetry</code> - the sampler receives the parent <code>Context</code> instead of the ambient one</li>                                                                                                                                                                               
    <li><code>flow-php/telemetry</code> - <code>Tracer::complete()</code> no longer re-exports a span when called twice</li>                                                                                                                                                                                 
    <li><code>flow-php/etl</code> - <code>LimitReachedException</code> no longer escapes <code>to_transformation()</code></li>                                                                                                                                                                               
    <li><code>flow-php/etl</code> - limit reached is logged without the exception stacktrace</li>                                                                                                                                                                                                            
  </ul>                                                                                                                                                                                                                                                                                                      
  <h4>Changed</h4>                                                                                                                                                                                                                                                                                           
  <ul id="changed">                                                                                                                                                                                                                                                                                          
    <!-- <li>Something into something new</li> -->                                                                                                                                                                                                                                                           
    <li><code>flow-php/telemetry</code> - <code>Tracer::span()</code> no longer makes the span current</li>                                                                                                                                                                                                  
    <li><code>flow-php/telemetry</code> - <code>Tracer::span()</code> and <code>trace()</code> take a <code>Context</code> parent instead of a <code>SpanContext</code></li>                                                                                                                                 
    <li><code>flow-php/telemetry</code> - <code>Tracer::complete()</code> no longer detaches the scope</li>                                                                                                                                                                                                  
    <li><code>flow-php/etl</code> - <code>to_transformation()</code> expands a <code>Transformation</code> once per loader, not per batch</li>                                                                                                                                                               
    <li><code>flow-php/etl</code> - nested loading and transformation spans are tracked on a stack</li>                                                                                                                                                                                                      
    <li><code>flow-php/phpunit-telemetry-bridge</code> - <code>SpanStack::push()</code> takes the span scope</li>                                                                                                                                                                                            
  </ul>                                                                                                                                                                                                                                                                                                      
  <h4>Removed</h4>                                                                                                                                                                                                                                                                                           
  <ul id="removed">                                                                                                                                                                                                                                                                                          
    <!-- <li>Something</li> -->                                                                                                                                                                                                                                                                              
    <li><code>flow-php/telemetry</code> - <code>Span::contextScope()</code> and <code>Span::setContextScope()</code></li>                                                                                                                                                                                    
    <li><code>flow-php/telemetry</code> - <code>MemoryContextStorage::store()</code></li>                                                                                                                                                                                                                    
  </ul>                                                                                                                                                                                                                                                                                                      
  <h4>Deprecated</h4>                                                                                                                                                                                                                                                                                        
  <ul id="deprecated">                                                                                                                                                                                                                                                                                       
    <!-- <li>Something is from now deprecated</li> -->                                                                                                                                                                                                                                                       
  </ul>                                                                                                                                                                                                                                                                                                      
  <h4>Security</h4>                                                                                                                                                                                                                                                                                          
  <ul id="security">                                                                                                                                                                                                                                                                                         
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->                                                                                                                                                                                                                           
  </ul>                                                                                                                                                                                                                                                                                                      
</div>