### PR TITLE
Ensure false return from uncompressToBuffer is bubbled up (Snappy lib)

### DIFF
--- a/src/lib/snappy/polyfill.php
+++ b/src/lib/snappy/polyfill.php
@@ -12,7 +12,7 @@ if (!function_exists('snappy_compress')) {
 }
 
 if (!function_exists('snappy_uncompress')) {
-    function snappy_uncompress(string $compressedText): string
+    function snappy_uncompress(string $compressedText): string|false
     {
         return (new Snappy())->uncompress($compressedText);
     }

--- a/src/lib/snappy/src/Flow/Snappy/Snappy.php
+++ b/src/lib/snappy/src/Flow/Snappy/Snappy.php
@@ -26,7 +26,7 @@ final class Snappy
         return pack('C*', ...$outputBuffer);
     }
 
-    public function uncompress(string $compressedText): string
+    public function uncompress(string $compressedText): string|false
     {
         if ($compressedText === '') {
             return $compressedText;
@@ -35,7 +35,9 @@ final class Snappy
         $byteArray = array_values(unpack('C*', $compressedText) ?: []);
 
         $outputBuffer = [];
-        (new SnappyDecompressor($byteArray))->uncompressToBuffer($outputBuffer);
+        if (!(new SnappyDecompressor($byteArray))->uncompressToBuffer($outputBuffer)) {
+            return false;
+        }
 
         return pack('C*', ...$outputBuffer);
     }

--- a/src/lib/snappy/tests/Flow/Snappy/Tests/Integration/SnappyTest.php
+++ b/src/lib/snappy/tests/Flow/Snappy/Tests/Integration/SnappyTest.php
@@ -82,4 +82,11 @@ final class SnappyTest extends TestCase
 
         static::assertSame($string, $snappy->uncompress($snappy->compress($string)));
     }
+
+    public function test_uncompress_returns_false_on_malformed_input(): void
+    {
+        $snappy = new Snappy();
+
+        static::assertFalse($snappy->uncompress("\xFF\xFF\xFF\xFF"));
+    }
 }


### PR DESCRIPTION


<!-- 
    Please replace #xxx with a GitHub issue id from flow-php/flow repository. For example #1234 
    If there is no item in a roadmap related to this PR, please check our contributing guidelines first. 
-->
Resolves: #xxx

<!-- 
    Below section will be used to automatically generate changelog, please do not modify HTML code structure
    DO NOT REMOVE that HTML STRUCTURE, INSTEAD ADD YOUR CHANGES INSIDE THE LISTS 
    PULL REQUESTS WITHOUT CHANGELOG CAN'T BE MERGED 
-->
<h2>Change Log</h2>
<hr /> 
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <li>Ensure false return from uncompressToBuffer is bubbled up, not silently ignored (e.g. on malformed input)</li>
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was a security issue, is not an issue anymore</li> -->
  </ul>     
</div>